### PR TITLE
chore: add issue and pull request templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,41 @@
+---
+name: Bug report
+about: Report a problem so we can fix it
+title: "[Bug] "
+labels: bug
+assignees: ''
+---
+
+**Describe the bug**
+A clear and concise description of what the bug is.
+
+**To reproduce**
+Steps to reproduce the behavior:
+1. Go to '...'
+2. Run '...'
+3. See error
+
+**Expected behavior**
+A clear and concise description of what you expected to happen.
+
+**Actual behavior**
+What actually happened, including full error output or stack traces (please use code blocks).
+
+**Affected layer / component**
+Which part of Citadel is involved? (e.g. `backend` AppSync resolver, `arbiter` StepRunner, `gateway` authorizer, `frontend`, `service` AgentCore, a specific adapter/integration, CDK stack)
+
+**Version / commit**
+The version or git commit SHA of the code being used.
+
+**Environment**
+- AWS region:
+- Node.js version:
+- Python version:
+- CDK version:
+- Anything unusual about your environment or deployment:
+
+**Additional context**
+Add any other context, logs, or screenshots about the problem here.
+
+> Note: If you believe this is a **security** issue, do **not** file a public issue.
+> Report it via the AWS vulnerability reporting page: http://aws.amazon.com/security/vulnerability-reporting/

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,8 @@
+blank_issues_enabled: true
+contact_links:
+  - name: Security vulnerability
+    url: http://aws.amazon.com/security/vulnerability-reporting/
+    about: Please report security issues to AWS/Amazon Security — do NOT open a public GitHub issue.
+  - name: Code of Conduct
+    url: https://aws.github.io/code-of-conduct
+    about: This project has adopted the Amazon Open Source Code of Conduct.

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,27 @@
+---
+name: Feature request
+about: Suggest an enhancement or new capability
+title: "[Feature] "
+labels: enhancement
+assignees: ''
+---
+
+**Is your feature request related to a problem? Please describe.**
+A clear and concise description of the problem or gap. Ex. "As a partner I can't tell which agent app is driving spend because ..."
+
+**Describe the solution you'd like**
+A clear and concise description of what you want to happen.
+
+**Affected layer / component**
+Which part of Citadel would this touch? (e.g. `backend`, `arbiter`, `gateway`, `frontend`, `service`, governance, a specific adapter/integration, CDK stacks)
+
+**Describe alternatives you've considered**
+Any alternative solutions or features you've considered.
+
+**Scope / non-goals**
+What is explicitly in scope, and what is intentionally left out of this request.
+
+**Additional context**
+Add any other context, mockups, or links here.
+
+> Per `CONTRIBUTING.md`, please open an issue to discuss any significant work before sending a pull request — we'd hate for your time to be wasted.

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,45 @@
+<!--
+Thanks for contributing to Citadel! Please keep PRs focused on a single change.
+See CONTRIBUTING.md before submitting.
+-->
+
+## Description
+
+<!-- What does this PR do and why? -->
+
+## Related issue
+
+<!-- e.g. Closes #123. Per CONTRIBUTING.md, significant work should start from a discussed issue. -->
+
+## Type of change
+
+- [ ] Bug fix (non-breaking change that fixes an issue)
+- [ ] New feature (non-breaking change that adds functionality)
+- [ ] Breaking change (fix or feature that changes existing behavior)
+- [ ] Documentation only
+- [ ] Chore / tooling / CI
+
+## Affected layer(s)
+
+- [ ] `backend` (AppSync / Cognito / DynamoDB / EventBridge)
+- [ ] `arbiter` (Supervisor / Fabricator / Worker / StepRunner)
+- [ ] `gateway` (per-app API Gateway / authorizer / metrics)
+- [ ] `frontend` (React / Vite)
+- [ ] `service` (AgentCore Runtime / Gateway / Knowledge Base)
+- [ ] governance
+- [ ] infra / CDK
+- [ ] docs
+
+## Checklist
+
+- [ ] I am working against the latest source on the `main` branch
+- [ ] I checked existing open and recently merged PRs to avoid duplicates
+- [ ] My change is focused; I did not reformat unrelated code
+- [ ] I added or updated tests (this project follows TDD — Red/Green/Refactor)
+- [ ] Local tests pass
+- [ ] I updated relevant documentation
+- [ ] I confirm the licensing of my contribution (see `LICENSE`)
+
+## Testing
+
+<!-- How did you verify this change? Commands run, output, screenshots. -->


### PR DESCRIPTION
Adds the missing GitHub contribution scaffolding:
- .github/ISSUE_TEMPLATE/bug_report.md
- .github/ISSUE_TEMPLATE/feature_request.md
- .github/ISSUE_TEMPLATE/config.yml (routes security reports to AWS vulnerability reporting; links Code of Conduct)
- .github/pull_request_template.md (focused-change checklist aligned with CONTRIBUTING.md and the project's TDD workflow)


Claude-Session: https://claude.ai/code/session_01Jo23wVkjxvhMhEbyWxngEv

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
