### PR TITLE
Release GitHub 2026 06 22

### DIFF
--- a/arbiter/fabricator/__tests__/test_fabrication_status.py
+++ b/arbiter/fabricator/__tests__/test_fabrication_status.py
@@ -1,0 +1,177 @@
+"""
+Tests for the durable fabrication-jobs status writes in
+arbiter/fabricator/index.py process_event.
+
+process_event must:
+  - write status=PROCESSING (+updatedAt) at the START of processing,
+  - write status=COMPLETED (+agentId +updatedAt) on success,
+  - write status=FAILED (+errorMessage +updatedAt) on exception (then re-raise),
+  - skip the write when FABRICATION_JOBS_TABLE is unset,
+  - never let a status-write failure change the fabrication outcome.
+"""
+
+import sys
+import os
+from unittest.mock import patch, MagicMock
+
+import pytest
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+
+os.environ.setdefault("TOOL_CONFIG_TABLE", "fake-tool-table")
+os.environ.setdefault("AGENT_CONFIG_TABLE", "fake-agent-table")
+os.environ.setdefault("AGENT_BUCKET_NAME", "fake-bucket")
+os.environ.setdefault("COMPLETION_BUS_NAME", "fake-bus")
+os.environ.setdefault("WORKER_QUEUE_URL", "https://sqs.fake/queue")
+
+import index
+
+
+def _base_event():
+    return {
+        "orchestration_id": "sess-1",
+        "agent_use_id": "MyAgent",
+        "node": "fabricator",
+        "agent_input": {"taskDetails": "Create an agent that does things"},
+        "agent_index": 0,
+        "total_agents": 1,
+    }
+
+
+class TestFabricationStatusWrites:
+    def setup_method(self):
+        os.environ["FABRICATION_JOBS_TABLE"] = "citadel-fabrication-jobs-test"
+
+    def teardown_method(self):
+        os.environ.pop("FABRICATION_JOBS_TABLE", None)
+
+    def test_processing_then_completed_on_success(self):
+        statuses = []
+
+        def record(orchestration_id, agent_use_id, status, **kwargs):
+            statuses.append((status, kwargs))
+
+        with patch.object(index, "_write_fabrication_status", side_effect=record), \
+                patch.object(index, "check_design_assessment"), \
+                patch.object(index, "create_agent_fabricator") as mk, \
+                patch.object(index, "publish_intake_progress"):
+            mk.return_value = MagicMock()
+            index.process_event(_base_event(), {}, request_type="agent-creation")
+
+        seq = [s for s, _ in statuses]
+        assert seq[0] == "PROCESSING"
+        assert "COMPLETED" in seq
+        completed_kwargs = next(kw for s, kw in statuses if s == "COMPLETED")
+        assert completed_kwargs.get("agent_id") == "MyAgent"
+
+    def test_failed_on_exception_and_reraises(self):
+        statuses = []
+
+        def record(orchestration_id, agent_use_id, status, **kwargs):
+            statuses.append((status, kwargs))
+
+        boom = RuntimeError("fabrication blew up")
+        with patch.object(index, "_write_fabrication_status", side_effect=record), \
+                patch.object(index, "check_design_assessment"), \
+                patch.object(index, "create_agent_fabricator") as mk, \
+                patch.object(index, "publish_intake_progress"), \
+                patch.object(index, "publish_fabrication_event"):
+            agent = MagicMock(side_effect=boom)
+            mk.return_value = agent
+            with pytest.raises(RuntimeError):
+                index.process_event(_base_event(), {}, request_type="agent-creation")
+
+        seq = [s for s, _ in statuses]
+        assert seq[0] == "PROCESSING"
+        assert "FAILED" in seq
+        failed_kwargs = next(kw for s, kw in statuses if s == "FAILED")
+        assert "fabrication blew up" in (failed_kwargs.get("error_message") or "")
+
+    def test_status_write_failure_does_not_change_success(self):
+        # The underlying DynamoDB update_item raising must not break
+        # fabrication — the helper swallows it (best-effort).
+        failing_ddb = MagicMock()
+        failing_ddb.update_item.side_effect = Exception("ddb down")
+        with patch.object(index.boto3, "client", return_value=failing_ddb), \
+                patch.object(index, "check_design_assessment"), \
+                patch.object(index, "create_agent_fabricator") as mk, \
+                patch.object(index, "publish_intake_progress"), \
+                patch.object(index, "publish_fabrication_event"):
+            mk.return_value = MagicMock()
+            # Should NOT raise — status writes are best-effort.
+            index.process_event(_base_event(), {}, request_type="agent-creation")
+
+    def test_helper_skips_when_table_unset(self):
+        os.environ.pop("FABRICATION_JOBS_TABLE", None)
+        mock_client = MagicMock()
+        with patch.object(index.boto3, "client", return_value=mock_client):
+            index._write_fabrication_status("sess-1", "MyAgent", "PROCESSING")
+        mock_client.update_item.assert_not_called()
+
+    def test_helper_writes_update_item_with_keys(self):
+        mock_client = MagicMock()
+        with patch.object(index.boto3, "client", return_value=mock_client):
+            index._write_fabrication_status(
+                "sess-1", "MyAgent", "COMPLETED", agent_id="MyAgent"
+            )
+        assert mock_client.update_item.called
+        kwargs = mock_client.update_item.call_args.kwargs
+        assert kwargs["TableName"] == "citadel-fabrication-jobs-test"
+        assert kwargs["Key"] == {
+            "orchestrationId": {"S": "sess-1"},
+            "agentUseId": {"S": "MyAgent"},
+        }
+
+    def test_helper_sets_agent_name_via_if_not_exists(self):
+        # agentName must be set with if_not_exists so a producer-set value
+        # is never clobbered, using the threaded agent_name param.
+        mock_client = MagicMock()
+        with patch.object(index.boto3, "client", return_value=mock_client):
+            index._write_fabrication_status(
+                "sess-1", "MyAgent", "PROCESSING", agent_name="MyAgent"
+            )
+        kwargs = mock_client.update_item.call_args.kwargs
+        expr = kwargs["UpdateExpression"]
+        assert "agentName = if_not_exists(agentName, :agentName)" in expr
+        assert kwargs["ExpressionAttributeValues"][":agentName"] == {"S": "MyAgent"}
+
+    def test_helper_sets_submitted_at_via_if_not_exists(self):
+        # submittedAt must be stamped with if_not_exists so the first write
+        # records a submit time when no PENDING row exists.
+        mock_client = MagicMock()
+        with patch.object(index.boto3, "client", return_value=mock_client):
+            index._write_fabrication_status(
+                "sess-1", "MyAgent", "PROCESSING", agent_name="MyAgent"
+            )
+        kwargs = mock_client.update_item.call_args.kwargs
+        expr = kwargs["UpdateExpression"]
+        assert "submittedAt = if_not_exists(submittedAt, :submittedAt)" in expr
+        assert ":submittedAt" in kwargs["ExpressionAttributeValues"]
+
+    def test_helper_omits_agent_name_when_not_provided(self):
+        # Backward compatible: with no agent_name the agentName clause is
+        # skipped (no :agentName binding).
+        mock_client = MagicMock()
+        with patch.object(index.boto3, "client", return_value=mock_client):
+            index._write_fabrication_status("sess-1", "MyAgent", "PROCESSING")
+        kwargs = mock_client.update_item.call_args.kwargs
+        assert "agentName" not in kwargs["UpdateExpression"]
+        assert ":agentName" not in kwargs["ExpressionAttributeValues"]
+
+    def test_process_event_threads_agent_use_id_as_agent_name(self):
+        # process_event must pass agent_use_id as agent_name at the
+        # PROCESSING/COMPLETED call sites.
+        calls = []
+
+        def record(orchestration_id, agent_use_id, status, **kwargs):
+            calls.append((status, kwargs))
+
+        with patch.object(index, "_write_fabrication_status", side_effect=record), \
+                patch.object(index, "check_design_assessment"), \
+                patch.object(index, "create_agent_fabricator") as mk, \
+                patch.object(index, "publish_intake_progress"):
+            mk.return_value = MagicMock()
+            index.process_event(_base_event(), {}, request_type="agent-creation")
+
+        processing_kwargs = next(kw for s, kw in calls if s == "PROCESSING")
+        assert processing_kwargs.get("agent_name") == "MyAgent"

--- a/arbiter/fabricator/__tests__/test_store_agent_config_registry_idempotency.py
+++ b/arbiter/fabricator/__tests__/test_store_agent_config_registry_idempotency.py
@@ -1,0 +1,123 @@
+"""Idempotency tests for store_agent_config_registry.
+
+Harden the agent-fabrication pipeline: SQS redeliveries and re-triggers must
+not create DUPLICATE Registry records for the same agent name.
+
+Contract under test:
+  - When a Registry record with the same name (agent_id) already EXISTS,
+    store_agent_config_registry SKIPS CreateRegistryRecord (no duplicate),
+    still refreshes the AppsTable #META mirror for the existing record, and
+    returns True.
+  - When NO record with that name exists, CreateRegistryRecord is called
+    exactly once.
+
+The lookup mirrors resolveRecordId/listResources in
+backend/src/services/registry-service.ts: list CUSTOM records and match on
+the record name.
+"""
+
+import sys
+import os
+from unittest.mock import patch, MagicMock
+
+import pytest
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+
+# Set required env vars before import.
+os.environ.setdefault("TOOL_CONFIG_TABLE", "fake-tool-table")
+os.environ.setdefault("AGENT_CONFIG_TABLE", "fake-agent-table")
+os.environ.setdefault("AGENT_BUCKET_NAME", "fake-bucket")
+os.environ.setdefault("COMPLETION_BUS_NAME", "fake-bus")
+os.environ.setdefault("WORKER_QUEUE_URL", "https://sqs.fake/queue")
+os.environ.setdefault("REGISTRY_ID", "fake-registry-id")
+os.environ.setdefault("AWS_DEFAULT_REGION", "us-west-2")
+
+from index import store_agent_config_registry  # noqa: E402
+import index  # noqa: E402  — used for _reset_registry_client_for_test
+
+
+SCHEMA = {
+    "type": "object",
+    "properties": {"q": {"type": "string", "description": "query"}},
+    "required": ["q"],
+}
+
+
+def _make_registry_mock(existing_records=None, record_id="gen-record-id"):
+    """Build a mock bedrock-agentcore-control client.
+
+    Args:
+        existing_records: list of record-summary dicts returned by
+            list_registry_records (the idempotency lookup). Defaults to [].
+        record_id: recordId surfaced in the create_registry_record response.
+    """
+    client = MagicMock()
+    client.list_registry_records.return_value = {
+        "records": existing_records or [],
+    }
+    client.create_registry_record.return_value = {
+        "recordArn": (
+            "arn:aws:bedrock-agentcore:us-west-2:123456789012:"
+            f"registry/reg/record/{record_id}"
+        ),
+        "recordId": record_id,
+        "status": "DRAFT",
+    }
+    return client
+
+
+@pytest.fixture(autouse=True)
+def _reset_cached_client():
+    index._reset_registry_client_for_test()
+    yield
+    index._reset_registry_client_for_test()
+
+
+class TestIdempotentAgentCreation:
+    def test_skips_create_when_same_named_record_exists(self):
+        agent_id = "duplicate_agent"
+        client = _make_registry_mock(
+            existing_records=[{"name": agent_id, "recordId": "existing-rec-id"}],
+        )
+        with patch("index._get_registry_client", return_value=client):
+            result = store_agent_config_registry(
+                file_name=f"/tmp/{agent_id}.py",
+                agent_id=agent_id,
+                llm_tool_schema=SCHEMA,
+                agent_description="dup",
+            )
+
+        assert result is True
+        client.create_registry_record.assert_not_called()
+
+    def test_creates_once_when_no_matching_record_exists(self):
+        agent_id = "fresh_agent"
+        client = _make_registry_mock(existing_records=[])
+        with patch("index._get_registry_client", return_value=client):
+            result = store_agent_config_registry(
+                file_name=f"/tmp/{agent_id}.py",
+                agent_id=agent_id,
+                llm_tool_schema=SCHEMA,
+                agent_description="fresh",
+            )
+
+        assert result is True
+        client.create_registry_record.assert_called_once()
+
+    def test_does_not_match_on_different_name(self):
+        """A record whose name differs must NOT block creation."""
+        agent_id = "wanted_agent"
+        client = _make_registry_mock(
+            existing_records=[{"name": "some_other_agent", "recordId": "other-id"}],
+        )
+        with patch("index._get_registry_client", return_value=client):
+            result = store_agent_config_registry(
+                file_name=f"/tmp/{agent_id}.py",
+                agent_id=agent_id,
+                llm_tool_schema=SCHEMA,
+                agent_description="wanted",
+            )
+
+        assert result is True
+        client.create_registry_record.assert_called_once()

--- a/arbiter/fabricator/__tests__/test_store_agent_config_registry_properties.py
+++ b/arbiter/fabricator/__tests__/test_store_agent_config_registry_properties.py
@@ -3,7 +3,12 @@ Property-based tests for store_agent_config_registry.
 
 Covers task 9.1 of the agentcore-registry-migration spec:
   - Calls CreateRegistryRecord with agent metadata and custom metadata
-  - Sets initial status to DRAFT (maps to inactive state)
+  - Leaves the freshly created record in its post-create DRAFT
+    (pending-activation) state — the Fabricator does NOT call
+    UpdateRegistryRecordStatus(status="DRAFT"). The AgentCore registry
+    rejects a DRAFT->DRAFT transition with ValidationException
+    ('Invalid target status: DRAFT'), which previously caused fabrication
+    to fail even though the record had been created.
   - On failure: logs error and publishes agent.fabrication.failed event
     to EventBridge
 
@@ -282,18 +287,29 @@ class TestCreateResourceCall:
 
 
 # ---------------------------------------------------------------------------
-# Requirement 8.3: initial status is DRAFT (maps to inactive)
+# Requirement 8.3: record is LEFT in its post-create DRAFT (pending-activation)
+# state — the Fabricator must NOT call UpdateRegistryRecordStatus("DRAFT").
 # ---------------------------------------------------------------------------
 
 class TestInitialStatusDraft:
-    """Verify records are created with DRAFT status / state inactive.
+    """Verify the freshly created record is left in DRAFT WITHOUT a redundant
+    UpdateRegistryRecordStatus(status="DRAFT") call.
+
+    CreateRegistryRecord already leaves the record in DRAFT (the
+    pre-activation state). The AgentCore registry rejects a DRAFT->DRAFT
+    transition with ValidationException ('Invalid target status: DRAFT'),
+    so re-asserting DRAFT after create is both redundant AND invalid — it
+    previously made store_agent_config_registry raise and publish
+    agent.fabrication.failed even though the record was created.
 
     **Validates: Requirements 8.3**
     """
 
     @given(agent_id=agent_ids, schema=tool_schemas)
     @settings(max_examples=20)
-    def test_status_update_called_with_draft(self, agent_id, schema):
+    def test_status_update_not_called_after_create(self, agent_id, schema):
+        """No UpdateRegistryRecordStatus call at all on the happy path — the
+        record is left in its post-create DRAFT state."""
         client = _make_registry_mock(record_id="rec-123")
         with patch("index._get_registry_client", return_value=client):
             store_agent_config_registry(
@@ -303,12 +319,72 @@ class TestInitialStatusDraft:
                 agent_description="desc",
             )
 
-        assert client.update_registry_record_status.called
-        kwargs = client.update_registry_record_status.call_args.kwargs
-        assert kwargs["status"] == "DRAFT"
-        assert kwargs["registryId"] == os.environ["REGISTRY_ID"]
-        # recordId is extracted from the create response ARN
-        assert kwargs["recordId"] == "rec-123"
+        assert not client.update_registry_record_status.called
+
+    @given(agent_id=agent_ids, schema=tool_schemas)
+    @settings(max_examples=20)
+    def test_status_update_never_called_with_draft(self, agent_id, schema):
+        """Regression for the ValidationException bug: even hypothetically, the
+        record status is NEVER re-asserted to DRAFT after create. Capturing the
+        invalid DRAFT->DRAFT transition would make the registry raise and
+        fabrication would fail."""
+        client = _make_registry_mock(record_id="rec-123")
+        with patch("index._get_registry_client", return_value=client):
+            store_agent_config_registry(
+                file_name=f"/tmp/{agent_id}.py",
+                agent_id=agent_id,
+                llm_tool_schema=schema,
+                agent_description="desc",
+            )
+
+        for call in client.update_registry_record_status.call_args_list:
+            assert call.kwargs.get("status") != "DRAFT"
+
+    @given(agent_id=agent_ids, schema=tool_schemas)
+    @settings(max_examples=20)
+    def test_create_registry_record_called_exactly_once(self, agent_id, schema):
+        client = _make_registry_mock(record_id="rec-123")
+        with patch("index._get_registry_client", return_value=client):
+            store_agent_config_registry(
+                file_name=f"/tmp/{agent_id}.py",
+                agent_id=agent_id,
+                llm_tool_schema=schema,
+                agent_description="desc",
+            )
+
+        assert client.create_registry_record.call_count == 1
+
+    @given(agent_id=agent_ids, schema=tool_schemas)
+    @settings(max_examples=20)
+    def test_returns_true_on_happy_path(self, agent_id, schema):
+        client = _make_registry_mock(record_id="rec-123")
+        with patch("index._get_registry_client", return_value=client):
+            result = store_agent_config_registry(
+                file_name=f"/tmp/{agent_id}.py",
+                agent_id=agent_id,
+                llm_tool_schema=schema,
+                agent_description="desc",
+            )
+
+        assert result is True
+
+    @given(agent_id=agent_ids, schema=tool_schemas)
+    @settings(max_examples=20)
+    def test_no_fabrication_failed_event_on_happy_path(self, agent_id, schema):
+        """The successful create path must not publish agent.fabrication.failed.
+        Before the fix, the invalid DRAFT->DRAFT update raised and this event
+        was published despite the record having been created."""
+        client = _make_registry_mock(record_id="rec-123")
+        with patch("index._get_registry_client", return_value=client), \
+             patch("index.publish_fabrication_event") as mock_publish:
+            store_agent_config_registry(
+                file_name=f"/tmp/{agent_id}.py",
+                agent_id=agent_id,
+                llm_tool_schema=schema,
+                agent_description="desc",
+            )
+
+        assert not mock_publish.called
 
     @given(agent_id=agent_ids, schema=tool_schemas)
     @settings(max_examples=20)

--- a/arbiter/fabricator/__tests__/test_store_agent_config_registry_source_project.py
+++ b/arbiter/fabricator/__tests__/test_store_agent_config_registry_source_project.py
@@ -1,0 +1,139 @@
+"""Source-project tagging tests for store_agent_config_registry.
+
+Identifiability: a fabricated agent must carry the source project (intake
+session / orchestration id) so the catalog can show and group by it.
+
+Contract under test:
+  - When ``source_project_id`` is provided (and not '0'/empty/None):
+      * the human description gets a ' (Project: <id>)' suffix,
+      * the CUSTOM descriptor inlineContent carries ``sourceProjectId``.
+  - The suffix is NOT duplicated if the description already ends with it.
+  - When ``source_project_id`` is absent/'0'/empty: no suffix is appended and
+    ``sourceProjectId`` is omitted (backward compatible).
+"""
+
+import json
+import sys
+import os
+from unittest.mock import patch, MagicMock
+
+import pytest
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+
+os.environ.setdefault("TOOL_CONFIG_TABLE", "fake-tool-table")
+os.environ.setdefault("AGENT_CONFIG_TABLE", "fake-agent-table")
+os.environ.setdefault("AGENT_BUCKET_NAME", "fake-bucket")
+os.environ.setdefault("COMPLETION_BUS_NAME", "fake-bus")
+os.environ.setdefault("WORKER_QUEUE_URL", "https://sqs.fake/queue")
+os.environ.setdefault("REGISTRY_ID", "fake-registry-id")
+os.environ.setdefault("AWS_DEFAULT_REGION", "us-west-2")
+
+from index import store_agent_config_registry  # noqa: E402
+import index  # noqa: E402
+
+
+SCHEMA = {
+    "type": "object",
+    "properties": {"q": {"type": "string", "description": "query"}},
+    "required": ["q"],
+}
+
+
+def _make_registry_mock(record_id="gen-record-id"):
+    client = MagicMock()
+    client.list_registry_records.return_value = {"records": []}
+    client.create_registry_record.return_value = {
+        "recordArn": (
+            "arn:aws:bedrock-agentcore:us-west-2:123456789012:"
+            f"registry/reg/record/{record_id}"
+        ),
+        "recordId": record_id,
+        "status": "DRAFT",
+    }
+    return client
+
+
+@pytest.fixture(autouse=True)
+def _reset_cached_client():
+    index._reset_registry_client_for_test()
+    yield
+    index._reset_registry_client_for_test()
+
+
+def _create_kwargs(client):
+    return client.create_registry_record.call_args.kwargs
+
+
+def _custom_metadata(client):
+    inline = _create_kwargs(client)["descriptors"]["custom"]["inlineContent"]
+    return json.loads(inline)
+
+
+class TestSourceProjectTagging:
+    def test_appends_project_suffix_and_stores_source_project_id(self):
+        client = _make_registry_mock()
+        with patch("index._get_registry_client", return_value=client), \
+                patch.object(index, "_write_app_meta_row", return_value=True):
+            store_agent_config_registry(
+                file_name="/tmp/a.py",
+                agent_id="agent_a",
+                llm_tool_schema=SCHEMA,
+                agent_description="Does a thing",
+                source_project_id="proj-123",
+            )
+
+        kwargs = _create_kwargs(client)
+        assert kwargs["description"] == "Does a thing (Project: proj-123)"
+        meta = _custom_metadata(client)
+        assert meta["sourceProjectId"] == "proj-123"
+
+    def test_does_not_duplicate_suffix(self):
+        client = _make_registry_mock()
+        with patch("index._get_registry_client", return_value=client), \
+                patch.object(index, "_write_app_meta_row", return_value=True):
+            store_agent_config_registry(
+                file_name="/tmp/a.py",
+                agent_id="agent_a",
+                llm_tool_schema=SCHEMA,
+                agent_description="Does a thing (Project: proj-123)",
+                source_project_id="proj-123",
+            )
+
+        kwargs = _create_kwargs(client)
+        assert kwargs["description"] == "Does a thing (Project: proj-123)"
+        assert kwargs["description"].count("(Project: proj-123)") == 1
+
+    def test_omits_suffix_and_metadata_when_no_project(self):
+        client = _make_registry_mock()
+        with patch("index._get_registry_client", return_value=client), \
+                patch.object(index, "_write_app_meta_row", return_value=True):
+            store_agent_config_registry(
+                file_name="/tmp/a.py",
+                agent_id="agent_a",
+                llm_tool_schema=SCHEMA,
+                agent_description="Does a thing",
+            )
+
+        kwargs = _create_kwargs(client)
+        assert kwargs["description"] == "Does a thing"
+        meta = _custom_metadata(client)
+        assert "sourceProjectId" not in meta
+
+    @pytest.mark.parametrize("blank", ["0", "", None])
+    def test_treats_blank_project_ids_as_absent(self, blank):
+        client = _make_registry_mock()
+        with patch("index._get_registry_client", return_value=client), \
+                patch.object(index, "_write_app_meta_row", return_value=True):
+            store_agent_config_registry(
+                file_name="/tmp/a.py",
+                agent_id="agent_a",
+                llm_tool_schema=SCHEMA,
+                agent_description="Does a thing",
+                source_project_id=blank,
+            )
+
+        kwargs = _create_kwargs(client)
+        assert kwargs["description"] == "Does a thing"
+        meta = _custom_metadata(client)
+        assert "sourceProjectId" not in meta

--- a/arbiter/fabricator/index.py
+++ b/arbiter/fabricator/index.py
@@ -53,6 +53,44 @@ def _reset_registry_client_for_test() -> None:
     _registry_client = None
 
 
+def _find_existing_record_id(registry_id: str, agent_id: str) -> str | None:
+    """Return the recordId of an existing Registry record named ``agent_id``.
+
+    Idempotency support for ``store_agent_config_registry``: SQS redeliveries
+    and re-triggers must not create duplicate Registry records for the same
+    agent name. Mirrors ``resolveRecordId`` / ``listResources`` in
+    ``backend/src/services/registry-service.ts`` — list CUSTOM records and
+    match on the record name. Uses the server-side ``name`` filter to bound
+    the result set, then verifies an EXACT name match (the filter may be a
+    prefix / substring match) and paginates via ``nextToken``.
+
+    Returns the matched recordId, or ``None`` when no record with that exact
+    name exists. Defensive ``isinstance`` guards keep the loop bounded if the
+    API surfaces an unexpected (non-dict) shape so the caller falls back to
+    the create path rather than hanging or raising.
+    """
+    client = _get_registry_client()
+    next_token = None
+    while True:
+        kwargs: dict[str, Any] = {
+            "registryId": registry_id,
+            "descriptorType": "CUSTOM",
+            "name": agent_id,
+        }
+        if next_token:
+            kwargs["nextToken"] = next_token
+        response = client.list_registry_records(**kwargs)
+        if not isinstance(response, dict):
+            return None
+        for summary in response.get("records", []):
+            if isinstance(summary, dict) and summary.get("name") == agent_id:
+                return summary.get("recordId")
+        next_token = response.get("nextToken")
+        if not isinstance(next_token, str) or not next_token:
+            break
+    return None
+
+
 def _write_app_meta_row(
     record_id: str,
     agent_id: str,
@@ -124,6 +162,90 @@ def _write_app_meta_row(
             f'_write_app_meta_row failed (eventually-consistent, reconciler will recover): {e}'
         )
         return False
+
+# ~7 day TTL (epoch seconds) keeps the fabrication-jobs table self-pruning.
+FABRICATION_JOBS_TTL_SECONDS = 7 * 24 * 60 * 60
+
+
+def _write_fabrication_status(
+    orchestration_id: str,
+    agent_use_id: str,
+    status: str,
+    agent_id: str | None = None,
+    error_message: str | None = None,
+    agent_name: str | None = None,
+) -> bool:
+    """Upsert a per-agent fabrication status row in the durable jobs table.
+
+    Mirrors the ingestion jobs-table pattern: the table
+    (``citadel-fabrication-jobs-${env}``) is keyed by orchestrationId (PK) /
+    agentUseId (SK). process_event calls this at the START (PROCESSING), on
+    SUCCESS (COMPLETED + agentId) and on EXCEPTION (FAILED + errorMessage).
+
+    Backward-compatible and best-effort: when ``FABRICATION_JOBS_TABLE`` is
+    unset the write is skipped (logged); any failure is logged and swallowed
+    so a status-write error NEVER changes fabrication success/failure
+    behavior. Never an empty except.
+
+    Returns True on a successful write, False when skipped or on failure.
+    """
+    table = os.environ.get("FABRICATION_JOBS_TABLE")
+    if not table:
+        logger.info(
+            "_write_fabrication_status: FABRICATION_JOBS_TABLE unset; "
+            "skipping status=%s for %s/%s",
+            status, orchestration_id, agent_use_id,
+        )
+        return False
+
+    now = datetime.now(timezone.utc).isoformat().replace("+00:00", "Z")
+    set_parts = ["#status = :status", "#updatedAt = :updatedAt", "#ttl = :ttl"]
+    names = {"#status": "status", "#updatedAt": "updatedAt", "#ttl": "ttl"}
+    import time as _time
+    values: dict[str, Any] = {
+        ":status": {"S": status},
+        ":updatedAt": {"S": now},
+        ":ttl": {"N": str(int(_time.time()) + FABRICATION_JOBS_TTL_SECONDS)},
+    }
+    # submittedAt: stamp the first write with a real submit time so the queue
+    # view never falls back to epoch-0 (1970). if_not_exists preserves a
+    # producer-set value (e.g. the PENDING row) on later writes.
+    set_parts.append("submittedAt = if_not_exists(submittedAt, :submittedAt)")
+    values[":submittedAt"] = {"S": now}
+    # agentName: thread the human-readable name (== agent_use_id for intake)
+    # so the resolver can render it instead of 'Unknown Agent'. if_not_exists
+    # never clobbers a producer-set name (the UI-direct path's PENDING row).
+    if agent_name is not None:
+        set_parts.append("agentName = if_not_exists(agentName, :agentName)")
+        values[":agentName"] = {"S": agent_name}
+    if agent_id is not None:
+        set_parts.append("#agentId = :agentId")
+        names["#agentId"] = "agentId"
+        values[":agentId"] = {"S": agent_id}
+    if error_message is not None:
+        set_parts.append("#errorMessage = :errorMessage")
+        names["#errorMessage"] = "errorMessage"
+        values[":errorMessage"] = {"S": error_message[:1000]}
+
+    try:
+        boto3.client("dynamodb").update_item(
+            TableName=table,
+            Key={
+                "orchestrationId": {"S": orchestration_id},
+                "agentUseId": {"S": agent_use_id},
+            },
+            UpdateExpression="SET " + ", ".join(set_parts),
+            ExpressionAttributeNames=names,
+            ExpressionAttributeValues=values,
+        )
+        return True
+    except Exception as e:  # noqa: BLE001 — best-effort: never change outcome
+        logger.warning(
+            "_write_fabrication_status failed (status=%s, %s/%s): %s",
+            status, orchestration_id, agent_use_id, e,
+        )
+        return False
+
 
 # Retry configuration for Bedrock API calls — exponential backoff with jitter
 BEDROCK_RETRY_CONFIG = Config(
@@ -965,6 +1087,7 @@ def store_agent_config_registry(
     app_id: str = None,
     requested_by: str = "fabricator",
     org_id: str = "",
+    source_project_id: str | None = None,
 ) -> bool:
     """Store agent configuration in AgentCore Registry.
 
