### PR TITLE
fix(backend): handle undefined description in organization creation

### DIFF
--- a/backend/src/lambda/__tests__/organization-resolver.test.ts
+++ b/backend/src/lambda/__tests__/organization-resolver.test.ts
@@ -27,7 +27,7 @@ describe('organization-resolver', () => {
   });
 
   const makeEvent = (fieldName: string, args: any) => ({
-    fieldName,
+    info: { fieldName },
     arguments: args,
   });
 
@@ -55,6 +55,32 @@ describe('organization-resolver', () => {
           input: { name: 'Duplicate' },
         }))
       ).rejects.toThrow('already exists');
+    });
+
+    test('creates organization with no description, writing no undefined attributes', async () => {
+      // Regression: the resolver's document client is created without
+      // `removeUndefinedValues`, so a PutCommand carrying `description:
+      // undefined` fails marshalling at runtime (surfaces as
+      // Lambda:Unhandled). The frontend sends `description: undefined`
+      // whenever the field is left blank, so this path must not write
+      // an undefined value.
+      dynamoMock.on(ScanCommand).resolves({ Items: [] });
+      dynamoMock.on(PutCommand).resolves({});
+
+      const result = await handler(makeEvent('createOrganization', {
+        input: { name: 'No Desc Org' },
+      }));
+
+      expect(result.name).toBe('No Desc Org');
+
+      const putCalls = dynamoMock.commandCalls(PutCommand);
+      expect(putCalls).toHaveLength(1);
+      const item = (putCalls[0].args[0].input as any).Item;
+      // Absent description defaults to '' (mirrors project-resolver).
+      expect(item.description).toBe('');
+      // No attribute may be undefined — that is exactly what breaks
+      // DynamoDB marshalling in production.
+      expect(Object.values(item).every((v) => v !== undefined)).toBe(true);
     });
   });
 

--- a/backend/src/lambda/__tests__/organization-resolver.test.ts
+++ b/backend/src/lambda/__tests__/organization-resolver.test.ts
@@ -75,7 +75,7 @@ describe('organization-resolver', () => {
 
       const putCalls = dynamoMock.commandCalls(PutCommand);
       expect(putCalls).toHaveLength(1);
-      const item = (putCalls[0].args[0].input as any).Item;
+      const item = putCalls[0].args[0].input.Item!;
       // Absent description defaults to '' (mirrors project-resolver).
       expect(item.description).toBe('');
       // No attribute may be undefined — that is exactly what breaks

--- a/backend/src/lambda/organization-resolver.ts
+++ b/backend/src/lambda/organization-resolver.ts
@@ -33,7 +33,8 @@ interface UserManagementResponse {
 export const handler = async (event: any): Promise<any> => {
   console.log('Organization resolver event:', JSON.stringify(event, null, 2));
 
-  const { fieldName, arguments: args } = event;
+  const { info, arguments: args } = event;
+  const fieldName = info.fieldName;
 
   try {
     switch (fieldName) {
@@ -77,7 +78,13 @@ async function createOrganization(input: CreateOrganizationInput): Promise<Organ
   const organization: Organization = {
     orgId,
     name: input.name,
-    description: input.description,
+    // Default to '' rather than passing through undefined. The document
+    // client is created without `removeUndefinedValues`, so a PutCommand
+    // with `description: undefined` fails marshalling ("Pass
+    // options.removeUndefinedValues=true ...") and surfaces as a
+    // Lambda:Unhandled error when an org is created with no description.
+    // Mirrors the `input.description || ''` idiom in project-resolver.
+    description: input.description || '',
     createdAt: now,
   };
 


### PR DESCRIPTION
*Issue #, if available:*
#14 

*Description of changes:*

backend/src/lambda/organization-resolver.ts
Read the field name from event.info.fieldName (consistent with every other resolver).
Default description to '' (input.description || ''), mirroring the existing project-resolver.ts idiom, so no undefined attribute reaches DynamoDB.
backend/src/lambda/__tests__/organization-resolver.test.ts
Fixed the makeEvent helper to use the real AppSync shape ({ info: { fieldName } }) so the suite exercises the actual contract.
Added a regression test for creating an org with no description, asserting no item attribute is undefined.
Testing
npx jest src/lambda/__tests__/organization-resolver.test.ts — all 7 tests pass.
Confirmed the undefined-marshalling failure mode against the installed @aws-sdk/util-dynamodb.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
