### PR TITLE
fix: match custom:organization by org name in delete-org guard (#19)

### DIFF
--- a/backend/src/lambda/__tests__/organization-resolver.test.ts
+++ b/backend/src/lambda/__tests__/organization-resolver.test.ts
@@ -117,17 +117,21 @@ describe('organization-resolver', () => {
     // client-side, failing closed on the first match.
 
     // (b): a delete SUCCEEDS when users exist in the pool but NONE carry
-    // custom:organization === orgId — the resolver must discriminate on the
-    // attribute value, not merely on "any users returned".
-    test('deletes organization when no user matches the orgId, then calls DeleteCommand', async () => {
-      // Existence check returns the org row.
+    // custom:organization === the org NAME — the resolver must discriminate on
+    // the attribute value, not merely on "any users returned". The org's
+    // orgId (a UUID) differs from its name, so a user still carrying the orgId
+    // as its attribute value must NOT block the delete (Issue #19).
+    test('deletes organization when no user matches the org name, then calls DeleteCommand', async () => {
+      // Existence check returns the org row (name differs from orgId).
       dynamoMock.on(ScanCommand).resolves({
-        Items: [{ orgId: 'org-1', name: 'Org' }],
+        Items: [{ orgId: 'org-1', name: 'Operations' }],
       });
-      // Users exist but NONE carry custom:organization === 'org-1'.
+      // Users exist but NONE carry custom:organization === 'Operations'.
+      // 'other-1' still holds the orgId UUID — proving the guard keys off name.
       cognitoMock.on(ListUsersCommand).resolves({
         Users: [
-          { Username: 'other-1', Attributes: [{ Name: 'custom:organization', Value: 'different-org' }] },
+          { Username: 'other-1', Attributes: [{ Name: 'custom:organization', Value: 'org-1' }] },
+          { Username: 'diff-org', Attributes: [{ Name: 'custom:organization', Value: 'different-org' }] },
           { Username: 'no-attr', Attributes: [] },
         ],
       });
@@ -144,7 +148,7 @@ describe('organization-resolver', () => {
     // that server-side filter is precisely what Cognito rejects.
     test('does NOT send a custom: attribute Filter to ListUsers', async () => {
       dynamoMock.on(ScanCommand).resolves({
-        Items: [{ orgId: 'org-1', name: 'Org' }],
+        Items: [{ orgId: 'org-1', name: 'Operations' }],
       });
       cognitoMock.on(ListUsersCommand).resolves({ Users: [] });
       dynamoMock.on(DeleteCommand).resolves({});
@@ -160,14 +164,14 @@ describe('organization-resolver', () => {
     });
 
     // (a): delete is BLOCKED (fail-closed) when a returned user's
-    // custom:organization attribute equals the target orgId.
-    test('throws when a user custom:organization matches orgId, DeleteCommand NOT called', async () => {
+    // custom:organization attribute equals the target org NAME.
+    test('throws when a user custom:organization matches the org name, DeleteCommand NOT called', async () => {
       dynamoMock.on(ScanCommand).resolves({
-        Items: [{ orgId: 'org-1', name: 'Org' }],
+        Items: [{ orgId: 'org-1', name: 'Operations' }],
       });
       cognitoMock.on(ListUsersCommand).resolves({
         Users: [
-          { Username: 'still-here-user', Attributes: [{ Name: 'custom:organization', Value: 'org-1' }] },
+          { Username: 'still-here-user', Attributes: [{ Name: 'custom:organization', Value: 'Operations' }] },
         ],
       });
 
@@ -179,12 +183,34 @@ describe('organization-resolver', () => {
       expect(dynamoMock.commandCalls(DeleteCommand)).toHaveLength(0);
     });
 
+    // (a'): regression for Issue #19 — the guard must key off the org NAME,
+    // not the orgId. A user whose custom:organization holds the orgId UUID
+    // (which is NEVER what the attribute actually stores) must NOT block the
+    // delete; the pre-fix code compared against orgId and would wrongly block
+    // here while wrongly allowing the real name-valued case above.
+    test('does NOT block on the orgId UUID (custom:organization stores the name, not the id)', async () => {
+      dynamoMock.on(ScanCommand).resolves({
+        Items: [{ orgId: 'org-1', name: 'Operations' }],
+      });
+      cognitoMock.on(ListUsersCommand).resolves({
+        Users: [
+          { Username: 'carries-uuid', Attributes: [{ Name: 'custom:organization', Value: 'org-1' }] },
+        ],
+      });
+      dynamoMock.on(DeleteCommand).resolves({});
+
+      const result = await handler(makeEvent('deleteOrganization', { orgId: 'org-1' }));
+
+      expect(result.success).toBe(true);
+      expect(dynamoMock.commandCalls(DeleteCommand)).toHaveLength(1);
+    });
+
     // (d): pagination — a match on the SECOND page must still block the delete.
     // Page 1 returns a non-matching user + PaginationToken; page 2 returns the
     // match. The resolver must follow the token and catch it.
     test('paginates ListUsers and blocks the delete on a second-page match', async () => {
       dynamoMock.on(ScanCommand).resolves({
-        Items: [{ orgId: 'org-1', name: 'Org' }],
+        Items: [{ orgId: 'org-1', name: 'Operations' }],
       });
       cognitoMock
         .on(ListUsersCommand)
@@ -196,7 +222,7 @@ describe('organization-resolver', () => {
         })
         .resolvesOnce({
           Users: [
-            { Username: 'matching-user', Attributes: [{ Name: 'custom:organization', Value: 'org-1' }] },
+            { Username: 'matching-user', Attributes: [{ Name: 'custom:organization', Value: 'Operations' }] },
           ],
         });
 

--- a/backend/src/lambda/organization-resolver.ts
+++ b/backend/src/lambda/organization-resolver.ts
@@ -123,12 +123,27 @@ async function deleteOrganization(orgId: string): Promise<UserManagementResponse
     throw new Error(`Organization with ID "${orgId}" not found`);
   }
 
+  //    The Cognito `custom:organization` attribute stores the org NAME, not
+  //    the orgId — it is written verbatim from the (name-valued) org picker in
+  //    assignUserRole, read back verbatim by listUsers, and used name-first for
+  //    org scoping everywhere else (see extractOrgFromEvent + project/workflow
+  //    resolvers). The orphan-user check below must therefore compare against
+  //    the org NAME; comparing against the orgId (a generated UUID) would never
+  //    match and would silently bypass the guard (Issue #19).
+  const orgName = (existingOrgs.Items[0] as { name?: string }).name;
+  if (!orgName) {
+    // Fail closed: without the name we cannot correlate users to this org.
+    throw new Error(
+      'Cannot delete organization: organization record has no name; orphan-user verification cannot run.'
+    );
+  }
+
   // 2. Orphan-user verification.
   //
   //    The user↔org link lives in the Cognito `custom:organization`
   //    user-pool attribute (there is no DynamoDB users table). Deleting
   //    an org while users still point to it leaves dangling JWT claims
-  //    and risks cross-tenant access if the orgId is ever reused.
+  //    and risks cross-tenant access if the org name is ever reused.
   //
   //    Mirror the `createOrganization` "pre-check + throw" idiom used
   //    above — enumerate users and fail closed if any still point at this
@@ -151,8 +166,9 @@ async function deleteOrganization(orgId: string): Promise<UserManagementResponse
   //    — surfaced to the client as "Input fails to satisfy the constraints"
   //    and logged as Lambda:Unhandled (Issue #14, 2nd bug). We therefore PAGE
   //    through the pool (max 60 users per page) and match custom:organization
-  //    CLIENT-SIDE, failing closed on the FIRST match. Bounded by design: we
-  //    check-and-early-exit per page and never buffer an unbounded user array.
+  //    (the org NAME, per the note above) CLIENT-SIDE, failing closed on the
+  //    FIRST match. Bounded by design: we check-and-early-exit per page and
+  //    never buffer an unbounded user array.
   let paginationToken: string | undefined;
   do {
     const usersResponse = await cognitoClient.send(
@@ -165,7 +181,7 @@ async function deleteOrganization(orgId: string): Promise<UserManagementResponse
 
     for (const user of usersResponse.Users ?? []) {
       const assignedToOrg = (user.Attributes ?? []).some(
-        (attr) => attr.Name === 'custom:organization' && attr.Value === orgId
+        (attr) => attr.Name === 'custom:organization' && attr.Value === orgName
       );
       if (assignedToOrg) {
         throw new Error(


### PR DESCRIPTION
## Summary

The `deleteOrganization` orphan-user guard (`backend/src/lambda/organization-resolver.ts`) compared each user's Cognito `custom:organization` attribute against the `orgId` (a generated UUID). That attribute actually stores the org **name** — it is written verbatim from the name-valued org picker in `assignUserRole`, read back verbatim by `listUsers`, and used name-first for org scoping everywhere else (`extractOrgFromEvent` + project/workflow resolvers). Because a name never equals a UUID, the guard never matched and silently allowed deleting an org that still had users assigned.

## Fix (Option A from the issue — align to the name representation the codebase already uses)

- Extract the org `name` from the existence-check result and match `custom:organization === orgName` in the paginated `ListUsers` scan.
- Fail closed if the org record has no name (mirrors the existing `USER_POOL_ID` guard).
- Left `extractOrgFromEvent` unchanged: it returns the name, which is consistent with its other consumers (they store and query by that same name), so no change was needed there.

## Tests

The existing `deleteOrganization` tests masked the bug by setting `name === orgId`. Updated so `name` ('Operations') differs from `orgId` ('org-1'), matches now occur on the name, and added a regression test asserting a user still carrying the `orgId` UUID does **not** block the delete.

## Verification (mirrors backend-static + backend-test)

- `npm test -- --ci --testPathPattern organization-resolver` → 10/10 pass
- `npm run lint` → 0 errors (pre-existing warnings only)
- `npx tsc --noEmit` → clean

Closes #19