@@ -974,9 +1097,13 @@ def store_agent_config_registry(
     manifest, categories, state, the requester user id (as ``createdBy``), and
     the caller's organization id (as ``orgId``, Phase 2b) are serialized as JSON
     and stored in the CUSTOM descriptor's inlineContent.
-    After creation the record status is moved to DRAFT so it requires activation
-    before use (DRAFT maps to internal state "inactive" for fabricator-created
-    records, per Requirement 8.3).
+    After creation the record is left in its post-create DRAFT
+    (pending-activation) state so it requires activation before use (DRAFT
+    maps to internal state "inactive" for fabricator-created records, per
+    Requirement 8.3). The Fabricator does NOT call UpdateRegistryRecordStatus
+    to re-assert DRAFT — CreateRegistryRecord already leaves the record in
+    DRAFT, and the registry rejects a DRAFT->DRAFT transition with
+    ValidationException.
 
     Requirements:
     - REGISTRY_ID environment variable must be set with the Registry ID.
@@ -1033,6 +1160,25 @@ def store_agent_config_registry(
             f"{type(llm_tool_schema)}"
         )
 
+        # Source-project tagging (identifiability): when a real source project
+        # id is supplied, append a ' (Project: <id>)' suffix to the human
+        # description so the catalog can attribute the fabricated agent to the
+        # intake session it came from, and stash the raw id in custom metadata
+        # for grouping. '0'/empty/None are treated as "no project" so legacy
+        # / UI-direct fabrications stay unchanged. The suffix is idempotent —
+        # never duplicated if the description already carries it.
+        base_description = agent_description or ""
+        display_description = base_description
+        normalized_project_id = (
+            source_project_id
+            if source_project_id and source_project_id != "0"
+            else None
+        )
+        if normalized_project_id:
+            suffix = f" (Project: {normalized_project_id})"
+            if not display_description.endswith(suffix):
+                display_description = f"{display_description}{suffix}"
+
         # Executable agent config — stashed under custom metadata so the cache
         # sync / resolvers can parse it verbatim without colliding with the
         # human description.
@@ -1041,7 +1187,7 @@ def store_agent_config_registry(
             "filename": file_name.split('/')[-1],
             "schema": llm_tool_schema,
             "version": 1,
-            "description": agent_description,
+            "description": display_description,
             "action": {
                 "type": "sqs",
                 "target": os.environ.get("WORKER_QUEUE_URL", "MISSING"),
@@ -1051,14 +1197,16 @@ def store_agent_config_registry(
         # Auto-generate agent manifest.
         manifest = {
             "name": agent_id,
-            "description": agent_description,
+            "description": display_description,
             "version": 1,
             "tools": [],
         }
 
         # Custom metadata — serialized into the CUSTOM descriptor inlineContent.
-        # state is recorded as "inactive" to match Requirement 8.3; status is
-        # set to DRAFT below via UpdateRegistryRecordStatus. The full ``config``
+        # state is recorded as "inactive" to match Requirement 8.3; the record
+        # is left in its post-create DRAFT (pending-activation) state — no
+        # UpdateRegistryRecordStatus call is made (a DRAFT->DRAFT transition is
+        # rejected by the registry). The full ``config``
         # dict and requester ``createdBy`` are preserved here so that moving
         # the executable config out of the top-level description doesn't lose
         # information (QB-013-2 post-boto3-1.42 refactor). Phase 2b stamps the
@@ -1074,11 +1222,36 @@ def store_agent_config_registry(
         }
         if app_id:
             custom_metadata["appId"] = app_id
+        if normalized_project_id:
+            custom_metadata["sourceProjectId"] = normalized_project_id
 
         print(
             f"[store_agent_config_registry] Creating Registry record for agent: "
             f"{agent_id}"
         )
+
+        # Idempotency guard (pipeline-reliability hardening): SQS redeliveries
+        # and re-triggers must NOT create a duplicate Registry record for the
+        # same agent name. Look the name up first (mirrors resolveRecordId /
+        # listResources in backend/src/services/registry-service.ts). When a
+        # record already exists we SKIP CreateRegistryRecord, still refresh the
+        # AppsTable #META mirror for that existing record, and return True so
+        # the re-trigger is a no-op rather than a duplicate fabrication.
+        existing_record_id = _find_existing_record_id(registry_id, agent_id)
+        if existing_record_id is not None:
+            print(
+                f"[store_agent_config_registry] Record with name '{agent_id}' "
+                f"already exists (recordId={existing_record_id}); skipping "
+                f"CreateRegistryRecord to keep fabrication idempotent"
+            )
+            _write_app_meta_row(
+                record_id=existing_record_id,
+                agent_id=agent_id,
+                agent_description=display_description,
+                requested_by=requested_by,
+                org_id=org_id,
+            )
+            return True
 
         # CreateRegistryRecord does NOT accept a recordId — the service generates
         # one. We use the agentId as the record name so records can be located
@@ -1086,7 +1259,7 @@ def store_agent_config_registry(
         response = _get_registry_client().create_registry_record(
             registryId=registry_id,
             name=agent_id,
-            description=agent_description or "",
+            description=display_description,
             descriptorType="CUSTOM",
             descriptors={
                 "custom": {
@@ -1107,25 +1280,26 @@ def store_agent_config_registry(
         _write_app_meta_row(
             record_id=record_id,
             agent_id=agent_id,
-            agent_description=agent_description,
+            agent_description=display_description,
             requested_by=requested_by,
             org_id=org_id,
         )
 
         print(
-            f"[store_agent_config_registry] Record created (recordId={record_id}), "
-            f"setting status to DRAFT"
+            f"[store_agent_config_registry] Record created (recordId={record_id}); "
+            f"leaving record in its post-create DRAFT (pending-activation) state"
         )
 
-        # Draft status => internal state "inactive" for fabricator-created agents
-        # (Requirement 8.3). Records require activation via the catalog before
-        # the Supervisor will route tasks to them.
-        _get_registry_client().update_registry_record_status(
-            registryId=registry_id,
-            recordId=record_id,
-            status="DRAFT",
-            statusReason="Initial status set by Fabricator",
-        )
+        # No status update here: CreateRegistryRecord already leaves the record
+        # in DRAFT (the pre-activation state), which is the intended
+        # 'requires activation before use' behavior for fabricator-created
+        # agents (Requirement 8.3; DRAFT maps to internal state "inactive").
+        # The AgentCore registry REJECTS a redundant DRAFT->DRAFT transition
+        # with ValidationException ('Invalid target status: DRAFT'), so calling
+        # UpdateRegistryRecordStatus(status="DRAFT") here would make this
+        # function raise and publish agent.fabrication.failed even though the
+        # record was created successfully. The record is therefore left as-is;
+        # activation to a usable state happens later via the catalog.
 
         print(f"[store_agent_config_registry] SUCCESS - Registry response: {response}")
         return True
@@ -1536,6 +1710,12 @@ def process_event(event, context, request_type=None):
         raise
 
     try:
+        # Durable status: mark this agent PROCESSING at the start. Best-effort
+        # — a status-write failure never changes fabrication behavior.
+        _write_fabrication_status(
+            orchestration_id, agent_use_id, "PROCESSING", agent_name=agent_use_id
+        )
+
         # since this needs variable injection, keep within handler method scope.
         @tool
         def complete_task():
@@ -1671,6 +1851,7 @@ def process_event(event, context, request_type=None):
                     app_id=app_id,
                     requested_by=requested_by,
                     org_id=org_id,
+                    source_project_id=orchestration_id,
                 )
 
             # Create the Agent Fabricator with access to create_custom_tool
@@ -1679,9 +1860,22 @@ def process_event(event, context, request_type=None):
                 store_agent_tool=store_agent_config_registry_bound,
             )
             agent_fabricator(TASK)
-    
+
+        # Durable status: fabrication dispatch completed without raising — mark
+        # COMPLETED and stamp the agent name/recordId. Best-effort.
+        _write_fabrication_status(
+            orchestration_id, agent_use_id, "COMPLETED",
+            agent_id=agent_use_id, agent_name=agent_use_id
+        )
+
     except Exception as e:
         print(f"Fabrication failed: {str(e)}")
+        # Durable status: mark FAILED + errorMessage before re-raising. The
+        # status write is best-effort and must not mask the original error.
+        _write_fabrication_status(
+            orchestration_id, agent_use_id, "FAILED",
+            error_message=str(e), agent_name=agent_use_id
+        )
         # Publish intake progress failure
         publish_intake_progress(orchestration_id, agent_index, total_agents, agent_use_id, failed=True)
         # Publish fabrication failure event

--- a/backend/bin/app.ts
+++ b/backend/bin/app.ts
@@ -39,6 +39,10 @@ const servicesStack = new ServicesStack(app, `citadel-services-${environment}`, 
   description: `Agent services for Citadel - ${environment}`,
   agentEventBus: backendStack.agentEventBus,
   documentBucket: backendStack.documentBucket,
+  // Registry handles so the intake runtime can read the factory catalog from
+  // the AgentCore Registry (conditionally wired in the stack).
+  registryArn: backendStack.registryArn,
+  registryId: backendStack.registryId,
 });
 
 // Governance stack — AI-Accelerated Modernization Governance.
@@ -241,6 +245,12 @@ if (app.node.tryGetContext('nag')!== 'false') {
               [servicesStack, 'HldPdfCreatedNotifierV2/ServiceRole/DefaultPolicy/Resource'],
               [servicesStack, 'HealthMonitorFunction/ServiceRole/DefaultPolicy/Resource'],
               [servicesStack, 'ToolSandboxFunction/ServiceRole/DefaultPolicy/Resource'],
+              // Phase 1 server-side ingestion: residual Resource::* is only the
+              // un-scopable xray:Put* (tracing ACTIVE) + cloudwatch:PutMetricData
+              // (namespace-conditioned to Citadel/DocumentIngestion). All
+              // bedrock/dynamodb/events/ssm grants are resource-scoped.
+              [servicesStack, 'DocumentIngestStartFunction/ServiceRole/DefaultPolicy/Resource'],
+              [servicesStack, 'DocumentIngestPollerFunction/ServiceRole/DefaultPolicy/Resource'],
               [servicesStack, 'AgentIntakeSingleRuntime/ExecutionRole/DefaultPolicy/Resource'],
               [arbiterStack, 'AgentCredentialVender/ServiceRole/DefaultPolicy/Resource'],
               [arbiterStack, 'WorkerAgentWrapper/ServiceRole/DefaultPolicy/Resource'],
@@ -293,6 +303,7 @@ if (app.node.tryGetContext('nag')!== 'false') {
                 [arbiterStack, 'GovernanceUiResolverFn/ServiceRole/DefaultPolicy/Resource'],
                 [backendStack, 'RegistryAgentRecordResolverFunction/ServiceRole/DefaultPolicy/Resource'],
                 [backendStack, 'ReconcileAppsMetaScheduledFunction/ServiceRole/DefaultPolicy/Resource'],
+                [servicesStack, 'AgentIntakeSingleRuntime/ExecutionRole/DefaultPolicy/Resource'],
               ];
               for (const [stack, path] of registryArnPaths) {
                 NagSuppressions.addResourceSuppressionsByPath(stack, `/${stack.stackName}/${path}`, registryArnSuppression);

--- a/backend/lib/arbiter-stack.ts
+++ b/backend/lib/arbiter-stack.ts
@@ -389,7 +389,22 @@ export class ArbiterStack extends cdk.Stack {
 
         const fabricatorQueue = new Queue(this, `fabricatorQueue`, {
           queueName: `citadel-fabricator-queue-${props.environment}`,
-          visibilityTimeout: cdk.Duration.minutes(15),
+          // Reliability hardening: visibilityTimeout MUST strictly exceed the
+          // FabricatorAgent Lambda timeout (15 min, below). When they are
+          // equal, an invocation that runs near the function timeout causes
+          // SQS to redeliver the same message — stacking duplicate
+          // fabrications and prematurely draining the DLQ. AWS guidance for
+          // SQS->Lambda is visibilityTimeout >= 6x the function timeout to
+          // absorb retries/throttling, i.e. 6 x 15 min = 90 min. With
+          // batchSize=1 (see SqsEventSource below) each invocation handles a
+          // single fabrication (~11 min observed worst case), so the message
+          // is well within one visibility window. Tradeoff: a genuinely
+          // poison message takes up to maxReceiveCount(3) x 90 min before it
+          // lands in the DLQ — acceptable because real fabrication failures
+          // surface via the agent.fabrication.failed event and the
+          // FabricatorErrorAlarm, not via DLQ latency. Never set this equal
+          // to (or below) the function timeout.
+          visibilityTimeout: cdk.Duration.minutes(90),
           retentionPeriod: cdk.Duration.days(7),
           enforceSSL: true,
           deadLetterQueue: {
@@ -413,6 +428,10 @@ export class ArbiterStack extends cdk.Stack {
         TOOL_CONFIG_TABLE: toolsConfigTable.tableName,
         AGENT_BUCKET_NAME: props.codeBucket.bucketName,
         WORKER_QUEUE_URL: workerAgentQueue.queueUrl,
+        // Durable per-agent fabrication status table (owned by BackendStack).
+        // The consumer writes PROCESSING/COMPLETED/FAILED transitions. Empty
+        // string keeps the write a no-op when the table isn't provisioned.
+        FABRICATION_JOBS_TABLE: `citadel-fabrication-jobs-${props.environment}`,
         CODE_VERSION: '2', // Force Lambda code update
         // QT3-6: fabrication-time spec status validation.
         EXECUTION_SPECS_TABLE: props.executionSpecificationsTable.tableName,
@@ -450,6 +469,18 @@ export class ArbiterStack extends cdk.Stack {
     // assert_spec_approved can verify the bound spec_id is APPROVED.
     props.executionSpecificationsTable.grantReadData(fabricatorLambda);
 
+    // PutItem/UpdateItem on the durable fabrication-jobs table (owned by
+    // BackendStack) so the consumer can upsert PROCESSING/COMPLETED/FAILED
+    // status. Referenced by deterministic name + constructed ARN — importing
+    // the BackendStack table construct here would create a circular dependency
+    // (ArbiterStack already depends ON ServicesStack which depends ON
+    // BackendStack). Least privilege: PutItem + UpdateItem only.
+    fabricatorLambda.addToRolePolicy(new PolicyStatement({
+      effect: Effect.ALLOW,
+      actions: ['dynamodb:PutItem', 'dynamodb:UpdateItem'],
+      resources: [`arn:aws:dynamodb:${this.region}:${this.account}:table/citadel-fabrication-jobs-${props.environment}`],
+    }));
+
     // Phase 3 Step 2: write-only grant on AppsTable so the fabricator can
     // synchronously mirror new Registry agent records into the #META row
     // consumed by listApps via OrgIndex. Eventually-consistent — failures
@@ -485,7 +516,12 @@ export class ArbiterStack extends cdk.Stack {
       );
     }
 
-    fabricatorLambda.addEventSource(new SqsEventSource(fabricatorQueue));
+    // Reliability hardening: batchSize=1 so each Lambda invocation processes
+    // exactly ONE fabrication message. The SQS default (up to 10) lets a
+    // single invocation stack many agents and blow past the 15-min function
+    // timeout, triggering redelivery + duplicate fabrication. One message per
+    // invocation bounds the invocation to a single agent fabrication.
+    fabricatorLambda.addEventSource(new SqsEventSource(fabricatorQueue, { batchSize: 1 }));
 
     // Grant scoped SQS permissions to Supervisor (S-02 fix)
     supervisorLambda.addToRolePolicy(new PolicyStatement({

--- a/backend/lib/backend-stack.ts
+++ b/backend/lib/backend-stack.ts
@@ -668,6 +668,14 @@ export class BackendStack extends cdk.Stack {
           KB_ID_PARAM: `/citadel/knowledge-base-id-${props.environment}`,
           DS_ID_PARAM: `/citadel/knowledge-base-datasource-id-${props.environment}`,
           EVENT_BUS_NAME: this.agentEventBus.eventBusName,
+          // Source-of-truth jobs table (created in ServicesStack). Referenced by
+          // deterministic name — NOT a cross-stack construct import — because
+          // ServicesStack already depends ON BackendStack (it consumes
+          // props.documentBucket / props.agentEventBus); importing the table
+          // construct here would create a circular stack dependency. The
+          // resolver reads this table first and degrades to a Bedrock KB query
+          // if the var/table is absent.
+          INGESTION_TABLE: `citadel-document-ingestion-${props.environment}`,
         },
         timeout: cdk.Duration.seconds(30),
         logGroup: new logs.LogGroup(this, 'DocumentUploadResolverFunctionLogs', { retention: logs.RetentionDays.ONE_WEEK, removalPolicy: cdk.RemovalPolicy.DESTROY }),
@@ -750,6 +758,7 @@ export class BackendStack extends cdk.Stack {
         code: lambda.Code.fromAsset("dist/lambda"),
         environment: {
           FABRICATOR_QUEUE_URL: `https://sqs.${this.region}.amazonaws.com/${this.account}/citadel-fabricator-queue-${props.environment}`,
+          FABRICATION_JOBS_TABLE: `citadel-fabrication-jobs-${props.environment}`,
         },
         timeout: cdk.Duration.seconds(30),
         logGroup: new logs.LogGroup(this, 'FabricatorRequestResolverFunctionLogs', { retention: logs.RetentionDays.ONE_WEEK, removalPolicy: cdk.RemovalPolicy.DESTROY }),
@@ -765,6 +774,7 @@ export class BackendStack extends cdk.Stack {
         code: lambda.Code.fromAsset("dist/lambda"),
         environment: {
           FABRICATOR_QUEUE_URL: `https://sqs.${this.region}.amazonaws.com/${this.account}/citadel-fabricator-queue-${props.environment}`,
+          FABRICATION_JOBS_TABLE: `citadel-fabrication-jobs-${props.environment}`,
         },
         timeout: cdk.Duration.seconds(30),
         logGroup: new logs.LogGroup(this, 'FabricatorQueueResolverFunctionLogs', { retention: logs.RetentionDays.ONE_WEEK, removalPolicy: cdk.RemovalPolicy.DESTROY }),
@@ -791,7 +801,7 @@ export class BackendStack extends cdk.Stack {
     this.documentBucket.grantRead(documentUploadResolverFunction);
     this.documentBucket.grantDelete(documentUploadResolverFunction);
     documentUploadResolverFunction.addToRolePolicy(new iam.PolicyStatement({
-      actions: ['bedrock:IngestKnowledgeBaseDocuments', 'bedrock:StartIngestionJob', 'bedrock:GetKnowledgeBaseDocuments', 'bedrock:DeleteKnowledgeBaseDocuments'],
+      actions: ['bedrock:GetKnowledgeBaseDocuments', 'bedrock:DeleteKnowledgeBaseDocuments'],
       resources: ['*'],
     }));
     documentUploadResolverFunction.addToRolePolicy(new iam.PolicyStatement({
@@ -802,6 +812,60 @@ export class BackendStack extends cdk.Stack {
       ],
     }));
     this.agentEventBus.grantPutEventsTo(documentUploadResolverFunction);
+
+    // Read-only access to the authoritative document-ingestion jobs table
+    // (source of truth for per-document ingestion status). The resolver only
+    // READS this table (GetItem on the base table, Query on the base table /
+    // status-index GSI), so grant the minimum required actions. ARNs are built
+    // from account/region/name rather than importing the ServicesStack table
+    // construct, which would create a circular stack dependency (ServicesStack
+    // already depends ON BackendStack).
+    const ingestionTableName = `citadel-document-ingestion-${props.environment}`;
+    const ingestionTableArn = `arn:aws:dynamodb:${this.region}:${this.account}:table/${ingestionTableName}`;
+    documentUploadResolverFunction.addToRolePolicy(new iam.PolicyStatement({
+      effect: iam.Effect.ALLOW,
+      actions: ['dynamodb:GetItem', 'dynamodb:Query'],
+      resources: [ingestionTableArn, `${ingestionTableArn}/index/status-index`],
+    }));
+
+    // ── Durable fabrication-jobs status table ────────────────────────────────
+    // Source of truth for per-agent fabrication status, replacing the old
+    // SQS-peek queue read. Owned HERE in BackendStack because it is the
+    // dependency root (services→backend, arbiter→services→backend): owning it
+    // here lets the two fabricator resolvers below use scoped grants, ensures
+    // the table is provisioned before any cross-stack writer (the services
+    // intake runtime and the arbiter fabricator Lambda) deploys, and makes a
+    // circular stack dependency impossible because those stacks reference the
+    // table only by deterministic name + constructed ARN.
+    // PK orchestrationId (intake session id, or '0' for direct UI requests) /
+    // SK agentUseId (agent name / requestId). On-demand + PITR per conventions;
+    // a `ttl` attribute (epoch seconds, ~7 days) keeps the table self-pruning.
+    new dynamodb.Table(this, 'FabricationJobsTable', {
+      tableName: `citadel-fabrication-jobs-${props.environment}`,
+      partitionKey: { name: 'orchestrationId', type: dynamodb.AttributeType.STRING },
+      sortKey: { name: 'agentUseId', type: dynamodb.AttributeType.STRING },
+      billingMode: dynamodb.BillingMode.PAY_PER_REQUEST,
+      pointInTimeRecoverySpecification: { pointInTimeRecoveryEnabled: true },
+      timeToLiveAttribute: 'ttl',
+      removalPolicy: cdk.RemovalPolicy.DESTROY,
+    });
+
+    // Grants use the deterministic name + constructed ARN so the wiring is
+    // uniform with the cross-stack writers in ServicesStack / ArbiterStack,
+    // which cannot import this construct without a circular dependency. Least
+    // privilege: the request resolver only writes PENDING rows; the queue
+    // resolver only reads (Query for a given project, Scan otherwise).
+    const fabricationJobsTableArn = `arn:aws:dynamodb:${this.region}:${this.account}:table/citadel-fabrication-jobs-${props.environment}`;
+    fabricatorRequestResolverFunction.addToRolePolicy(new iam.PolicyStatement({
+      effect: iam.Effect.ALLOW,
+      actions: ['dynamodb:PutItem'],
+      resources: [fabricationJobsTableArn],
+    }));
+    fabricatorQueueResolverFunction.addToRolePolicy(new iam.PolicyStatement({
+      effect: iam.Effect.ALLOW,
+      actions: ['dynamodb:Query', 'dynamodb:Scan'],
+      resources: [fabricationJobsTableArn],
+    }));
 
     // Grant S3 + Lambda permissions for document resolver
     const sessionBucketArn = `arn:aws:s3:::citadel-sessions-${props.environment}-${this.account}-${this.region}`;
@@ -2200,13 +2264,6 @@ export class BackendStack extends cdk.Stack {
       responseMappingTemplate: appsync.MappingTemplate.lambdaResult(),
     });
 
-    documentUploadLambdaDataSource.createResolver("IngestDocumentResolver", {
-      typeName: "Mutation",
-      fieldName: "ingestDocument",
-      requestMappingTemplate: appsync.MappingTemplate.lambdaRequest(),
-      responseMappingTemplate: appsync.MappingTemplate.lambdaResult(),
-    });
-
     documentUploadLambdaDataSource.createResolver("GetDocumentIngestionStatusResolver", {
       typeName: "Query",
       fieldName: "getDocumentIngestionStatus",
@@ -2217,13 +2274,6 @@ export class BackendStack extends cdk.Stack {
     documentUploadLambdaDataSource.createResolver("ListProjectDocumentsResolver", {
       typeName: "Query",
       fieldName: "listProjectDocuments",
-      requestMappingTemplate: appsync.MappingTemplate.lambdaRequest(),
-      responseMappingTemplate: appsync.MappingTemplate.lambdaResult(),
-    });
-
-    documentUploadLambdaDataSource.createResolver("NotifyDocumentReadyResolver", {
-      typeName: "Mutation",
-      fieldName: "notifyDocumentReady",
       requestMappingTemplate: appsync.MappingTemplate.lambdaRequest(),
       responseMappingTemplate: appsync.MappingTemplate.lambdaResult(),
     });
@@ -2280,6 +2330,13 @@ export class BackendStack extends cdk.Stack {
     agentConfigLambdaDataSource.createResolver("DeleteAgentConfigResolver", {
       typeName: "Mutation",
       fieldName: "deleteAgentConfig",
+      requestMappingTemplate: appsync.MappingTemplate.lambdaRequest(),
+      responseMappingTemplate: appsync.MappingTemplate.lambdaResult(),
+    });
+
+    agentConfigLambdaDataSource.createResolver("ActivateProjectAgentsResolver", {
+      typeName: "Mutation",
+      fieldName: "activateProjectAgents",
       requestMappingTemplate: appsync.MappingTemplate.lambdaRequest(),
       responseMappingTemplate: appsync.MappingTemplate.lambdaResult(),
     });

--- a/backend/lib/services-stack.ts
+++ b/backend/lib/services-stack.ts
@@ -20,10 +20,35 @@ import * as s3n from 'aws-cdk-lib/aws-s3-notifications';
 import { NagSuppressions } from 'cdk-nag';
 import * as path from 'path';
 
+/**
+ * Derive the Bedrock cross-region inference-profile prefix for a region.
+ *
+ * Mirrors arbiter/supervisor/index.py::_cross_region_prefix EXACTLY so the
+ * TypeScript (CDK) and Python (runtime) sides stay consistent. The 'au.'
+ * profile only exists in ap-southeast-2; every other region resolves to its
+ * geographic code, defaulting to 'us' (valid in us-west-2).
+ */
+export function crossRegionPrefix(region: string): string {
+  if (region.startsWith('us-')) return 'us';
+  if (region.startsWith('eu-')) return 'eu';
+  if (region === 'ap-southeast-2') return 'au';
+  if (region.startsWith('ap-')) return 'apac';
+  if (region.startsWith('me-')) return 'me';
+  if (region.startsWith('ca-')) return 'ca';
+  if (region.startsWith('sa-')) return 'sa';
+  return 'us';
+}
+
 export interface ServicesStackProps extends cdk.StackProps {
   environment: string;
   agentEventBus: events.EventBus;
   documentBucket: s3.Bucket;
+  // Optional AgentCore Registry handles so the intake runtime can read the
+  // factory catalog (fabricated agents live in the Registry, not DynamoDB).
+  // Optional + conditionally wired — mirrors the fabricator in arbiter-stack.ts
+  // — so test paths that construct ServicesStack without a registry still work.
+  registryArn?: string;
+  registryId?: string;
 }
 
 export class ServicesStack extends cdk.Stack {
@@ -553,6 +578,152 @@ def handler(event, context):
         { suffix: '/design/high_level_design.pdf' }
       );
 
+      // ── Server-side Document Ingestion (Phase 1) ────────────────────────────
+      // Authoritative jobs table tracking each document's ingestion lifecycle.
+      // PK projectId / SK documentKey; GSI 'status-index' lets the poller find
+      // non-terminal rows by status. On-demand billing + PITR per conventions.
+      const ingestionTable = new dynamodb.Table(this, 'DocumentIngestionTable', {
+        tableName: `citadel-document-ingestion-${props.environment}`,
+        partitionKey: { name: 'projectId', type: dynamodb.AttributeType.STRING },
+        sortKey: { name: 'documentKey', type: dynamodb.AttributeType.STRING },
+        billingMode: dynamodb.BillingMode.PAY_PER_REQUEST,
+        pointInTimeRecoverySpecification: { pointInTimeRecoveryEnabled: true },
+        removalPolicy: cdk.RemovalPolicy.DESTROY,
+      });
+      ingestionTable.addGlobalSecondaryIndex({
+        indexName: 'status-index',
+        partitionKey: { name: 'status', type: dynamodb.AttributeType.STRING },
+        sortKey: { name: 'updatedAt', type: dynamodb.AttributeType.STRING },
+      });
+
+      // Publish the table name for cross-stack consumers (the document-upload
+      // resolver in BackendStack reads it as source of truth in a later phase).
+      new ssm.StringParameter(this, 'DocumentIngestionTableParam', {
+        parameterName: `/citadel/document-ingestion-table-${props.environment}`,
+        stringValue: ingestionTable.tableName,
+      });
+
+      const kbIdParamName = `/citadel/knowledge-base-id-${props.environment}`;
+      const dsIdParamName = `/citadel/knowledge-base-datasource-id-${props.environment}`;
+      const ssmParamArns = [
+        `arn:aws:ssm:${this.region}:${this.account}:parameter${kbIdParamName}`,
+        `arn:aws:ssm:${this.region}:${this.account}:parameter${dsIdParamName}`,
+      ];
+
+      // ingest-start: S3 ObjectCreated -> create jobs row + start Bedrock ingestion.
+      const ingestStartFunction = new lambda.Function(this, 'DocumentIngestStartFunction', {
+        functionName: `citadel-document-ingest-start-${props.environment}`,
+        runtime: lambda.Runtime.NODEJS_24_X,
+        handler: 'document-ingestion-start.handler',
+        code: lambda.Code.fromAsset('dist/lambda'),
+        environment: {
+          INGESTION_TABLE: ingestionTable.tableName,
+          KB_ID_PARAM: kbIdParamName,
+          DS_ID_PARAM: dsIdParamName,
+          EVENT_BUS_NAME: props.agentEventBus.eventBusName,
+          DOCUMENT_BUCKET: props.documentBucket.bucketName,
+          POWERTOOLS_SERVICE_NAME: 'citadel',
+          POWERTOOLS_LOG_LEVEL: 'INFO',
+        },
+        timeout: cdk.Duration.minutes(2),
+        memorySize: 256,
+        tracing: lambda.Tracing.ACTIVE,
+      });
+
+      // ingest-start writes the jobs row...
+      ingestionTable.grantWriteData(ingestStartFunction);
+      // ...and starts/reads Bedrock ingestion on the session KB (explicitly scoped).
+      ingestStartFunction.addToRolePolicy(new iam.PolicyStatement({
+        effect: iam.Effect.ALLOW,
+        actions: ['bedrock:IngestKnowledgeBaseDocuments', 'bedrock:StartIngestionJob', 'bedrock:GetKnowledgeBaseDocuments'],
+        resources: [sessionKb.attrKnowledgeBaseArn],
+      }));
+      ingestStartFunction.addToRolePolicy(new iam.PolicyStatement({
+        effect: iam.Effect.ALLOW,
+        actions: ['ssm:GetParameter'],
+        resources: ssmParamArns,
+      }));
+      props.documentBucket.grantRead(ingestStartFunction);
+
+      // Cross-stack S3 notification choice:
+      // props.documentBucket is owned by BackendStack and ServicesStack already
+      // depends on BackendStack. Calling addEventNotification on the concrete
+      // (BackendStack-owned) Bucket would make BackendStack reference this
+      // stack's Lambda ARN, creating a circular stack dependency. To avoid that
+      // we wire the notification through an IMPORTED reference (fromBucketName),
+      // which provisions a BucketNotifications custom resource in THIS stack
+      // that calls PutBucketNotificationConfiguration at deploy time — no CFN
+      // cross-stack cycle. Caveat: the imported-bucket notifier manages the
+      // bucket's notification config; this is safe here because DocumentBucket
+      // currently has no other event notifications. If notifications are later
+      // added in BackendStack, move this wiring there instead.
+      // S3 prefix/suffix filters cannot express the design/planning excludes, so
+      // we subscribe to all OBJECT_CREATED events and filter in shouldProcessKey.
+      const importedDocumentBucket = s3.Bucket.fromBucketName(
+        this,
+        'ImportedDocumentBucketForIngest',
+        props.documentBucket.bucketName,
+      );
+      importedDocumentBucket.addEventNotification(
+        s3.EventType.OBJECT_CREATED,
+        new s3n.LambdaDestination(ingestStartFunction),
+      );
+
+      // poller: scheduled detection of INDEXED/FAILED + exactly-once trigger.
+      const ingestPollerFunction = new lambda.Function(this, 'DocumentIngestPollerFunction', {
+        functionName: `citadel-document-ingest-poller-${props.environment}`,
+        runtime: lambda.Runtime.NODEJS_24_X,
+        handler: 'document-ingestion-poller.handler',
+        code: lambda.Code.fromAsset('dist/lambda'),
+        environment: {
+          INGESTION_TABLE: ingestionTable.tableName,
+          KB_ID_PARAM: kbIdParamName,
+          DS_ID_PARAM: dsIdParamName,
+          EVENT_BUS_NAME: props.agentEventBus.eventBusName,
+          DOCUMENT_BUCKET: props.documentBucket.bucketName,
+          MAX_AGE_MS: String(10 * 60 * 1000),
+          START_GRACE_MS: String(2 * 60 * 1000),
+          ENVIRONMENT: props.environment,
+          POWERTOOLS_SERVICE_NAME: 'citadel',
+          POWERTOOLS_LOG_LEVEL: 'INFO',
+        },
+        timeout: cdk.Duration.minutes(2),
+        memorySize: 256,
+        tracing: lambda.Tracing.ACTIVE,
+      });
+
+      // poller reads/updates jobs rows (table + GSI), reads Bedrock status,
+      // emits trigger/failure events, and publishes a failure metric.
+      ingestionTable.grantReadWriteData(ingestPollerFunction);
+      ingestPollerFunction.addToRolePolicy(new iam.PolicyStatement({
+        effect: iam.Effect.ALLOW,
+        actions: ['bedrock:IngestKnowledgeBaseDocuments', 'bedrock:StartIngestionJob', 'bedrock:GetKnowledgeBaseDocuments'],
+        resources: [sessionKb.attrKnowledgeBaseArn],
+      }));
+      ingestPollerFunction.addToRolePolicy(new iam.PolicyStatement({
+        effect: iam.Effect.ALLOW,
+        actions: ['ssm:GetParameter'],
+        resources: ssmParamArns,
+      }));
+      ingestPollerFunction.addToRolePolicy(new iam.PolicyStatement({
+        effect: iam.Effect.ALLOW,
+        actions: ['cloudwatch:PutMetricData'],
+        resources: ['*'],
+        conditions: { StringEquals: { 'cloudwatch:namespace': 'Citadel/DocumentIngestion' } },
+      }));
+      props.agentEventBus.grantPutEventsTo(ingestPollerFunction);
+
+      // Scheduled poll every minute (resilient to closed tabs/timeouts).
+      const ingestPollRule = new events.Rule(this, 'DocumentIngestPollRule', {
+        ruleName: `citadel-document-ingest-poll-${props.environment}`,
+        description: 'Polls Bedrock ingestion status and fires the assessment trigger exactly once',
+        schedule: events.Schedule.rate(cdk.Duration.minutes(1)),
+      });
+      ingestPollRule.addTarget(new targets.LambdaFunction(ingestPollerFunction, {
+        retryAttempts: 1,
+        maxEventAge: cdk.Duration.minutes(5),
+      }));
+
       // --- Health Monitor Lambda (DS-10) ---
       // EventBridge scheduled rule triggers health checks on CONNECTED/ERROR data stores
       const healthMonitorFunction = new lambda.Function(this, 'HealthMonitorFunction', {
@@ -700,11 +871,16 @@ def handler(event, context):
           KNOWLEDGE_BASE_ID: sessionKb.attrKnowledgeBaseId,
           INLINE_DATA_SOURCE_ID: sessionKbDataSource.attrDataSourceId,
           FABRICATOR_QUEUE_URL: `https://sqs.${cdk.Stack.of(this).region}.amazonaws.com/${cdk.Stack.of(this).account}/citadel-fabricator-queue-${props.environment}`,
+          FABRICATION_JOBS_TABLE: `citadel-fabrication-jobs-${props.environment}`,
           AGENT_CONFIG_TABLE: `citadel-agents-${props.environment}`,
           PROJECTS_TABLE: `citadel-projects-${props.environment}`,
           CONVERSATIONS_TABLE: `citadel-conversations-${props.environment}`,
-          AGENT_MODEL: process.env.AGENT_MODEL || 'au.anthropic.claude-sonnet-4-6',
-          EXTRACTION_MODEL: process.env.EXTRACTION_MODEL || 'au.anthropic.claude-haiku-4-5-20251001-v1:0',
+          // Registry id so the intake catalog (list_factory_agents /
+          // plan_fabrication) can read fabricated agents from the AgentCore
+          // Registry. Conditionally wired, mirroring the fabricator.
+          ...(props.registryId && { REGISTRY_ID: props.registryId }),
+          AGENT_MODEL: process.env.AGENT_MODEL || `${crossRegionPrefix(this.region)}.anthropic.claude-sonnet-4-6`,
+          EXTRACTION_MODEL: process.env.EXTRACTION_MODEL || `${crossRegionPrefix(this.region)}.anthropic.claude-haiku-4-5-20251001-v1:0`,
           LANGFUSE_SECRET_KEY: '',
           LANGFUSE_PUBLIC_KEY: '',
           LANGFUSE_BASE_URL: '',
@@ -755,6 +931,32 @@ def handler(event, context):
         actions: ['dynamodb:Scan'],
         resources: [`arn:aws:dynamodb:${cdk.Stack.of(this).region}:${cdk.Stack.of(this).account}:table/citadel-agents-${props.environment}`],
       }));
+
+      // PutItem on the durable fabrication-jobs table (owned by BackendStack)
+      // so the intake runtime can write a PENDING row per build agent it
+      // enqueues. Referenced by deterministic name + constructed ARN — NOT a
+      // cross-stack construct import — because importing the BackendStack table
+      // here is unnecessary (deterministic name) and keeps wiring uniform with
+      // the other writers. Least privilege: PutItem only.
+      agentIntakeSingleRuntime.grantPrincipal.addToPrincipalPolicy(new iam.PolicyStatement({
+        actions: ['dynamodb:PutItem'],
+        resources: [`arn:aws:dynamodb:${cdk.Stack.of(this).region}:${cdk.Stack.of(this).account}:table/citadel-fabrication-jobs-${props.environment}`],
+      }));
+
+      // Least-privilege read access to the AgentCore Registry so the intake
+      // runtime can list/get fabricated agent records for the factory catalog
+      // (list_factory_agents / plan_fabrication). Mirrors the fabricator's
+      // registry grant scope in arbiter-stack.ts (ARN + its /* sub-resources).
+      // Conditional on props.registryArn — wired only when a registry exists.
+      if (props.registryArn) {
+        agentIntakeSingleRuntime.grantPrincipal.addToPrincipalPolicy(new iam.PolicyStatement({
+          actions: [
+            'bedrock-agentcore:ListRegistryRecords',
+            'bedrock-agentcore:GetRegistryRecord',
+          ],
+          resources: [props.registryArn, `${props.registryArn}/*`],
+        }));
+      }
 
       // ── Outputs ──────────────────────────────────────────────────────────────
 

--- a/backend/src/lambda/__tests__/agent-config-resolver.test.ts
+++ b/backend/src/lambda/__tests__/agent-config-resolver.test.ts
@@ -6,7 +6,31 @@ import { mockClient } from 'aws-sdk-client-mock';
 
 const dynamoMock = mockClient(DynamoDBDocumentClient);
 
-import { handler } from '../agent-config-resolver';
+// Mock the RegistryService so registry-backed paths (activateProjectAgents)
+// can be driven without hitting the AgentCore Registry SDK. DynamoDB-only
+// tests never construct a RegistryService, so this mock does not affect them.
+const mockListResources = jest.fn();
+const mockUpdateResourceStatus = jest.fn();
+
+jest.mock('../../services/registry-service', () => ({
+  RegistryService: jest.fn().mockImplementation(() => ({
+    listResources: mockListResources,
+    updateResourceStatus: mockUpdateResourceStatus,
+  })),
+  RegistryRecordStatusValues: {
+    DRAFT: 'DRAFT',
+    PENDING_APPROVAL: 'PENDING_APPROVAL',
+    APPROVED: 'APPROVED',
+    REJECTED: 'REJECTED',
+    DEPRECATED: 'DEPRECATED',
+    CREATING: 'CREATING',
+    UPDATING: 'UPDATING',
+    CREATE_FAILED: 'CREATE_FAILED',
+    UPDATE_FAILED: 'UPDATE_FAILED',
+  },
+}));
+
+import { handler, _resetRegistryService } from '../agent-config-resolver';
 
 describe('agent-config-resolver', () => {
   beforeEach(() => {
@@ -110,6 +134,77 @@ describe('agent-config-resolver', () => {
 
       const result = await handler(makeEvent('deleteAgentConfig', { agentId: 'a1' }));
       expect(result.success).toBe(true);
+    });
+  });
+
+  describe('activateProjectAgents', () => {
+    beforeEach(() => {
+      process.env.REGISTRY_ID = 'reg-123';
+      _resetRegistryService();
+      mockListResources.mockReset();
+      mockUpdateResourceStatus.mockReset();
+    });
+
+    afterEach(() => {
+      delete process.env.REGISTRY_ID;
+    });
+
+    const agentRecord = (
+      recordId: string,
+      name: string,
+      sourceProjectId: string | undefined,
+      status: string,
+    ) => ({
+      recordId,
+      name,
+      status,
+      customDescriptorContent: JSON.stringify({ sourceProjectId, manifest: {} }),
+    });
+
+    test('filters by sourceProjectId, activates non-active, skips already-active', async () => {
+      mockListResources.mockResolvedValue([
+        agentRecord('r1', 'Agent One', 'proj-1', 'DRAFT'),
+        agentRecord('r2', 'Agent Two', 'proj-1', 'APPROVED'),
+        agentRecord('r3', 'Other Project', 'proj-2', 'DRAFT'),
+      ]);
+      mockUpdateResourceStatus.mockResolvedValue({});
+
+      const result = await handler(makeEvent('activateProjectAgents', { projectId: 'proj-1' }));
+
+      expect(mockListResources).toHaveBeenCalledWith('agent');
+      expect(mockUpdateResourceStatus).toHaveBeenCalledTimes(1);
+      expect(mockUpdateResourceStatus).toHaveBeenCalledWith('agent', 'r1', 'APPROVED');
+      expect(result.activated).toEqual(['Agent One']);
+      expect(result.alreadyActive).toEqual(['Agent Two']);
+      expect(result.failed).toEqual([]);
+    });
+
+    test('continues and records failed when one agent errors', async () => {
+      mockListResources.mockResolvedValue([
+        agentRecord('r1', 'Agent One', 'proj-1', 'DRAFT'),
+        agentRecord('r2', 'Agent Two', 'proj-1', 'DRAFT'),
+      ]);
+      mockUpdateResourceStatus
+        .mockRejectedValueOnce(new Error('boom'))
+        .mockResolvedValueOnce({});
+
+      const result = await handler(makeEvent('activateProjectAgents', { projectId: 'proj-1' }));
+
+      expect(result.activated).toEqual(['Agent Two']);
+      expect(result.failed).toEqual(['Agent One']);
+      expect(result.alreadyActive).toEqual([]);
+    });
+
+    test('returns empty arrays when no agents match the project', async () => {
+      mockListResources.mockResolvedValue([
+        agentRecord('r3', 'Other Project', 'proj-2', 'DRAFT'),
+        agentRecord('r4', 'No Project', undefined, 'DRAFT'),
+      ]);
+
+      const result = await handler(makeEvent('activateProjectAgents', { projectId: 'proj-1' }));
+
+      expect(mockUpdateResourceStatus).not.toHaveBeenCalled();
+      expect(result).toEqual({ activated: [], failed: [], alreadyActive: [] });
     });
   });
 

--- a/backend/src/lambda/__tests__/agent-message-handler-idempotency.test.ts
+++ b/backend/src/lambda/__tests__/agent-message-handler-idempotency.test.ts
@@ -1,0 +1,78 @@
+/**
+ * Finding #1 (consumer side): agent-message-handler must dedupe on the
+ * logical message identity (`event.detail.messageId`) rather than the
+ * EventBridge envelope id (`event.id`, unique per emit). The deterministic
+ * messageId set by emitAssessmentTrigger lets two overlapping poller emits
+ * for the same document collapse to a single processed message.
+ *
+ * The IdempotencyGuard is mocked with an in-memory set that mirrors the real
+ * DynamoDB conditional-put semantics (first key wins, duplicates are skipped),
+ * so this unit isolates the KEY-SELECTION decision in the handler.
+ */
+jest.mock('../../utils/idempotency', () => {
+  const records: Array<{ key: string; executed: boolean }> = [];
+  const seen = new Set<string>();
+  return {
+    IdempotencyGuard: jest.fn().mockImplementation(() => ({
+      withIdempotency: jest.fn(async (key: string) => {
+        const executed = !seen.has(key);
+        if (executed) seen.add(key);
+        records.push({ key, executed });
+        return { executed };
+      }),
+    })),
+    __records: records,
+    __reset: () => {
+      records.length = 0;
+      seen.clear();
+    },
+  };
+});
+
+import { handler } from '../agent-message-handler';
+
+const idem = jest.requireMock('../../utils/idempotency') as {
+  __records: Array<{ key: string; executed: boolean }>;
+  __reset: () => void;
+};
+
+const makeEvent = (id: string, messageId?: string) =>
+  ({
+    id,
+    detail: {
+      projectId: 'proj-1',
+      agentId: 'agent_intake_single',
+      message: 'A document has been uploaded and indexed.',
+      messageId,
+      userId: 'system',
+      timestamp: new Date().toISOString(),
+    },
+  }) as any;
+
+describe('agent-message-handler idempotency key (Finding #1)', () => {
+  beforeEach(() => {
+    idem.__reset();
+  });
+
+  test('uses detail.messageId as the idempotency key', async () => {
+    await handler(makeEvent('evt-1', 'doc-indexed-proj-1-proj-1/a.pdf'));
+    expect(idem.__records[0].key).toBe('doc-indexed-proj-1-proj-1/a.pdf');
+  });
+
+  test('dedupes a second event with the same messageId but a different event.id', async () => {
+    await handler(makeEvent('evt-1', 'doc-indexed-proj-1-proj-1/a.pdf'));
+    await handler(makeEvent('evt-2', 'doc-indexed-proj-1-proj-1/a.pdf'));
+    expect(idem.__records.map((r) => r.executed)).toEqual([true, false]);
+  });
+
+  test('two events with different messageIds both execute', async () => {
+    await handler(makeEvent('evt-1', 'doc-indexed-proj-1-proj-1/a.pdf'));
+    await handler(makeEvent('evt-2', 'doc-indexed-proj-1-proj-1/b.pdf'));
+    expect(idem.__records.map((r) => r.executed)).toEqual([true, true]);
+  });
+
+  test('falls back to event.id when detail.messageId is absent', async () => {
+    await handler(makeEvent('evt-1', undefined));
+    expect(idem.__records[0].key).toBe('evt-1');
+  });
+});

--- a/backend/src/lambda/__tests__/document-ingestion-poller.test.ts
+++ b/backend/src/lambda/__tests__/document-ingestion-poller.test.ts
@@ -1,0 +1,264 @@
+/**
+ * Tests for document-ingestion-poller (scheduled status detection + trigger).
+ */
+import { DynamoDBDocumentClient, QueryCommand, UpdateCommand } from '@aws-sdk/lib-dynamodb';
+import {
+  BedrockAgentClient,
+  GetKnowledgeBaseDocumentsCommand,
+  IngestKnowledgeBaseDocumentsCommand,
+} from '@aws-sdk/client-bedrock-agent';
+import { SSMClient, GetParameterCommand } from '@aws-sdk/client-ssm';
+import { EventBridgeClient, PutEventsCommand } from '@aws-sdk/client-eventbridge';
+import { CloudWatchClient, PutMetricDataCommand } from '@aws-sdk/client-cloudwatch';
+import { mockClient } from 'aws-sdk-client-mock';
+
+const ddbMock = mockClient(DynamoDBDocumentClient);
+const bedrockMock = mockClient(BedrockAgentClient);
+const ssmMock = mockClient(SSMClient);
+const eventBridgeMock = mockClient(EventBridgeClient);
+const cloudwatchMock = mockClient(CloudWatchClient);
+
+import { handler } from '../document-ingestion-poller';
+import { _resetKbIdCache } from '../document-ingestion-shared';
+
+const NOW_ISO = new Date().toISOString();
+const OLD_ISO = new Date(Date.now() - 20 * 60 * 1000).toISOString(); // 20 min ago
+
+const job = (overrides: Record<string, any> = {}) => ({
+  projectId: 'proj-1',
+  documentKey: 'proj-1/a.pdf',
+  fileName: 'a.pdf',
+  size: 100,
+  fileType: 'application/pdf',
+  status: 'IN_PROGRESS',
+  triggered: false,
+  attempts: 1,
+  createdAt: NOW_ISO,
+  ...overrides,
+});
+
+/** Mock the GSI: return `rows` for the IN_PROGRESS partition, empty otherwise. */
+function mockJobs(rows: any[]) {
+  ddbMock.on(QueryCommand, { ExpressionAttributeValues: { ':status': 'IN_PROGRESS' } }).resolves({ Items: rows });
+  ddbMock.on(QueryCommand, { ExpressionAttributeValues: { ':status': 'STARTING' } }).resolves({ Items: [] });
+  ddbMock.on(QueryCommand, { ExpressionAttributeValues: { ':status': 'PENDING' } }).resolves({ Items: [] });
+}
+
+function condFailed(): Error {
+  const e = new Error('conditional');
+  e.name = 'ConditionalCheckFailedException';
+  return e;
+}
+
+const triggerCalls = () =>
+  eventBridgeMock.commandCalls(PutEventsCommand).filter((c) =>
+    (c.args[0].input.Entries![0].DetailType) === 'message.sent_to_agent'
+  );
+const failureCalls = () =>
+  eventBridgeMock.commandCalls(PutEventsCommand).filter((c) =>
+    (c.args[0].input.Entries![0].DetailType) === 'document.ingestion.failed'
+  );
+
+describe('document-ingestion-poller', () => {
+  beforeEach(() => {
+    ddbMock.reset();
+    bedrockMock.reset();
+    ssmMock.reset();
+    eventBridgeMock.reset();
+    cloudwatchMock.reset();
+    _resetKbIdCache();
+    process.env.INGESTION_TABLE = 'citadel-document-ingestion-test';
+    process.env.DOCUMENT_BUCKET = 'citadel-docs-test';
+    process.env.KB_ID_PARAM = '/citadel/kb/id';
+    process.env.DS_ID_PARAM = '/citadel/ds/id';
+    process.env.EVENT_BUS_NAME = 'citadel-agents-test';
+    process.env.ENVIRONMENT = 'test';
+    process.env.MAX_AGE_MS = String(10 * 60 * 1000);
+    process.env.START_GRACE_MS = String(2 * 60 * 1000);
+    ssmMock.on(GetParameterCommand).resolves({ Parameter: { Value: 'kb-or-ds' } });
+    ddbMock.on(UpdateCommand).resolves({});
+    eventBridgeMock.on(PutEventsCommand).resolves({ FailedEntryCount: 0 });
+    cloudwatchMock.on(PutMetricDataCommand).resolves({});
+  });
+
+  test('INDEXED -> emits exactly one assessment trigger and sets triggered=true', async () => {
+    mockJobs([job()]);
+    bedrockMock.on(GetKnowledgeBaseDocumentsCommand).resolves({
+      documentDetails: [{ status: 'INDEXED', identifier: { custom: { id: 'proj-1/a.pdf' } } }],
+    } as any);
+
+    await handler();
+
+    expect(triggerCalls()).toHaveLength(1);
+    const updates = ddbMock.commandCalls(UpdateCommand);
+    expect(updates).toHaveLength(1);
+    expect(updates[0].args[0].input.ConditionExpression).toBe('triggered = :false');
+    expect(updates[0].args[0].input.ExpressionAttributeValues![':true']).toBe(true);
+  });
+
+  test('re-poll after triggered=true emits nothing', async () => {
+    mockJobs([job({ triggered: true })]);
+    bedrockMock.on(GetKnowledgeBaseDocumentsCommand).resolves({
+      documentDetails: [{ status: 'INDEXED', identifier: { custom: { id: 'proj-1/a.pdf' } } }],
+    } as any);
+
+    await handler();
+
+    expect(triggerCalls()).toHaveLength(0);
+    expect(ddbMock.commandCalls(UpdateCommand)).toHaveLength(0);
+  });
+
+  test('FAILED -> no trigger, failure event emitted, reason persisted, metric emitted', async () => {
+    mockJobs([job()]);
+    bedrockMock.on(GetKnowledgeBaseDocumentsCommand).resolves({
+      documentDetails: [{ status: 'FAILED', statusReason: 'bad doc', identifier: { custom: { id: 'proj-1/a.pdf' } } }],
+    } as any);
+
+    await handler();
+
+    expect(triggerCalls()).toHaveLength(0);
+    expect(failureCalls()).toHaveLength(1);
+    const updates = ddbMock.commandCalls(UpdateCommand);
+    expect(updates[0].args[0].input.ExpressionAttributeValues![':status']).toBe('FAILED');
+    expect(updates[0].args[0].input.ExpressionAttributeValues![':reason']).toBe('bad doc');
+    expect(cloudwatchMock.commandCalls(PutMetricDataCommand)).toHaveLength(1);
+  });
+
+  test('IGNORED (Bedrock dedup) is transient: keeps polling, no failure, no trigger', async () => {
+    mockJobs([job()]);
+    bedrockMock.on(GetKnowledgeBaseDocumentsCommand).resolves({
+      documentDetails: [{
+        status: 'IGNORED',
+        statusReason: 'You submitted multiple requests for the same document',
+        identifier: { custom: { id: 'proj-1/a.pdf' } },
+      }],
+    } as any);
+
+    await handler();
+
+    expect(triggerCalls()).toHaveLength(0);
+    expect(failureCalls()).toHaveLength(0);
+    const updates = ddbMock.commandCalls(UpdateCommand);
+    expect(updates).toHaveLength(1);
+    // Transient bookkeeping: IGNORED normalizes to a pollable status.
+    expect(updates[0].args[0].input.ExpressionAttributeValues![':status']).toBe('IN_PROGRESS');
+  });
+
+  test('marks TIMEOUT when a transient job is older than MAX_AGE_MS', async () => {
+    mockJobs([job({ createdAt: OLD_ISO, status: 'IN_PROGRESS' })]);
+    bedrockMock.on(GetKnowledgeBaseDocumentsCommand).resolves({
+      documentDetails: [{ status: 'IN_PROGRESS', identifier: { custom: { id: 'proj-1/a.pdf' } } }],
+    } as any);
+
+    await handler();
+
+    expect(triggerCalls()).toHaveLength(0);
+    const updates = ddbMock.commandCalls(UpdateCommand);
+    expect(updates[0].args[0].input.ExpressionAttributeValues![':status']).toBe('TIMEOUT');
+  });
+
+  test('chunks GetKnowledgeBaseDocuments in groups of <=10', async () => {
+    const rows = Array.from({ length: 12 }, (_, i) => job({ documentKey: `proj-1/doc-${i}.pdf`, fileName: `doc-${i}.pdf` }));
+    mockJobs(rows);
+    bedrockMock.on(GetKnowledgeBaseDocumentsCommand).resolves({
+      documentDetails: rows.map((r) => ({ status: 'IN_PROGRESS', identifier: { custom: { id: r.documentKey } } })),
+    } as any);
+
+    await handler();
+
+    expect(bedrockMock.commandCalls(GetKnowledgeBaseDocumentsCommand)).toHaveLength(2);
+  });
+
+  test('conditional-write race is swallowed -> still a single trigger emission', async () => {
+    mockJobs([job()]);
+    bedrockMock.on(GetKnowledgeBaseDocumentsCommand).resolves({
+      documentDetails: [{ status: 'INDEXED', identifier: { custom: { id: 'proj-1/a.pdf' } } }],
+    } as any);
+    ddbMock.on(UpdateCommand).rejects(condFailed());
+
+    const result = await handler();
+
+    expect(triggerCalls()).toHaveLength(1);
+    expect(result.processed).toBe(1);
+  });
+
+  test('no non-terminal jobs -> no polling', async () => {
+    mockJobs([]);
+    const result = await handler();
+    expect(result.processed).toBe(0);
+    expect(bedrockMock.commandCalls(GetKnowledgeBaseDocumentsCommand)).toHaveLength(0);
+  });
+
+  describe('stale STARTING re-kick (Finding #2)', () => {
+    const FIVE_MIN_AGO = new Date(Date.now() - 5 * 60 * 1000).toISOString(); // > grace, < maxAge
+
+    /** Put `rows` in the given status GSI partition, empty for the others. */
+    function mockJobsIn(status: string, rows: any[]) {
+      for (const s of ['IN_PROGRESS', 'STARTING', 'PENDING']) {
+        ddbMock
+          .on(QueryCommand, { ExpressionAttributeValues: { ':status': s } })
+          .resolves({ Items: s === status ? rows : [] });
+      }
+    }
+
+    const ingestCalls = () => bedrockMock.commandCalls(IngestKnowledgeBaseDocumentsCommand);
+
+    beforeEach(() => {
+      bedrockMock.on(IngestKnowledgeBaseDocumentsCommand).resolves({
+        documentDetails: [{ status: 'STARTING', identifier: { custom: { id: 'proj-1/a.pdf' } } }],
+      } as any);
+      // Document not present yet in the KB.
+      bedrockMock.on(GetKnowledgeBaseDocumentsCommand).resolves({
+        documentDetails: [{ status: 'NOT_FOUND', identifier: { custom: { id: 'proj-1/a.pdf' } } }],
+      } as any);
+    });
+
+    test('STARTING older than START_GRACE_MS with absent doc re-invokes startIngestion', async () => {
+      mockJobsIn('STARTING', [job({ status: 'STARTING', createdAt: FIVE_MIN_AGO, attempts: 1 })]);
+
+      await handler();
+
+      expect(ingestCalls()).toHaveLength(1);
+      const updates = ddbMock.commandCalls(UpdateCommand);
+      expect(updates).toHaveLength(1);
+      // Re-kick keeps the row STARTING (still re-pollable) and bumps attempts.
+      expect(updates[0].args[0].input.ExpressionAttributeValues![':status']).toBe('STARTING');
+      expect(updates[0].args[0].input.UpdateExpression).toContain('attempts');
+      expect(triggerCalls()).toHaveLength(0);
+    });
+
+    test('fresh STARTING row within grace does NOT re-invoke startIngestion', async () => {
+      mockJobsIn('STARTING', [job({ status: 'STARTING', createdAt: NOW_ISO, attempts: 1 })]);
+
+      await handler();
+
+      expect(ingestCalls()).toHaveLength(0);
+      const updates = ddbMock.commandCalls(UpdateCommand);
+      expect(updates).toHaveLength(1);
+      // Plain transient bookkeeping (NOT_FOUND normalizes to IN_PROGRESS).
+      expect(updates[0].args[0].input.ExpressionAttributeValues![':status']).toBe('IN_PROGRESS');
+    });
+
+    test('re-kick stops after the attempts cap (attempts >= 3)', async () => {
+      mockJobsIn('STARTING', [job({ status: 'STARTING', createdAt: FIVE_MIN_AGO, attempts: 3 })]);
+
+      await handler();
+
+      expect(ingestCalls()).toHaveLength(0);
+      const updates = ddbMock.commandCalls(UpdateCommand);
+      expect(updates).toHaveLength(1);
+      expect(updates[0].args[0].input.ExpressionAttributeValues![':status']).toBe('IN_PROGRESS');
+    });
+
+    test('STARTING row older than MAX_AGE_MS still rides to TIMEOUT (no re-kick)', async () => {
+      mockJobsIn('STARTING', [job({ status: 'STARTING', createdAt: OLD_ISO, attempts: 1 })]);
+
+      await handler();
+
+      expect(ingestCalls()).toHaveLength(0);
+      const updates = ddbMock.commandCalls(UpdateCommand);
+      expect(updates).toHaveLength(1);
+      expect(updates[0].args[0].input.ExpressionAttributeValues![':status']).toBe('TIMEOUT');
+    });
+  });
+});

--- a/backend/src/lambda/__tests__/document-ingestion-shared.property.test.ts
+++ b/backend/src/lambda/__tests__/document-ingestion-shared.property.test.ts
@@ -1,0 +1,81 @@
+/**
+ * Property tests for the shared ingestion status model.
+ * The core invariant: classifyStatus is TOTAL — it returns exactly one of the
+ * three dispositions for ANY string (and for null/undefined), and is consistent
+ * with the SUCCESS/FAILED status sets.
+ */
+import fc from 'fast-check';
+import {
+  classifyStatus,
+  isTerminal,
+  normalizeTransientStatus,
+  SUCCESS_STATUSES,
+  FAILED_STATUSES,
+  POLLABLE_STATUSES,
+  TERMINAL_STATUSES,
+} from '../document-ingestion-shared';
+
+const ALL_BEDROCK_STATUSES = [
+  'STARTING',
+  'IN_PROGRESS',
+  'PENDING',
+  'INDEXED',
+  'PARTIALLY_INDEXED',
+  'FAILED',
+  'METADATA_UPDATE_FAILED',
+  'IGNORED',
+  'NOT_FOUND',
+  'DELETING',
+  'DELETE_IN_PROGRESS',
+  'EMBEDDING',
+  'TIMEOUT',
+];
+
+describe('classifyStatus (total mapping)', () => {
+  test('returns a valid disposition for every arbitrary string', () => {
+    fc.assert(
+      fc.property(fc.string(), (s) => {
+        const d = classifyStatus(s);
+        return d === 'SUCCESS' || d === 'FAILED' || d === 'TRANSIENT';
+      })
+    );
+  });
+
+  test('handles null and undefined as TRANSIENT', () => {
+    expect(classifyStatus(null)).toBe('TRANSIENT');
+    expect(classifyStatus(undefined)).toBe('TRANSIENT');
+  });
+
+  test('is consistent with the SUCCESS / FAILED sets across known Bedrock statuses', () => {
+    for (const status of ALL_BEDROCK_STATUSES) {
+      const d = classifyStatus(status);
+      if (SUCCESS_STATUSES.has(status)) expect(d).toBe('SUCCESS');
+      else if (FAILED_STATUSES.has(status)) expect(d).toBe('FAILED');
+      else expect(d).toBe('TRANSIENT');
+    }
+  });
+
+  test('SUCCESS and FAILED status sets are disjoint', () => {
+    for (const s of SUCCESS_STATUSES) {
+      expect(FAILED_STATUSES.has(s)).toBe(false);
+    }
+  });
+
+  test('isTerminal is true for every SUCCESS/FAILED/TIMEOUT status and never for pollable statuses', () => {
+    fc.assert(
+      fc.property(fc.constantFrom(...ALL_BEDROCK_STATUSES), (status) => {
+        const terminal = isTerminal(status);
+        if (TERMINAL_STATUSES.has(status)) return terminal === true;
+        return terminal === false;
+      })
+    );
+  });
+
+  test('normalizeTransientStatus always yields a pollable status', () => {
+    fc.assert(
+      fc.property(fc.string(), (s) => {
+        return (POLLABLE_STATUSES as readonly string[]).includes(normalizeTransientStatus(s));
+      })
+    );
+  });
+});

--- a/backend/src/lambda/__tests__/document-ingestion-shared.test.ts
+++ b/backend/src/lambda/__tests__/document-ingestion-shared.test.ts
@@ -1,0 +1,98 @@
+/**
+ * Tests for shared ingestion side-effects (EventBridge emit shape).
+ *
+ * Finding #1: emitAssessmentTrigger must use a DETERMINISTIC messageId derived
+ * from the document identity so that duplicate emits (the poller emits the
+ * trigger BEFORE the conditional `triggered=true` claim, so overlapping runs
+ * can emit twice) collapse to a single logical message downstream.
+ */
+import { EventBridgeClient, PutEventsCommand } from '@aws-sdk/client-eventbridge';
+import { mockClient } from 'aws-sdk-client-mock';
+
+const eventBridgeMock = mockClient(EventBridgeClient);
+
+import {
+  emitAssessmentTrigger,
+  isDocumentAbsent,
+  classifyStatus,
+  isTerminal,
+  FAILED_STATUSES,
+} from '../document-ingestion-shared';
+
+function emittedDetail(callIndex: number): any {
+  const calls = eventBridgeMock.commandCalls(PutEventsCommand);
+  return JSON.parse(calls[callIndex].args[0].input.Entries![0].Detail as string);
+}
+
+describe('emitAssessmentTrigger deterministic messageId (Finding #1)', () => {
+  beforeEach(() => {
+    eventBridgeMock.reset();
+    eventBridgeMock.on(PutEventsCommand).resolves({ FailedEntryCount: 0 });
+    process.env.EVENT_BUS_NAME = 'citadel-agents-test';
+  });
+
+  test('messageId is derived deterministically from projectId + documentKey', async () => {
+    await emitAssessmentTrigger('proj-1', 'proj-1/a.pdf', 'a.pdf', 2048, 'application/pdf');
+    expect(emittedDetail(0).messageId).toBe('doc-indexed-proj-1-proj-1/a.pdf');
+  });
+
+  test('two emits for the same document share the same messageId', async () => {
+    await emitAssessmentTrigger('proj-1', 'proj-1/a.pdf', 'a.pdf', 2048, 'application/pdf');
+    await emitAssessmentTrigger('proj-1', 'proj-1/a.pdf', 'a.pdf', 2048, 'application/pdf');
+    expect(emittedDetail(0).messageId).toBe(emittedDetail(1).messageId);
+  });
+
+  test('distinct documents produce distinct messageIds', async () => {
+    await emitAssessmentTrigger('proj-1', 'proj-1/a.pdf', 'a.pdf', 1, 'application/pdf');
+    await emitAssessmentTrigger('proj-1', 'proj-1/b.pdf', 'b.pdf', 1, 'application/pdf');
+    expect(emittedDetail(0).messageId).not.toBe(emittedDetail(1).messageId);
+  });
+
+  test('other detail fields are unchanged (shape preserved)', async () => {
+    await emitAssessmentTrigger('proj-1', 'proj-1/a.pdf', 'a.pdf', 2048, 'application/pdf');
+    const detail = emittedDetail(0);
+    expect(detail.projectId).toBe('proj-1');
+    expect(detail.agentId).toBe('agent_intake_single');
+    expect(detail.userId).toBe('system');
+    expect(detail.metadata).toEqual({ documentKey: 'proj-1/a.pdf', trigger: 'document_indexed' });
+  });
+});
+
+describe('isDocumentAbsent (Finding #2 helper)', () => {
+  test('absent when polled status missing/empty/NOT_FOUND or not returned', () => {
+    expect(isDocumentAbsent(undefined)).toBe(true);
+    expect(isDocumentAbsent({ status: '' })).toBe(true);
+    expect(isDocumentAbsent({ status: 'NOT_FOUND' })).toBe(true);
+  });
+
+  test('present when polled status is a real Bedrock status', () => {
+    expect(isDocumentAbsent({ status: 'IN_PROGRESS' })).toBe(false);
+    expect(isDocumentAbsent({ status: 'INDEXED' })).toBe(false);
+  });
+});
+
+describe('IGNORED is a Bedrock dedup/no-op, not a failure', () => {
+  test("classifyStatus('IGNORED') is TRANSIENT (poll for the real status)", () => {
+    expect(classifyStatus('IGNORED')).toBe('TRANSIENT');
+  });
+
+  test("isTerminal('IGNORED') is false (keep re-polling)", () => {
+    expect(isTerminal('IGNORED')).toBe(false);
+  });
+
+  test('IGNORED is not in FAILED_STATUSES', () => {
+    expect(FAILED_STATUSES.has('IGNORED')).toBe(false);
+  });
+
+  test('genuine hard failures remain FAILED', () => {
+    expect(classifyStatus('FAILED')).toBe('FAILED');
+    expect(classifyStatus('METADATA_UPDATE_FAILED')).toBe('FAILED');
+    expect(isTerminal('FAILED')).toBe(true);
+    expect(isTerminal('METADATA_UPDATE_FAILED')).toBe(true);
+  });
+
+  test('INDEXED/PARTIALLY_INDEXED remain SUCCESS', () => {
+    expect(classifyStatus('INDEXED')).toBe('SUCCESS');
+    expect(classifyStatus('PARTIALLY_INDEXED')).toBe('SUCCESS');
+  });
+});

--- a/backend/src/lambda/__tests__/document-ingestion-start.test.ts
+++ b/backend/src/lambda/__tests__/document-ingestion-start.test.ts
@@ -1,0 +1,285 @@
+/**
+ * Tests for document-ingestion-start (S3 ObjectCreated -> jobs row + ingest).
+ */
+import { DynamoDBDocumentClient, PutCommand, UpdateCommand, GetCommand } from '@aws-sdk/lib-dynamodb';
+import {
+  BedrockAgentClient,
+  IngestKnowledgeBaseDocumentsCommand,
+} from '@aws-sdk/client-bedrock-agent';
+import { SSMClient, GetParameterCommand } from '@aws-sdk/client-ssm';
+import { mockClient } from 'aws-sdk-client-mock';
+
+const ddbMock = mockClient(DynamoDBDocumentClient);
+const bedrockMock = mockClient(BedrockAgentClient);
+const ssmMock = mockClient(SSMClient);
+
+import { handler, shouldProcessKey, parseKey, decodeS3Key } from '../document-ingestion-start';
+import { _resetKbIdCache } from '../document-ingestion-shared';
+
+const makeS3Event = (records: { key: string; size?: number }[]) => ({
+  Records: records.map((r) => ({
+    s3: { object: { key: r.key, size: r.size ?? 123 }, bucket: { name: 'docs' } },
+  })),
+}) as any;
+
+function condFailed(): Error {
+  const e = new Error('conditional');
+  e.name = 'ConditionalCheckFailedException';
+  return e;
+}
+
+describe('document-ingestion-start', () => {
+  beforeEach(() => {
+    ddbMock.reset();
+    bedrockMock.reset();
+    ssmMock.reset();
+    _resetKbIdCache();
+    process.env.INGESTION_TABLE = 'citadel-document-ingestion-test';
+    process.env.DOCUMENT_BUCKET = 'citadel-docs-test';
+    process.env.KB_ID_PARAM = '/citadel/kb/id';
+    process.env.DS_ID_PARAM = '/citadel/ds/id';
+    process.env.EVENT_BUS_NAME = 'citadel-agents-test';
+    ssmMock.on(GetParameterCommand).resolves({ Parameter: { Value: 'kb-or-ds' } });
+  });
+
+  describe('key helpers', () => {
+    test('shouldProcessKey accepts a flat project upload', () => {
+      expect(shouldProcessKey('proj-1/report.pdf')).toBe(true);
+    });
+    test('shouldProcessKey rejects design/ and planning/ artifacts', () => {
+      expect(shouldProcessKey('proj-1/design/high_level_design.pdf')).toBe(false);
+      expect(shouldProcessKey('proj-1/planning/roadmap.md')).toBe(false);
+    });
+    test('shouldProcessKey rejects keys without a project prefix', () => {
+      expect(shouldProcessKey('report.pdf')).toBe(false);
+      expect(shouldProcessKey('proj-1/')).toBe(false);
+    });
+    test('parseKey splits projectId and fileName', () => {
+      expect(parseKey('proj-1/report.pdf')).toEqual({ projectId: 'proj-1', fileName: 'report.pdf' });
+    });
+    test('decodeS3Key decodes + and percent escapes', () => {
+      expect(decodeS3Key('proj-1/my+report%202.pdf')).toBe('proj-1/my report 2.pdf');
+    });
+  });
+
+  test('creates a STARTING jobs row then records the returned status', async () => {
+    ddbMock.on(PutCommand).resolves({});
+    ddbMock.on(UpdateCommand).resolves({});
+    bedrockMock.on(IngestKnowledgeBaseDocumentsCommand).resolves({
+      documentDetails: [{ status: 'IN_PROGRESS', identifier: { custom: { id: 'proj-1/report.pdf' } } }],
+    } as any);
+
+    await handler(makeS3Event([{ key: 'proj-1/report.pdf', size: 500 }]));
+
+    const puts = ddbMock.commandCalls(PutCommand);
+    expect(puts).toHaveLength(1);
+    const item = puts[0].args[0].input.Item as any;
+    expect(item.status).toBe('STARTING');
+    expect(item.triggered).toBe(false);
+    expect(item.projectId).toBe('proj-1');
+    expect(item.documentKey).toBe('proj-1/report.pdf');
+    expect(item.size).toBe(500);
+
+    expect(bedrockMock.commandCalls(IngestKnowledgeBaseDocumentsCommand)).toHaveLength(1);
+    const updates = ddbMock.commandCalls(UpdateCommand);
+    expect(updates).toHaveLength(1);
+    expect(updates[0].args[0].input.ExpressionAttributeValues![':status']).toBe('IN_PROGRESS');
+  });
+
+  test('is idempotent on a duplicate S3 delivery (conditional create fails -> no second ingest)', async () => {
+    ddbMock.on(PutCommand).resolvesOnce({}).rejects(condFailed());
+    ddbMock.on(UpdateCommand).resolves({});
+    bedrockMock.on(IngestKnowledgeBaseDocumentsCommand).resolves({
+      documentDetails: [{ status: 'IN_PROGRESS' }],
+    } as any);
+
+    await handler(makeS3Event([
+      { key: 'proj-1/report.pdf' },
+      { key: 'proj-1/report.pdf' },
+    ]));
+
+    // Two create attempts, but only the first proceeds to ingestion.
+    expect(ddbMock.commandCalls(PutCommand)).toHaveLength(2);
+    expect(bedrockMock.commandCalls(IngestKnowledgeBaseDocumentsCommand)).toHaveLength(1);
+  });
+
+  test('ignores excluded design/planning artifacts (no DB write, no ingest)', async () => {
+    ddbMock.on(PutCommand).resolves({});
+    await handler(makeS3Event([
+      { key: 'proj-1/design/high_level_design.pdf' },
+      { key: 'proj-1/planning/roadmap.md' },
+    ]));
+    expect(ddbMock.commandCalls(PutCommand)).toHaveLength(0);
+    expect(bedrockMock.commandCalls(IngestKnowledgeBaseDocumentsCommand)).toHaveLength(0);
+  });
+
+  test('persists statusReason when ingestion returns FAILED immediately', async () => {
+    ddbMock.on(PutCommand).resolves({});
+    ddbMock.on(UpdateCommand).resolves({});
+    bedrockMock.on(IngestKnowledgeBaseDocumentsCommand).resolves({
+      documentDetails: [{ status: 'FAILED', statusReason: 'parse error', identifier: { custom: { id: 'proj-1/bad.pdf' } } }],
+    } as any);
+
+    await handler(makeS3Event([{ key: 'proj-1/bad.pdf' }]));
+
+    const updates = ddbMock.commandCalls(UpdateCommand);
+    expect(updates).toHaveLength(1);
+    const values = updates[0].args[0].input.ExpressionAttributeValues!;
+    expect(values[':status']).toBe('FAILED');
+    expect(values[':reason']).toBe('parse error');
+  });
+
+  describe('synchronous status is never written as a non-pollable terminal status', () => {
+    // The poller is the single authority for SUCCESS/FAILED + the trigger and
+    // only re-polls pollable rows. IngestKnowledgeBaseDocuments can synchronously
+    // return IGNORED (dedup) or even INDEXED; neither may be persisted terminally.
+    test('IGNORED (Bedrock dedup) is persisted as a POLLABLE status, no statusReason', async () => {
+      ddbMock.on(PutCommand).resolves({});
+      ddbMock.on(UpdateCommand).resolves({});
+      bedrockMock.on(IngestKnowledgeBaseDocumentsCommand).resolves({
+        documentDetails: [{
+          status: 'IGNORED',
+          statusReason: 'You submitted multiple requests for the same document',
+          identifier: { custom: { id: 'proj-1/dup.pdf' } },
+        }],
+      } as any);
+
+      await handler(makeS3Event([{ key: 'proj-1/dup.pdf' }]));
+
+      const updates = ddbMock.commandCalls(UpdateCommand);
+      expect(updates).toHaveLength(1);
+      const input = updates[0].args[0].input;
+      const values = input.ExpressionAttributeValues!;
+      expect(values[':status']).toBe('IN_PROGRESS');
+      expect(values[':status']).not.toBe('IGNORED');
+      // No statusReason is written for a non-failure synchronous status.
+      expect(values[':reason']).toBeUndefined();
+      expect(input.UpdateExpression).not.toMatch(/statusReason = :reason/);
+    });
+
+    test('synchronous INDEXED is persisted as a pollable status (poller owns INDEXED)', async () => {
+      ddbMock.on(PutCommand).resolves({});
+      ddbMock.on(UpdateCommand).resolves({});
+      bedrockMock.on(IngestKnowledgeBaseDocumentsCommand).resolves({
+        documentDetails: [{ status: 'INDEXED', identifier: { custom: { id: 'proj-1/fast.pdf' } } }],
+      } as any);
+
+      await handler(makeS3Event([{ key: 'proj-1/fast.pdf' }]));
+
+      const values = ddbMock.commandCalls(UpdateCommand)[0].args[0].input.ExpressionAttributeValues!;
+      expect(values[':status']).toBe('IN_PROGRESS');
+      expect(values[':reason']).toBeUndefined();
+    });
+
+    test('STARTING is persisted as-is (already pollable)', async () => {
+      ddbMock.on(PutCommand).resolves({});
+      ddbMock.on(UpdateCommand).resolves({});
+      bedrockMock.on(IngestKnowledgeBaseDocumentsCommand).resolves({
+        documentDetails: [{ status: 'STARTING', identifier: { custom: { id: 'proj-1/s.pdf' } } }],
+      } as any);
+
+      await handler(makeS3Event([{ key: 'proj-1/s.pdf' }]));
+
+      const values = ddbMock.commandCalls(UpdateCommand)[0].args[0].input.ExpressionAttributeValues!;
+      expect(values[':status']).toBe('STARTING');
+    });
+  });
+
+  describe('retry of an existing row (conditional create fails)', () => {
+    const resetCall = () =>
+      ddbMock
+        .commandCalls(UpdateCommand)
+        .find((u) => (u.args[0].input.UpdateExpression as string).includes('REMOVE statusReason'));
+
+    test('existing FAILED row is reset to STARTING (statusReason removed) and re-ingested', async () => {
+      ddbMock.on(PutCommand).rejects(condFailed());
+      ddbMock.on(GetCommand).resolves({
+        Item: { projectId: 'proj-1', documentKey: 'proj-1/report.pdf', status: 'FAILED', statusReason: 'old parse error' },
+      });
+      ddbMock.on(UpdateCommand).resolves({});
+      bedrockMock.on(IngestKnowledgeBaseDocumentsCommand).resolves({
+        documentDetails: [{ status: 'IN_PROGRESS' }],
+      } as any);
+
+      await handler(makeS3Event([{ key: 'proj-1/report.pdf', size: 999 }]));
+
+      const reset = resetCall();
+      expect(reset).toBeDefined();
+      const input = reset!.args[0].input;
+      const values = input.ExpressionAttributeValues!;
+      expect(values[':starting']).toBe('STARTING');
+      expect(values[':false']).toBe(false);
+      expect(values[':zero']).toBe(0);
+      expect(values[':size']).toBe(999);
+      expect(values[':expected']).toBe('FAILED');
+      expect(input.UpdateExpression).toMatch(/REMOVE statusReason/);
+      expect(input.ConditionExpression).toBe('#status = :expected');
+      // startIngestion ran, and the post-start status was recorded.
+      expect(bedrockMock.commandCalls(IngestKnowledgeBaseDocumentsCommand)).toHaveLength(1);
+    });
+
+    test('existing in-flight STARTING row is skipped (no reset, no re-ingest)', async () => {
+      ddbMock.on(PutCommand).rejects(condFailed());
+      ddbMock.on(GetCommand).resolves({
+        Item: { projectId: 'proj-1', documentKey: 'proj-1/report.pdf', status: 'STARTING' },
+      });
+      ddbMock.on(UpdateCommand).resolves({});
+      bedrockMock.on(IngestKnowledgeBaseDocumentsCommand).resolves({
+        documentDetails: [{ status: 'IN_PROGRESS' }],
+      } as any);
+
+      await handler(makeS3Event([{ key: 'proj-1/report.pdf' }]));
+
+      expect(ddbMock.commandCalls(UpdateCommand)).toHaveLength(0);
+      expect(bedrockMock.commandCalls(IngestKnowledgeBaseDocumentsCommand)).toHaveLength(0);
+    });
+
+    test('existing INDEXED row is reset and re-ingested (retry of a succeeded doc)', async () => {
+      ddbMock.on(PutCommand).rejects(condFailed());
+      ddbMock.on(GetCommand).resolves({
+        Item: { projectId: 'proj-1', documentKey: 'proj-1/report.pdf', status: 'INDEXED' },
+      });
+      ddbMock.on(UpdateCommand).resolves({});
+      bedrockMock.on(IngestKnowledgeBaseDocumentsCommand).resolves({
+        documentDetails: [{ status: 'IN_PROGRESS' }],
+      } as any);
+
+      await handler(makeS3Event([{ key: 'proj-1/report.pdf' }]));
+
+      const reset = resetCall();
+      expect(reset).toBeDefined();
+      expect(reset!.args[0].input.ExpressionAttributeValues![':expected']).toBe('INDEXED');
+      expect(bedrockMock.commandCalls(IngestKnowledgeBaseDocumentsCommand)).toHaveLength(1);
+    });
+
+    test('brand-new key takes the create path without a GetItem', async () => {
+      ddbMock.on(PutCommand).resolves({});
+      ddbMock.on(UpdateCommand).resolves({});
+      bedrockMock.on(IngestKnowledgeBaseDocumentsCommand).resolves({
+        documentDetails: [{ status: 'IN_PROGRESS' }],
+      } as any);
+
+      await handler(makeS3Event([{ key: 'proj-1/fresh.pdf' }]));
+
+      expect(ddbMock.commandCalls(GetCommand)).toHaveLength(0);
+      expect(ddbMock.commandCalls(PutCommand)).toHaveLength(1);
+      expect(bedrockMock.commandCalls(IngestKnowledgeBaseDocumentsCommand)).toHaveLength(1);
+    });
+
+    test('concurrent reset race: guarded UpdateItem ConditionalCheckFailed -> no re-ingest, no throw', async () => {
+      ddbMock.on(PutCommand).rejects(condFailed());
+      ddbMock.on(GetCommand).resolves({
+        Item: { projectId: 'proj-1', documentKey: 'proj-1/report.pdf', status: 'FAILED' },
+      });
+      // The guarded reset loses the race.
+      ddbMock.on(UpdateCommand).rejects(condFailed());
+      bedrockMock.on(IngestKnowledgeBaseDocumentsCommand).resolves({
+        documentDetails: [{ status: 'IN_PROGRESS' }],
+      } as any);
+
+      await expect(handler(makeS3Event([{ key: 'proj-1/report.pdf' }]))).resolves.toBeUndefined();
+
+      expect(bedrockMock.commandCalls(IngestKnowledgeBaseDocumentsCommand)).toHaveLength(0);
+    });
+  });
+});

--- a/backend/src/lambda/__tests__/document-upload-resolver.test.ts
+++ b/backend/src/lambda/__tests__/document-upload-resolver.test.ts
@@ -1,10 +1,19 @@
 /**
  * Tests for document-upload-resolver Lambda
  */
-import { S3Client } from '@aws-sdk/client-s3';
+import { S3Client, ListObjectsV2Command } from '@aws-sdk/client-s3';
+import {
+  BedrockAgentClient,
+  GetKnowledgeBaseDocumentsCommand,
+} from '@aws-sdk/client-bedrock-agent';
+import { SSMClient, GetParameterCommand } from '@aws-sdk/client-ssm';
+import { DynamoDBDocumentClient, QueryCommand, GetCommand } from '@aws-sdk/lib-dynamodb';
 import { mockClient } from 'aws-sdk-client-mock';
 
 const s3Mock = mockClient(S3Client);
+const bedrockMock = mockClient(BedrockAgentClient);
+const ssmMock = mockClient(SSMClient);
+const ddbMock = mockClient(DynamoDBDocumentClient);
 
 jest.mock('@aws-sdk/s3-request-presigner', () => ({
   getSignedUrl: jest.fn().mockResolvedValue('https://signed-url.example.com/upload'),
@@ -19,11 +28,26 @@ import { handler } from '../document-upload-resolver';
 describe('document-upload-resolver', () => {
   beforeEach(() => {
     s3Mock.reset();
+    bedrockMock.reset();
+    ssmMock.reset();
+    ddbMock.reset();
     process.env.DOCUMENT_BUCKET = 'test-docs-bucket';
+    process.env.KB_ID_PARAM = '/citadel/kb/id';
+    process.env.DS_ID_PARAM = '/citadel/ds/id';
+    process.env.EVENT_BUS_NAME = 'citadel-agents-test';
+    // INGESTION_TABLE is left unset by default so status reads fall back to the
+    // KB query path; individual tests opt in to the jobs-table path.
+    delete process.env.INGESTION_TABLE;
+    // SSM resolves KB + DS ids (cached at module level after first call)
+    ssmMock.on(GetParameterCommand).resolves({ Parameter: { Value: 'kb-or-ds-id' } });
   });
 
   afterEach(() => {
     delete process.env.DOCUMENT_BUCKET;
+    delete process.env.KB_ID_PARAM;
+    delete process.env.DS_ID_PARAM;
+    delete process.env.EVENT_BUS_NAME;
+    delete process.env.INGESTION_TABLE;
   });
 
   const makeEvent = (fieldName: string, args: any) => ({
@@ -111,6 +135,119 @@ describe('document-upload-resolver', () => {
       }) as any);
 
       expect(result.uploadUrl).toBeDefined();
+    });
+  });
+
+  describe('retired client-side ingestion fields', () => {
+    test('ingestDocument is no longer a handled field', async () => {
+      await expect(
+        handler(makeEvent('ingestDocument', {
+          projectId: 'proj-1',
+          documentKey: 'proj-1/a.pdf',
+        }) as any)
+      ).rejects.toThrow('Unknown field');
+    });
+
+    test('notifyDocumentReady is no longer a handled field', async () => {
+      await expect(
+        handler(makeEvent('notifyDocumentReady', {
+          projectId: 'proj-1',
+          documentKey: 'proj-1/a.pdf',
+          fileName: 'a.pdf',
+          fileSize: 2048,
+          fileType: 'application/pdf',
+        }) as any)
+      ).rejects.toThrow('Unknown field');
+    });
+  });
+
+  describe('listProjectDocuments', () => {
+    test('reads ingestion status from the jobs table when INGESTION_TABLE is set', async () => {
+      process.env.INGESTION_TABLE = 'citadel-document-ingestion-test';
+      s3Mock.on(ListObjectsV2Command).resolves({
+        Contents: [
+          { Key: 'proj-1/a.pdf', Size: 100, LastModified: new Date('2026-01-01T00:00:00Z') },
+          { Key: 'proj-1/b.pdf', Size: 200, LastModified: new Date('2026-01-02T00:00:00Z') },
+        ],
+      });
+      ddbMock.on(QueryCommand).resolves({
+        Items: [
+          { projectId: 'proj-1', documentKey: 'proj-1/a.pdf', status: 'INDEXED' },
+          { projectId: 'proj-1', documentKey: 'proj-1/b.pdf', status: 'FAILED', statusReason: 'oops' },
+        ],
+      });
+
+      const result = await handler(makeEvent('listProjectDocuments', { projectId: 'proj-1' }) as any);
+
+      expect(result).toHaveLength(2);
+      const a = result.find((r: any) => r.documentKey === 'proj-1/a.pdf');
+      const b = result.find((r: any) => r.documentKey === 'proj-1/b.pdf');
+      expect(a.status).toBe('INDEXED');
+      expect(b.status).toBe('FAILED');
+      expect(b.statusReason).toBe('oops');
+      // Source of truth is the table — no KB query needed.
+      expect(bedrockMock.commandCalls(GetKnowledgeBaseDocumentsCommand)).toHaveLength(0);
+    });
+
+    test('falls back to the KB query when the jobs-table read fails', async () => {
+      process.env.INGESTION_TABLE = 'citadel-document-ingestion-test';
+      const errorSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+      s3Mock.on(ListObjectsV2Command).resolves({
+        Contents: [{ Key: 'proj-1/a.pdf', Size: 100, LastModified: new Date('2026-01-01T00:00:00Z') }],
+      });
+      ddbMock.on(QueryCommand).rejects(new Error('table unavailable'));
+      bedrockMock.on(GetKnowledgeBaseDocumentsCommand).resolves({
+        documentDetails: [{ status: 'INDEXED', identifier: { custom: { id: 'proj-1/a.pdf' } } }],
+      } as any);
+
+      const result = await handler(makeEvent('listProjectDocuments', { projectId: 'proj-1' }) as any);
+
+      expect(result).toHaveLength(1);
+      expect(result[0].status).toBe('INDEXED');
+      expect(errorSpy).toHaveBeenCalled();
+      errorSpy.mockRestore();
+    });
+
+    test('degrades to UNKNOWN (does not throw) when both table and KB fail', async () => {
+      const errorSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+      // INGESTION_TABLE unset -> straight to KB fallback, which also fails.
+      s3Mock.on(ListObjectsV2Command).resolves({
+        Contents: [{ Key: 'proj-1/a.pdf', Size: 100, LastModified: new Date('2026-01-01T00:00:00Z') }],
+      });
+      bedrockMock.on(GetKnowledgeBaseDocumentsCommand).rejects(new Error('throttled'));
+
+      const result = await handler(makeEvent('listProjectDocuments', { projectId: 'proj-1' }) as any);
+
+      expect(result).toHaveLength(1);
+      expect(result[0].status).toBe('UNKNOWN');
+      expect(errorSpy).toHaveBeenCalled();
+      errorSpy.mockRestore();
+    });
+  });
+
+  describe('getDocumentIngestionStatus', () => {
+    test('reads the jobs table as source of truth', async () => {
+      process.env.INGESTION_TABLE = 'citadel-document-ingestion-test';
+      ddbMock.on(GetCommand).resolves({
+        Item: { projectId: 'proj-1', documentKey: 'proj-1/a.pdf', status: 'INDEXED', updatedAt: '2026-01-01T00:00:00Z' },
+      });
+
+      const result = await handler(makeEvent('getDocumentIngestionStatus', { documentKey: 'proj-1/a.pdf' }) as any);
+
+      expect(result.status).toBe('INDEXED');
+      expect(bedrockMock.commandCalls(GetKnowledgeBaseDocumentsCommand)).toHaveLength(0);
+    });
+
+    test('falls back to the KB query when the row is absent', async () => {
+      process.env.INGESTION_TABLE = 'citadel-document-ingestion-test';
+      ddbMock.on(GetCommand).resolves({ Item: undefined });
+      bedrockMock.on(GetKnowledgeBaseDocumentsCommand).resolves({
+        documentDetails: [{ status: 'PARTIALLY_INDEXED', identifier: { custom: { id: 'proj-1/a.pdf' } } }],
+      } as any);
+
+      const result = await handler(makeEvent('getDocumentIngestionStatus', { documentKey: 'proj-1/a.pdf' }) as any);
+
+      expect(result.status).toBe('PARTIALLY_INDEXED');
     });
   });
 

--- a/backend/src/lambda/__tests__/fabricator-queue-resolver.test.ts
+++ b/backend/src/lambda/__tests__/fabricator-queue-resolver.test.ts
@@ -1,72 +1,171 @@
 /**
- * Tests for fabricator-queue-resolver Lambda
+ * Tests for fabricator-queue-resolver Lambda.
+ *
+ * The resolver reads the durable fabrication-jobs table (source of truth for
+ * per-agent fabrication status) instead of peeking SQS. When a projectId is
+ * supplied it Queries by PK=orchestrationId; otherwise it Scans with a bounded
+ * Limit. Rows map to FabricationQueueItem, sorted by submittedAt descending.
+ * On any error it returns [] to preserve the existing contract.
  */
-import { SQSClient, ReceiveMessageCommand } from '@aws-sdk/client-sqs';
+import { DynamoDBDocumentClient, QueryCommand, ScanCommand } from '@aws-sdk/lib-dynamodb';
 import { mockClient } from 'aws-sdk-client-mock';
 
-const sqsMock = mockClient(SQSClient);
+const ddbMock = mockClient(DynamoDBDocumentClient);
+
+process.env.FABRICATION_JOBS_TABLE = 'citadel-fabrication-jobs-test';
 
 import { handler } from '../fabricator-queue-resolver';
 
+const row = (over: Record<string, any>) => ({
+  orchestrationId: '0',
+  agentUseId: 'req-1',
+  status: 'PENDING',
+  agentName: 'AgentOne',
+  taskDescription: 'do a thing',
+  submittedAt: '2026-06-01T00:00:00.000Z',
+  ...over,
+});
+
 describe('fabricator-queue-resolver', () => {
   beforeEach(() => {
-    sqsMock.reset();
-    process.env.FABRICATOR_QUEUE_URL = 'https://sqs.us-west-2.amazonaws.com/123/test-queue';
+    ddbMock.reset();
+    process.env.FABRICATION_JOBS_TABLE = 'citadel-fabrication-jobs-test';
   });
 
-  afterEach(() => {
-    delete process.env.FABRICATOR_QUEUE_URL;
-  });
-
-  test('returns parsed queue items from SQS messages', async () => {
-    sqsMock.on(ReceiveMessageCommand).resolves({
-      Messages: [
-        {
-          MessageId: 'msg-1',
-          Body: JSON.stringify({
-            orchestration_id: 'orch-1',
-            agent_input: { taskDetails: 'Build something' },
-          }),
-          Attributes: {
-            SentTimestamp: '1700000000000',
-            ApproximateReceiveCount: '0',
-          },
-        },
+  test('Scans (bounded) and maps rows when no projectId is given', async () => {
+    ddbMock.on(ScanCommand).resolves({
+      Items: [
+        row({ agentUseId: 'req-1', submittedAt: '2026-06-01T00:00:00.000Z' }),
+        row({
+          agentUseId: 'req-2',
+          status: 'COMPLETED',
+          agentName: 'AgentTwo',
+          agentId: 'AgentTwo',
+          submittedAt: '2026-06-02T00:00:00.000Z',
+        }),
       ],
     });
 
-    const result = await handler({ info: { fieldName: 'getFabricatorQueue' } } as any);
+    const result = await handler({ info: { fieldName: 'getFabricatorQueue' }, arguments: {} } as any);
 
+    expect(ddbMock.commandCalls(ScanCommand)).toHaveLength(1);
+    expect(ddbMock.commandCalls(QueryCommand)).toHaveLength(0);
+    expect(ddbMock.commandCalls(ScanCommand)[0].args[0].input.Limit).toBeDefined();
+    // Sorted by submittedAt descending → req-2 first.
+    expect(result.map((r) => r.requestId)).toEqual(['req-2', 'req-1']);
+    expect(result[0]).toMatchObject({
+      requestId: 'req-2',
+      agentName: 'AgentTwo',
+      status: 'COMPLETED',
+      taskDescription: 'do a thing',
+      submittedAt: '2026-06-02T00:00:00.000Z',
+      metadata: { orchestrationId: '0', agentId: 'AgentTwo' },
+    });
+  });
+
+  test('Queries by PK=orchestrationId when projectId is provided', async () => {
+    ddbMock.on(QueryCommand).resolves({
+      Items: [row({ agentUseId: 'req-9', status: 'FAILED', errorMessage: 'boom' })],
+    });
+
+    const result = await handler({
+      info: { fieldName: 'getFabricatorQueue' },
+      arguments: { projectId: 'proj-42' },
+    } as any);
+
+    expect(ddbMock.commandCalls(QueryCommand)).toHaveLength(1);
+    expect(ddbMock.commandCalls(ScanCommand)).toHaveLength(0);
+    const qInput = ddbMock.commandCalls(QueryCommand)[0].args[0].input;
+    expect(qInput.ExpressionAttributeValues).toMatchObject({ ':pk': 'proj-42' });
     expect(result).toHaveLength(1);
-    expect(result[0].requestId).toBe('orch-1');
-    expect(result[0].status).toBe('PENDING');
-    expect(result[0].taskDescription).toBe('Build something');
+    expect(result[0]).toMatchObject({
+      requestId: 'req-9',
+      status: 'FAILED',
+      errorMessage: 'boom',
+    });
   });
 
-  test('marks items as PROCESSING when receive count > 0', async () => {
-    sqsMock.on(ReceiveMessageCommand).resolves({
-      Messages: [
+  test('falls back agentName to agentId when agentName is absent', async () => {
+    ddbMock.on(ScanCommand).resolves({
+      Items: [
         {
-          MessageId: 'msg-2',
-          Body: JSON.stringify({ orchestration_id: 'orch-2', agent_input: {} }),
-          Attributes: { SentTimestamp: '1700000000000', ApproximateReceiveCount: '2' },
+          orchestrationId: '0',
+          agentUseId: 'req-1',
+          status: 'PROCESSING',
+          agentId: 'FabricatedAgentX',
+          updatedAt: '2026-06-10T00:00:00.000Z',
         },
       ],
     });
 
-    const result = await handler({} as any);
-    expect(result[0].status).toBe('PROCESSING');
+    const result = await handler({ info: { fieldName: 'getFabricatorQueue' }, arguments: {} } as any);
+
+    expect(result[0].agentName).toBe('FabricatedAgentX');
   });
 
-  test('returns empty array when queue is empty', async () => {
-    sqsMock.on(ReceiveMessageCommand).resolves({ Messages: [] });
-    const result = await handler({} as any);
+  test('falls back agentName to agentUseId when only agentUseId is present', async () => {
+    ddbMock.on(ScanCommand).resolves({
+      Items: [
+        {
+          orchestrationId: '0',
+          agentUseId: 'agent-use-77',
+          status: 'PROCESSING',
+          updatedAt: '2026-06-10T00:00:00.000Z',
+        },
+      ],
+    });
+
+    const result = await handler({ info: { fieldName: 'getFabricatorQueue' }, arguments: {} } as any);
+
+    expect(result[0].agentName).toBe('agent-use-77');
+  });
+
+  test('falls back submittedAt to updatedAt when submittedAt is absent', async () => {
+    ddbMock.on(ScanCommand).resolves({
+      Items: [
+        {
+          orchestrationId: '0',
+          agentUseId: 'req-1',
+          status: 'PROCESSING',
+          agentId: 'FabricatedAgentX',
+          updatedAt: '2026-06-10T12:34:56.000Z',
+        },
+      ],
+    });
+
+    const result = await handler({ info: { fieldName: 'getFabricatorQueue' }, arguments: {} } as any);
+
+    expect(result[0].submittedAt).toBe('2026-06-10T12:34:56.000Z');
+  });
+
+  test('uses agentName and submittedAt as-is when both are present', async () => {
+    ddbMock.on(ScanCommand).resolves({
+      Items: [
+        row({
+          agentName: 'RealName',
+          agentId: 'OtherId',
+          submittedAt: '2026-06-05T00:00:00.000Z',
+          updatedAt: '2026-06-10T00:00:00.000Z',
+        }),
+      ],
+    });
+
+    const result = await handler({ info: { fieldName: 'getFabricatorQueue' }, arguments: {} } as any);
+
+    expect(result[0].agentName).toBe('RealName');
+    expect(result[0].submittedAt).toBe('2026-06-05T00:00:00.000Z');
+  });
+
+  test('returns [] on a DynamoDB error', async () => {
+    ddbMock.on(ScanCommand).rejects(new Error('ddb down'));
+    const result = await handler({ info: { fieldName: 'getFabricatorQueue' }, arguments: {} } as any);
     expect(result).toEqual([]);
   });
 
-  test('returns empty array on SQS error', async () => {
-    sqsMock.on(ReceiveMessageCommand).rejects(new Error('SQS down'));
-    const result = await handler({} as any);
+  test('returns [] when FABRICATION_JOBS_TABLE is unset', async () => {
+    delete process.env.FABRICATION_JOBS_TABLE;
+    const result = await handler({ info: { fieldName: 'getFabricatorQueue' }, arguments: {} } as any);
     expect(result).toEqual([]);
+    expect(ddbMock.commandCalls(ScanCommand)).toHaveLength(0);
   });
 });

--- a/backend/src/lambda/__tests__/fabricator-request-resolver.test.ts
+++ b/backend/src/lambda/__tests__/fabricator-request-resolver.test.ts
@@ -1,163 +1,104 @@
 /**
- * Tests for fabricator-request-resolver Lambda
+ * Tests for fabricator-request-resolver Lambda.
+ *
+ * The resolver enqueues a fabrication request onto SQS and then writes a
+ * PENDING row to the durable fabrication-jobs table so the queue UI shows
+ * real per-agent status instead of peeking SQS. The status write is
+ * best-effort: a failure must NOT fail the enqueue (the caller already got a
+ * queued request).
  */
 import { SQSClient, SendMessageCommand } from '@aws-sdk/client-sqs';
+import { DynamoDBDocumentClient, PutCommand } from '@aws-sdk/lib-dynamodb';
 import { mockClient } from 'aws-sdk-client-mock';
 
 const sqsMock = mockClient(SQSClient);
+const ddbMock = mockClient(DynamoDBDocumentClient);
+
+process.env.FABRICATOR_QUEUE_URL = 'https://sqs.test/queue';
+process.env.FABRICATION_JOBS_TABLE = 'citadel-fabrication-jobs-test';
 
 import { handler } from '../fabricator-request-resolver';
+
+const makeEvent = (fieldName: string, input: any) => ({
+  info: { fieldName },
+  arguments: { input },
+  identity: { sub: 'user-123' },
+});
 
 describe('fabricator-request-resolver', () => {
   beforeEach(() => {
     sqsMock.reset();
-    process.env.FABRICATOR_QUEUE_URL = 'https://sqs.us-west-2.amazonaws.com/123/test-queue';
+    ddbMock.reset();
+    sqsMock.on(SendMessageCommand).resolves({ MessageId: 'm1' });
+    ddbMock.on(PutCommand).resolves({});
+    process.env.FABRICATION_JOBS_TABLE = 'citadel-fabrication-jobs-test';
   });
 
-  afterEach(() => {
-    delete process.env.FABRICATOR_QUEUE_URL;
+  test('writes a PENDING row after the SQS send for agent creation', async () => {
+    const result = await handler(
+      makeEvent('requestAgentCreation', {
+        agentName: 'InvoiceParser',
+        taskDescription: 'Parse invoices from PDFs',
+      }),
+    );
+
+    expect(result.success).toBe(true);
+    expect(sqsMock.commandCalls(SendMessageCommand)).toHaveLength(1);
+
+    const puts = ddbMock.commandCalls(PutCommand);
+    expect(puts).toHaveLength(1);
+    const item = puts[0].args[0].input.Item!;
+    expect(puts[0].args[0].input.TableName).toBe('citadel-fabrication-jobs-test');
+    expect(item.orchestrationId).toBe('0');
+    expect(item.agentUseId).toBe(result.requestId);
+    expect(item.status).toBe('PENDING');
+    expect(item.agentName).toBe('InvoiceParser');
+    expect(item.requestType).toBe('agent-creation');
+    expect(item.requestedBy).toBe('user-123');
+    expect(typeof item.submittedAt).toBe('string');
+    expect(typeof item.updatedAt).toBe('string');
+    expect(typeof item.ttl).toBe('number');
+    expect(item.ttl).toBeGreaterThan(Math.floor(Date.now() / 1000));
   });
 
-  const makeEvent = (fieldName: string, args: any, identity?: any) => ({
-    info: { fieldName },
-    arguments: args,
-    identity,
+  test('truncates taskDescription to ~500 chars', async () => {
+    const longDesc = 'x'.repeat(2000);
+    await handler(
+      makeEvent('requestAgentCreation', {
+        agentName: 'BigAgent',
+        taskDescription: longDesc,
+      }),
+    );
+    const item = ddbMock.commandCalls(PutCommand)[0].args[0].input.Item!;
+    expect((item.taskDescription as string).length).toBeLessThanOrEqual(500);
   });
 
-  describe('requestAgentCreation', () => {
-    test('sends message to SQS and returns success', async () => {
-      sqsMock.on(SendMessageCommand).resolves({});
+  test('does NOT fail the enqueue when the status write throws', async () => {
+    ddbMock.on(PutCommand).rejects(new Error('ddb down'));
 
-      const result = await handler(makeEvent('requestAgentCreation', {
-        input: {
-          agentName: 'TestAgent',
-          taskDescription: 'Build a test agent',
-          tools: ['tool1'],
-          integrations: ['int1'],
-          dataStores: ['ds1'],
-        },
-      }, {
-        sub: 'test-user-123',
-        username: 'ignored-when-sub-present',
-        'custom:organization': 'org-42',
-      }));
+    const result = await handler(
+      makeEvent('requestToolCreation', {
+        toolName: 'CsvExporter',
+        toolDescription: 'Export rows to CSV',
+      }),
+    );
 
-      expect(result.success).toBe(true);
-      expect(result.requestId).toBeDefined();
-
-      const calls = sqsMock.commandCalls(SendMessageCommand);
-      expect(calls).toHaveLength(1);
-      const body = JSON.parse(calls[0].args[0].input.MessageBody!);
-      expect(body.node).toBe('fabricator');
-      expect(body.agent_input.taskDetails).toContain('TestAgent');
-      expect(body.agent_input.taskDetails).toContain('tool1');
-      expect(body.requested_by).toBe('test-user-123');
-      expect(body.org_id).toBe('org-42');
-    });
-
-    test('works without optional fields', async () => {
-      sqsMock.on(SendMessageCommand).resolves({});
-
-      const result = await handler(makeEvent('requestAgentCreation', {
-        input: { agentName: 'Simple', taskDescription: 'Simple agent' },
-      }, { sub: 'test-user-123' }));
-
-      expect(result.success).toBe(true);
-    });
-
-    test('falls back to username when identity has no sub (IAM auth mode)', async () => {
-      sqsMock.on(SendMessageCommand).resolves({});
-
-      await handler(makeEvent('requestAgentCreation', {
-        input: { agentName: 'IamAgent', taskDescription: 'Built via IAM' },
-      }, { username: 'iam-caller' }));
-
-      const body = JSON.parse(
-        sqsMock.commandCalls(SendMessageCommand)[0].args[0].input.MessageBody!,
-      );
-      expect(body.requested_by).toBe('iam-caller');
-    });
-
-    test("falls back to 'unknown' when event.identity is undefined", async () => {
-      sqsMock.on(SendMessageCommand).resolves({});
-
-      await handler(makeEvent('requestAgentCreation', {
-        input: { agentName: 'Anon', taskDescription: 'No identity' },
-      })); // no identity supplied
-
-      const body = JSON.parse(
-        sqsMock.commandCalls(SendMessageCommand)[0].args[0].input.MessageBody!,
-      );
-      expect(body.requested_by).toBe('unknown');
-    });
-
-    test('sets org_id to null when identity has no org claim', async () => {
-      sqsMock.on(SendMessageCommand).resolves({});
-
-      // Identity carries a sub (so requested_by resolves) but no
-      // custom:organization claim — org_id must serialize as null so the
-      // Python side can fall back to '' rather than blocking fabrication.
-      await handler(makeEvent('requestAgentCreation', {
-        input: { agentName: 'NoOrgAgent', taskDescription: 'No org claim' },
-      }, { sub: 'user-without-org' }));
-
-      const body = JSON.parse(
-        sqsMock.commandCalls(SendMessageCommand)[0].args[0].input.MessageBody!,
-      );
-      expect(body.org_id).toBeNull();
-    });
-
-    test('reads org_id from identity.claims fallback shape', async () => {
-      sqsMock.on(SendMessageCommand).resolves({});
-
-      // Some AppSync proxy/IAM modes nest claims under identity.claims.
-      // auth-event's readClaim tolerates that shape.
-      await handler(makeEvent('requestAgentCreation', {
-        input: { agentName: 'ClaimsAgent', taskDescription: 'Claims nested' },
-      }, {
-        sub: 'user-1',
-        claims: { 'custom:organization': 'org-from-claims' },
-      }));
-
-      const body = JSON.parse(
-        sqsMock.commandCalls(SendMessageCommand)[0].args[0].input.MessageBody!,
-      );
-      expect(body.org_id).toBe('org-from-claims');
-    });
+    expect(result.success).toBe(true);
+    expect(result.requestId).toBeDefined();
+    expect(sqsMock.commandCalls(SendMessageCommand)).toHaveLength(1);
   });
 
-  describe('requestToolCreation', () => {
-    test('sends tool creation message to SQS', async () => {
-      sqsMock.on(SendMessageCommand).resolves({});
+  test('skips the status write when FABRICATION_JOBS_TABLE is unset', async () => {
+    delete process.env.FABRICATION_JOBS_TABLE;
 
-      const result = await handler(makeEvent('requestToolCreation', {
-        input: { toolName: 'TestTool', toolDescription: 'A test tool' },
-      }, { sub: 'tool-requester-42', 'custom:organization': 'org-tool' }));
+    const result = await handler(
+      makeEvent('requestAgentCreation', {
+        agentName: 'NoTableAgent',
+        taskDescription: 'No table configured',
+      }),
+    );
 
-      expect(result.success).toBe(true);
-      const body = JSON.parse(
-        sqsMock.commandCalls(SendMessageCommand)[0].args[0].input.MessageBody!
-      );
-      expect(body.agent_input.taskDetails).toContain('TestTool');
-      expect(body.requested_by).toBe('tool-requester-42');
-      expect(body.org_id).toBe('org-tool');
-    });
-
-    test('tool creation sets org_id to null when claim absent', async () => {
-      sqsMock.on(SendMessageCommand).resolves({});
-
-      await handler(makeEvent('requestToolCreation', {
-        input: { toolName: 'NoOrgTool', toolDescription: 'No org claim' },
-      }, { sub: 'tool-requester-99' }));
-
-      const body = JSON.parse(
-        sqsMock.commandCalls(SendMessageCommand)[0].args[0].input.MessageBody!,
-      );
-      expect(body.org_id).toBeNull();
-    });
-  });
-
-  test('throws on unknown field', async () => {
-    await expect(handler(makeEvent('unknownField', {}))).rejects.toThrow('Unknown field');
+    expect(result.success).toBe(true);
+    expect(ddbMock.commandCalls(PutCommand)).toHaveLength(0);
   });
 });

--- a/backend/src/lambda/agent-config-resolver.ts
+++ b/backend/src/lambda/agent-config-resolver.ts
@@ -1,6 +1,6 @@
 import { DynamoDBClient } from '@aws-sdk/client-dynamodb';
 import { DynamoDBDocumentClient, GetCommand, PutCommand, ScanCommand, DeleteCommand, UpdateCommand } from '@aws-sdk/lib-dynamodb';
-import { RegistryService } from '../services/registry-service';
+import { RegistryService, RegistryRecordStatusValues } from '../services/registry-service';
 import { extractOrgFromEvent, isAdminFromEvent } from '../utils/auth-event';
 
 const client = new DynamoDBClient({});
@@ -106,6 +106,9 @@ export const handler = async (event: any) => {
 
       case 'searchAgentConfigs':
         return await searchAgentConfigsRegistry(event.arguments.query);
+
+      case 'activateProjectAgents':
+        return await activateProjectAgents(event.arguments.projectId);
 
       default:
         throw new Error(`Unknown field: ${fieldName}`);
@@ -457,6 +460,78 @@ async function searchAgentConfigsRegistry(query: string): Promise<AgentConfig[]>
   const registryService = getRegistryService();
   const records = await registryService.searchResources('agent', query);
   return records.map((record) => registryService.mapToAgentConfig(record));
+}
+
+/** Result of a bulk activation, grouped by per-agent outcome. */
+interface ActivateAgentsResult {
+  activated: string[];
+  failed: string[];
+  alreadyActive: string[];
+}
+
+/**
+ * Parses a Registry record's customDescriptorContent JSON and returns its
+ * `sourceProjectId` when present. Malformed/missing metadata yields
+ * `undefined` rather than throwing — a single bad record must not abort the
+ * whole bulk operation.
+ */
+function extractSourceProjectId(customDescriptorContent: string | undefined): string | undefined {
+  if (!customDescriptorContent) return undefined;
+  try {
+    const parsed = JSON.parse(customDescriptorContent);
+    if (parsed && typeof parsed === 'object' && typeof parsed.sourceProjectId === 'string') {
+      return parsed.sourceProjectId;
+    }
+  } catch {
+    // Malformed metadata — treat as "no project" and skip.
+  }
+  return undefined;
+}
+
+/**
+ * Activates every fabricated agent belonging to a project in one operation.
+ *
+ * Fabricated agents carry their originating `sourceProjectId` inside the
+ * Registry record's customDescriptorContent JSON. We list all agent records,
+ * select those matching `projectId`, and submit each non-active one for
+ * approval (APPROVED == active via toInternalState). Already-active agents
+ * (status APPROVED) are reported separately and skipped.
+ *
+ * Per-agent failures are swallowed and collected so one bad agent never
+ * aborts activation of the rest; the whole operation never throws on a
+ * single-agent error. Logs are kept free of record metadata (which can
+ * carry org-scoped fields) — only the agent name and error message are
+ * logged.
+ */
+export async function activateProjectAgents(projectId: string): Promise<ActivateAgentsResult> {
+  const registryService = getRegistryService();
+  const result: ActivateAgentsResult = { activated: [], failed: [], alreadyActive: [] };
+
+  const records = await registryService.listResources('agent');
+  for (const record of records) {
+    if (extractSourceProjectId(record.customDescriptorContent) !== projectId) {
+      continue;
+    }
+
+    const name = record.name || record.recordId;
+
+    if (record.status === RegistryRecordStatusValues.APPROVED) {
+      result.alreadyActive.push(name);
+      continue;
+    }
+
+    try {
+      await registryService.updateResourceStatus('agent', record.recordId, RegistryRecordStatusValues.APPROVED);
+      result.activated.push(name);
+    } catch (err) {
+      console.error(
+        `Failed to activate agent "${name}": ${err instanceof Error ? err.message : String(err)}`,
+      );
+      result.failed.push(name);
+    }
+  }
+
+  return result;
 }
 
 async function listAgentConfigs(): Promise<AgentConfig[]> {

--- a/backend/src/lambda/agent-message-handler.ts
+++ b/backend/src/lambda/agent-message-handler.ts
@@ -388,8 +388,16 @@ export const handler = async (
 ): Promise<void> => {
   console.log("Received event:", JSON.stringify(event, null, 2));
 
-  // Idempotency check using EventBridge event ID
-  const { executed } = await idempotencyGuard.withIdempotency(event.id, async () => {
+  // Idempotency key: prefer the logical message id (deterministic for the
+  // document-indexed trigger, a unique uuid for every other producer) so that
+  // duplicate emits of the same logical message collapse to one execution.
+  // Fall back to the EventBridge envelope id for any producer that omits a
+  // messageId (events.ts publishEvent does not set one), preserving today's
+  // behaviour for those.
+  const idempotencyKey = event.detail?.messageId ?? event.id;
+
+  // Idempotency check using the logical message id (falls back to event.id).
+  const { executed } = await idempotencyGuard.withIdempotency(idempotencyKey, async () => {
     const { projectId, agentId, message, messageId, userId, metadata } =
       event.detail;
 
@@ -481,6 +489,6 @@ export const handler = async (
   }); // end idempotency guard
 
   if (!executed) {
-    console.log("Skipping duplicate event:", event.id);
+    console.log("Skipping duplicate event:", idempotencyKey);
   }
 };

--- a/backend/src/lambda/document-ingestion-poller.ts
+++ b/backend/src/lambda/document-ingestion-poller.ts
@@ -1,0 +1,257 @@
+/**
+ * document-ingestion-poller
+ *
+ * Scheduled (rate(1 minute)) handler that drives non-terminal ingestion jobs to
+ * completion independently of the browser:
+ *   - queries the jobs-table GSI for rows still in a pollable status;
+ *   - re-polls Bedrock for their current status (chunked <=10);
+ *   - on SUCCESS: emits the assessment trigger EXACTLY ONCE (conditional write
+ *     on `triggered = false`), swallowing the conditional-check race as a logged
+ *     no-op;
+ *   - on FAILED: persists the status/reason, emits a failure event + metric;
+ *   - on age > MAX_AGE_MS: marks the row TIMEOUT;
+ *   - otherwise: records the latest transient status.
+ */
+
+import { DynamoDBClient } from '@aws-sdk/client-dynamodb';
+import { DynamoDBDocumentClient, QueryCommand, UpdateCommand } from '@aws-sdk/lib-dynamodb';
+import { CloudWatchClient, PutMetricDataCommand } from '@aws-sdk/client-cloudwatch';
+import {
+  POLLABLE_STATUSES,
+  classifyStatus,
+  normalizeTransientStatus,
+  pollStatuses,
+  emitAssessmentTrigger,
+  emitIngestionFailed,
+  isDocumentAbsent,
+  startIngestion,
+} from './document-ingestion-shared';
+
+const ddb = DynamoDBDocumentClient.from(new DynamoDBClient({}));
+const cloudwatch = new CloudWatchClient({});
+
+const STATUS_INDEX = 'status-index';
+const DEFAULT_MAX_AGE_MS = 10 * 60 * 1000; // 10 minutes
+const DEFAULT_START_GRACE_MS = 2 * 60 * 1000; // 2 minutes
+const START_MAX_ATTEMPTS = 3; // cap re-kicks of a stale STARTING row
+
+interface JobRow {
+  projectId: string;
+  documentKey: string;
+  fileName: string;
+  size?: number;
+  fileType?: string;
+  status: string;
+  statusReason?: string;
+  triggered?: boolean;
+  attempts?: number;
+  createdAt: string;
+  updatedAt?: string;
+}
+
+/** Query each pollable status partition on the GSI and dedupe by job key. */
+async function loadNonTerminalJobs(tableName: string): Promise<JobRow[]> {
+  const byKey = new Map<string, JobRow>();
+  for (const status of POLLABLE_STATUSES) {
+    let nextToken: Record<string, any> | undefined;
+    do {
+      const resp = await ddb.send(new QueryCommand({
+        TableName: tableName,
+        IndexName: STATUS_INDEX,
+        KeyConditionExpression: '#status = :status',
+        ExpressionAttributeNames: { '#status': 'status' },
+        ExpressionAttributeValues: { ':status': status },
+        ExclusiveStartKey: nextToken,
+      }));
+      for (const item of (resp.Items ?? []) as JobRow[]) {
+        byKey.set(`${item.projectId}#${item.documentKey}`, item);
+      }
+      nextToken = resp.LastEvaluatedKey;
+    } while (nextToken);
+  }
+  return [...byKey.values()];
+}
+
+async function markSuccessAndTrigger(tableName: string, job: JobRow, status: string): Promise<void> {
+  // Spec ordering: emit first, then claim with a conditional write. The
+  // conditional write makes the persisted `triggered` flag exactly-once; a lost
+  // race (another poller already flipped it) is swallowed as a logged no-op.
+  await emitAssessmentTrigger(job.projectId, job.documentKey, job.fileName, job.size ?? 0, job.fileType ?? '');
+  try {
+    await ddb.send(new UpdateCommand({
+      TableName: tableName,
+      Key: { projectId: job.projectId, documentKey: job.documentKey },
+      UpdateExpression: 'SET #status = :status, triggered = :true, updatedAt = :now',
+      ConditionExpression: 'triggered = :false',
+      ExpressionAttributeNames: { '#status': 'status' },
+      ExpressionAttributeValues: {
+        ':status': status,
+        ':true': true,
+        ':false': false,
+        ':now': new Date().toISOString(),
+      },
+    }));
+  } catch (err: any) {
+    if (err?.name === 'ConditionalCheckFailedException') {
+      console.log('poller: trigger already claimed by a concurrent poll, no-op', {
+        documentKey: job.documentKey,
+      });
+      return;
+    }
+    console.error('poller: failed to persist trigger state', { documentKey: job.documentKey, err });
+    throw err;
+  }
+}
+
+async function markFailed(tableName: string, job: JobRow, status: string, reason: string | undefined, environment: string): Promise<void> {
+  try {
+    await ddb.send(new UpdateCommand({
+      TableName: tableName,
+      Key: { projectId: job.projectId, documentKey: job.documentKey },
+      UpdateExpression: 'SET #status = :status, statusReason = :reason, updatedAt = :now',
+      ExpressionAttributeNames: { '#status': 'status' },
+      ExpressionAttributeValues: { ':status': status, ':reason': reason ?? null, ':now': new Date().toISOString() },
+    }));
+  } catch (err) {
+    console.error('poller: failed to persist FAILED status', { documentKey: job.documentKey, err });
+    throw err;
+  }
+  await emitIngestionFailed(job.projectId, job.documentKey, job.fileName, status, reason);
+  try {
+    await cloudwatch.send(new PutMetricDataCommand({
+      Namespace: 'Citadel/DocumentIngestion',
+      MetricData: [{
+        MetricName: 'IngestionFailed',
+        Value: 1,
+        Unit: 'Count',
+        Dimensions: [{ Name: 'Environment', Value: environment }],
+      }],
+    }));
+  } catch (err) {
+    console.error('poller: failed to emit CloudWatch metric', { documentKey: job.documentKey, err });
+  }
+}
+
+async function markTimeout(tableName: string, job: JobRow): Promise<void> {
+  try {
+    await ddb.send(new UpdateCommand({
+      TableName: tableName,
+      Key: { projectId: job.projectId, documentKey: job.documentKey },
+      UpdateExpression: 'SET #status = :status, updatedAt = :now',
+      ExpressionAttributeNames: { '#status': 'status' },
+      ExpressionAttributeValues: { ':status': 'TIMEOUT', ':now': new Date().toISOString() },
+    }));
+  } catch (err) {
+    console.error('poller: failed to persist TIMEOUT status', { documentKey: job.documentKey, err });
+    throw err;
+  }
+}
+
+async function markTransient(tableName: string, job: JobRow, status: string): Promise<void> {
+  try {
+    await ddb.send(new UpdateCommand({
+      TableName: tableName,
+      Key: { projectId: job.projectId, documentKey: job.documentKey },
+      UpdateExpression: 'SET #status = :status, attempts = if_not_exists(attempts, :zero) + :one, updatedAt = :now',
+      ExpressionAttributeNames: { '#status': 'status' },
+      ExpressionAttributeValues: {
+        ':status': normalizeTransientStatus(status),
+        ':zero': 0,
+        ':one': 1,
+        ':now': new Date().toISOString(),
+      },
+    }));
+  } catch (err) {
+    console.error('poller: failed to persist transient status', { documentKey: job.documentKey, err });
+    throw err;
+  }
+}
+
+/**
+ * Re-kick Bedrock ingestion for a stale STARTING row. The start Lambda can die
+ * after the conditional jobs-row create but before/while calling startIngestion,
+ * leaving a STARTING row whose document was never actually submitted. Re-start
+ * is safe (idempotent — stable customDocumentIdentifier). The row is left
+ * STARTING (still re-pollable) with `attempts` bumped so the START_MAX_ATTEMPTS
+ * cap eventually stops the re-kicks and the row rides to TIMEOUT via MAX_AGE_MS.
+ */
+async function reKickStart(tableName: string, job: JobRow): Promise<void> {
+  await startIngestion(job.projectId, job.documentKey);
+  try {
+    await ddb.send(new UpdateCommand({
+      TableName: tableName,
+      Key: { projectId: job.projectId, documentKey: job.documentKey },
+      UpdateExpression: 'SET #status = :status, attempts = if_not_exists(attempts, :zero) + :one, updatedAt = :now',
+      ExpressionAttributeNames: { '#status': 'status' },
+      ExpressionAttributeValues: {
+        ':status': 'STARTING',
+        ':zero': 0,
+        ':one': 1,
+        ':now': new Date().toISOString(),
+      },
+    }));
+  } catch (err) {
+    console.error('poller: failed to persist re-kick state', { documentKey: job.documentKey, err });
+    throw err;
+  }
+}
+
+export const handler = async (): Promise<{ processed: number }> => {
+  const tableName = process.env.INGESTION_TABLE!;
+  const environment = process.env.ENVIRONMENT ?? 'dev';
+  const maxAgeMs = Number(process.env.MAX_AGE_MS ?? DEFAULT_MAX_AGE_MS);
+  const startGraceMs = Number(process.env.START_GRACE_MS ?? DEFAULT_START_GRACE_MS);
+
+  const jobs = await loadNonTerminalJobs(tableName);
+  console.log('poller: non-terminal jobs', { count: jobs.length });
+  if (jobs.length === 0) return { processed: 0 };
+
+  const statusMap = await pollStatuses(jobs.map((j) => j.documentKey));
+  const now = Date.now();
+
+  for (const job of jobs) {
+    // Isolate per-job failures so one bad row doesn't abort the whole sweep.
+    try {
+      const polled = statusMap.get(job.documentKey);
+      const status = polled?.status ?? job.status;
+      const disposition = classifyStatus(status);
+
+      if (disposition === 'SUCCESS') {
+        if (job.triggered) {
+          console.log('poller: already triggered, skipping', { documentKey: job.documentKey });
+          continue;
+        }
+        await markSuccessAndTrigger(tableName, job, status);
+      } else if (disposition === 'FAILED') {
+        await markFailed(tableName, job, status, polled?.statusReason, environment);
+      } else {
+        const createdMs = Date.parse(job.createdAt);
+        const ageMs = Number.isNaN(createdMs) ? NaN : now - createdMs;
+        if (!Number.isNaN(ageMs) && ageMs > maxAgeMs) {
+          await markTimeout(tableName, job);
+        } else if (
+          job.status === 'STARTING' &&
+          isDocumentAbsent(polled) &&
+          !Number.isNaN(ageMs) &&
+          ageMs > startGraceMs &&
+          (job.attempts ?? 0) < START_MAX_ATTEMPTS
+        ) {
+          // Stale STARTING row past the grace window whose document is still
+          // absent from the KB: ingestion likely never actually started. Re-kick
+          // it (idempotent), capped by attempts so it can't loop forever.
+          console.log('poller: re-kicking stale STARTING job', {
+            documentKey: job.documentKey,
+            attempts: job.attempts ?? 0,
+          });
+          await reKickStart(tableName, job);
+        } else {
+          await markTransient(tableName, job, status);
+        }
+      }
+    } catch (err) {
+      console.error('poller: job processing error', { documentKey: job.documentKey, err });
+    }
+  }
+
+  return { processed: jobs.length };
+};

--- a/backend/src/lambda/document-ingestion-shared.ts
+++ b/backend/src/lambda/document-ingestion-shared.ts
@@ -1,0 +1,269 @@
+/**
+ * Shared document-ingestion primitives.
+ *
+ * Centralizes the Bedrock Knowledge Base ingestion logic that was previously
+ * inlined in document-upload-resolver.ts so the resolver, the S3-triggered
+ * ingest-start handler, and the scheduled poller all share one implementation.
+ *
+ * Status model (authoritative for the jobs table + poller):
+ *   SUCCESS   = INDEXED | PARTIALLY_INDEXED      -> assessment trigger eligible
+ *   FAILED    = FAILED | METADATA_UPDATE_FAILED
+ *   TRANSIENT = everything else (STARTING, IN_PROGRESS, PENDING, NOT_FOUND,
+ *               IGNORED, ...)
+ *
+ * Note on IGNORED: Bedrock's IngestKnowledgeBaseDocuments synchronously returns
+ * IGNORED ("You submitted multiple requests for the same document") when the
+ * customDocumentIdentifier already exists in the KB. That is a DEDUP/NO-OP, not
+ * a failure — the document is actually indexed. IGNORED is therefore TRANSIENT;
+ * the poller resolves the true status by GetKnowledgeBaseDocuments.
+ */
+
+import {
+  BedrockAgentClient,
+  IngestKnowledgeBaseDocumentsCommand,
+  GetKnowledgeBaseDocumentsCommand,
+} from '@aws-sdk/client-bedrock-agent';
+import { SSMClient, GetParameterCommand } from '@aws-sdk/client-ssm';
+import { EventBridgeClient, PutEventsCommand } from '@aws-sdk/client-eventbridge';
+
+const bedrockAgentClient = new BedrockAgentClient({});
+const ssmClient = new SSMClient({});
+const eventBridgeClient = new EventBridgeClient({});
+
+/** Bedrock statuses that mean the document is usable for the assessment. */
+export const SUCCESS_STATUSES = new Set<string>(['INDEXED', 'PARTIALLY_INDEXED']);
+
+/**
+ * Bedrock statuses that are terminal failures.
+ *
+ * IGNORED is intentionally NOT here: it is a Bedrock dedup/no-op (the document
+ * already exists and is indexed), resolved by polling GetKnowledgeBaseDocuments
+ * for the true status — so classifyStatus('IGNORED') is TRANSIENT and
+ * isTerminal('IGNORED') is false.
+ */
+export const FAILED_STATUSES = new Set<string>(['FAILED', 'METADATA_UPDATE_FAILED']);
+
+/**
+ * Statuses the poller keeps re-polling. The jobs-table GSI is partitioned on
+ * `status`, so transient rows are normalized into this bounded set to keep the
+ * GSI query surface finite (see normalizeTransientStatus).
+ */
+export const POLLABLE_STATUSES = ['STARTING', 'IN_PROGRESS', 'PENDING'] as const;
+
+/** Our own terminal markers layered on top of the Bedrock failure set. */
+export const TERMINAL_STATUSES = new Set<string>([
+  ...SUCCESS_STATUSES,
+  ...FAILED_STATUSES,
+  'TIMEOUT',
+]);
+
+export type IngestionDisposition = 'SUCCESS' | 'FAILED' | 'TRANSIENT';
+
+/**
+ * Total mapping from any Bedrock (or internal) status string to a disposition.
+ * Defined over every possible string input — unknown/empty inputs map to
+ * TRANSIENT so the poller keeps watching rather than silently dropping them.
+ */
+export function classifyStatus(status: string | undefined | null): IngestionDisposition {
+  if (status && SUCCESS_STATUSES.has(status)) return 'SUCCESS';
+  if (status && FAILED_STATUSES.has(status)) return 'FAILED';
+  return 'TRANSIENT';
+}
+
+/** True if the row's status is terminal and should not be re-polled. */
+export function isTerminal(status: string | undefined | null): boolean {
+  return !!status && TERMINAL_STATUSES.has(status);
+}
+
+/**
+ * Map an observed transient Bedrock status to one of POLLABLE_STATUSES so the
+ * GSI partition stays bounded and the poller can always re-query the row.
+ */
+export function normalizeTransientStatus(status: string | undefined | null): string {
+  if (status && (POLLABLE_STATUSES as readonly string[]).includes(status)) return status;
+  return 'IN_PROGRESS';
+}
+
+let _kbId: string | undefined;
+let _dsId: string | undefined;
+
+/** Resolve (and container-cache) the Knowledge Base + data source ids from SSM. */
+export async function getKbIds(): Promise<{ kbId: string; dsId: string }> {
+  if (!_kbId || !_dsId) {
+    const [kb, ds] = await Promise.all([
+      ssmClient.send(new GetParameterCommand({ Name: process.env.KB_ID_PARAM! })),
+      ssmClient.send(new GetParameterCommand({ Name: process.env.DS_ID_PARAM! })),
+    ]);
+    _kbId = kb.Parameter!.Value!;
+    _dsId = ds.Parameter!.Value!;
+  }
+  return { kbId: _kbId, dsId: _dsId };
+}
+
+/** Reset the cached KB/DS ids — test seam only. */
+export function _resetKbIdCache(): void {
+  _kbId = undefined;
+  _dsId = undefined;
+}
+
+export interface StartIngestionResult {
+  documentKey: string;
+  status: string;
+  statusReason?: string;
+}
+
+/**
+ * Start Bedrock ingestion of a single S3 document into the custom KB data source.
+ * Returns the synchronously-reported status (often STARTING/IN_PROGRESS, but
+ * can be FAILED immediately for malformed input).
+ */
+export async function startIngestion(projectId: string, documentKey: string): Promise<StartIngestionResult> {
+  const { kbId, dsId } = await getKbIds();
+  const bucket = process.env.DOCUMENT_BUCKET!;
+  const s3Uri = `s3://${bucket}/${documentKey}`;
+  const parts = documentKey.split('/');
+  const filename = parts.slice(1).join('/');
+
+  const command = new IngestKnowledgeBaseDocumentsCommand({
+    knowledgeBaseId: kbId,
+    dataSourceId: dsId,
+    documents: [{
+      content: {
+        dataSourceType: 'CUSTOM',
+        custom: {
+          customDocumentIdentifier: { id: documentKey },
+          sourceType: 'S3_LOCATION',
+          s3Location: { uri: s3Uri },
+        },
+      },
+      metadata: {
+        type: 'IN_LINE_ATTRIBUTE',
+        inlineAttributes: [
+          { key: 'session_id', value: { type: 'STRING', stringValue: projectId } },
+          { key: 'filename', value: { type: 'STRING', stringValue: filename } },
+        ],
+      },
+    }],
+  });
+
+  const response = (await bedrockAgentClient.send(command)) as any;
+  console.log('startIngestion Bedrock response:', JSON.stringify(response));
+  const detail = response.documentDetails?.[0] ?? response.ingestedDocuments?.[0];
+  const status = (typeof detail?.status === 'string' ? detail?.status : detail?.status?.status) ?? 'UNKNOWN';
+  const statusReason = detail?.statusReason ?? detail?.status?.statusReason;
+  const failureReasons = detail?.failureReasons ?? detail?.status?.failureReasons;
+  if (status === 'FAILED' || statusReason || (failureReasons && failureReasons.length)) {
+    console.error('startIngestion document ingestion problem:', { documentKey, status, statusReason, failureReasons });
+  }
+  return { documentKey, status, statusReason: statusReason ?? (failureReasons?.length ? String(failureReasons[0]) : undefined) };
+}
+
+export interface PolledStatus {
+  status: string;
+  statusReason?: string;
+  updatedAt?: string;
+}
+
+/**
+ * True when a polled result indicates the document is not present in the KB
+ * yet: no row returned (undefined), an empty status, or an explicit NOT_FOUND.
+ * Used by the poller to detect a stale STARTING job whose Bedrock ingestion was
+ * never actually started (the start Lambda died after creating the jobs row).
+ */
+export function isDocumentAbsent(polled: PolledStatus | undefined): boolean {
+  return !polled || !polled.status || polled.status === 'NOT_FOUND';
+}
+
+/**
+ * Fetch current KB ingestion status for the given document keys.
+ * The GetKnowledgeBaseDocuments API caps identifiers per call, so we chunk in
+ * groups of <=10. Returns a map keyed by documentKey.
+ */
+export async function pollStatuses(documentKeys: string[]): Promise<Map<string, PolledStatus>> {
+  const statusMap = new Map<string, PolledStatus>();
+  if (documentKeys.length === 0) return statusMap;
+
+  const { kbId, dsId } = await getKbIds();
+  for (let i = 0; i < documentKeys.length; i += 10) {
+    const chunk = documentKeys.slice(i, i + 10);
+    const resp = await bedrockAgentClient.send(new GetKnowledgeBaseDocumentsCommand({
+      knowledgeBaseId: kbId,
+      dataSourceId: dsId,
+      documentIdentifiers: chunk.map((id) => ({ dataSourceType: 'CUSTOM', custom: { id } })),
+    }));
+    for (const detail of resp.documentDetails || []) {
+      const id = detail.identifier?.custom?.id;
+      if (id) {
+        statusMap.set(id, {
+          status: detail.status ?? 'UNKNOWN',
+          statusReason: detail.statusReason,
+          updatedAt: detail.updatedAt?.toISOString(),
+        });
+      }
+    }
+  }
+  return statusMap;
+}
+
+/**
+ * Emit the assessment-trigger EventBridge event for a successfully-indexed
+ * document. Callers are responsible for the exactly-once guard.
+ */
+export async function emitAssessmentTrigger(
+  projectId: string,
+  documentKey: string,
+  fileName: string,
+  fileSize: number,
+  fileType: string,
+): Promise<void> {
+  const eventBusName = process.env.EVENT_BUS_NAME!;
+  const sizeKB = Math.round((fileSize || 0) / 1024);
+  await eventBridgeClient.send(new PutEventsCommand({
+    Entries: [{
+      Source: 'citadel',
+      DetailType: 'message.sent_to_agent',
+      Detail: JSON.stringify({
+        projectId,
+        agentId: 'agent_intake_single',
+        message: `A document has been uploaded and indexed: ${fileName} (${sizeKB}KB, ${fileType}). Extract information from it.`,
+        // Deterministic id derived from the document identity. The poller emits
+        // this trigger BEFORE the conditional `triggered=true` claim, so two
+        // overlapping runs can emit twice for the same document; a stable
+        // messageId lets the consumer (agent-message-handler) dedupe logical
+        // duplicates rather than treating each unique EventBridge envelope id
+        // as a distinct message.
+        messageId: `doc-indexed-${projectId}-${documentKey}`,
+        userId: 'system',
+        timestamp: new Date().toISOString(),
+        metadata: { documentKey, trigger: 'document_indexed' },
+      }),
+      EventBusName: eventBusName,
+    }],
+  }));
+}
+
+/** Emit a failure event when a document ingestion terminally fails. */
+export async function emitIngestionFailed(
+  projectId: string,
+  documentKey: string,
+  fileName: string,
+  status: string,
+  statusReason?: string,
+): Promise<void> {
+  const eventBusName = process.env.EVENT_BUS_NAME!;
+  await eventBridgeClient.send(new PutEventsCommand({
+    Entries: [{
+      Source: 'citadel.documents',
+      DetailType: 'document.ingestion.failed',
+      Detail: JSON.stringify({
+        projectId,
+        documentKey,
+        fileName,
+        status,
+        statusReason: statusReason ?? null,
+        timestamp: new Date().toISOString(),
+      }),
+      EventBusName: eventBusName,
+    }],
+  }));
+}

--- a/backend/src/lambda/document-ingestion-start.ts
+++ b/backend/src/lambda/document-ingestion-start.ts
@@ -1,0 +1,249 @@
+/**
+ * document-ingestion-start
+ *
+ * S3 ObjectCreated handler. When a document lands in the upload bucket this
+ * Lambda:
+ *   1. skips keys that are not real user uploads (generated design/planning
+ *      artifacts, keys without a project prefix);
+ *   2. idempotently creates an authoritative jobs row in the ingestion table;
+ *   3. starts Bedrock ingestion;
+ *   4. records the synchronously-returned status/reason on the row.
+ *
+ * This moves the upload->ingest step off the browser entirely: ingestion is
+ * server-authoritative and is no longer initiated by any client mutation
+ * (Bedrock ingestion is idempotent per documentKey).
+ */
+
+import { S3Event, S3EventRecord } from 'aws-lambda';
+import { DynamoDBClient } from '@aws-sdk/client-dynamodb';
+import { DynamoDBDocumentClient, PutCommand, UpdateCommand, GetCommand } from '@aws-sdk/lib-dynamodb';
+import { startIngestion, POLLABLE_STATUSES, classifyStatus, normalizeTransientStatus } from './document-ingestion-shared';
+
+const ddb = DynamoDBDocumentClient.from(new DynamoDBClient({}));
+
+/** Relative-path prefixes (after the projectId/) that are generated artifacts. */
+const EXCLUDED_PREFIXES = ['design/', 'planning/'];
+
+const EXTENSION_CONTENT_TYPES: Record<string, string> = {
+  pdf: 'application/pdf',
+  docx: 'application/vnd.openxmlformats-officedocument.wordprocessingml.document',
+  txt: 'text/plain',
+  md: 'text/markdown',
+};
+
+interface ParsedKey {
+  projectId: string;
+  fileName: string;
+}
+
+/** Decode an S3 event object key (spaces are '+', other chars %XX-encoded). */
+export function decodeS3Key(rawKey: string): string {
+  return decodeURIComponent(rawKey.replace(/\+/g, ' '));
+}
+
+/**
+ * Decide whether a key represents a user-uploaded document we should ingest.
+ * Uploads are stored flat as `${projectId}/${fileName}`. Generated artifacts
+ * live under `${projectId}/design/...` or `${projectId}/planning/...` and must
+ * be skipped to avoid feeding the assessment its own outputs.
+ */
+export function shouldProcessKey(key: string): boolean {
+  const slash = key.indexOf('/');
+  if (slash <= 0) return false; // no project prefix, or leading slash
+  const relative = key.slice(slash + 1);
+  if (relative.length === 0) return false; // the prefix "folder" placeholder itself
+  for (const prefix of EXCLUDED_PREFIXES) {
+    if (relative.startsWith(prefix)) return false;
+  }
+  return true;
+}
+
+export function parseKey(key: string): ParsedKey {
+  const slash = key.indexOf('/');
+  return { projectId: key.slice(0, slash), fileName: key.slice(slash + 1) };
+}
+
+function inferFileType(fileName: string): string {
+  const ext = fileName.split('.').pop()?.toLowerCase() ?? '';
+  return EXTENSION_CONTENT_TYPES[ext] ?? '';
+}
+
+/**
+ * Start Bedrock ingestion and record the synchronously-returned status on the
+ * jobs row. Shared by both the fresh-create path and the retry-reset path so
+ * the ingest + status-update logic lives in exactly one place.
+ *
+ * ingest-start NEVER writes a non-pollable terminal status: the poller is the
+ * single authority for SUCCESS/FAILED detection and the exactly-once assessment
+ * trigger, and only re-polls rows in a POLLABLE status.
+ *   - A genuine hard failure (classifyStatus === 'FAILED', e.g. FAILED /
+ *     METADATA_UPDATE_FAILED) is persisted as-is with its statusReason.
+ *   - Everything else (STARTING/IN_PROGRESS/PENDING/IGNORED/INDEXED/UNKNOWN/...)
+ *     is normalized to a POLLABLE status with no statusReason.
+ *     IngestKnowledgeBaseDocuments can synchronously return IGNORED (dedup) or
+ *     even INDEXED; neither is written terminally because the poller owns
+ *     INDEXED detection + the exactly-once trigger and only re-polls pollable
+ *     rows.
+ * A thrown exception, by contrast, IS a real failure and is persisted FAILED.
+ */
+async function runIngestion(tableName: string, projectId: string, documentKey: string): Promise<void> {
+  try {
+    const result = await startIngestion(projectId, documentKey);
+    const now = new Date().toISOString();
+    if (classifyStatus(result.status) === 'FAILED') {
+      await ddb.send(new UpdateCommand({
+        TableName: tableName,
+        Key: { projectId, documentKey },
+        UpdateExpression: 'SET #status = :status, statusReason = :reason, attempts = :one, updatedAt = :now',
+        ExpressionAttributeNames: { '#status': 'status' },
+        ExpressionAttributeValues: {
+          ':status': result.status,
+          ':reason': result.statusReason ?? null,
+          ':one': 1,
+          ':now': now,
+        },
+      }));
+    } else {
+      // Non-failure synchronous status -> persist a pollable status, no reason.
+      await ddb.send(new UpdateCommand({
+        TableName: tableName,
+        Key: { projectId, documentKey },
+        UpdateExpression: 'SET #status = :status, attempts = :one, updatedAt = :now REMOVE statusReason',
+        ExpressionAttributeNames: { '#status': 'status' },
+        ExpressionAttributeValues: {
+          ':status': normalizeTransientStatus(result.status),
+          ':one': 1,
+          ':now': now,
+        },
+      }));
+    }
+  } catch (err) {
+    // Persist the failure on the row so the poller/UI can see it; never swallow.
+    console.error('ingest-start: startIngestion failed', { documentKey, err });
+    try {
+      await ddb.send(new UpdateCommand({
+        TableName: tableName,
+        Key: { projectId, documentKey },
+        UpdateExpression: 'SET #status = :status, statusReason = :reason, updatedAt = :now',
+        ExpressionAttributeNames: { '#status': 'status' },
+        ExpressionAttributeValues: {
+          ':status': 'FAILED',
+          ':reason': err instanceof Error ? err.message : String(err),
+          ':now': new Date().toISOString(),
+        },
+      }));
+    } catch (updateErr) {
+      console.error('ingest-start: failed to persist ingestion failure', { documentKey, updateErr });
+    }
+  }
+}
+
+async function processRecord(record: S3EventRecord): Promise<void> {
+  const tableName = process.env.INGESTION_TABLE!;
+  const rawKey = record.s3?.object?.key;
+  if (!rawKey) {
+    console.warn('ingest-start: record without object key, skipping');
+    return;
+  }
+  const documentKey = decodeS3Key(rawKey);
+
+  if (!shouldProcessKey(documentKey)) {
+    console.log('ingest-start: skipping non-upload key', { documentKey });
+    return;
+  }
+
+  const { projectId, fileName } = parseKey(documentKey);
+  const size = record.s3.object.size ?? 0;
+  const fileType = inferFileType(fileName);
+  const now = new Date().toISOString();
+
+  // 1. Idempotently create the jobs row. On a conditional miss the row already
+  //    exists; we then distinguish a genuine in-flight duplicate from a retry
+  //    of a terminal/stale row (a previously FAILED/INDEXED document being
+  //    re-uploaded must be re-ingested, not silently skipped).
+  try {
+    await ddb.send(new PutCommand({
+      TableName: tableName,
+      Item: {
+        projectId,
+        documentKey,
+        fileName,
+        size,
+        fileType,
+        status: 'STARTING',
+        triggered: false,
+        attempts: 0,
+        createdAt: now,
+        updatedAt: now,
+      },
+      ConditionExpression: 'attribute_not_exists(projectId) AND attribute_not_exists(documentKey)',
+    }));
+  } catch (err: any) {
+    if (err?.name !== 'ConditionalCheckFailedException') {
+      console.error('ingest-start: failed to create jobs row', { documentKey, err });
+      throw err;
+    }
+
+    // Row already exists — inspect it to decide skip vs. retry.
+    const existing = await ddb.send(new GetCommand({
+      TableName: tableName,
+      Key: { projectId, documentKey },
+    }));
+    const existingStatus = existing.Item?.status as string | undefined;
+
+    // In-flight (STARTING/IN_PROGRESS/PENDING) => genuine duplicate S3 delivery.
+    if (existingStatus && (POLLABLE_STATUSES as readonly string[]).includes(existingStatus)) {
+      console.log('ingest-start: skipping in-flight duplicate', { documentKey, status: existingStatus });
+      return;
+    }
+
+    // Terminal or stale (FAILED, INDEXED, TIMEOUT, missing, ...) => explicit
+    // RETRY. Reset the row to STARTING, guarded on the status we just read so a
+    // concurrent change is not clobbered, then re-run the shared ingest block.
+    const statusGuardSet = existingStatus !== undefined;
+    try {
+      await ddb.send(new UpdateCommand({
+        TableName: tableName,
+        Key: { projectId, documentKey },
+        UpdateExpression:
+          'SET #status = :starting, triggered = :false, attempts = :zero, #size = :size, fileType = :fileType, updatedAt = :now REMOVE statusReason',
+        ConditionExpression: statusGuardSet ? '#status = :expected' : 'attribute_not_exists(#status)',
+        ExpressionAttributeNames: { '#status': 'status', '#size': 'size' },
+        ExpressionAttributeValues: {
+          ':starting': 'STARTING',
+          ':false': false,
+          ':zero': 0,
+          ':size': size,
+          ':fileType': fileType,
+          ':now': now,
+          ...(statusGuardSet ? { ':expected': existingStatus } : {}),
+        },
+      }));
+    } catch (resetErr: any) {
+      if (resetErr?.name === 'ConditionalCheckFailedException') {
+        // Lost the race: another invocation already claimed/changed the row.
+        console.log('ingest-start: reset lost race, another invocation handling retry', { documentKey });
+        return;
+      }
+      console.error('ingest-start: failed to reset jobs row for retry', { documentKey, resetErr });
+      throw resetErr;
+    }
+    console.log('ingest-start: reset terminal/stale row for retry', { documentKey, previousStatus: existingStatus ?? null });
+  }
+
+  // 2. Kick off Bedrock ingestion and record the returned status/reason. Shared
+  //    by both the fresh-create path and the retry-reset path above.
+  await runIngestion(tableName, projectId, documentKey);
+}
+
+export const handler = async (event: S3Event): Promise<void> => {
+  console.log('ingest-start event:', JSON.stringify({ records: event.Records?.length ?? 0 }));
+  for (const record of event.Records ?? []) {
+    // Isolate per-record failures so one bad object doesn't drop the batch.
+    try {
+      await processRecord(record);
+    } catch (err) {
+      console.error('ingest-start: record processing error', err);
+    }
+  }
+};

--- a/backend/src/lambda/document-upload-resolver.ts
+++ b/backend/src/lambda/document-upload-resolver.ts
@@ -1,41 +1,30 @@
 /**
  * Document Upload Resolver Lambda
- * Generates pre-signed URLs for uploading documents to S3
+ * Generates pre-signed URLs for uploading documents to S3 and surfaces
+ * ingestion status. Ingestion itself is server-authoritative: an S3
+ * ObjectCreated event drives ingestion and a poller fires the assessment
+ * trigger, so this resolver no longer ingests or notifies. listProjectDocuments
+ * / getDocumentIngestionStatus read the authoritative DynamoDB jobs table as the
+ * source of truth, falling back to a direct Bedrock KB query when the table is
+ * unavailable (or not yet wired in this env).
  */
 
 import { AppSyncResolverHandler } from "aws-lambda";
 import { S3Client, PutObjectCommand, DeleteObjectCommand, ListObjectsV2Command } from "@aws-sdk/client-s3";
 import { getSignedUrl } from "@aws-sdk/s3-request-presigner";
-import { BedrockAgentClient, IngestKnowledgeBaseDocumentsCommand, GetKnowledgeBaseDocumentsCommand, DeleteKnowledgeBaseDocumentsCommand } from "@aws-sdk/client-bedrock-agent";
-import { SSMClient, GetParameterCommand } from "@aws-sdk/client-ssm";
-import { EventBridgeClient, PutEventsCommand } from "@aws-sdk/client-eventbridge";
-import { v4 as uuidv4 } from "uuid";
+import { BedrockAgentClient, DeleteKnowledgeBaseDocumentsCommand } from "@aws-sdk/client-bedrock-agent";
+import { DynamoDBClient } from "@aws-sdk/client-dynamodb";
+import { DynamoDBDocumentClient, GetCommand, QueryCommand } from "@aws-sdk/lib-dynamodb";
 import { getUserId } from "../utils/appsync";
+import {
+  getKbIds,
+  pollStatuses,
+} from "./document-ingestion-shared";
 
 const s3Client = new S3Client({});
 const bedrockAgentClient = new BedrockAgentClient({});
-const ssmClient = new SSMClient({});
-const eventBridgeClient = new EventBridgeClient({});
+const ddb = DynamoDBDocumentClient.from(new DynamoDBClient({}));
 const DOCUMENT_BUCKET = process.env.DOCUMENT_BUCKET!;
-const KB_ID_PARAM = process.env.KB_ID_PARAM!;
-const DS_ID_PARAM = process.env.DS_ID_PARAM!;
-const EVENT_BUS_NAME = process.env.EVENT_BUS_NAME!;
-
-// Cached at Lambda container level
-let _kbId: string | undefined;
-let _dsId: string | undefined;
-
-async function getKbIds(): Promise<{ kbId: string; dsId: string }> {
-  if (!_kbId || !_dsId) {
-    const [kb, ds] = await Promise.all([
-      ssmClient.send(new GetParameterCommand({ Name: KB_ID_PARAM })),
-      ssmClient.send(new GetParameterCommand({ Name: DS_ID_PARAM })),
-    ]);
-    _kbId = kb.Parameter!.Value!;
-    _dsId = ds.Parameter!.Value!;
-  }
-  return { kbId: _kbId, dsId: _dsId };
-}
 
 interface GenerateUploadUrlInput {
   projectId: string;
@@ -85,7 +74,6 @@ async function generateUploadUrl(
   const docParts = fileName.split(".");
   const fileExtension = docParts.pop();
   const docName = docParts.at(0);
-  //const documentId = uuidv4();
   const documentKey = `${projectId}/${docName}.${fileExtension}`;
 
   console.log("Generating upload URL:", {
@@ -126,96 +114,111 @@ async function generateUploadUrl(
   };
 }
 
-/**
- * Ingest an uploaded document into the Bedrock Knowledge Base
- */
-async function ingestDocument(projectId: string, documentKey: string): Promise<{ documentKey: string; status: string }> {
-  const { kbId, dsId } = await getKbIds();
-  const s3Uri = `s3://${DOCUMENT_BUCKET}/${documentKey}`;
-  const parts = documentKey.split('/');
-  const filename = parts.slice(1).join('/');
+interface ProjectDocument {
+  documentKey: string;
+  fileName: string;
+  size: number;
+  lastModified: string;
+  status?: string;
+  statusReason?: string;
+}
 
-  const command = new IngestKnowledgeBaseDocumentsCommand({
-    knowledgeBaseId: kbId,
-    dataSourceId: dsId,
-    documents: [{
-      content: {
-        dataSourceType: 'CUSTOM',
-        custom: {
-          customDocumentIdentifier: { id: documentKey },
-          sourceType: 'S3_LOCATION',
-          s3Location: { uri: s3Uri },
-        },
-      },
-      metadata: {
-        type: 'IN_LINE_ATTRIBUTE',
-        inlineAttributes: [
-          { key: 'session_id', value: { type: 'STRING', stringValue: projectId } },
-          { key: 'filename',   value: { type: 'STRING', stringValue: filename } },
-        ],
-      },
-    }],
-  });
-
-  const response = await bedrockAgentClient.send(command) as any;
-  const status = response.ingestedDocuments?.[0]?.status?.status ?? 'UNKNOWN';
-  return { documentKey, status };
+/** Read jobs rows for a project keyed by documentKey. Throws on table errors. */
+async function readJobsForProject(projectId: string): Promise<Map<string, { status: string; statusReason?: string }>> {
+  const tableName = process.env.INGESTION_TABLE;
+  const map = new Map<string, { status: string; statusReason?: string }>();
+  if (!tableName) {
+    // Table not wired into this environment yet — signal "no data" so the
+    // caller falls back to the KB query path.
+    throw new Error("INGESTION_TABLE not configured");
+  }
+  let nextToken: Record<string, any> | undefined;
+  do {
+    const resp = await ddb.send(new QueryCommand({
+      TableName: tableName,
+      KeyConditionExpression: "projectId = :pid",
+      ExpressionAttributeValues: { ":pid": projectId },
+      ExclusiveStartKey: nextToken,
+    }));
+    for (const item of (resp.Items ?? []) as any[]) {
+      if (item.documentKey) map.set(item.documentKey, { status: item.status ?? "UNKNOWN", statusReason: item.statusReason });
+    }
+    nextToken = resp.LastEvaluatedKey;
+  } while (nextToken);
+  return map;
 }
 
 /**
- * List documents uploaded for a project
+ * List documents uploaded for a project. The jobs table is the source of
+ * truth for ingestion status; on any table read failure we degrade gracefully
+ * to a direct Bedrock KB query (never failing the whole list).
  */
-async function listProjectDocuments(projectId: string): Promise<{ documentKey: string; fileName: string; size: number; lastModified: string }[]> {
+async function listProjectDocuments(projectId: string): Promise<ProjectDocument[]> {
   const response = await s3Client.send(new ListObjectsV2Command({ Bucket: DOCUMENT_BUCKET, Prefix: `${projectId}/` }));
-  return (response.Contents || []).map((obj) => ({
+  const items: ProjectDocument[] = (response.Contents || []).map((obj) => ({
     documentKey: obj.Key!,
     fileName: obj.Key!.split('/').slice(1).join('/'),
     size: obj.Size ?? 0,
     lastModified: obj.LastModified?.toISOString() ?? '',
+    status: undefined,
+    statusReason: undefined,
   }));
+
+  if (items.length === 0) return items;
+
+  // Preferred path: authoritative jobs table.
+  try {
+    const jobs = await readJobsForProject(projectId);
+    return items.map((item) => {
+      const j = jobs.get(item.documentKey);
+      return { ...item, status: j?.status ?? 'NOT_FOUND', statusReason: j?.statusReason };
+    });
+  } catch (tableErr) {
+    console.error('listProjectDocuments: jobs-table read failed, falling back to KB query', tableErr);
+  }
+
+  // Fallback path: direct Bedrock KB query (chunked <=10 inside pollStatuses).
+  try {
+    const statusMap = await pollStatuses(items.map((it) => it.documentKey));
+    return items.map((item) => {
+      const s = statusMap.get(item.documentKey);
+      return { ...item, status: s?.status ?? 'NOT_FOUND', statusReason: s?.statusReason };
+    });
+  } catch (err) {
+    console.error('listProjectDocuments: failed to fetch KB ingestion status, degrading to UNKNOWN', err);
+    return items.map((item) => ({ ...item, status: 'UNKNOWN' }));
+  }
 }
 
 /**
- * Get document ingestion status from Bedrock KB
+ * Get document ingestion status. Reads the jobs table first (source of truth),
+ * falling back to a direct Bedrock KB query when the row is absent or the table
+ * read fails.
  */
 async function getDocumentIngestionStatus(documentKey: string): Promise<{ documentKey: string; status: string; statusReason?: string; updatedAt?: string }> {
-  const { kbId, dsId } = await getKbIds();
-  const response = await bedrockAgentClient.send(new GetKnowledgeBaseDocumentsCommand({
-    knowledgeBaseId: kbId,
-    dataSourceId: dsId,
-    documentIdentifiers: [{ dataSourceType: 'CUSTOM', custom: { id: documentKey } }],
-  }));
-  const detail = response.documentDetails?.[0];
-  return {
-    documentKey,
-    status: detail?.status ?? 'NOT_FOUND',
-    statusReason: detail?.statusReason,
-    updatedAt: detail?.updatedAt?.toISOString(),
-  };
-}
+  const tableName = process.env.INGESTION_TABLE;
+  const projectId = documentKey.split('/')[0];
 
-/**
- * Notify agent that a document is ready via EventBridge
- */
-async function notifyDocumentReady(projectId: string, documentKey: string, fileName: string, fileSize: number, fileType: string): Promise<{ success: boolean }> {
-  const sizeKB = Math.round(fileSize / 1024);
-  await eventBridgeClient.send(new PutEventsCommand({
-    Entries: [{
-      Source: 'citadel',
-      DetailType: 'message.sent_to_agent',
-      Detail: JSON.stringify({
-        projectId,
-        agentId: 'agent_intake_single',
-        message: `A document has been uploaded and indexed: ${fileName} (${sizeKB}KB, ${fileType}). Extract information from it.`,
-        messageId: `doc-upload-${uuidv4()}`,
-        userId: 'system',
-        timestamp: new Date().toISOString(),
-        metadata: { documentKey, trigger: 'document_indexed' },
-      }),
-      EventBusName: EVENT_BUS_NAME,
-    }],
-  }));
-  return { success: true };
+  if (tableName) {
+    try {
+      const resp = await ddb.send(new GetCommand({ TableName: tableName, Key: { projectId, documentKey } }));
+      if (resp.Item) {
+        return {
+          documentKey,
+          status: resp.Item.status ?? 'UNKNOWN',
+          statusReason: resp.Item.statusReason,
+          updatedAt: resp.Item.updatedAt,
+        };
+      }
+    } catch (err) {
+      console.error('getDocumentIngestionStatus: jobs-table read failed, falling back to KB query', err);
+    }
+  }
+
+  // Fallback: direct KB query.
+  const statusMap = await pollStatuses([documentKey]);
+  const s = statusMap.get(documentKey);
+  return { documentKey, status: s?.status ?? 'NOT_FOUND', statusReason: s?.statusReason, updatedAt: s?.updatedAt };
 }
 
 /**
@@ -251,12 +254,8 @@ export const handler: AppSyncResolverHandler<any, any> = async (event) => {
         return await generateUploadUrl(args.input, userId);
       case "listProjectDocuments":
         return await listProjectDocuments(args.projectId);
-      case "ingestDocument":
-        return await ingestDocument(args.projectId, args.documentKey);
       case "getDocumentIngestionStatus":
         return await getDocumentIngestionStatus(args.documentKey);
-      case "notifyDocumentReady":
-        return await notifyDocumentReady(args.projectId, args.documentKey, args.fileName, args.fileSize, args.fileType);
       case "deleteDocument":
         return await deleteDocument(args.projectId, args.documentKey);
       default:

--- a/backend/src/lambda/fabricator-queue-resolver.ts
+++ b/backend/src/lambda/fabricator-queue-resolver.ts
@@ -1,68 +1,104 @@
-import { SQSClient, ReceiveMessageCommand } from '@aws-sdk/client-sqs';
+import { DynamoDBClient } from '@aws-sdk/client-dynamodb';
+import {
+  DynamoDBDocumentClient,
+  QueryCommand,
+  ScanCommand,
+} from '@aws-sdk/lib-dynamodb';
 import { AppSyncResolverEvent } from 'aws-lambda';
 
-const sqs = new SQSClient({});
-const FABRICATOR_QUEUE_URL = process.env.FABRICATOR_QUEUE_URL!;
+const docClient = DynamoDBDocumentClient.from(new DynamoDBClient({}));
+
+// Durable per-agent fabrication status table (citadel-fabrication-jobs-${env}).
+// Read at call-time so unit tests can toggle it per case.
+function getFabricationJobsTable(): string | undefined {
+  return process.env.FABRICATION_JOBS_TABLE;
+}
+
+// Upper bound on rows returned by the unfiltered (Scan) path so the queue
+// view stays cheap regardless of table size.
+const SCAN_LIMIT = 100;
+
+type FabricationStatus = 'PENDING' | 'PROCESSING' | 'COMPLETED' | 'FAILED';
 
 interface FabricationQueueItem {
   requestId: string;
   agentName: string;
   taskDescription: string;
-  status: 'PENDING' | 'PROCESSING';
+  status: FabricationStatus;
   submittedAt: string;
+  errorMessage?: string;
   metadata?: Record<string, any>;
 }
 
+/**
+ * Map a fabrication-jobs DynamoDB row to the GraphQL FabricationQueueItem the
+ * frontend drawer already renders. agentUseId is the per-request key the UI
+ * uses as requestId; orchestrationId + agentId travel in metadata.
+ */
+function mapRow(item: Record<string, any>): FabricationQueueItem {
+  return {
+    requestId: item.agentUseId,
+    agentName: item.agentName || item.agentId || item.agentUseId || 'Unknown Agent',
+    taskDescription: item.taskDescription || 'No description',
+    status: (item.status as FabricationStatus) || 'PENDING',
+    submittedAt: item.submittedAt || item.updatedAt || new Date(0).toISOString(),
+    errorMessage: item.errorMessage,
+    metadata: {
+      orchestrationId: item.orchestrationId,
+      agentId: item.agentId,
+    },
+  };
+}
+
+/**
+ * Read the durable fabrication-jobs table as the source of truth for per-agent
+ * fabrication status. Replaces the previous SQS ReceiveMessage approach, which
+ * was unreliable and competed with the fabricator consumer for messages.
+ *
+ * - With projectId: Query PK=orchestrationId (the intake session/project id).
+ * - Without projectId: Scan with a bounded Limit.
+ * Rows are sorted by submittedAt descending. On any error (or when the table
+ * env var is unset) returns [] to preserve the resolver's existing contract.
+ */
 export const handler = async (
-  event: AppSyncResolverEvent<any>
+  event: AppSyncResolverEvent<{ projectId?: string }>,
 ): Promise<FabricationQueueItem[]> => {
-  console.log('Querying fabricator queue:', JSON.stringify(event, null, 2));
+  const table = getFabricationJobsTable();
+  if (!table) {
+    console.warn('FABRICATION_JOBS_TABLE unset; returning empty fabricator queue');
+    return [];
+  }
+
+  const projectId = event.arguments?.projectId;
 
   try {
-    // Receive messages from SQS without removing them
-    const command = new ReceiveMessageCommand({
-      QueueUrl: FABRICATOR_QUEUE_URL,
-      MaxNumberOfMessages: 10,
-      VisibilityTimeout: 0, // Don't hide messages
-      AttributeNames: ['All'],
-    });
+    let items: Record<string, any>[] = [];
+    if (projectId) {
+      const response = await docClient.send(
+        new QueryCommand({
+          TableName: table,
+          KeyConditionExpression: 'orchestrationId = :pk',
+          ExpressionAttributeValues: { ':pk': projectId },
+        }),
+      );
+      items = response.Items || [];
+    } else {
+      const response = await docClient.send(
+        new ScanCommand({
+          TableName: table,
+          Limit: SCAN_LIMIT,
+        }),
+      );
+      items = response.Items || [];
+    }
 
-    const response = await sqs.send(command);
-    const messages = response.Messages || [];
-
-    console.log(`Retrieved ${messages.length} messages from queue`);
-
-    // Parse and format queue items
-    const queueItems: FabricationQueueItem[] = messages.map(message => {
-      const body = JSON.parse(message.Body || '{}');
-      const agentInput = body.agent_input || {};
-      const sentTimestamp = message.Attributes?.SentTimestamp;
-      const receiveCount = parseInt(message.Attributes?.ApproximateReceiveCount || '0');
-
-      // Extract agent name from task details (first word or fallback)
-      const taskDetails = agentInput.taskDetails || '';
-      const agentName = taskDetails.split(' ')[0] || 'Unknown Agent';
-
-      return {
-        requestId: body.orchestration_id || message.MessageId || '',
-        agentName,
-        taskDescription: taskDetails || 'No description',
-        status: receiveCount > 0 ? 'PROCESSING' : 'PENDING',
-        submittedAt: sentTimestamp 
-          ? new Date(parseInt(sentTimestamp)).toISOString()
-          : new Date().toISOString(),
-        metadata: {
-          messageId: message.MessageId,
-          receiveCount,
-        },
-      };
-    });
-
-    console.log(`Formatted ${queueItems.length} queue items`);
+    const queueItems = items.map(mapRow);
+    queueItems.sort((a, b) => (a.submittedAt < b.submittedAt ? 1 : -1));
+    console.log(`Returning ${queueItems.length} fabrication queue items`);
     return queueItems;
   } catch (error) {
-    console.error('Error querying fabricator queue:', error);
-    // Return empty array on failure as per requirements
+    console.error('Error reading fabrication-jobs table:', error);
+    // Preserve the existing contract: empty array on failure.
     return [];
   }
 };

--- a/backend/src/lambda/fabricator-request-resolver.ts
+++ b/backend/src/lambda/fabricator-request-resolver.ts
@@ -1,6 +1,6 @@
 import { SQSClient, SendMessageCommand } from '@aws-sdk/client-sqs';
 import { DynamoDBClient } from '@aws-sdk/client-dynamodb';
-import { DynamoDBDocumentClient, GetCommand } from '@aws-sdk/lib-dynamodb';
+import { DynamoDBDocumentClient, GetCommand, PutCommand } from '@aws-sdk/lib-dynamodb';
 import { randomUUID } from 'crypto';
 import type { RegistryRecord } from '../services/registry-service';
 import { extractOrgFromEvent } from '../utils/auth-event';
@@ -17,6 +17,79 @@ const FABRICATOR_QUEUE_URL = process.env.FABRICATOR_QUEUE_URL!;
 // time) so unit tests can toggle the env var per case.
 function getAppsTable(): string | undefined {
   return process.env.APPS_TABLE;
+}
+
+// Durable per-agent fabrication status table (citadel-fabrication-jobs-${env}).
+// Read at call-time (not module-load) so unit tests can toggle the env var per
+// case. When unset, the status write is skipped entirely so the resolver stays
+// backward-compatible in environments that haven't wired the table yet.
+function getFabricationJobsTable(): string | undefined {
+  return process.env.FABRICATION_JOBS_TABLE;
+}
+
+// ~7 day TTL in epoch seconds — keeps the queue table self-pruning so old
+// terminal rows don't accumulate. DynamoDB TTL deletes are best-effort/async.
+const FABRICATION_JOBS_TTL_SECONDS = 7 * 24 * 60 * 60;
+// DynamoDB row stores at most this many chars of the task description so the
+// UI has enough context without bloating the item.
+const TASK_DESCRIPTION_MAX = 500;
+
+/**
+ * Derive a human-readable agent/tool name from the composed taskDetails block.
+ * The resolver builds taskDetails with an "Agent Name:" / "Tool Name:" line,
+ * so we prefer that; otherwise fall back to the first non-empty line.
+ */
+function deriveAgentName(taskDetails: string): string {
+  const match = taskDetails.match(/(?:Agent|Tool) Name:\s*(.+)/);
+  if (match && match[1].trim()) {
+    return match[1].trim();
+  }
+  const firstLine = taskDetails.split('\n').find((l) => l.trim().length > 0);
+  return firstLine ? firstLine.trim() : 'Unknown Agent';
+}
+
+/**
+ * Best-effort PENDING-row write to the durable fabrication-jobs table.
+ *
+ * Mirrors the UI producer path: orchestrationId is '0' (direct request, not
+ * part of an intake orchestration) and agentUseId is the generated requestId.
+ * A status-write failure NEVER fails the enqueue — the SQS message is already
+ * accepted, so we log and swallow rather than re-raising.
+ */
+async function writePendingFabricationStatus(
+  requestId: string,
+  taskDetails: string,
+  requestType: 'agent-creation' | 'tool-creation',
+  requestedBy: string,
+): Promise<void> {
+  const table = getFabricationJobsTable();
+  if (!table) {
+    console.log('FABRICATION_JOBS_TABLE unset; skipping fabrication status write');
+    return;
+  }
+  const now = new Date().toISOString();
+  try {
+    await docClient.send(
+      new PutCommand({
+        TableName: table,
+        Item: {
+          orchestrationId: '0',
+          agentUseId: requestId,
+          status: 'PENDING',
+          agentName: deriveAgentName(taskDetails),
+          taskDescription: taskDetails.slice(0, TASK_DESCRIPTION_MAX),
+          requestType,
+          requestedBy: requestedBy || 'unknown',
+          submittedAt: now,
+          updatedAt: now,
+          ttl: Math.floor(Date.now() / 1000) + FABRICATION_JOBS_TTL_SECONDS,
+        },
+      }),
+    );
+  } catch (error) {
+    // Eventually-consistent: never block the enqueue on a status-write error.
+    console.error('Failed to write PENDING fabrication status (continuing):', error);
+  }
 }
 
 /**
@@ -168,6 +241,11 @@ async function sendToFabricatorQueue(
     console.error('Error sending message to Fabricator queue:', error);
     throw new Error(`Failed to send request to Fabricator: ${error}`);
   }
+
+  // Durable PENDING status row so the queue UI reflects this request even
+  // after the consumer pulls the SQS message. Best-effort — never fails the
+  // enqueue.
+  await writePendingFabricationStatus(requestId, taskDetails, requestType, requestedBy);
 }
 
 /**

--- a/backend/src/schema/schema.graphql
+++ b/backend/src/schema/schema.graphql
@@ -30,7 +30,7 @@ type Query {
   generateReportDownloadUrl(projectId: ID!): ReportDownloadUrl
   listIntegrations(orgId: String!, integrationType: IntegrationType, status: IntegrationStatus): [Integration]
   getIntegration(integrationId: ID!): Integration
-  getFabricatorQueue: [FabricationQueueItem]
+  getFabricatorQueue(projectId: ID): [FabricationQueueItem]
   listDataStores(orgId: String!, category: DataStoreCategory): [DataStore]
   getDataStore(dataStoreId: ID!): DataStore
   getDataStoreStats(orgId: String!): DataStoreStats
@@ -128,13 +128,12 @@ type Mutation {
   publishConversationMessage(input: PublishMessageInput!): ConversationMessage
     @aws_iam
   generateDocumentUploadUrl(input: GenerateUploadUrlInput!): DocumentUploadUrl
-  ingestDocument(projectId: ID!, documentKey: String!): IngestDocumentResult
-  notifyDocumentReady(projectId: ID!, documentKey: String!, fileName: String!, fileSize: Int!, fileType: String!): NotifyDocumentReadyResult
   deleteDocument(projectId: ID!, documentKey: String!): DocumentDeleteResult
   generateDocumentPdf(projectId: ID!, documentKey: String!): ReportDownloadUrl
   updateAgentConfig(input: UpdateAgentConfigInput!): AgentConfig
   createAgentConfig(input: CreateAgentConfigInput!): AgentConfig
   deleteAgentConfig(agentId: String!): DeleteAgentConfigResult
+  activateProjectAgents(projectId: ID!): ActivateAgentsResult
   updateAgentCode(input: UpdateAgentCodeInput!): AgentCode
   updateToolConfig(input: UpdateToolConfigInput!): ToolConfig
   createToolConfig(input: CreateToolConfigInput!): ToolConfig
@@ -411,20 +410,11 @@ type DocumentUploadUrl {
   expiresIn: Int!
 }
 
-type IngestDocumentResult {
-  documentKey: String!
-  status: String!
-}
-
 type DocumentIngestionStatus {
   documentKey: String!
   status: String!
   statusReason: String
   updatedAt: String
-}
-
-type NotifyDocumentReadyResult {
-  success: Boolean!
 }
 
 type DocumentDeleteResult {
@@ -437,6 +427,8 @@ type ProjectDocumentItem {
   fileName: String!
   size: Int!
   lastModified: String!
+  status: String
+  statusReason: String
 }
 
 type ProjectDocument {
@@ -468,6 +460,12 @@ type AgentConfig {
 type DeleteAgentConfigResult {
   success: Boolean!
   message: String
+}
+
+type ActivateAgentsResult {
+  activated: [String!]!
+  failed: [String!]!
+  alreadyActive: [String!]!
 }
 
 type AgentCode {

--- a/backend/test/arbiter-stack-fabricator-reliability.test.ts
+++ b/backend/test/arbiter-stack-fabricator-reliability.test.ts
@@ -1,0 +1,137 @@
+/**
+ * Fabricator pipeline reliability (hardening)
+ *
+ * Two SQS->Lambda invariants that previously caused duplicate fabrication
+ * and premature DLQ delivery:
+ *
+ *   1. The fabricator queue's visibilityTimeout MUST strictly exceed the
+ *      FabricatorAgent Lambda's function timeout. Equal values guarantee an
+ *      SQS redelivery whenever an invocation runs near the timeout (a single
+ *      fabrication was observed at ~11 min against a 15-min timeout), which
+ *      stacks duplicate fabrications and prematurely drains the DLQ.
+ *
+ *   2. The SqsEventSource batchSize MUST be 1 so each Lambda invocation
+ *      processes exactly ONE fabrication message, bounding invocation
+ *      duration to a single agent rather than up to 10 stacked agents under
+ *      the SQS default batch size.
+ */
+import * as cdk from 'aws-cdk-lib';
+import { Template } from 'aws-cdk-lib/assertions';
+import * as dynamodb from 'aws-cdk-lib/aws-dynamodb';
+import * as events from 'aws-cdk-lib/aws-events';
+import { Bucket } from 'aws-cdk-lib/aws-s3';
+import * as path from 'path';
+import * as fs from 'fs';
+
+// CI + clean-checkout safety: stub the asset dirs that ArbiterStack expects.
+const assetDirs = [
+  path.resolve(__dirname, '../dist/lambda'),
+  path.resolve(__dirname, '../src/schema'),
+];
+for (const dir of assetDirs) {
+  if (!fs.existsSync(dir)) fs.mkdirSync(dir, { recursive: true });
+}
+const libDir = path.resolve(__dirname, '../lib');
+for (const mod of ['supervisor', 'workerWrapper', 'fabricator', 'seedConfig', 'stepRunner', 'activator']) {
+  const resolvedDir = path.resolve(libDir, `../../../arbiter/${mod}`);
+  if (!fs.existsSync(resolvedDir)) fs.mkdirSync(resolvedDir, { recursive: true });
+  const indexFile = path.join(resolvedDir, 'index.py');
+  if (!fs.existsSync(indexFile)) {
+    fs.writeFileSync(indexFile, 'def handler(event, context): pass\ndef lambda_handler(event, context): pass\n');
+  }
+}
+
+import { ArbiterStack } from '../lib/arbiter-stack';
+
+type Resources = Record<string, any>;
+
+function buildResources(): Resources {
+  const app = new cdk.App();
+  const backendStack = new cdk.Stack(app, 'MockBackendStack', {
+    env: { account: '123456789012', region: 'us-east-1' },
+  });
+  const agentEventBus = new events.EventBus(backendStack, 'AgentEventBus', {
+    eventBusName: 'citadel-agents-test',
+  });
+  const agentConfigTable = new dynamodb.Table(backendStack, 'AgentConfigTable', {
+    tableName: 'citadel-agents-test',
+    partitionKey: { name: 'agentId', type: dynamodb.AttributeType.STRING },
+    billingMode: dynamodb.BillingMode.PAY_PER_REQUEST,
+    removalPolicy: cdk.RemovalPolicy.DESTROY,
+  });
+  const codeBucket = new Bucket(backendStack, 'CodeBucket', { bucketName: 'citadel-code-test' });
+  const executionSpecificationsTable = new dynamodb.Table(backendStack, 'ExecutionSpecificationsTable', {
+    tableName: 'citadel-execution-specifications-test',
+    partitionKey: { name: 'specId', type: dynamodb.AttributeType.STRING },
+    billingMode: dynamodb.BillingMode.PAY_PER_REQUEST,
+    removalPolicy: cdk.RemovalPolicy.DESTROY,
+  });
+  const stack = new ArbiterStack(app, 'TestArbiterStack', {
+    environment: 'test',
+    env: { account: '123456789012', region: 'us-east-1' },
+    agentEventBus,
+    agentConfigTable,
+    codeBucket,
+    executionSpecificationsTable,
+  });
+  return Template.fromStack(stack).toJSON().Resources as Resources;
+}
+
+function findFabricatorFunctionTimeout(resources: Resources): number {
+  // The FabricatorAgent PythonFunction is the python3.14 Lambda whose
+  // logical id starts with "FabricatorAgent".
+  const entry = Object.entries(resources).find(
+    ([key, r]) =>
+      (r as any).Type === 'AWS::Lambda::Function' &&
+      (r as any).Properties?.Runtime === 'python3.14' &&
+      key.startsWith('FabricatorAgent'),
+  );
+  if (!entry) throw new Error('FabricatorAgent Lambda not found');
+  const timeout = (entry[1] as any).Properties?.Timeout;
+  if (typeof timeout !== 'number') throw new Error('FabricatorAgent timeout not a number');
+  return timeout;
+}
+
+function findFabricatorQueueLogicalId(resources: Resources): string {
+  const entry = Object.entries(resources).find(
+    ([, r]) =>
+      (r as any).Type === 'AWS::SQS::Queue' &&
+      (r as any).Properties?.QueueName === 'citadel-fabricator-queue-test',
+  );
+  if (!entry) throw new Error('fabricator queue not found');
+  return entry[0];
+}
+
+function findFabricatorQueueVisibility(resources: Resources): number {
+  const logicalId = findFabricatorQueueLogicalId(resources);
+  const vt = (resources[logicalId] as any).Properties?.VisibilityTimeout;
+  if (typeof vt !== 'number') throw new Error('fabricator queue VisibilityTimeout not a number');
+  return vt;
+}
+
+function findFabricatorEventSourceBatchSize(resources: Resources): number {
+  const queueLogicalId = findFabricatorQueueLogicalId(resources);
+  const entry = Object.entries(resources).find(([, r]) => {
+    if ((r as any).Type !== 'AWS::Lambda::EventSourceMapping') return false;
+    const arn = (r as any).Properties?.EventSourceArn;
+    // Queue ARN is emitted as { 'Fn::GetAtt': [<queueLogicalId>, 'Arn'] }.
+    return arn?.['Fn::GetAtt']?.[0] === queueLogicalId;
+  });
+  if (!entry) throw new Error('fabricator queue event source mapping not found');
+  return (entry[1] as any).Properties?.BatchSize;
+}
+
+describe('ArbiterStack — fabricator pipeline reliability', () => {
+  let resources: Resources;
+  beforeAll(() => { resources = buildResources(); });
+
+  test('fabricator queue visibilityTimeout strictly exceeds the FabricatorAgent function timeout', () => {
+    const functionTimeout = findFabricatorFunctionTimeout(resources);
+    const queueVisibility = findFabricatorQueueVisibility(resources);
+    expect(queueVisibility).toBeGreaterThan(functionTimeout);
+  });
+
+  test('fabricator SqsEventSource batchSize is 1', () => {
+    expect(findFabricatorEventSourceBatchSize(resources)).toBe(1);
+  });
+});

--- a/backend/test/backend-stack-fabrication-jobs-table-wiring.test.ts
+++ b/backend/test/backend-stack-fabrication-jobs-table-wiring.test.ts
@@ -1,0 +1,108 @@
+/**
+ * Durable fabrication-jobs status table wiring.
+ *
+ * The authoritative DynamoDB table `citadel-fabrication-jobs-${env}` is created
+ * in BackendStack (the dependency root: services→backend, arbiter→services→
+ * backend). Owning it here lets BackendStack's two fabricator resolvers use
+ * real construct grants, guarantees the table is provisioned before any
+ * cross-stack writer (services intake runtime, arbiter fabricator Lambda)
+ * deploys, and makes circular dependencies impossible because the other stacks
+ * reference the table only by deterministic name + constructed ARN.
+ *
+ * These assertions verify:
+ *  - the table exists with PK orchestrationId / SK agentUseId, on-demand
+ *    billing, PITR, and a TTL attribute named `ttl`;
+ *  - the request resolver gets FABRICATION_JOBS_TABLE + a scoped PutItem grant;
+ *  - the queue resolver gets FABRICATION_JOBS_TABLE + scoped Query/Scan.
+ */
+
+import * as cdk from 'aws-cdk-lib';
+import { Template, Match } from 'aws-cdk-lib/assertions';
+import * as path from 'path';
+import * as fs from 'fs';
+
+const assetDirs = [
+  path.resolve(__dirname, '../src/schema'),
+  path.resolve(__dirname, '../dist/lambda'),
+  path.resolve(__dirname, '../src/lambda/seed-admin-user'),
+  path.resolve(__dirname, '../src/lambda/seed-organizations'),
+];
+for (const dir of assetDirs) {
+  if (!fs.existsSync(dir)) fs.mkdirSync(dir, { recursive: true });
+}
+
+import { BackendStack } from '../lib/backend-stack';
+
+describe('BackendStack — fabrication-jobs table + resolver grants', () => {
+  const account = '123456789012';
+  const region = 'us-east-1';
+  const tableName = 'citadel-fabrication-jobs-test';
+
+  let template: Template;
+
+  beforeAll(() => {
+    const app = new cdk.App();
+    const stack = new BackendStack(app, 'TestBackendStackFabricationJobs', {
+      environment: 'test',
+      env: { account, region },
+    });
+    template = Template.fromStack(stack);
+  });
+
+  test('creates the fabrication-jobs table with PK orchestrationId / SK agentUseId + TTL', () => {
+    template.hasResourceProperties('AWS::DynamoDB::Table', {
+      TableName: tableName,
+      BillingMode: 'PAY_PER_REQUEST',
+      KeySchema: [
+        { AttributeName: 'orchestrationId', KeyType: 'HASH' },
+        { AttributeName: 'agentUseId', KeyType: 'RANGE' },
+      ],
+      AttributeDefinitions: Match.arrayWith([
+        { AttributeName: 'orchestrationId', AttributeType: 'S' },
+        { AttributeName: 'agentUseId', AttributeType: 'S' },
+      ]),
+      TimeToLiveSpecification: { AttributeName: 'ttl', Enabled: true },
+      PointInTimeRecoverySpecification: { PointInTimeRecoveryEnabled: true },
+    });
+  });
+
+  test('request resolver has FABRICATION_JOBS_TABLE env set to the deterministic name', () => {
+    template.hasResourceProperties('AWS::Lambda::Function', {
+      Handler: 'fabricator-request-resolver.handler',
+      Environment: { Variables: Match.objectLike({ FABRICATION_JOBS_TABLE: tableName }) },
+    });
+  });
+
+  test('queue resolver has FABRICATION_JOBS_TABLE env set to the deterministic name', () => {
+    template.hasResourceProperties('AWS::Lambda::Function', {
+      Handler: 'fabricator-queue-resolver.handler',
+      Environment: { Variables: Match.objectLike({ FABRICATION_JOBS_TABLE: tableName }) },
+    });
+  });
+
+  test('queue resolver role grants scoped Query/Scan on the jobs table', () => {
+    template.hasResourceProperties('AWS::IAM::Policy', {
+      PolicyDocument: {
+        Statement: Match.arrayWith([
+          Match.objectLike({
+            Effect: 'Allow',
+            Action: Match.arrayWith(['dynamodb:Query', 'dynamodb:Scan']),
+          }),
+        ]),
+      },
+    });
+  });
+
+  test('a PutItem grant scoped to the jobs-table ARN exists (request resolver)', () => {
+    const policies = template.findResources('AWS::IAM::Policy');
+    const hasScopedPut = Object.values(policies).some((policy: any) =>
+      (policy.Properties.PolicyDocument.Statement as any[]).some((stmt) => {
+        const resourceStr = JSON.stringify(stmt.Resource ?? '');
+        if (!resourceStr.includes(tableName)) return false;
+        const actions: string[] = Array.isArray(stmt.Action) ? stmt.Action : [stmt.Action];
+        return actions.includes('dynamodb:PutItem');
+      }),
+    );
+    expect(hasScopedPut).toBe(true);
+  });
+});

--- a/backend/test/backend-stack-ingestion-table-wiring.test.ts
+++ b/backend/test/backend-stack-ingestion-table-wiring.test.ts
@@ -1,0 +1,97 @@
+/**
+ * Phase 1 activation — document-upload resolver jobs-table read path.
+ *
+ * The authoritative DynamoDB jobs table `citadel-document-ingestion-${env}` is
+ * created in ServicesStack. The document-upload resolver (handler
+ * 'document-upload-resolver.handler') reads it as source of truth via the
+ * INGESTION_TABLE env var, falling back to a direct Bedrock KB query when the
+ * var/table is absent.
+ *
+ * These assertions verify that BackendStack ACTIVATES that path:
+ *  - INGESTION_TABLE is set to the deterministic table name.
+ *  - The resolver role has a scoped, READ-ONLY dynamodb policy
+ *    (GetItem/Query) on the table ARN and its `status-index` GSI ARN.
+ *  - No write actions are granted on the jobs table (least privilege).
+ *
+ * The ARNs are built from account/region/name (NOT a cross-stack construct
+ * import) to avoid a circular dependency: ServicesStack already depends ON
+ * BackendStack (it consumes props.documentBucket / props.agentEventBus), so
+ * BackendStack must not reference a ServicesStack construct.
+ */
+
+import * as cdk from 'aws-cdk-lib';
+import { Template, Match } from 'aws-cdk-lib/assertions';
+import * as path from 'path';
+import * as fs from 'fs';
+
+// Ensure asset directories exist for CDK synthesis
+const assetDirs = [
+  path.resolve(__dirname, '../src/schema'),
+  path.resolve(__dirname, '../dist/lambda'),
+  path.resolve(__dirname, '../src/lambda/seed-admin-user'),
+  path.resolve(__dirname, '../src/lambda/seed-organizations'),
+];
+for (const dir of assetDirs) {
+  if (!fs.existsSync(dir)) fs.mkdirSync(dir, { recursive: true });
+}
+
+import { BackendStack } from '../lib/backend-stack';
+
+describe('BackendStack — document-upload resolver jobs-table read path', () => {
+  const account = '123456789012';
+  const region = 'us-east-1';
+  const tableName = 'citadel-document-ingestion-test';
+  const tableArn = `arn:aws:dynamodb:${region}:${account}:table/${tableName}`;
+  const gsiArn = `${tableArn}/index/status-index`;
+
+  let template: Template;
+
+  beforeAll(() => {
+    const app = new cdk.App();
+    const stack = new BackendStack(app, 'TestBackendStackIngestionWiring', {
+      environment: 'test',
+      env: { account, region },
+    });
+    template = Template.fromStack(stack);
+  });
+
+  test('document-upload resolver has INGESTION_TABLE set to the deterministic jobs-table name', () => {
+    template.hasResourceProperties('AWS::Lambda::Function', {
+      Handler: 'document-upload-resolver.handler',
+      Environment: {
+        Variables: Match.objectLike({
+          INGESTION_TABLE: tableName,
+        }),
+      },
+    });
+  });
+
+  test('document-upload resolver role grants read-only dynamodb on the jobs table + status-index GSI', () => {
+    template.hasResourceProperties('AWS::IAM::Policy', {
+      PolicyDocument: {
+        Statement: Match.arrayWith([
+          Match.objectLike({
+            Effect: 'Allow',
+            Action: Match.arrayWith(['dynamodb:GetItem', 'dynamodb:Query']),
+            Resource: Match.arrayWith([tableArn, gsiArn]),
+          }),
+        ]),
+      },
+    });
+  });
+
+  test('document-upload resolver jobs-table policy grants NO write actions (least privilege)', () => {
+    const policies = template.findResources('AWS::IAM::Policy');
+    const hasWriteOnJobsTable = Object.values(policies).some((policy: any) =>
+      (policy.Properties.PolicyDocument.Statement as any[]).some((stmt) => {
+        const resourceStr = JSON.stringify(stmt.Resource ?? '');
+        if (!resourceStr.includes(tableName)) return false;
+        const actions: string[] = Array.isArray(stmt.Action) ? stmt.Action : [stmt.Action];
+        return actions.some((a) =>
+          ['dynamodb:PutItem', 'dynamodb:UpdateItem', 'dynamodb:DeleteItem', 'dynamodb:BatchWriteItem'].includes(a),
+        );
+      }),
+    );
+    expect(hasWriteOnJobsTable).toBe(false);
+  });
+});

--- a/backend/test/services-stack-intake-registry.test.ts
+++ b/backend/test/services-stack-intake-registry.test.ts
@@ -1,0 +1,130 @@
+import * as cdk from 'aws-cdk-lib';
+import * as events from 'aws-cdk-lib/aws-events';
+import * as s3 from 'aws-cdk-lib/aws-s3';
+import * as path from 'path';
+import * as fs from 'fs';
+
+// Ensure asset directories / Dockerfile stub exist for CDK synthesis (mirrors
+// services-stack.test.ts bootstrap so this file runs standalone).
+const assetDirs = [
+  path.resolve(__dirname, '../../src/schema'),
+  path.resolve(__dirname, '../../src/lambda/cognito-secret-handler'),
+  path.resolve(__dirname, '../../../service/hld_pdf_generator'),
+  path.resolve(__dirname, '../../../service/agent_intake_single'),
+];
+for (const dir of assetDirs) {
+  if (!fs.existsSync(dir)) fs.mkdirSync(dir, { recursive: true });
+}
+const dockerStub = 'FROM public.ecr.aws/lambda/python:3.12\nCMD ["handler.handler"]\n';
+for (const dockerDir of [
+  path.resolve(__dirname, '../../../service/hld_pdf_generator'),
+  path.resolve(__dirname, '../../../service/agent_intake_single'),
+]) {
+  const df = path.join(dockerDir, 'Dockerfile');
+  if (!fs.existsSync(df)) fs.writeFileSync(df, dockerStub);
+}
+
+import { ServicesStack } from '../lib/services-stack';
+
+const REGISTRY_ID = 'reg-abc123';
+const REGISTRY_ARN =
+  'arn:aws:bedrock-agentcore:us-west-2:123456789012:registry/reg-abc123';
+
+describe('AgentIntakeSingle runtime — AgentCore Registry read access', () => {
+  let template: cdk.assertions.Template;
+
+  beforeAll(() => {
+    const app = new cdk.App();
+    const prereq = new cdk.Stack(app, 'IntakeRegistryPrereq', {
+      env: { account: '123456789012', region: 'us-west-2' },
+    });
+    const bus = new events.EventBus(prereq, 'Bus', { eventBusName: 'reg-bus' });
+    const bucket = new s3.Bucket(prereq, 'DocBucket');
+
+    const stack = new ServicesStack(app, 'citadel-services-regtest', {
+      environment: 'test',
+      agentEventBus: bus,
+      documentBucket: bucket,
+      registryArn: REGISTRY_ARN,
+      registryId: REGISTRY_ID,
+      env: { account: '123456789012', region: 'us-west-2' },
+    });
+    template = cdk.assertions.Template.fromStack(stack);
+  });
+
+  test('the intake runtime has REGISTRY_ID env wired from props.registryId', () => {
+    template.hasResourceProperties('AWS::BedrockAgentCore::Runtime', {
+      EnvironmentVariables: cdk.assertions.Match.objectLike({
+        REGISTRY_ID,
+      }),
+    });
+  });
+
+  test('the intake runtime role has a bedrock-agentcore Registry read grant', () => {
+    template.hasResourceProperties('AWS::IAM::Policy', {
+      PolicyDocument: {
+        Statement: cdk.assertions.Match.arrayWith([
+          cdk.assertions.Match.objectLike({
+            Effect: 'Allow',
+            Action: cdk.assertions.Match.arrayWith([
+              'bedrock-agentcore:ListRegistryRecords',
+              'bedrock-agentcore:GetRegistryRecord',
+            ]),
+            Resource: cdk.assertions.Match.arrayWith([
+              REGISTRY_ARN,
+              `${REGISTRY_ARN}/*`,
+            ]),
+          }),
+        ]),
+      },
+    });
+  });
+});
+
+describe('AgentIntakeSingle runtime — registry props omitted', () => {
+  let template: cdk.assertions.Template;
+
+  beforeAll(() => {
+    const app = new cdk.App();
+    const prereq = new cdk.Stack(app, 'IntakeNoRegistryPrereq', {
+      env: { account: '123456789012', region: 'us-west-2' },
+    });
+    const bus = new events.EventBus(prereq, 'Bus', { eventBusName: 'noreg-bus' });
+    const bucket = new s3.Bucket(prereq, 'DocBucket');
+
+    const stack = new ServicesStack(app, 'citadel-services-noreg', {
+      environment: 'test',
+      agentEventBus: bus,
+      documentBucket: bucket,
+      env: { account: '123456789012', region: 'us-west-2' },
+    });
+    template = cdk.assertions.Template.fromStack(stack);
+  });
+
+  test('no runtime carries a REGISTRY_ID when registryId is unset', () => {
+    const runtimes = template.findResources('AWS::BedrockAgentCore::Runtime');
+    for (const runtime of Object.values(runtimes)) {
+      const env =
+        ((runtime.Properties as { EnvironmentVariables?: Record<string, unknown> } | undefined)
+          ?.EnvironmentVariables) ?? {};
+      expect(env).not.toHaveProperty('REGISTRY_ID');
+    }
+  });
+
+  test('no registry read grant is attached when registryArn is unset', () => {
+    const policies = template.findResources('AWS::IAM::Policy');
+    const hasRegistryGrant = Object.values(policies).some((policy) => {
+      const statements: Array<Record<string, unknown>> =
+        (policy.Properties as { PolicyDocument?: { Statement?: unknown[] } } | undefined)
+          ?.PolicyDocument?.Statement as Array<Record<string, unknown>> ?? [];
+      return statements.some((stmt) => {
+        const rawAction = stmt.Action;
+        const actions: string[] = Array.isArray(rawAction)
+          ? (rawAction as string[])
+          : [rawAction as string];
+        return actions.includes('bedrock-agentcore:ListRegistryRecords');
+      });
+    });
+    expect(hasRegistryGrant).toBe(false);
+  });
+});

--- a/backend/test/services-stack.test.ts
+++ b/backend/test/services-stack.test.ts
@@ -25,7 +25,7 @@ for (const dockerDir of [
   if (!fs.existsSync(df)) fs.writeFileSync(df, dockerStub);
 }
 
-import { ServicesStack } from '../lib/services-stack';
+import { ServicesStack, crossRegionPrefix } from '../lib/services-stack';
 
 describe('ServicesStack', () => {
   let app: cdk.App;
@@ -162,5 +162,187 @@ describe('ServicesStack', () => {
     // AWS::Logs::LogGroup resource rather than a Custom::LogRetention resource.
     const customLogRetention = template.findResources('Custom::LogRetention');
     expect(Object.keys(customLogRetention)).toHaveLength(0);
+  });
+
+  describe('server-side document ingestion (Phase 1)', () => {
+    test('creates the document-ingestion jobs table with status-index GSI', () => {
+      template.hasResourceProperties('AWS::DynamoDB::Table', {
+        TableName: 'citadel-document-ingestion-test',
+        BillingMode: 'PAY_PER_REQUEST',
+        PointInTimeRecoverySpecification: { PointInTimeRecoveryEnabled: true },
+        KeySchema: [
+          { AttributeName: 'projectId', KeyType: 'HASH' },
+          { AttributeName: 'documentKey', KeyType: 'RANGE' },
+        ],
+        GlobalSecondaryIndexes: [
+          {
+            IndexName: 'status-index',
+            KeySchema: [
+              { AttributeName: 'status', KeyType: 'HASH' },
+              { AttributeName: 'updatedAt', KeyType: 'RANGE' },
+            ],
+          },
+        ],
+      });
+    });
+
+    test('creates the ingest-start Lambda', () => {
+      template.hasResourceProperties('AWS::Lambda::Function', {
+        Handler: 'document-ingestion-start.handler',
+        Runtime: 'nodejs24.x',
+      });
+    });
+
+    test('creates the poller Lambda', () => {
+      template.hasResourceProperties('AWS::Lambda::Function', {
+        Handler: 'document-ingestion-poller.handler',
+        Runtime: 'nodejs24.x',
+      });
+    });
+
+    test('schedules the poller every minute', () => {
+      template.hasResourceProperties('AWS::Events::Rule', {
+        ScheduleExpression: 'rate(1 minute)',
+        State: 'ENABLED',
+      });
+    });
+
+    test('publishes the ingestion table name to SSM', () => {
+      template.hasResourceProperties('AWS::SSM::Parameter', {
+        Name: '/citadel/document-ingestion-table-test',
+      });
+    });
+
+    test('grants ingestion lambdas scoped Bedrock KB access', () => {
+      // Both lambdas get a policy statement allowing GetKnowledgeBaseDocuments
+      // on the KB ARN (ingest-start also gets Ingest).
+      template.hasResourceProperties('AWS::IAM::Policy', {
+        PolicyDocument: {
+          Statement: cdk.assertions.Match.arrayWith([
+            cdk.assertions.Match.objectLike({
+              Action: cdk.assertions.Match.arrayWith(['bedrock:GetKnowledgeBaseDocuments']),
+            }),
+          ]),
+        },
+      });
+    });
+
+    test('grants both ingestion lambdas StartIngestionJob + Ingest scoped to the KB ARN', () => {
+      // IngestKnowledgeBaseDocuments authorizes against bedrock:StartIngestionJob,
+      // so both the ingest-start role and the poller role (stale-row re-kick)
+      // must carry the full action set, scoped to the KB ARN (never '*').
+      const policies = template.findResources('AWS::IAM::Policy');
+      const matching = Object.values(policies).filter((policy) => {
+        const statements: Array<Record<string, unknown>> =
+          (policy.Properties as { PolicyDocument?: { Statement?: unknown[] } } | undefined)
+            ?.PolicyDocument?.Statement as Array<Record<string, unknown>> ?? [];
+        return statements.some((stmt) => {
+          const rawAction = stmt.Action;
+          const actions: string[] = Array.isArray(rawAction)
+            ? (rawAction as string[])
+            : [rawAction as string];
+          const resource = stmt.Resource;
+          const scopedToKb =
+            resource !== '*' &&
+            !(Array.isArray(resource) && (resource as unknown[]).includes('*'));
+          return (
+            scopedToKb &&
+            actions.includes('bedrock:IngestKnowledgeBaseDocuments') &&
+            actions.includes('bedrock:StartIngestionJob') &&
+            actions.includes('bedrock:GetKnowledgeBaseDocuments')
+          );
+        });
+      });
+      // ingest-start role + poller role each carry the full KB-scoped action set.
+      expect(matching.length).toBeGreaterThanOrEqual(2);
+    });
+  });
+});
+
+describe('crossRegionPrefix', () => {
+  // Mirrors arbiter/supervisor/index.py::_cross_region_prefix exactly.
+  test('us-* regions map to "us"', () => {
+    expect(crossRegionPrefix('us-west-2')).toBe('us');
+    expect(crossRegionPrefix('us-east-1')).toBe('us');
+  });
+
+  test('eu-* regions map to "eu"', () => {
+    expect(crossRegionPrefix('eu-west-1')).toBe('eu');
+    expect(crossRegionPrefix('eu-central-1')).toBe('eu');
+  });
+
+  test('ap-southeast-2 maps to "au" (special case before the ap-* fallback)', () => {
+    expect(crossRegionPrefix('ap-southeast-2')).toBe('au');
+  });
+
+  test('other ap-* regions map to "apac"', () => {
+    expect(crossRegionPrefix('ap-southeast-1')).toBe('apac');
+    expect(crossRegionPrefix('ap-northeast-1')).toBe('apac');
+  });
+
+  test('me-/ca-/sa- regions map to their codes', () => {
+    expect(crossRegionPrefix('me-south-1')).toBe('me');
+    expect(crossRegionPrefix('ca-central-1')).toBe('ca');
+    expect(crossRegionPrefix('sa-east-1')).toBe('sa');
+  });
+
+  test('unknown regions default to "us"', () => {
+    expect(crossRegionPrefix('xx-unknown-9')).toBe('us');
+  });
+});
+
+describe('AgentIntakeSingle runtime model identifiers (us-west-2 dev stack)', () => {
+  let template: cdk.assertions.Template;
+  let savedAgentModel: string | undefined;
+  let savedExtractionModel: string | undefined;
+
+  beforeAll(() => {
+    // Ensure no process.env override masks the region-derived default.
+    savedAgentModel = process.env.AGENT_MODEL;
+    savedExtractionModel = process.env.EXTRACTION_MODEL;
+    delete process.env.AGENT_MODEL;
+    delete process.env.EXTRACTION_MODEL;
+
+    const app = new cdk.App();
+    const prereq = new cdk.Stack(app, 'ModelPrereq', {
+      env: { account: '123456789012', region: 'us-west-2' },
+    });
+    const bus = new events.EventBus(prereq, 'ModelBus', { eventBusName: 'model-bus' });
+    const bucket = new s3.Bucket(prereq, 'ModelDocBucket');
+
+    const stack = new ServicesStack(app, 'citadel-services-dev', {
+      environment: 'dev',
+      agentEventBus: bus,
+      documentBucket: bucket,
+      env: { account: '123456789012', region: 'us-west-2' },
+    });
+    template = cdk.assertions.Template.fromStack(stack);
+  });
+
+  afterAll(() => {
+    if (savedAgentModel !== undefined) process.env.AGENT_MODEL = savedAgentModel;
+    if (savedExtractionModel !== undefined) process.env.EXTRACTION_MODEL = savedExtractionModel;
+  });
+
+  test('AGENT_MODEL/EXTRACTION_MODEL use the us. prefix (no au. prefix) in us-west-2', () => {
+    template.hasResourceProperties('AWS::BedrockAgentCore::Runtime', {
+      EnvironmentVariables: cdk.assertions.Match.objectLike({
+        AGENT_MODEL: 'us.anthropic.claude-sonnet-4-6',
+        EXTRACTION_MODEL: 'us.anthropic.claude-haiku-4-5-20251001-v1:0',
+      }),
+    });
+  });
+
+  test('no runtime EnvironmentVariables retains the invalid au. inference-profile prefix', () => {
+    const runtimes = template.findResources('AWS::BedrockAgentCore::Runtime');
+    for (const runtime of Object.values(runtimes)) {
+      const env = ((runtime.Properties as { EnvironmentVariables?: Record<string, unknown> } | undefined)
+        ?.EnvironmentVariables) ?? {};
+      for (const value of Object.values(env)) {
+        if (typeof value === 'string') {
+          expect(value.startsWith('au.')).toBe(false);
+        }
+      }
+    }
   });
 });

--- a/frontend/src/components/FabricationStatusPanel.tsx
+++ b/frontend/src/components/FabricationStatusPanel.tsx
@@ -1,0 +1,231 @@
+import { useState, useEffect, useCallback, useRef } from 'react';
+import { Clock, Loader2, CheckCircle, XCircle, PackageOpen, RefreshCw, Rocket } from 'lucide-react';
+import { toast } from 'sonner';
+import { Badge } from './ui/badge';
+import { Button } from './ui/button';
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipProvider,
+  TooltipTrigger,
+} from './ui/tooltip';
+import {
+  getFabricatorQueue,
+  subscribeToFabricationEvents,
+  type FabricationQueueItem,
+} from '../services/fabricatorQueueService';
+import { agentConfigService } from '../services/agentConfigService';
+
+interface FabricationStatusPanelProps {
+  /** Project/orchestration id. Jobs are filtered to this project. */
+  projectId: string;
+  /**
+   * Whether the build/implementation phase is active or complete. When true the
+   * panel renders even with zero jobs (showing an empty state); when false the
+   * panel only appears once at least one job exists.
+   */
+  phaseActive?: boolean;
+}
+
+type FabricationStatus = FabricationQueueItem['status'];
+
+interface StatusMeta {
+  /** Human-readable label — rendered as text so status is never color-only. */
+  label: string;
+  variant: 'secondary' | 'info' | 'success' | 'destructive';
+  Icon: typeof Clock;
+  spin?: boolean;
+}
+
+const STATUS_META: Record<FabricationStatus, StatusMeta> = {
+  PENDING: { label: 'Queued', variant: 'secondary', Icon: Clock },
+  PROCESSING: { label: 'Building', variant: 'info', Icon: Loader2, spin: true },
+  COMPLETED: { label: 'Built', variant: 'success', Icon: CheckCircle },
+  FAILED: { label: 'Failed', variant: 'destructive', Icon: XCircle },
+};
+
+function StatusBadge({ status, errorMessage }: { status: FabricationStatus; errorMessage?: string }) {
+  const meta = STATUS_META[status] ?? STATUS_META.PENDING;
+  const { label, variant, Icon, spin } = meta;
+
+  const badge = (
+    <Badge variant={variant} className="gap-1">
+      <Icon className={`size-3 ${spin ? 'animate-spin' : ''}`} aria-hidden="true" />
+      <span>{label}</span>
+    </Badge>
+  );
+
+  if (status === 'FAILED' && errorMessage) {
+    return (
+      <TooltipProvider>
+        <Tooltip>
+          <TooltipTrigger asChild>
+            {/* tabIndex so keyboard users can reveal the error tooltip */}
+            <span tabIndex={0} className="cursor-help">{badge}</span>
+          </TooltipTrigger>
+          <TooltipContent>
+            <span className="text-xs">{errorMessage}</span>
+          </TooltipContent>
+        </Tooltip>
+      </TooltipProvider>
+    );
+  }
+
+  return badge;
+}
+
+export function FabricationStatusPanel({ projectId, phaseActive = false }: FabricationStatusPanelProps) {
+  const [items, setItems] = useState<FabricationQueueItem[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [activating, setActivating] = useState(false);
+  const [activated, setActivated] = useState(false);
+  const subscriptionRef = useRef<(() => void) | null>(null);
+
+  const loadQueue = useCallback(async () => {
+    setLoading(true);
+    try {
+      const queue = await getFabricatorQueue(projectId);
+      setItems(queue);
+    } catch (err) {
+      console.error('Failed to load fabrication queue:', err);
+    } finally {
+      setLoading(false);
+    }
+  }, [projectId]);
+
+  // Initial load (and reload when the project changes)
+  useEffect(() => {
+    loadQueue();
+  }, [loadQueue]);
+
+  // Subscribe to real-time fabrication events; update the matching row in place.
+  useEffect(() => {
+    const unsubscribe = subscribeToFabricationEvents((event) => {
+      setItems((prev) =>
+        prev.map((item) =>
+          item.requestId === event.requestId
+            ? { ...item, status: event.type, errorMessage: event.errorMessage ?? item.errorMessage }
+            : item,
+        ),
+      );
+    });
+    subscriptionRef.current = unsubscribe;
+    return () => {
+      if (subscriptionRef.current) {
+        subscriptionRef.current();
+        subscriptionRef.current = null;
+      }
+    };
+  }, []);
+
+  // Visibility: show during/after build, or whenever jobs exist. Avoid a
+  // loading flash before the build phase when there are no jobs.
+  const visible = phaseActive || items.length > 0;
+  if (!visible) {
+    return null;
+  }
+
+  // Every fabrication job for this project has finished building. Only then
+  // does bulk activation make sense.
+  const allBuilt = items.length > 0 && items.every((i) => i.status === 'COMPLETED');
+
+  const handleActivateAll = async () => {
+    setActivating(true);
+    try {
+      const result = await agentConfigService.activateProjectAgents(projectId);
+      const activatedCount = result.activated.length;
+      const failedCount = result.failed.length;
+
+      if (failedCount > 0) {
+        toast.warning(
+          `Activated ${activatedCount} agent${activatedCount === 1 ? '' : 's'}, ${failedCount} failed`,
+          { description: result.failed.join(', ') },
+        );
+      } else {
+        toast.success(`Activated ${activatedCount} agent${activatedCount === 1 ? '' : 's'}`);
+      }
+      // Disable after a run that did not fail outright so the user isn't
+      // tempted to re-activate already-active agents.
+      setActivated(true);
+    } catch (err) {
+      console.error('Failed to activate project agents:', err);
+      toast.error('Failed to activate agents. Please try again.');
+    } finally {
+      setActivating(false);
+    }
+  };
+
+  return (
+    <section
+      aria-label="Fabrication status"
+      className="px-4 py-3 border-b border-border/50 bg-card"
+    >
+      <div className="flex items-center justify-between mb-2">
+        <span className="text-xs font-medium text-muted-foreground uppercase tracking-wider">
+          Agent Fabrication
+        </span>
+        <div className="flex items-center gap-1">
+          {allBuilt && (
+            <Button
+              variant="default"
+              size="sm"
+              className="h-6 text-xs gap-1"
+              onClick={handleActivateAll}
+              disabled={activating || activated}
+              aria-label="Activate all agents"
+            >
+              {activating ? (
+                <Loader2 className="size-3 animate-spin" aria-hidden="true" />
+              ) : (
+                <Rocket className="size-3" aria-hidden="true" />
+              )}
+              {activated ? 'Agents activated' : 'Activate all agents'}
+            </Button>
+          )}
+          <Button
+            variant="ghost"
+            size="sm"
+            className="h-6 text-xs gap-1"
+            onClick={loadQueue}
+            aria-label="Refresh fabrication status"
+          >
+            <RefreshCw className="size-3" aria-hidden="true" /> Refresh
+          </Button>
+        </div>
+      </div>
+
+      {loading && items.length === 0 ? (
+        <div className="flex items-center gap-2 py-3 text-xs text-muted-foreground" role="status" aria-live="polite">
+          <Loader2 className="size-4 animate-spin" aria-hidden="true" />
+          <span>Loading fabrication status...</span>
+        </div>
+      ) : items.length === 0 ? (
+        <div className="flex flex-col items-center justify-center py-6 text-center gap-2">
+          <PackageOpen className="size-6 text-muted-foreground" aria-hidden="true" />
+          <p className="text-xs text-muted-foreground">No agents are being fabricated yet.</p>
+        </div>
+      ) : (
+        <ul role="list" className="flex flex-col gap-1.5">
+          {items.map((item) => {
+            const meta = STATUS_META[item.status] ?? STATUS_META.PENDING;
+            const label = `${item.agentName}: ${meta.label}${
+              item.status === 'FAILED' && item.errorMessage ? ` — ${item.errorMessage}` : ''
+            }`;
+            return (
+              <li
+                key={item.requestId}
+                aria-label={label}
+                className="flex items-center justify-between gap-2 rounded-md bg-accent border border-border px-2.5 py-1.5"
+              >
+                <span className="truncate text-sm text-foreground" title={item.agentName}>
+                  {item.agentName}
+                </span>
+                <StatusBadge status={item.status} errorMessage={item.errorMessage} />
+              </li>
+            );
+          })}
+        </ul>
+      )}
+    </section>
+  );
+}

--- a/frontend/src/components/ProjectWorkspace.tsx
+++ b/frontend/src/components/ProjectWorkspace.tsx
@@ -17,12 +17,13 @@ import { projectService, type ProjectProgress } from '../services/projectService
 import { sendMessageToAgent, getConversationHistoryForProject, subscribeToConversation, type ConversationMessage } from '../services/conversationService';
 import { Dialog, DialogContent, DialogHeader, DialogTitle, DialogDescription } from './ui/dialog';
 import {
-  uploadDocument, ingestDocument, getProjectDocument, listDocumentVersions,
-  getDocumentVersion, generateDocumentPdf, waitForDocumentIndexed, notifyDocumentReady,
+  uploadDocument, getProjectDocument, listDocumentVersions,
+  getDocumentVersion, generateDocumentPdf, waitForDocumentIndexed,
   deleteDocument as deleteDocumentApi, listProjectDocuments,
   type ProjectDocument, type DocumentVersion,
 } from '../services/documentService';
 import { diffLines, type Change } from 'diff';
+import { FabricationStatusPanel } from './FabricationStatusPanel';
 
 // ── Types ────────────────────────────────────────────────────────────────────
 
@@ -46,7 +47,7 @@ interface DocTab {
   id: string;
   label: string;
   documentKey: string;
-  progressKey: 'design' | 'planning';
+  progressKey: 'design' | 'planning' | 'implementation';
   planningOrder?: number; // 0=resourcing, 1=business, 2=commercial
 }
 
@@ -281,6 +282,31 @@ function DocTabContent({ projectId, tab, phaseProgress, phaseExpected }: { proje
 
 // ── Main Component ───────────────────────────────────────────────────────────
 
+/**
+ * Map a Bedrock KB ingestion status to the UI document status. Failed ingestions
+ * must NOT render as 'ready'; unknown/undefined stays on a safe non-success value.
+ */
+function mapIngestionStatusToUi(status?: string): UploadedFile['status'] {
+  switch (status) {
+    case 'INDEXED':
+    case 'PARTIALLY_INDEXED':
+      return 'ready';
+    case 'FAILED':
+    case 'METADATA_UPDATE_FAILED':
+    case 'NOT_FOUND':
+      return 'failed';
+    case 'STARTING':
+    case 'PENDING':
+    case 'IN_PROGRESS':
+    // IGNORED is a Bedrock dedup/no-op (already indexed), not a failure: show as
+    // transient indexing and let the poller resolve the true status.
+    case 'IGNORED':
+      return 'indexing';
+    default:
+      return 'indexing';
+  }
+}
+
 interface ProjectWorkspaceProps {
   project: Project;
   onBack: () => void;
@@ -324,7 +350,7 @@ export function ProjectWorkspace({ project, onBack }: ProjectWorkspaceProps) {
         id: d.documentKey,
         name: d.fileName,
         size: d.size,
-        status: 'ready' as const,
+        status: mapIngestionStatusToUi(d.status),
         documentKey: d.documentKey,
       })));
     }).catch(() => {});
@@ -536,10 +562,7 @@ export function ProjectWorkspace({ project, onBack }: ProjectWorkspaceProps) {
     setUploadModal({ open: true, fileName: file.name, status: 'Uploading...' });
     try {
       const documentKey = await uploadDocument(project.id, file);
-      updateFileStatus(id, { status: 'ingesting', documentKey });
-      setUploadModal((m) => ({ ...m, status: 'Processing document...' }));
-      await ingestDocument(project.id, documentKey);
-      updateFileStatus(id, { status: 'indexing' });
+      updateFileStatus(id, { status: 'indexing', documentKey });
       setUploadModal((m) => ({ ...m, status: 'Indexing document...' }));
       await waitForDocumentIndexed(project.id, documentKey, {
         timeoutMs: 300_000,
@@ -550,12 +573,10 @@ export function ProjectWorkspace({ project, onBack }: ProjectWorkspaceProps) {
         },
       });
       updateFileStatus(id, { status: 'ready' });
-      setUploadModal((m) => ({ ...m, status: 'Finalising index...' }));
-      // Allow OpenSearch index to become searchable after INDEXED status
-      await new Promise((r) => setTimeout(r, 10_000));
       setUploadModal((m) => ({ ...m, status: 'Document ready! Extracting information...' }));
-      await notifyDocumentReady(project.id, documentKey, file.name, file.size, file.type);
-      // Wait for agent response before closing modal
+      // Wait for agent response before closing modal. The server-side ingestion
+      // path fires the assessment trigger exactly once after the document is
+      // indexed, so the client only listens for the resulting agent response.
       await new Promise<void>((resolve) => {
         const unsub = subscribeToConversation(project.id, (msg) => {
           if (msg.messageType === 'AGENT_RESPONSE') { unsub(); resolve(); }
@@ -674,6 +695,17 @@ export function ProjectWorkspace({ project, onBack }: ProjectWorkspaceProps) {
                 </div>
               </div>
             )}
+
+            {/* Fabrication status — visible during/after the build phase or
+                whenever fabrication jobs exist for this project. The panel
+                self-hides when neither condition holds. */}
+            <FabricationStatusPanel
+              projectId={project.id}
+              phaseActive={
+                (progress?.implementation ?? 0) > 0 ||
+                (progress?.currentPhase ?? '').toUpperCase().includes('IMPLEMENTATION')
+              }
+            />
 
             {/* Messages */}
             <ScrollArea className="flex-1 min-h-0 px-4 py-3">

--- a/frontend/src/components/__tests__/FabricationStatusPanel.test.tsx
+++ b/frontend/src/components/__tests__/FabricationStatusPanel.test.tsx
@@ -1,0 +1,256 @@
+/**
+ * FabricationStatusPanel tests
+ * TDD — renders rows with status badges, updates a row on a live fabrication
+ * event, unsubscribes on unmount, and shows loading/empty states.
+ *
+ * The fabricator queue service is fully mocked; no network is hit.
+ *
+ * NOTE: requires the jsdom test environment. If `jest-environment-jsdom` is
+ * not installed locally these component tests cannot execute — see the task
+ * report. They are written correctly against the public component API.
+ */
+
+import { render, screen, waitFor, act, fireEvent } from '@testing-library/react';
+import '@testing-library/jest-dom';
+
+jest.mock('../../services/fabricatorQueueService', () => ({
+  __esModule: true,
+  getFabricatorQueue: jest.fn(),
+  subscribeToFabricationEvents: jest.fn(),
+}));
+
+jest.mock('../../services/agentConfigService', () => ({
+  __esModule: true,
+  agentConfigService: {
+    activateProjectAgents: jest.fn(),
+  },
+}));
+
+jest.mock('sonner', () => ({
+  __esModule: true,
+  toast: {
+    success: jest.fn(),
+    warning: jest.fn(),
+    error: jest.fn(),
+  },
+}));
+
+import {
+  getFabricatorQueue,
+  subscribeToFabricationEvents,
+  type FabricationQueueItem,
+  type FabricationEvent,
+} from '../../services/fabricatorQueueService';
+import { agentConfigService } from '../../services/agentConfigService';
+import { toast } from 'sonner';
+import { FabricationStatusPanel } from '../FabricationStatusPanel';
+
+const mockGetQueue = getFabricatorQueue as jest.MockedFunction<typeof getFabricatorQueue>;
+const mockSubscribe = subscribeToFabricationEvents as jest.MockedFunction<typeof subscribeToFabricationEvents>;
+const mockActivate = agentConfigService.activateProjectAgents as jest.MockedFunction<
+  typeof agentConfigService.activateProjectAgents
+>;
+
+const COMPLETED_ITEMS: FabricationQueueItem[] = [
+  {
+    requestId: 'r1',
+    agentName: 'agent_alpha',
+    taskDescription: 'build alpha',
+    status: 'COMPLETED',
+    submittedAt: '2026-01-01T00:00:00Z',
+  },
+  {
+    requestId: 'r2',
+    agentName: 'agent_beta',
+    taskDescription: 'build beta',
+    status: 'COMPLETED',
+    submittedAt: '2026-01-01T00:01:00Z',
+  },
+];
+
+const ITEMS: FabricationQueueItem[] = [
+  {
+    requestId: 'r1',
+    agentName: 'agent_alpha',
+    taskDescription: 'build alpha',
+    status: 'PENDING',
+    submittedAt: '2026-01-01T00:00:00Z',
+  },
+  {
+    requestId: 'r2',
+    agentName: 'agent_beta',
+    taskDescription: 'build beta',
+    status: 'PROCESSING',
+    submittedAt: '2026-01-01T00:01:00Z',
+  },
+];
+
+describe('FabricationStatusPanel', () => {
+  beforeEach(() => {
+    mockGetQueue.mockReset();
+    mockSubscribe.mockReset();
+    mockActivate.mockReset();
+    (toast.success as jest.Mock).mockReset();
+    (toast.warning as jest.Mock).mockReset();
+    (toast.error as jest.Mock).mockReset();
+    // Default: a no-op unsubscribe.
+    mockSubscribe.mockReturnValue(() => {});
+  });
+
+  it('passes the projectId to getFabricatorQueue', async () => {
+    mockGetQueue.mockResolvedValue([]);
+    render(<FabricationStatusPanel projectId="proj-1" phaseActive />);
+    await waitFor(() => expect(mockGetQueue).toHaveBeenCalledWith('proj-1'));
+  });
+
+  it('renders a row per agent with the correct status badge', async () => {
+    mockGetQueue.mockResolvedValue(ITEMS);
+    render(<FabricationStatusPanel projectId="proj-1" phaseActive />);
+
+    expect(await screen.findByText('agent_alpha')).toBeInTheDocument();
+    expect(screen.getByText('agent_beta')).toBeInTheDocument();
+    // Status conveyed by text (not color-only).
+    expect(screen.getByText('Queued')).toBeInTheDocument();
+    expect(screen.getByText('Building')).toBeInTheDocument();
+  });
+
+  it('exposes an accessible status label per row (not color-only)', async () => {
+    mockGetQueue.mockResolvedValue(ITEMS);
+    render(<FabricationStatusPanel projectId="proj-1" phaseActive />);
+
+    expect(await screen.findByLabelText('agent_alpha: Queued')).toBeInTheDocument();
+    expect(screen.getByLabelText('agent_beta: Building')).toBeInTheDocument();
+  });
+
+  it('updates the matching row when an onFabricationEvent fires', async () => {
+    mockGetQueue.mockResolvedValue(ITEMS);
+    let emit: (event: FabricationEvent) => void = () => {};
+    mockSubscribe.mockImplementation((onEvent: (event: FabricationEvent) => void) => {
+      emit = onEvent;
+      return () => {};
+    });
+
+    render(<FabricationStatusPanel projectId="proj-1" phaseActive />);
+    await screen.findByText('agent_alpha');
+    expect(screen.getByText('Queued')).toBeInTheDocument();
+
+    act(() => {
+      emit({
+        type: 'FAILED',
+        requestId: 'r1',
+        errorMessage: 'fabrication exploded',
+        timestamp: '2026-01-01T00:05:00Z',
+      });
+    });
+
+    await waitFor(() => expect(screen.getByText('Failed')).toBeInTheDocument());
+    // Old status for that row is gone.
+    expect(screen.queryByText('Queued')).not.toBeInTheDocument();
+    // Error message is accessible via the row label.
+    expect(
+      screen.getByLabelText('agent_alpha: Failed — fabrication exploded'),
+    ).toBeInTheDocument();
+  });
+
+  it('unsubscribes on unmount', async () => {
+    mockGetQueue.mockResolvedValue(ITEMS);
+    const unsubscribe = jest.fn();
+    mockSubscribe.mockReturnValue(unsubscribe);
+
+    const { unmount } = render(<FabricationStatusPanel projectId="proj-1" phaseActive />);
+    await screen.findByText('agent_alpha');
+
+    unmount();
+    expect(unsubscribe).toHaveBeenCalledTimes(1);
+  });
+
+  it('shows a loading state while the queue is loading', async () => {
+    let resolve: (items: FabricationQueueItem[]) => void = () => {};
+    mockGetQueue.mockReturnValue(new Promise((r) => { resolve = r; }));
+
+    render(<FabricationStatusPanel projectId="proj-1" phaseActive />);
+    expect(screen.getByText('Loading fabrication status...')).toBeInTheDocument();
+
+    await act(async () => { resolve([]); });
+    await waitFor(() =>
+      expect(screen.queryByText('Loading fabrication status...')).not.toBeInTheDocument(),
+    );
+  });
+
+  it('shows an empty state when the build phase is active but there are no jobs', async () => {
+    mockGetQueue.mockResolvedValue([]);
+    render(<FabricationStatusPanel projectId="proj-1" phaseActive />);
+    expect(await screen.findByText('No agents are being fabricated yet.')).toBeInTheDocument();
+  });
+
+  it('renders nothing when the build phase is inactive and there are no jobs', async () => {
+    mockGetQueue.mockResolvedValue([]);
+    const { container } = render(<FabricationStatusPanel projectId="proj-1" />);
+    await waitFor(() => expect(mockGetQueue).toHaveBeenCalled());
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it('renders jobs even when the build phase is inactive (jobs > 0)', async () => {
+    mockGetQueue.mockResolvedValue(ITEMS);
+    render(<FabricationStatusPanel projectId="proj-1" />);
+    expect(await screen.findByText('agent_alpha')).toBeInTheDocument();
+  });
+
+  describe('Activate all agents', () => {
+    it('does not render the button until every job is COMPLETED', async () => {
+      mockGetQueue.mockResolvedValue(ITEMS); // PENDING + PROCESSING
+      render(<FabricationStatusPanel projectId="proj-1" phaseActive />);
+      await screen.findByText('agent_alpha');
+      expect(screen.queryByLabelText('Activate all agents')).not.toBeInTheDocument();
+    });
+
+    it('renders the button when all jobs are COMPLETED', async () => {
+      mockGetQueue.mockResolvedValue(COMPLETED_ITEMS);
+      render(<FabricationStatusPanel projectId="proj-1" phaseActive />);
+      expect(await screen.findByLabelText('Activate all agents')).toBeInTheDocument();
+    });
+
+    it('calls activateProjectAgents and shows a success toast', async () => {
+      mockGetQueue.mockResolvedValue(COMPLETED_ITEMS);
+      mockActivate.mockResolvedValue({ activated: ['agent_alpha', 'agent_beta'], failed: [], alreadyActive: [] });
+
+      render(<FabricationStatusPanel projectId="proj-1" phaseActive />);
+      const btn = await screen.findByLabelText('Activate all agents');
+
+      await act(async () => {
+        fireEvent.click(btn);
+      });
+
+      expect(mockActivate).toHaveBeenCalledWith('proj-1');
+      await waitFor(() => expect(toast.success).toHaveBeenCalledWith('Activated 2 agents'));
+    });
+
+    it('shows a warning toast when some agents fail', async () => {
+      mockGetQueue.mockResolvedValue(COMPLETED_ITEMS);
+      mockActivate.mockResolvedValue({ activated: ['agent_alpha'], failed: ['agent_beta'], alreadyActive: [] });
+
+      render(<FabricationStatusPanel projectId="proj-1" phaseActive />);
+      const btn = await screen.findByLabelText('Activate all agents');
+
+      await act(async () => {
+        fireEvent.click(btn);
+      });
+
+      await waitFor(() => expect(toast.warning).toHaveBeenCalled());
+    });
+
+    it('shows an error toast when the mutation throws', async () => {
+      mockGetQueue.mockResolvedValue(COMPLETED_ITEMS);
+      mockActivate.mockRejectedValue(new Error('network down'));
+
+      render(<FabricationStatusPanel projectId="proj-1" phaseActive />);
+      const btn = await screen.findByLabelText('Activate all agents');
+
+      await act(async () => {
+        fireEvent.click(btn);
+      });
+
+      await waitFor(() => expect(toast.error).toHaveBeenCalled());
+    });
+  });
+});

--- a/frontend/src/services/__tests__/agentConfigService.activateProjectAgents.test.ts
+++ b/frontend/src/services/__tests__/agentConfigService.activateProjectAgents.test.ts
@@ -1,0 +1,48 @@
+/**
+ * @jest-environment node
+ *
+ * activateProjectAgents service tests.
+ *
+ * Verifies the mutation forwards the projectId GraphQL variable and returns
+ * the parsed { activated, failed, alreadyActive } result. The AppSync server
+ * is fully mocked — no DOM required, so this runs under the node environment.
+ */
+
+jest.mock('../server', () => ({
+  __esModule: true,
+  default: {
+    query: jest.fn(),
+    mutate: jest.fn(),
+    subscribe: jest.fn(),
+  },
+}));
+
+import serverService from '../server';
+import { agentConfigService } from '../agentConfigService';
+
+describe('agentConfigService.activateProjectAgents', () => {
+  beforeEach(() => jest.clearAllMocks());
+
+  it('passes projectId as a variable and returns the parsed result', async () => {
+    const result = {
+      activated: ['Agent One'],
+      failed: [],
+      alreadyActive: ['Agent Two'],
+    };
+    (serverService.mutate as jest.Mock).mockResolvedValue({ activateProjectAgents: result });
+
+    const out = await agentConfigService.activateProjectAgents('proj-1');
+
+    expect(serverService.mutate).toHaveBeenCalledWith(
+      expect.stringContaining('activateProjectAgents'),
+      { projectId: 'proj-1' }
+    );
+    expect(out).toEqual(result);
+  });
+
+  it('propagates errors from the server', async () => {
+    (serverService.mutate as jest.Mock).mockRejectedValue(new Error('network down'));
+
+    await expect(agentConfigService.activateProjectAgents('proj-1')).rejects.toThrow('network down');
+  });
+});

--- a/frontend/src/services/__tests__/documentService.test.ts
+++ b/frontend/src/services/__tests__/documentService.test.ts
@@ -1,0 +1,88 @@
+/**
+ * @jest-environment node
+ *
+ * Tests for documentService.waitForDocumentIndexed grace-window behavior.
+ *
+ * Regression coverage for Issue #8: NOT_FOUND right after ingestion is a transient
+ * pre-indexing state (Bedrock eventual consistency), not an immediate terminal failure.
+ */
+
+jest.mock('../server', () => ({
+  __esModule: true,
+  default: {
+    query: jest.fn(),
+    mutate: jest.fn(),
+  },
+}));
+
+import serverService from '../server';
+import { waitForDocumentIndexed } from '../documentService';
+
+const mockQuery = serverService.query as jest.Mock;
+
+const statusResponse = (status: string, statusReason?: string) => ({
+  getDocumentIngestionStatus: { documentKey: 'proj-1/a.pdf', status, statusReason },
+});
+
+describe('waitForDocumentIndexed', () => {
+  beforeEach(() => {
+    mockQuery.mockReset();
+  });
+
+  test('keeps polling on NOT_FOUND within the grace window, then resolves on INDEXED', async () => {
+    mockQuery
+      .mockResolvedValueOnce(statusResponse('NOT_FOUND'))
+      .mockResolvedValueOnce(statusResponse('NOT_FOUND'))
+      .mockResolvedValueOnce(statusResponse('INDEXED'));
+
+    const result = await waitForDocumentIndexed('proj-1', 'proj-1/a.pdf', {
+      pollIntervalMs: 1,
+      gracePeriodMs: 10_000,
+      timeoutMs: 10_000,
+    });
+
+    expect(result.status).toBe('INDEXED');
+    expect(mockQuery).toHaveBeenCalledTimes(3);
+  });
+
+  test('treats IGNORED (Bedrock dedup) as transient and resolves once INDEXED', async () => {
+    mockQuery
+      .mockResolvedValueOnce(statusResponse('IGNORED', 'You submitted multiple requests for the same document'))
+      .mockResolvedValueOnce(statusResponse('INDEXED'));
+
+    const result = await waitForDocumentIndexed('proj-1', 'proj-1/a.pdf', {
+      pollIntervalMs: 1,
+      gracePeriodMs: 10_000,
+      timeoutMs: 10_000,
+    });
+
+    expect(result.status).toBe('INDEXED');
+    expect(mockQuery).toHaveBeenCalledTimes(2);
+  });
+
+  test('throws immediately on FAILED', async () => {
+    mockQuery.mockResolvedValueOnce(statusResponse('FAILED', 'parse error'));
+
+    await expect(
+      waitForDocumentIndexed('proj-1', 'proj-1/a.pdf', {
+        pollIntervalMs: 1,
+        gracePeriodMs: 10_000,
+        timeoutMs: 10_000,
+      })
+    ).rejects.toThrow('Indexing failed: FAILED');
+
+    expect(mockQuery).toHaveBeenCalledTimes(1);
+  });
+
+  test('treats persistent NOT_FOUND as terminal once the grace window has elapsed', async () => {
+    mockQuery.mockResolvedValue(statusResponse('NOT_FOUND'));
+
+    await expect(
+      waitForDocumentIndexed('proj-1', 'proj-1/a.pdf', {
+        pollIntervalMs: 1,
+        gracePeriodMs: 0,
+        timeoutMs: 10_000,
+      })
+    ).rejects.toThrow('NOT_FOUND');
+  });
+});

--- a/frontend/src/services/__tests__/fabricatorQueueService.getFabricatorQueue.test.ts
+++ b/frontend/src/services/__tests__/fabricatorQueueService.getFabricatorQueue.test.ts
@@ -1,0 +1,69 @@
+/**
+ * getFabricatorQueue tests
+ *
+ * Verifies the query forwards the optional projectId as a GraphQL variable and
+ * that the no-arg call (Agent Catalog drawer) still works. The AppSync server
+ * is fully mocked — these tests never hit the network and run under any test
+ * environment (no DOM required).
+ */
+
+// Mock the AppSync server service (default export) before importing the SUT.
+jest.mock('../server', () => ({
+  __esModule: true,
+  default: { query: jest.fn() },
+}));
+
+import serverService from '../server';
+import { getFabricatorQueue } from '../fabricatorQueueService';
+
+const mockQuery = (serverService as unknown as { query: jest.Mock }).query;
+
+describe('getFabricatorQueue', () => {
+  beforeEach(() => {
+    mockQuery.mockReset();
+    mockQuery.mockResolvedValue({ getFabricatorQueue: [] });
+  });
+
+  it('passes projectId as a GraphQL variable when provided', async () => {
+    await getFabricatorQueue('project-123');
+
+    expect(mockQuery).toHaveBeenCalledTimes(1);
+    const [query, variables] = mockQuery.mock.calls[0];
+    expect(query).toContain('query GetFabricatorQueue($projectId: ID)');
+    expect(query).toContain('getFabricatorQueue(projectId: $projectId)');
+    expect(variables).toEqual({ projectId: 'project-123' });
+  });
+
+  it('passes projectId as undefined when called with no argument', async () => {
+    await getFabricatorQueue();
+
+    expect(mockQuery).toHaveBeenCalledTimes(1);
+    const [, variables] = mockQuery.mock.calls[0];
+    expect(variables).toEqual({ projectId: undefined });
+  });
+
+  it('returns items and parses JSON-string metadata', async () => {
+    mockQuery.mockResolvedValue({
+      getFabricatorQueue: [
+        {
+          requestId: 'r1',
+          agentName: 'agent_one',
+          taskDescription: 'do work',
+          status: 'PENDING',
+          submittedAt: '2026-01-01T00:00:00Z',
+          metadata: '{"appId":"a1"}',
+        },
+      ],
+    });
+
+    const items = await getFabricatorQueue('project-123');
+
+    expect(items).toHaveLength(1);
+    expect(items[0].metadata).toEqual({ appId: 'a1' });
+  });
+
+  it('propagates query errors', async () => {
+    mockQuery.mockRejectedValue(new Error('boom'));
+    await expect(getFabricatorQueue('project-123')).rejects.toThrow('boom');
+  });
+});

--- a/frontend/src/services/agentConfigService.ts
+++ b/frontend/src/services/agentConfigService.ts
@@ -13,6 +13,13 @@ export interface AgentConfig {
   updatedAt?: string;
 }
 
+/** Outcome of a bulk project-agent activation, grouped by per-agent result. */
+export interface ActivateAgentsResult {
+  activated: string[];
+  failed: string[];
+  alreadyActive: string[];
+}
+
 const listAgentConfigsQuery = `
   query ListAgentConfigs {
     listAgentConfigs {
@@ -84,6 +91,16 @@ const deleteAgentConfigMutation = `
     deleteAgentConfig(agentId: $agentId) {
       success
       message
+    }
+  }
+`;
+
+const activateProjectAgentsMutation = `
+  mutation ActivateProjectAgents($projectId: ID!) {
+    activateProjectAgents(projectId: $projectId) {
+      activated
+      failed
+      alreadyActive
     }
   }
 `;
@@ -263,6 +280,26 @@ export const agentConfigService = {
       return response.deleteAgentConfig;
     } catch (error) {
       console.error('Error deleting agent config:', error);
+      throw error;
+    }
+  },
+
+  /**
+   * Activates every fabricated agent belonging to a project in one call.
+   * Returns the per-agent outcome grouped into activated / failed /
+   * alreadyActive name lists. Never partially throws — the backend swallows
+   * per-agent errors and reports them in `failed`.
+   */
+  async activateProjectAgents(projectId: string): Promise<ActivateAgentsResult> {
+    try {
+      const response = await serverService.mutate<{ activateProjectAgents: ActivateAgentsResult }>(
+        activateProjectAgentsMutation,
+        { projectId }
+      );
+
+      return response.activateProjectAgents;
+    } catch (error) {
+      console.error('Error activating project agents:', error);
       throw error;
     }
   },

--- a/frontend/src/services/documentService.ts
+++ b/frontend/src/services/documentService.ts
@@ -128,14 +128,6 @@ const generateDocumentPdfMutation = /* GraphQL */ `
   }
 `;
 
-const ingestDocumentMutation = /* GraphQL */ `
-  mutation IngestDocument($projectId: ID!, $documentKey: String!) {
-    ingestDocument(projectId: $projectId, documentKey: $documentKey) {
-      documentKey status
-    }
-  }
-`;
-
 export interface ProjectDocument {
   documentKey: string;
   content: string;
@@ -182,16 +174,12 @@ export async function generateDocumentPdf(projectId: string, documentKey: string
   return res.generateDocumentPdf.url;
 }
 
-export async function ingestDocument(projectId: string, documentKey: string): Promise<void> {
-  await serverService.mutate(ingestDocumentMutation, { projectId, documentKey });
-}
-
 // ── Document Ingestion Status Polling ────────────────────────────────────────
 
 const listProjectDocumentsQuery = /* GraphQL */ `
   query ListProjectDocuments($projectId: ID!) {
     listProjectDocuments(projectId: $projectId) {
-      documentKey fileName size lastModified
+      documentKey fileName size lastModified status statusReason
     }
   }
 `;
@@ -201,6 +189,8 @@ export interface ProjectDocumentItem {
   fileName: string;
   size: number;
   lastModified: string;
+  status?: string;
+  statusReason?: string;
 }
 
 export async function listProjectDocuments(projectId: string): Promise<ProjectDocumentItem[]> {
@@ -232,12 +222,21 @@ export async function getDocumentIngestionStatus(projectId: string, documentKey:
   return response.getDocumentIngestionStatus;
 }
 
-const TERMINAL_STATUSES = ['INDEXED', 'PARTIALLY_INDEXED', 'FAILED', 'METADATA_UPDATE_FAILED', 'IGNORED', 'NOT_FOUND'];
 const SUCCESS_STATUSES = ['INDEXED', 'PARTIALLY_INDEXED'];
+// IGNORED is a Bedrock dedup/no-op (the doc already exists and is indexed), not a
+// failure — treat it as transient and keep polling for the true status.
+const FAILURE_STATUSES = ['FAILED', 'METADATA_UPDATE_FAILED'];
 
 export interface WaitForIndexedOptions {
   timeoutMs?: number;
   pollIntervalMs?: number;
+  /**
+   * Grace window during which a NOT_FOUND / empty status is treated as a TRANSIENT
+   * pre-indexing state (Bedrock is eventually consistent right after ingestion) rather
+   * than a terminal failure. The window ends once any concrete status is observed OR
+   * this duration elapses, whichever comes first.
+   */
+  gracePeriodMs?: number;
   onStatusChange?: (status: string) => void;
 }
 
@@ -246,33 +245,37 @@ export async function waitForDocumentIndexed(
   documentKey: string,
   opts: WaitForIndexedOptions = {},
 ): Promise<DocumentIngestionStatus> {
-  const { timeoutMs = 300_000, pollIntervalMs = 3_000, onStatusChange } = opts;
+  const { timeoutMs = 300_000, pollIntervalMs = 3_000, gracePeriodMs = 30_000, onStatusChange } = opts;
   const deadline = Date.now() + timeoutMs;
+  const graceDeadline = Date.now() + gracePeriodMs;
+  let sawConcreteStatus = false;
 
   while (Date.now() < deadline) {
     const result = await getDocumentIngestionStatus(projectId, documentKey);
     onStatusChange?.(result.status);
+
     if (SUCCESS_STATUSES.includes(result.status)) return result;
-    if (TERMINAL_STATUSES.includes(result.status)) throw new Error(`Indexing failed: ${result.status} — ${result.statusReason ?? ''}`);
+    if (FAILURE_STATUSES.includes(result.status)) {
+      throw new Error(`Indexing failed: ${result.status} — ${result.statusReason ?? ''}`);
+    }
+
+    const isNotFound = !result.status || result.status === 'NOT_FOUND';
+    if (isNotFound) {
+      // Transient pre-indexing state: keep polling while still inside the grace window and
+      // before any concrete status has been seen.
+      if (!sawConcreteStatus && Date.now() < graceDeadline) {
+        await new Promise((r) => setTimeout(r, pollIntervalMs));
+        continue;
+      }
+      // Grace window elapsed (or a concrete status was already observed): treat as terminal.
+      throw new Error(`Indexing failed: NOT_FOUND — ${result.statusReason ?? 'document not found after grace period'}`);
+    }
+
+    // Non-terminal concrete status (STARTING/PENDING/IN_PROGRESS): keep polling.
+    sawConcreteStatus = true;
     await new Promise((r) => setTimeout(r, pollIntervalMs));
   }
   throw new Error('TIMEOUT');
-}
-
-// ── Notify Document Ready ────────────────────────────────────────────────────
-
-const notifyDocumentReadyMutation = /* GraphQL */ `
-  mutation NotifyDocumentReady($projectId: ID!, $documentKey: String!, $fileName: String!, $fileSize: Int!, $fileType: String!) {
-    notifyDocumentReady(projectId: $projectId, documentKey: $documentKey, fileName: $fileName, fileSize: $fileSize, fileType: $fileType) {
-      success
-    }
-  }
-`;
-
-export async function notifyDocumentReady(
-  projectId: string, documentKey: string, fileName: string, fileSize: number, fileType: string,
-): Promise<void> {
-  await serverService.mutate(notifyDocumentReadyMutation, { projectId, documentKey, fileName, fileSize, fileType });
 }
 
 // ── Delete Document ──────────────────────────────────────────────────────────

--- a/frontend/src/services/fabricatorQueueService.ts
+++ b/frontend/src/services/fabricatorQueueService.ts
@@ -26,8 +26,8 @@ export interface FabricationQueueItem {
 
 // GraphQL Queries
 const getFabricatorQueueQuery = /* GraphQL */ `
-  query GetFabricatorQueue {
-    getFabricatorQueue {
+  query GetFabricatorQueue($projectId: ID) {
+    getFabricatorQueue(projectId: $projectId) {
       requestId
       agentName
       taskDescription
@@ -82,12 +82,18 @@ function initializeFabricationSubscription(): void {
 }
 
 /**
- * Get the current state of the fabricator queue
+ * Get the current state of the fabricator queue.
+ *
+ * @param projectId Optional project/orchestration id. When provided, only
+ *   fabrication jobs for that project are returned. When omitted (e.g. the
+ *   Agent Catalog drawer), all jobs are returned. The intake
+ *   session_id === orchestrationId === projectId.
  */
-export async function getFabricatorQueue(): Promise<FabricationQueueItem[]> {
+export async function getFabricatorQueue(projectId?: string): Promise<FabricationQueueItem[]> {
   try {
     const response = await serverService.query<{ getFabricatorQueue: FabricationQueueItem[] }>(
-      getFabricatorQueueQuery
+      getFabricatorQueueQuery,
+      { projectId }
     );
 
     const items = response.getFabricatorQueue || [];

--- a/service/agent_intake_single/agent.py
+++ b/service/agent_intake_single/agent.py
@@ -205,10 +205,8 @@ def get_agent(session_id: str) -> Agent:
             f"Current phase: {state['phase']} | "
             f"Assessment: {state['assessment_progress']}% | "
             f"Design: {state['design_progress']}% | "
-            f"Resourcing: {state.get('resourcing_progress', 0)}% | "
-            f"Business plan: {state.get('business_plan_progress', 0)}% | "
-            f"Commercial plan: {state.get('commercial_plan_progress', 0)}% | "
-            f"Fabrication: {state.get('fabrication_progress', 0)}%"
+            f"Planning: {state['planning_progress']}% | "
+            f"Implementation: {state['implementation_progress']}%"
         )
         _agent_cache[session_id] = Agent(
             model=AGENT_MODEL,

--- a/service/agent_intake_single/tests/test_fabrication_status.py
+++ b/service/agent_intake_single/tests/test_fabrication_status.py
@@ -1,0 +1,90 @@
+"""
+Tests for durable PENDING fabrication-status writes in
+service/agent_intake_single/tools/fabricate.py.
+
+confirm_fabrication_plan enqueues each 'build' agent onto SQS and then writes a
+PENDING row to the fabrication-jobs table so the queue UI reflects intake-driven
+fabrication. The status write is best-effort: a failure must NOT break the
+enqueue, and it is skipped entirely when FABRICATION_JOBS_TABLE is unset.
+
+Run with:
+    PYTHONPATH=. pytest tests/test_fabrication_status.py -q
+from the service/agent_intake_single directory.
+"""
+import json
+import os
+import sys
+from unittest import mock
+
+import pytest
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+
+os.environ.setdefault("FABRICATOR_QUEUE_URL", "https://sqs.fake/queue")
+
+import tools.fabricate as fab
+
+
+@pytest.fixture(autouse=True)
+def _stub_io(monkeypatch):
+    # Avoid real S3 / progress side-effects.
+    monkeypatch.setattr(fab, "s3_put", lambda *a, **k: None)
+    monkeypatch.setattr(fab, "FABRICATOR_QUEUE_URL", "https://sqs.fake/queue")
+    monkeypatch.setattr(fab, "sqs", mock.MagicMock())
+    # tools.state import inside confirm_fabrication_plan
+    state_mod = mock.MagicMock()
+    monkeypatch.setitem(sys.modules, "tools.state", state_mod)
+    yield
+
+
+def _plan():
+    return json.dumps([
+        {"name": "AgentA", "action": "build", "reason": "new", "spec": "spec A"},
+        {"name": "AgentB", "action": "build", "reason": "new", "spec": "spec B"},
+        {"name": "AgentC", "action": "reuse", "reason": "exists", "spec": "spec C"},
+    ])
+
+
+def test_writes_pending_row_per_build_agent(monkeypatch):
+    monkeypatch.setattr(fab, "FABRICATION_JOBS_TABLE", "citadel-fabrication-jobs-test")
+    table = mock.MagicMock()
+    monkeypatch.setattr(fab.dynamodb, "Table", mock.MagicMock(return_value=table))
+
+    fab.confirm_fabrication_plan("sess-1", _plan())
+
+    # One PutItem per BUILD agent (2), not for reuse.
+    assert table.put_item.call_count == 2
+    items = [c.kwargs["Item"] for c in table.put_item.call_args_list]
+    names = {i["agentUseId"] for i in items}
+    assert names == {"AgentA", "AgentB"}
+    first = items[0]
+    assert first["orchestrationId"] == "sess-1"
+    assert first["status"] == "PENDING"
+    assert first["requestType"] == "agent-creation"
+    assert first["requestedBy"] == "intake"
+    assert len(first["taskDescription"]) <= 500
+    assert "submittedAt" in first and "updatedAt" in first
+    assert isinstance(first["ttl"], int)
+
+
+def test_status_write_failure_does_not_break_enqueue(monkeypatch):
+    monkeypatch.setattr(fab, "FABRICATION_JOBS_TABLE", "citadel-fabrication-jobs-test")
+    table = mock.MagicMock()
+    table.put_item.side_effect = Exception("ddb down")
+    monkeypatch.setattr(fab.dynamodb, "Table", mock.MagicMock(return_value=table))
+
+    # Should not raise; SQS sends still happen for both build agents.
+    result = fab.confirm_fabrication_plan("sess-1", _plan())
+    assert fab.sqs.send_message.call_count == 2
+    assert "AgentA" in result and "AgentB" in result
+
+
+def test_skips_status_write_when_table_unset(monkeypatch):
+    monkeypatch.setattr(fab, "FABRICATION_JOBS_TABLE", "")
+    table = mock.MagicMock()
+    monkeypatch.setattr(fab.dynamodb, "Table", mock.MagicMock(return_value=table))
+
+    fab.confirm_fabrication_plan("sess-1", _plan())
+
+    assert fab.sqs.send_message.call_count == 2
+    table.put_item.assert_not_called()

--- a/service/agent_intake_single/tests/test_factory_registry.py
+++ b/service/agent_intake_single/tests/test_factory_registry.py
@@ -1,0 +1,178 @@
+"""Tests for registry-backed factory-agent discovery (Bug A).
+
+Fabricated agents are written to the AgentCore Registry (via the arbiter's
+store_agent_config_registry), NOT to AGENT_CONFIG_TABLE. So _get_existing_agents
+must read the registry; otherwise list_factory_agents / plan_fabrication never
+see fabricated ap-*-agent-v1 agents.
+
+Contract under test:
+  - _get_existing_agents returns a dict keyed by registry record NAME, each
+    value carrying name/state/recordId/description/sourceProjectId.
+  - State is derived from the registry record status (APPROVED-family -> active,
+    DRAFT/CREATING -> draft, otherwise inactive).
+  - Tool records (no `manifest` in custom metadata) are excluded.
+  - When REGISTRY_ID is unset OR the list call raises, it logs and returns {}
+    without raising.
+  - list_factory_agents renders the registry-backed agents.
+
+Run with:
+    PYTHONPATH=. pytest tests/test_factory_registry.py -q
+from the service/agent_intake_single directory.
+"""
+import json
+import os
+import sys
+from unittest import mock
+
+import pytest
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+
+os.environ.setdefault("FABRICATOR_QUEUE_URL", "https://sqs.fake/queue")
+
+import tools.fabricate as fab
+
+
+def _client(records, details):
+    """Build a mock bedrock-agentcore-control client.
+
+    Args:
+        records: summary dicts returned by list_registry_records.
+        details: {recordId: full record dict} returned by get_registry_record.
+    """
+    client = mock.MagicMock()
+    client.list_registry_records.return_value = {"records": records, "nextToken": None}
+
+    def _get(registryId, recordId):  # noqa: N803 — boto3 kwarg names
+        return details[recordId]
+
+    client.get_registry_record.side_effect = _get
+    return client
+
+
+def _agent_detail(name, record_id, status, description, source_project_id=None):
+    meta = {"manifest": {"name": name}}
+    if source_project_id is not None:
+        meta["sourceProjectId"] = source_project_id
+    return {
+        "name": name,
+        "recordId": record_id,
+        "status": status,
+        "description": description,
+        "descriptors": {"custom": {"inlineContent": json.dumps(meta)}},
+    }
+
+
+def test_get_existing_agents_returns_registry_backed_dict(monkeypatch):
+    monkeypatch.setattr(fab, "REGISTRY_ID", "reg-1")
+    records = [{"name": "ap-billing-agent-v1", "recordId": "rec1", "status": "DRAFT"}]
+    details = {
+        "rec1": _agent_detail(
+            "ap-billing-agent-v1", "rec1", "APPROVED", "Billing agent", "proj-9"
+        )
+    }
+    monkeypatch.setattr(fab, "_get_registry_client", lambda: _client(records, details))
+
+    result = fab._get_existing_agents()
+
+    assert "ap-billing-agent-v1" in result
+    entry = result["ap-billing-agent-v1"]
+    assert entry["name"] == "ap-billing-agent-v1"
+    assert entry["recordId"] == "rec1"
+    assert entry["state"] == "active"  # APPROVED (from the detail) -> active
+    assert entry["description"] == "Billing agent"
+    assert entry["sourceProjectId"] == "proj-9"
+
+
+def test_get_existing_agents_maps_draft_state(monkeypatch):
+    monkeypatch.setattr(fab, "REGISTRY_ID", "reg-1")
+    records = [{"name": "ap-draft-agent-v1", "recordId": "rd", "status": "DRAFT"}]
+    details = {"rd": _agent_detail("ap-draft-agent-v1", "rd", "DRAFT", "Draft agent")}
+    monkeypatch.setattr(fab, "_get_registry_client", lambda: _client(records, details))
+
+    result = fab._get_existing_agents()
+
+    assert result["ap-draft-agent-v1"]["state"] == "draft"
+    assert result["ap-draft-agent-v1"]["sourceProjectId"] is None
+
+
+def test_get_existing_agents_empty_when_registry_id_unset(monkeypatch):
+    monkeypatch.setattr(fab, "REGISTRY_ID", "")
+    client = mock.MagicMock()
+    monkeypatch.setattr(fab, "_get_registry_client", lambda: client)
+
+    assert fab._get_existing_agents() == {}
+    client.list_registry_records.assert_not_called()
+
+
+def test_get_existing_agents_empty_when_list_raises(monkeypatch):
+    monkeypatch.setattr(fab, "REGISTRY_ID", "reg-1")
+    client = mock.MagicMock()
+    client.list_registry_records.side_effect = Exception("registry down")
+    monkeypatch.setattr(fab, "_get_registry_client", lambda: client)
+
+    # Must degrade gracefully — never raise.
+    assert fab._get_existing_agents() == {}
+
+
+def test_get_existing_agents_skips_tool_records(monkeypatch):
+    monkeypatch.setattr(fab, "REGISTRY_ID", "reg-1")
+    records = [
+        {"name": "ap-agent-v1", "recordId": "a", "status": "APPROVED"},
+        {"name": "some-tool", "recordId": "t", "status": "APPROVED"},
+    ]
+    details = {
+        "a": _agent_detail("ap-agent-v1", "a", "APPROVED", "An agent"),
+        # Tool record: custom metadata has no `manifest` discriminator.
+        "t": {
+            "name": "some-tool",
+            "recordId": "t",
+            "status": "APPROVED",
+            "description": "A tool",
+            "descriptors": {"custom": {"inlineContent": json.dumps({"config": {}})}},
+        },
+    }
+    monkeypatch.setattr(fab, "_get_registry_client", lambda: _client(records, details))
+
+    result = fab._get_existing_agents()
+
+    assert "ap-agent-v1" in result
+    assert "some-tool" not in result
+
+
+def test_get_existing_agents_paginates(monkeypatch):
+    monkeypatch.setattr(fab, "REGISTRY_ID", "reg-1")
+    client = mock.MagicMock()
+    page1 = {"records": [{"name": "a1", "recordId": "r1", "status": "APPROVED"}], "nextToken": "tok"}
+    page2 = {"records": [{"name": "a2", "recordId": "r2", "status": "APPROVED"}], "nextToken": None}
+    client.list_registry_records.side_effect = [page1, page2]
+    details = {
+        "r1": _agent_detail("a1", "r1", "APPROVED", "first"),
+        "r2": _agent_detail("a2", "r2", "APPROVED", "second"),
+    }
+    client.get_registry_record.side_effect = lambda registryId, recordId: details[recordId]  # noqa: N803
+    monkeypatch.setattr(fab, "_get_registry_client", lambda: client)
+
+    result = fab._get_existing_agents()
+
+    assert set(result) == {"a1", "a2"}
+    assert client.list_registry_records.call_count == 2
+
+
+def test_list_factory_agents_renders_registry_agents(monkeypatch):
+    monkeypatch.setattr(fab, "REGISTRY_ID", "reg-1")
+    records = [{"name": "ap-billing-agent-v1", "recordId": "rec1", "status": "DRAFT"}]
+    details = {"rec1": _agent_detail("ap-billing-agent-v1", "rec1", "DRAFT", "Billing agent")}
+    monkeypatch.setattr(fab, "_get_registry_client", lambda: _client(records, details))
+
+    out = fab.list_factory_agents()
+
+    assert "ap-billing-agent-v1" in out
+    assert "Billing agent" in out
+    assert "draft" in out
+
+
+def test_list_factory_agents_empty_message(monkeypatch):
+    monkeypatch.setattr(fab, "REGISTRY_ID", "")
+    out = fab.list_factory_agents()
+    assert "No agents" in out

--- a/service/agent_intake_single/tests/test_intake_state.py
+++ b/service/agent_intake_single/tests/test_intake_state.py
@@ -1,0 +1,70 @@
+"""Tests for intake-state progress field alignment (Bug B).
+
+Writers store '<phase>_progress' for PHASES = assessment, design, planning,
+implementation. get_intake_state previously read 'delivery_plan_progress'
+(never written -> always 0). It must instead read the ACTUAL written fields.
+
+Run with:
+    PYTHONPATH=. pytest tests/test_intake_state.py -q
+from the service/agent_intake_single directory.
+"""
+import json
+import os
+import sys
+from unittest import mock
+
+import pytest
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+
+import tools.state as state
+
+
+def test_get_intake_state_reads_actual_written_fields(monkeypatch):
+    table = mock.MagicMock()
+    table.get_item.return_value = {
+        "Item": {
+            "phase": "planning",
+            "assessment_progress": 100,
+            "design_progress": 100,
+            "planning_progress": 66,
+            "implementation_progress": 0,
+            "last_updated": 123,
+        }
+    }
+    monkeypatch.setattr(state, "_table", lambda: table)
+
+    result = json.loads(state.get_intake_state(session_id="s1"))
+
+    assert result["phase"] == "planning"
+    assert result["assessment_progress"] == 100
+    assert result["design_progress"] == 100
+    assert result["planning_progress"] == 66
+    assert result["implementation_progress"] == 0
+    # The never-written legacy key must be gone.
+    assert "delivery_plan_progress" not in result
+
+
+def test_get_intake_state_defaults_when_no_item(monkeypatch):
+    table = mock.MagicMock()
+    table.get_item.return_value = {}
+    monkeypatch.setattr(state, "_table", lambda: table)
+
+    result = json.loads(state.get_intake_state(session_id="s1"))
+
+    assert result["phase"] == "assessment"
+    assert result["assessment_progress"] == 0
+    assert result["design_progress"] == 0
+    assert result["planning_progress"] == 0
+    assert result["implementation_progress"] == 0
+    assert "delivery_plan_progress" not in result
+
+
+def test_update_intake_progress_docstring_matches_phases():
+    """The documented phase names must EXACTLY match PHASES."""
+    doc = state.update_intake_progress.__doc__ or ""
+    for phase in state.PHASES:
+        assert phase in doc
+    # The rejected legacy names must be gone from the docstring.
+    assert "technical_design" not in doc
+    assert "delivery_plan" not in doc

--- a/service/agent_intake_single/tools/fabricate.py
+++ b/service/agent_intake_single/tools/fabricate.py
@@ -1,19 +1,91 @@
 """Fabrication tools — plan, confirm, and trigger agent fabrication."""
 import json
+import logging
 import os
+import time
+from datetime import datetime, timezone
 import boto3
 from strands.tools import tool
 from tools.kb import s3_get, s3_put
 from config import bedrock, AGENT_MODEL_ID
 
+logger = logging.getLogger(__name__)
+
 SECTION_KEY = "{session_id}/design/td_2.md"
 PLAN_KEY = "{session_id}/planning/fabrication_plan.md"
 FABRICATOR_QUEUE_URL = os.getenv("FABRICATOR_QUEUE_URL", "")
-AGENT_CONFIG_TABLE = os.getenv("AGENT_CONFIG_TABLE", "")
+# Fabricated agents are written to the AgentCore Registry (via the arbiter's
+# store_agent_config_registry), NOT to a DynamoDB table — so the intake
+# catalog reads the registry. REGISTRY_ID identifies the registry to list.
+REGISTRY_ID = os.getenv("REGISTRY_ID", "")
+# Durable per-agent fabrication status table (citadel-fabrication-jobs-${env}).
+# When unset the PENDING status write is skipped so this stays backward-
+# compatible in environments that haven't wired the table yet.
+FABRICATION_JOBS_TABLE = os.getenv("FABRICATION_JOBS_TABLE", "")
 AWS_REGION = os.getenv("AWS_REGION", "ap-southeast-2")
+
+# ~7 day TTL (epoch seconds) keeps the fabrication-jobs table self-pruning.
+FABRICATION_JOBS_TTL_SECONDS = 7 * 24 * 60 * 60
+# Cap the stored task description so rows stay small.
+TASK_DESCRIPTION_MAX = 500
 
 sqs = boto3.client("sqs", region_name=AWS_REGION)
 dynamodb = boto3.resource("dynamodb", region_name=AWS_REGION)
+
+_registry_client = None
+
+
+def _get_registry_client():
+    """Lazy boto3 client for the AgentCore Registry control-plane APIs.
+
+    Built on first use so module import stays cheap and tests can patch it.
+    """
+    global _registry_client
+    if _registry_client is None:
+        _registry_client = boto3.client("bedrock-agentcore-control", region_name=AWS_REGION)
+    return _registry_client
+
+
+def _reset_registry_client_for_test() -> None:
+    """Test-only hook — forces the next call to rebuild the cached client."""
+    global _registry_client
+    _registry_client = None
+
+
+def _write_pending_fabrication_status(session_id: str, agent: dict) -> None:
+    """Best-effort PENDING row for an intake-driven fabrication request.
+
+    Keyed by orchestrationId (the intake session id) / agentUseId (the agent
+    name), mirroring the SQS body. Skipped when FABRICATION_JOBS_TABLE is unset.
+    A failure here NEVER fails the fabrication enqueue — the SQS message is
+    already sent, so we log and swallow rather than re-raising. Never an empty
+    except.
+    """
+    if not FABRICATION_JOBS_TABLE:
+        logger.info(
+            "FABRICATION_JOBS_TABLE unset; skipping PENDING status for %s/%s",
+            session_id, agent.get("name"),
+        )
+        return
+    now = datetime.now(timezone.utc).isoformat().replace("+00:00", "Z")
+    try:
+        dynamodb.Table(FABRICATION_JOBS_TABLE).put_item(Item={
+            "orchestrationId": session_id,
+            "agentUseId": agent["name"],
+            "status": "PENDING",
+            "agentName": agent["name"],
+            "taskDescription": (agent.get("spec") or "")[:TASK_DESCRIPTION_MAX],
+            "requestType": "agent-creation",
+            "requestedBy": "intake",
+            "submittedAt": now,
+            "updatedAt": now,
+            "ttl": int(time.time()) + FABRICATION_JOBS_TTL_SECONDS,
+        })
+    except Exception as e:  # noqa: BLE001 — best-effort: never block enqueue
+        logger.warning(
+            "Failed to write PENDING fabrication status for %s/%s: %s",
+            session_id, agent.get("name"), e,
+        )
 
 
 def _llm(system: str, user: str, max_tokens: int = 8192) -> str:
@@ -51,13 +123,130 @@ Return ONLY a JSON array, no markdown.
     return json.loads(raw)
 
 
-def _get_existing_agents() -> dict[str, dict]:
-    """Returns {agentId: config} for all agents in the factory."""
-    if not AGENT_CONFIG_TABLE:
+def _registry_state_from_status(status: str) -> str:
+    """Map an AgentCore Registry record status to a simple lifecycle state.
+
+    Mirrors the spirit of registry-service.ts toInternalState():
+    APPROVED-family -> active, DRAFT/CREATING -> draft, everything else
+    (deprecated / rejected / failed / unknown) -> inactive.
+    """
+    s = (status or "").upper()
+    if s in ("APPROVED", "UPDATING", "PENDING_APPROVAL"):
+        return "active"
+    if s in ("DRAFT", "CREATING"):
+        return "draft"
+    return "inactive"
+
+
+def _get_registry_record_safe(client, record_id: str) -> dict | None:
+    """GetRegistryRecord for one record, returning None on any failure (logged).
+
+    Never raises — a single record's detail being unavailable must not abort
+    the whole catalog listing.
+    """
+    try:
+        resp = client.get_registry_record(registryId=REGISTRY_ID, recordId=record_id)
+        return resp if isinstance(resp, dict) else None
+    except Exception as e:  # noqa: BLE001 — per-record best effort, never raise
+        logger.warning("get_registry_record failed for %s: %s", record_id, e)
+        return None
+
+
+def _parse_inline_metadata(detail: dict) -> dict:
+    """Parse the CUSTOM descriptor inlineContent JSON from a registry record.
+
+    Returns {} when the content is missing or malformed (logged) — never raises.
+    """
+    try:
+        content = (
+            (detail.get("descriptors") or {})
+            .get("custom", {})
+            .get("inlineContent")
+        )
+        if not content:
+            return {}
+        parsed = json.loads(content)
+        return parsed if isinstance(parsed, dict) else {}
+    except Exception as e:  # noqa: BLE001 — malformed metadata must not raise
+        logger.warning("Failed to parse registry inlineContent: %s", e)
         return {}
-    table = dynamodb.Table(AGENT_CONFIG_TABLE)
-    resp = table.scan(ProjectionExpression="agentId, config, #s", ExpressionAttributeNames={"#s": "state"})
-    return {item["agentId"]: item for item in resp.get("Items", [])}
+
+
+def _get_existing_agents() -> dict[str, dict]:
+    """Return factory agents from the AgentCore Registry, keyed by record name.
+
+    Fabricated agents are persisted to the AgentCore Registry (via the arbiter's
+    store_agent_config_registry), NEVER to a DynamoDB agent-config table — so
+    the intake catalog must read the registry to see ap-*-agent-v1 agents.
+
+    Each value is::
+
+        {
+            'name': <registry record name>,
+            'state': <active|draft|inactive derived from record status>,
+            'recordId': <registry recordId, for disambiguation>,
+            'description': <human description>,
+            'sourceProjectId': <intake project id from custom metadata, or None>,
+        }
+
+    Tool records (custom metadata without a ``manifest`` discriminator) are
+    excluded so only agents surface. Degrades gracefully: when REGISTRY_ID is
+    unset or the list call fails this logs and returns {} — it never raises, so
+    the intake agent stays usable even without registry visibility.
+    """
+    if not REGISTRY_ID:
+        logger.info("REGISTRY_ID unset; cannot list factory agents from registry")
+        return {}
+
+    try:
+        client = _get_registry_client()
+    except Exception as e:  # noqa: BLE001 — client build must not raise
+        logger.warning("Failed to build registry client: %s", e)
+        return {}
+
+    agents: dict[str, dict] = {}
+    next_token = None
+    try:
+        while True:
+            kwargs = {"registryId": REGISTRY_ID, "descriptorType": "CUSTOM"}
+            if next_token:
+                kwargs["nextToken"] = next_token
+            response = client.list_registry_records(**kwargs)
+            if not isinstance(response, dict):
+                break
+            for summary in response.get("records", []):
+                if not isinstance(summary, dict):
+                    continue
+                name = summary.get("name")
+                record_id = summary.get("recordId")
+                if not name or not record_id:
+                    continue
+                detail = _get_registry_record_safe(client, record_id)
+                meta = _parse_inline_metadata(detail) if detail else {}
+                # Agents always carry a `manifest` in custom metadata; tools do
+                # not (the manifest is the agent/tool discriminator). When we
+                # have detail and it is clearly a tool record, skip it so the
+                # factory catalog lists agents only. When detail is unavailable
+                # we include the record rather than guess.
+                if detail is not None and meta and "manifest" not in meta:
+                    continue
+                status = (detail.get("status") if detail else None) or summary.get("status", "")
+                description = (detail.get("description") if detail else None) or summary.get("description", "")
+                agents[name] = {
+                    "name": name,
+                    "state": _registry_state_from_status(status),
+                    "recordId": record_id,
+                    "description": description or "",
+                    "sourceProjectId": meta.get("sourceProjectId"),
+                }
+            next_token = response.get("nextToken")
+            if not isinstance(next_token, str) or not next_token:
+                break
+    except Exception as e:  # noqa: BLE001 — degrade gracefully, never raise
+        logger.warning("Failed to list factory agents from registry: %s", e)
+        return {}
+
+    return agents
 
 
 def _send_to_fabricator(session_id: str, agent: dict, agent_index: int = 0, total_agents: int = 1):
@@ -76,6 +265,9 @@ def _send_to_fabricator(session_id: str, agent: dict, agent_index: int = 0, tota
             "requestId": {"DataType": "String", "StringValue": agent["name"]},
         },
     )
+    # Durable PENDING status so the queue UI reflects this request before the
+    # consumer picks it up. Best-effort — never fails the enqueue.
+    _write_pending_fabrication_status(session_id, agent)
 
 
 @tool
@@ -105,7 +297,11 @@ def plan_fabrication(session_id: str) -> str:
             reason = agent.get("external_reason", "Requires external setup")
         elif name in existing:
             action = "reuse"
-            reason = f"Already in factory (v{existing[name].get('config', {}).get('version', '1')})"
+            rec = existing[name]
+            reason = (
+                f"Already in factory "
+                f"(recordId={rec.get('recordId')}, state={rec.get('state')})"
+            )
         else:
             action = "build"
             reason = "Not yet in factory — will be auto-fabricated"
@@ -176,24 +372,21 @@ def confirm_fabrication_plan(session_id: str, plan_json: str) -> str:
 def list_factory_agents() -> str:
     """List all agents that have been built and registered in the factory.
 
-    Returns:
-        Summary of registered agents with their name, description, state, and version.
-    """
-    if not AGENT_CONFIG_TABLE:
-        return "Error: AGENT_CONFIG_TABLE environment variable not set."
+    Reads the AgentCore Registry (the source of truth for fabricated agents).
 
+    Returns:
+        Summary of registered agents with their name, state, and description.
+    """
     existing = _get_existing_agents()
     if not existing:
         return "No agents have been built yet."
 
-    lines = [f"{'Agent':<30} {'State':<12} {'Version':<8} Description"]
+    lines = [f"{'Agent':<40} {'State':<10} Description"]
     lines.append("-" * 90)
-    for agent_id, item in sorted(existing.items()):
-        config = item.get("config", {})
+    for name, item in sorted(existing.items()):
         lines.append(
-            f"{agent_id:<30} "
-            f"{item.get('state', ''):<12} "
-            f"{config.get('version', ''):<8} "
-            f"{config.get('description', '')[:50]}"
+            f"{name:<40} "
+            f"{item.get('state', ''):<10} "
+            f"{(item.get('description') or '')[:50]}"
         )
     return "\n".join(lines)

--- a/service/agent_intake_single/tools/state.py
+++ b/service/agent_intake_single/tools/state.py
@@ -111,7 +111,9 @@ def get_intake_state(session_id: str) -> str:
         session_id: The session ID
 
     Returns:
-        JSON with current phase and progress per phase.
+        JSON with current phase and progress per phase. The progress keys
+        mirror PHASES exactly (assessment, design, planning, implementation) —
+        i.e. the '<phase>_progress' fields the write path actually stores.
     """
     try:
         resp = _table().get_item(Key={'p_key': session_id, 's_key': 'intake:latest'})
@@ -121,7 +123,8 @@ def get_intake_state(session_id: str) -> str:
                 'phase': item.get('phase', 'assessment'),
                 'assessment_progress': int(item.get('assessment_progress', 0)),
                 'design_progress': int(item.get('design_progress', 0)),
-                'delivery_plan_progress': int(item.get('delivery_plan_progress', 0)),
+                'planning_progress': int(item.get('planning_progress', 0)),
+                'implementation_progress': int(item.get('implementation_progress', 0)),
                 'last_updated': int(item.get('last_updated', 0)),
             })
     except Exception as e:
@@ -131,7 +134,8 @@ def get_intake_state(session_id: str) -> str:
         'phase': 'assessment',
         'assessment_progress': 0,
         'design_progress': 0,
-        'delivery_plan_progress': 0,
+        'planning_progress': 0,
+        'implementation_progress': 0,
         'last_updated': 0,
     })
 
@@ -163,7 +167,7 @@ def update_intake_progress(session_id: str, phase: str, progress: int, change_su
 
     Args:
         session_id: The session ID
-        phase: One of: assessment, technical_design, delivery_plan
+        phase: One of: assessment, design, planning, implementation
         progress: Completion percentage (0-100)
         change_summary: Brief description of what changed
 


### PR DESCRIPTION
Fixes: Issue #8 - Reliable end-to-end Intake: server-side document ingestion + agent fabrication

## Summary
This release makes the Intake Request process work reliably from end-to-end - document upload and assessment through solution design, planning, and agent fabrication/activation. Document ingestion is now server-authoritative (resilient to client disconnects, such as closing browser tab/window), agent fabrication completes deterministically with durable status tracking, and the UI surfaces live fabrication progress with one-click activation.

## What's included

**`feat(intake): add server-side document ingestion with reliable status tracking`**
- Moves document ingestion off the browser to a server-driven flow: an S3 upload triggers ingestion, and a scheduled poller resolves the true indexing state and fires the assessment trigger exactly once — so progress no longer depends on the tab staying open.
- Introduces a durable ingestion status store as the single source of truth, replacing conflicting status signals, and surfaces real failure reasons for diagnosability.
- Correctly handles Bedrock Knowledge Base semantics (direct-ingestion permissions, dedup/no-op `IGNORED` status, region-correct model inference profiles) and retries previously-failed documents on re-upload.

**`feat(fabricator): add reliable agent fabrication with status tracking and source-project tagging`**
- Hardens the fabrication pipeline: bounded SQS processing, a visibility timeout safely above the function timeout, and idempotent record creation to prevent duplicate or redelivered builds.
- Adds a durable fabrication-jobs status table (`PENDING → PROCESSING → COMPLETED/FAILED`) powering an accurate queue view.
- Makes the intake agent aware of its real state: it reads the factory list from the agent registry and reports the actual project-stage progress.
- Tags each fabricated agent with its source project so same-named agents are easy to disambiguate in the catalog.

**`feat(intake): add live fabrication status and one-click agent activation`**
- Adds a fabrication status panel to the Intake build phase showing live per-agent status (queued/building/built/failed) via subscription updates.
- Adds an **"Activate all agents"** action once a project's agents are built, activating them in a single click.

## Outcomes
- Intake flow completes end-to-end: upload → assess → design → plan → build → fabricate → activate.
- Server-authoritative ingestion and fabrication: resilient to closed tabs, timeouts, duplicate triggers, and redeliveries.
- Accurate visibility into ingestion and fabrication status within the Intake Request UI.

## Testing
- Backend unit tests (Jest), Python tests (pytest), and CDK `Template.fromStack` assertions added across the changed areas; `cdk synth` validated for the affected stacks. Frontend component tests are included.

## Notes
- Schema changes are additive and backward-compatible.
- Requires deploying the backend, orchestration, and services stacks plus the frontend.
