### PR TITLE
fix: accept Lambda function ARNs in connector form validation (#20)

### DIFF
--- a/frontend/src/components/DynamicConnectorForm.tsx
+++ b/frontend/src/components/DynamicConnectorForm.tsx
@@ -725,8 +725,11 @@ function isValidHttpsUrl(url: string): boolean {
  * ARN format validation helper
  * Requirements: 1.8, 1.9, 2.10, 4.6, 8.5, 8.6
  */
-function isValidArn(arn: string): boolean {
-  const arnRegex = /^arn:aws:[a-z0-9-]+:[a-z0-9-]*:\d{12}:[a-zA-Z0-9/_-]+$/;
+export function isValidArn(arn: string): boolean {
+  // Resource segment allows ':' (e.g. Lambda 'function:<name>') and '/'
+  // (e.g. IAM 'role/<name>'). ':' is placed before the trailing '-' so '-'
+  // stays literal.
+  const arnRegex = /^arn:aws:[a-z0-9-]+:[a-z0-9-]*:\d{12}:[a-zA-Z0-9/_:-]+$/;
   return arnRegex.test(arn);
 }
 

--- a/frontend/src/components/__tests__/DynamicConnectorForm.test.tsx
+++ b/frontend/src/components/__tests__/DynamicConnectorForm.test.tsx
@@ -99,6 +99,7 @@ jest.mock('../ui/alert', () => ({
 
 import {
   DynamicConnectorForm,
+  isValidArn,
   type ConnectorFormData,
 } from '../DynamicConnectorForm';
 import {
@@ -384,5 +385,40 @@ describe('DynamicConnectorForm — MCP_SERVER OAuth2 validation', () => {
     const nameError = document.getElementById('name-error');
     expect(nameError).not.toBeNull();
     expect(nameError).toHaveAttribute('role', 'alert');
+  });
+});
+
+/**
+ * isValidArn — ARN format validation helper.
+ *
+ * Regression for #20: Lambda function ARNs use a colon in the resource segment
+ * ('function:<name>'), which must be accepted alongside IAM role ARNs that use
+ * a slash ('role/<name>').
+ */
+describe('isValidArn', () => {
+  it('accepts a Lambda function ARN (colon in resource segment)', () => {
+    expect(
+      isValidArn('arn:aws:lambda:us-east-1:123456789012:function:hubspot-reader-dev'),
+    ).toBe(true);
+  });
+
+  it('accepts an IAM role ARN (slash in resource segment)', () => {
+    expect(isValidArn('arn:aws:iam::123456789012:role/citadel-lambdas')).toBe(true);
+  });
+
+  it('rejects a malformed ARN with a non-12-digit account id', () => {
+    expect(
+      isValidArn('arn:aws:lambda:us-east-1:12345:function:hubspot-reader-dev'),
+    ).toBe(false);
+  });
+
+  it('rejects a string with a bad prefix', () => {
+    expect(
+      isValidArn('arn:azure:lambda:us-east-1:123456789012:function:foo'),
+    ).toBe(false);
+  });
+
+  it('rejects an ARN missing the resource segment', () => {
+    expect(isValidArn('arn:aws:lambda:us-east-1:123456789012:')).toBe(false);
   });
 });


### PR DESCRIPTION
## Summary
The **Add AWS Lambda Integration** form rejected valid Lambda function ARNs. `isValidArn` in `frontend/src/components/DynamicConnectorForm.tsx` used a resource character class `[a-zA-Z0-9/_-]` that allows `/` (IAM `role/<name>`) but not `:`, so Lambda ARNs (`function:<name>`) failed. Backend validation was unaffected.

## Change
- Add `:` to the resource character class (`[a-zA-Z0-9/_:-]`). This is a monotonic relaxation: no previously-accepted ARN regresses, and malformed ARNs (bad prefix, non-12-digit account, missing resource) stay rejected.
- Export `isValidArn` and add unit tests.

## Testing
- `npm test -- --ci --testPathPattern DynamicConnectorForm` — 15/15 pass (5 new: Lambda ARN accepted, IAM role ARN still accepted, plus three rejection cases).
- `npx tsc --noEmit` — clean.
- `npm run build` (vite) — succeeds.

Closes #20