### PR TITLE
fix: Team Management organization create/delete (#14)

### DIFF
--- a/backend/src/lambda/__tests__/organization-resolver.test.ts
+++ b/backend/src/lambda/__tests__/organization-resolver.test.ts
@@ -107,38 +107,68 @@ describe('organization-resolver', () => {
   });
 
   describe('deleteOrganization', () => {
-    test('deletes empty organization, calls ListUsersCommand with correct filter, then DeleteCommand', async () => {
+    // Orphan-user guard rationale (Issue #14, 2nd bug): the user↔org link lives
+    // ONLY in the Cognito `custom:organization` user-pool attribute. Cognito
+    // ListUsers supports server-side `Filter` on STANDARD attributes only — a
+    // `custom:*` Filter raises InvalidParameterException ("Input fails to
+    // satisfy the constraints") in the real service (aws-sdk-client-mock does
+    // NOT enforce that constraint, which is exactly what masked the bug). The
+    // resolver must therefore PAGINATE ListUsers and match attributes
+    // client-side, failing closed on the first match.
+
+    // (b): a delete SUCCEEDS when users exist in the pool but NONE carry
+    // custom:organization === orgId — the resolver must discriminate on the
+    // attribute value, not merely on "any users returned".
+    test('deletes organization when no user matches the orgId, then calls DeleteCommand', async () => {
       // Existence check returns the org row.
       dynamoMock.on(ScanCommand).resolves({
         Items: [{ orgId: 'org-1', name: 'Org' }],
       });
-      // Cognito returns no users with matching custom:organization claim.
-      cognitoMock.on(ListUsersCommand).resolves({ Users: [] });
+      // Users exist but NONE carry custom:organization === 'org-1'.
+      cognitoMock.on(ListUsersCommand).resolves({
+        Users: [
+          { Username: 'other-1', Attributes: [{ Name: 'custom:organization', Value: 'different-org' }] },
+          { Username: 'no-attr', Attributes: [] },
+        ],
+      });
       dynamoMock.on(DeleteCommand).resolves({});
 
       const result = await handler(makeEvent('deleteOrganization', { orgId: 'org-1' }));
 
       expect(result.success).toBe(true);
-
-      // ListUsersCommand was invoked with the correct user-pool + filter.
-      const listUsersCalls = cognitoMock.commandCalls(ListUsersCommand);
-      expect(listUsersCalls).toHaveLength(1);
-      const listInput = listUsersCalls[0].args[0].input as any;
-      expect(listInput.UserPoolId).toBe('us-east-1_testpool');
-      expect(listInput.Filter).toBe('"custom:organization" = "org-1"');
-      expect(listInput.Limit).toBe(1);
-
       // DeleteCommand ran exactly once.
       expect(dynamoMock.commandCalls(DeleteCommand)).toHaveLength(1);
     });
 
-    test('throws when organization still has users assigned, DeleteCommand NOT called', async () => {
+    // (c): the ListUsers input must NOT contain a `custom:` attribute Filter —
+    // that server-side filter is precisely what Cognito rejects.
+    test('does NOT send a custom: attribute Filter to ListUsers', async () => {
       dynamoMock.on(ScanCommand).resolves({
         Items: [{ orgId: 'org-1', name: 'Org' }],
       });
-      // Cognito returns one user — org cannot be deleted while users link to it.
+      cognitoMock.on(ListUsersCommand).resolves({ Users: [] });
+      dynamoMock.on(DeleteCommand).resolves({});
+
+      await handler(makeEvent('deleteOrganization', { orgId: 'org-1' }));
+
+      const listUsersCalls = cognitoMock.commandCalls(ListUsersCommand);
+      expect(listUsersCalls.length).toBeGreaterThanOrEqual(1);
+      const listInput = listUsersCalls[0].args[0].input as any;
+      expect(listInput.UserPoolId).toBe('us-east-1_testpool');
+      const filterStr = listInput.Filter === undefined ? '' : String(listInput.Filter);
+      expect(filterStr.includes('custom:')).toBe(false);
+    });
+
+    // (a): delete is BLOCKED (fail-closed) when a returned user's
+    // custom:organization attribute equals the target orgId.
+    test('throws when a user custom:organization matches orgId, DeleteCommand NOT called', async () => {
+      dynamoMock.on(ScanCommand).resolves({
+        Items: [{ orgId: 'org-1', name: 'Org' }],
+      });
       cognitoMock.on(ListUsersCommand).resolves({
-        Users: [{ Username: 'still-here-user', Attributes: [] }],
+        Users: [
+          { Username: 'still-here-user', Attributes: [{ Name: 'custom:organization', Value: 'org-1' }] },
+        ],
       });
 
       await expect(
@@ -146,6 +176,37 @@ describe('organization-resolver', () => {
       ).rejects.toThrow(/user\(s\) still assigned/);
 
       // DeleteCommand must NOT have run.
+      expect(dynamoMock.commandCalls(DeleteCommand)).toHaveLength(0);
+    });
+
+    // (d): pagination — a match on the SECOND page must still block the delete.
+    // Page 1 returns a non-matching user + PaginationToken; page 2 returns the
+    // match. The resolver must follow the token and catch it.
+    test('paginates ListUsers and blocks the delete on a second-page match', async () => {
+      dynamoMock.on(ScanCommand).resolves({
+        Items: [{ orgId: 'org-1', name: 'Org' }],
+      });
+      cognitoMock
+        .on(ListUsersCommand)
+        .resolvesOnce({
+          Users: [
+            { Username: 'other', Attributes: [{ Name: 'custom:organization', Value: 'different-org' }] },
+          ],
+          PaginationToken: 'page-2-token',
+        })
+        .resolvesOnce({
+          Users: [
+            { Username: 'matching-user', Attributes: [{ Name: 'custom:organization', Value: 'org-1' }] },
+          ],
+        });
+
+      await expect(
+        handler(makeEvent('deleteOrganization', { orgId: 'org-1' }))
+      ).rejects.toThrow(/user\(s\) still assigned/);
+
+      // Both pages were fetched — the PaginationToken from page 1 was followed.
+      expect(cognitoMock.commandCalls(ListUsersCommand)).toHaveLength(2);
+      // And the delete was blocked.
       expect(dynamoMock.commandCalls(DeleteCommand)).toHaveLength(0);
     });
 

--- a/backend/src/lambda/__tests__/organization-resolver.test.ts
+++ b/backend/src/lambda/__tests__/organization-resolver.test.ts
@@ -1,5 +1,17 @@
 /**
- * Tests for organization-resolver Lambda
+ * Tests for organization-resolver Lambda.
+ *
+ * Regression coverage for Issue #14 — "Team Management Add/Delete Organization
+ * fails with 'Unknown field: undefined' (Lambda:Unhandled)":
+ *   - Bug (a): the handler must dispatch on `event.info.fieldName` (the real
+ *     AppSync $context shape), NOT `event.fieldName`. `makeEvent` below builds
+ *     the REAL AppSync event so the dispatch path is exercised exactly as
+ *     production sees it. (The previous helper produced a fake `{ fieldName }`
+ *     object that agreed with the buggy resolver and masked the defect.)
+ *   - Bug (b): `createOrganization` must never place `description: undefined`
+ *     into the DynamoDB item — it must default to '' (matching
+ *     project-resolver.ts `input.description || ''`) so PutCommand marshalling
+ *     in the real (unmocked) client cannot throw.
  */
 // Env vars must be set BEFORE the resolver module loads — the resolver
 // captures process.env values into top-level constants at import time.
@@ -26,13 +38,17 @@ describe('organization-resolver', () => {
     cognitoMock.reset();
   });
 
+  // REAL AppSync $context shape: the field name lives under `info.fieldName`,
+  // with `arguments` and `identity` alongside — matching project-resolver.test.ts
+  // and docs/RESOLVER_GUIDE.md.
   const makeEvent = (fieldName: string, args: any) => ({
-    fieldName,
+    info: { fieldName },
     arguments: args,
+    identity: { sub: 'user-1' },
   });
 
   describe('createOrganization', () => {
-    test('creates organization when name is unique', async () => {
+    test('creates organization when name is unique and preserves the description', async () => {
       dynamoMock.on(ScanCommand).resolves({ Items: [] });
       dynamoMock.on(PutCommand).resolves({});
 
@@ -42,7 +58,39 @@ describe('organization-resolver', () => {
 
       expect(result.orgId).toBe('org-uuid-123');
       expect(result.name).toBe('New Org');
+      expect(result.description).toBe('A test org');
       expect(result.createdAt).toBeDefined();
+
+      const putCalls = dynamoMock.commandCalls(PutCommand);
+      expect(putCalls).toHaveLength(1);
+      expect((putCalls[0].args[0].input.Item as any).description).toBe('A test org');
+    });
+
+    test('creates organization with a blank description and writes NO undefined attribute', async () => {
+      dynamoMock.on(ScanCommand).resolves({ Items: [] });
+      dynamoMock.on(PutCommand).resolves({});
+
+      // `description` omitted from input -> resolver must default it to ''.
+      const result = await handler(makeEvent('createOrganization', {
+        input: { name: 'No Desc Org' },
+      }));
+
+      expect(result.orgId).toBe('org-uuid-123');
+      expect(result.name).toBe('No Desc Org');
+      // Defaulted to '' (matches project-resolver.ts `input.description || ''`).
+      expect(result.description).toBe('');
+
+      // The PutCommand Item must contain NO attribute whose value is undefined.
+      // An undefined value throws during DynamoDB marshalling in the real
+      // (unmocked) client and produced the Lambda:Unhandled error in Issue #14.
+      const putCalls = dynamoMock.commandCalls(PutCommand);
+      expect(putCalls).toHaveLength(1);
+      const item = putCalls[0].args[0].input.Item as Record<string, unknown>;
+      expect(item.description).toBe('');
+      const undefinedAttrs = Object.entries(item)
+        .filter(([, v]) => v === undefined)
+        .map(([k]) => k);
+      expect(undefinedAttrs).toEqual([]);
     });
 
     test('throws when organization name already exists', async () => {
@@ -116,7 +164,11 @@ describe('organization-resolver', () => {
     });
   });
 
-  test('throws on unknown field', async () => {
-    await expect(handler(makeEvent('unknownField', {}))).rejects.toThrow('Unknown field');
+  test('throws a clear error naming the unknown field', async () => {
+    // Dispatch must resolve the real field name from info.fieldName — an
+    // unknown field yields 'Unknown field: <name>', never 'Unknown field: undefined'.
+    await expect(
+      handler(makeEvent('unknownField', {}))
+    ).rejects.toThrow('Unknown field: unknownField');
   });
 });

--- a/backend/src/lambda/organization-resolver.ts
+++ b/backend/src/lambda/organization-resolver.ts
@@ -131,8 +131,8 @@ async function deleteOrganization(orgId: string): Promise<UserManagementResponse
   //    and risks cross-tenant access if the orgId is ever reused.
   //
   //    Mirror the `createOrganization` "pre-check + throw" idiom used
-  //    above — list users with a server-side filter, hard-cap to 1, fail
-  //    closed if any are returned.
+  //    above — enumerate users and fail closed if any still point at this
+  //    org (client-side match; see the ListUsers note below for why).
   //
   //    Defensive guard: if USER_POOL_ID is unset (e.g. transitional
   //    deploy ordering or local fixture), refuse the delete rather than
@@ -144,22 +144,38 @@ async function deleteOrganization(orgId: string): Promise<UserManagementResponse
     );
   }
 
-  const usersResponse = await cognitoClient.send(
-    new ListUsersCommand({
-      UserPoolId: USER_POOL_ID,
-      // Cognito ListUsers filter syntax requires the attribute name to be
-      // wrapped in double quotes when it contains a colon (custom:*).
-      // Reference: https://docs.aws.amazon.com/cognito/latest/developerguide/how-to-manage-user-accounts.html#cognito-user-pools-searching-for-users-using-listusers-api
-      Filter: `"custom:organization" = "${orgId}"`,
-      Limit: 1,
-    })
-  );
-
-  if (usersResponse.Users && usersResponse.Users.length > 0) {
-    throw new Error(
-      'Cannot delete organization: 1+ user(s) still assigned. Reassign or remove these users before deleting the organization.'
+  //    Cognito ListUsers server-side `Filter` supports STANDARD attributes
+  //    ONLY (username, email, phone_number, name, given_name, family_name,
+  //    preferred_username, sub, cognito:user_status, status). Filtering on a
+  //    CUSTOM attribute (custom:organization) raises InvalidParameterException
+  //    — surfaced to the client as "Input fails to satisfy the constraints"
+  //    and logged as Lambda:Unhandled (Issue #14, 2nd bug). We therefore PAGE
+  //    through the pool (max 60 users per page) and match custom:organization
+  //    CLIENT-SIDE, failing closed on the FIRST match. Bounded by design: we
+  //    check-and-early-exit per page and never buffer an unbounded user array.
+  let paginationToken: string | undefined;
+  do {
+    const usersResponse = await cognitoClient.send(
+      new ListUsersCommand({
+        UserPoolId: USER_POOL_ID,
+        Limit: 60,
+        PaginationToken: paginationToken,
+      })
     );
-  }
+
+    for (const user of usersResponse.Users ?? []) {
+      const assignedToOrg = (user.Attributes ?? []).some(
+        (attr) => attr.Name === 'custom:organization' && attr.Value === orgId
+      );
+      if (assignedToOrg) {
+        throw new Error(
+          'Cannot delete organization: 1+ user(s) still assigned. Reassign or remove these users before deleting the organization.'
+        );
+      }
+    }
+
+    paginationToken = usersResponse.PaginationToken;
+  } while (paginationToken);
 
   // 3. Safe to delete.
   //

--- a/backend/src/lambda/organization-resolver.ts
+++ b/backend/src/lambda/organization-resolver.ts
@@ -7,7 +7,12 @@ import {
 import { v4 as uuidv4 } from 'uuid';
 
 const client = new DynamoDBClient({});
-const docClient = DynamoDBDocumentClient.from(client);
+// removeUndefinedValues: defensive guard so no undefined attribute can break
+// PutCommand marshalling (Issue #14). The `input.description || ''` default in
+// createOrganization handles the known case; this covers any future field.
+const docClient = DynamoDBDocumentClient.from(client, {
+  marshallOptions: { removeUndefinedValues: true },
+});
 const cognitoClient = new CognitoIdentityProviderClient({});
 
 const ORGANIZATIONS_TABLE = process.env.ORGANIZATIONS_TABLE || '';
@@ -33,7 +38,12 @@ interface UserManagementResponse {
 export const handler = async (event: any): Promise<any> => {
   console.log('Organization resolver event:', JSON.stringify(event, null, 2));
 
-  const { fieldName, arguments: args } = event;
+  // AppSync delivers the operation name under event.info.fieldName (not
+  // event.fieldName). Reading the wrong path left fieldName undefined, so every
+  // dispatch fell through to the default case → 'Unknown field: undefined'
+  // (Issue #14). Match project-resolver.ts + docs/RESOLVER_GUIDE.md.
+  const { info, arguments: args } = event;
+  const fieldName = info.fieldName;
 
   try {
     switch (fieldName) {
@@ -77,7 +87,9 @@ async function createOrganization(input: CreateOrganizationInput): Promise<Organ
   const organization: Organization = {
     orgId,
     name: input.name,
-    description: input.description,
+    // Default to '' (matches project-resolver.ts). Writing `undefined` breaks
+    // DynamoDB marshalling in the real client → Lambda:Unhandled (Issue #14).
+    description: input.description || '',
     createdAt: now,
   };
 


### PR DESCRIPTION
## Summary

Resolves the Team Management organization failures reported in #14. Both **Add Organization** and **Delete Organization** failed with `Lambda:Unhandled` / `Unknown field: undefined`; once dispatch was corrected, Delete additionally failed with `Input fails to satisfy the constraints`. All of it is fixed in `backend/src/lambda/organization-resolver.ts` — backend resolver only, no schema or infra change.

Thanks to @mlwood-dev for the detailed report and root-cause analysis.

## Bugs fixed

**1. Wrong field-dispatch path (Add + Delete).** 
The handler read `event.fieldName`, but AppSync provides the operation name at `event.info.fieldName`. The field name was therefore always `undefined`, the dispatch `switch` fell through to `default`, and every mutation threw `Unknown field: undefined`.
→ Dispatch now reads `event.info.fieldName` (matching `docs/RESOLVER_GUIDE.md` and the other resolvers).

**2. Undefined description on create (Add).**
A blank description was written as `undefined` into the DynamoDB item, which fails marshalling.
→ Default a blank description to `''`, and configure the document client with `removeUndefinedValues` as a defensive guard.

**3. Unsupported Cognito filter in the delete orphan-check (Delete).**
The orphan-user guard called Cognito `ListUsers` with a server-side `Filter` on the **custom** attribute `custom:organization`. `ListUsers` does not support filtering on custom attributes (only a fixed set of standard ones), so the callwas rejected with `Input fails to satisfy the constraints`.
→ The orphan-check now **paginates `ListUsers` and matches `custom:organization` client-side**, failing closed on the first match (early-exit) and deleting only when no user is still assigned. Guard semantics are unchanged; the unsupported API call is removed.

## Tests

The existing unit tests had **masked both dispatch and filter bugs** — the event builder used a fake `{ fieldName }` shape instead of AppSync's real `event.info.fieldName`, and the delete test asserted the invalid server-side filter against a mock that doesn't enforce Cognito's constraints. Corrected, plus regression coverage (verified red→green):
- Add with and without a description (asserts no `undefined` attribute is written).
- Delete blocked when a user is still assigned; delete succeeds when none are; the orphan-check sends no `custom:` filter; pagination — a match on a later page is still caught.
- Unknown-field path still errors clearly.

## Scope & deployment

Backend AppSync resolver only — no schema or infrastructure change. Requires a backend Lambda redeploy after merge.

Fixes #14 