### PR TITLE
fix(lint): type registry cluster, ratchet eslint cap to 1724

### DIFF
--- a/backend/package.json
+++ b/backend/package.json
@@ -11,7 +11,7 @@
     "watch": "tsc -w",
     "test": "jest",
     "test:integration": "jest --config jest.integration.config.js",
-    "lint": "eslint \"src/**/*.ts\" --max-warnings 1997",
+    "lint": "eslint \"src/**/*.ts\" --max-warnings 1724",
     "lint:fix": "eslint \"src/**/*.ts\" --fix",
     "format": "prettier --write \"src/**/*.ts\"",
     "cdk:synth": "cdk synth",

--- a/backend/src/lambda/__tests__/app-import-publish-run.integration.test.ts
+++ b/backend/src/lambda/__tests__/app-import-publish-run.integration.test.ts
@@ -154,7 +154,6 @@ jest.mock('../../utils/appsync-publish', () => ({
 import { handler as registryHandler } from '../registry-agent-record-resolver';
 import { handler as workflowHandler } from '../workflow-resolver';
 import { handler as executionHandler } from '../execution-resolver';
-import type { Context } from 'aws-lambda';
 
 import * as registryServiceMockedModule from '../../services/registry-service';
 
@@ -167,7 +166,19 @@ const registryMock = registryServiceMockedModule as unknown as {
   __reset: () => void;
 };
 
-const mockContext = {} as unknown as Context;
+// aws-lambda's Handler type declares legacy required context and callback
+// parameters, but each resolver implementation is a one-parameter async
+// (event) function that never uses them — invoke through the real signature
+// (single cast per handler) so calls don't pass superfluous arguments.
+const invokeRegistryHandler = registryHandler as (
+  event: Parameters<typeof registryHandler>[0],
+) => Promise<unknown>;
+const invokeWorkflowHandler = workflowHandler as (
+  event: Parameters<typeof workflowHandler>[0],
+) => Promise<unknown>;
+const invokeExecutionHandler = executionHandler as (
+  event: Parameters<typeof executionHandler>[0],
+) => Promise<unknown>;
 
 // ─── Shared in-memory fake DynamoDB ─────────────────────────────────────────
 
@@ -363,15 +374,13 @@ interface TestRow {
 
 /** Runs createApp + importBlueprint and returns { appId, workflow }. */
 async function createAppAndImport(): Promise<{ appId: string; workflow: TestRow }> {
-  const app = (await registryHandler(
+  const app = (await invokeRegistryHandler(
     makeEvent('createApp', {
       input: { name: 'Import Test App', orgId: 'org-1' },
     }),
-    mockContext,
-    jest.fn(),
   )) as TestRow;
 
-  const workflow = (await workflowHandler(
+  const workflow = (await invokeWorkflowHandler(
     makeEvent('importBlueprint', {
       blueprintId: BLUEPRINT_ID,
       appId: app.appId,
@@ -381,8 +390,6 @@ async function createAppAndImport(): Promise<{ appId: string; workflow: TestRow 
         'placeholder-b': 'demo-echo-agent',
       },
     }),
-    mockContext,
-    jest.fn(),
   )) as TestRow;
 
   return { appId: app.appId, workflow };
@@ -414,12 +421,10 @@ describe('cross-resolver integration — createApp → importBlueprint → publi
 
   test('full flow: descriptionless createApp yields an importable appId, mapped import publishes and executes end to end', async () => {
     // ── Step 2: createApp with NO description ──────────────────────────────
-    const app = (await registryHandler(
+    const app = (await invokeRegistryHandler(
       makeEvent('createApp', {
         input: { name: 'Import Test App', orgId: 'org-1' },
       }),
-      mockContext,
-      jest.fn(),
     )) as TestRow;
 
     // Live bug #1: the description that reached the registry must be
@@ -437,7 +442,7 @@ describe('cross-resolver integration — createApp → importBlueprint → publi
     expect(mirrorRow.description).toBe('Import Test App');
 
     // ── Step 3: importBlueprint with agentMapping ──────────────────────────
-    const imported = (await workflowHandler(
+    const imported = (await invokeWorkflowHandler(
       makeEvent('importBlueprint', {
         blueprintId: BLUEPRINT_ID,
         appId: app.appId,
@@ -447,8 +452,6 @@ describe('cross-resolver integration — createApp → importBlueprint → publi
           'placeholder-b': 'demo-echo-agent',
         },
       }),
-      mockContext,
-      jest.fn(),
     )) as TestRow;
 
     // The regression this seam test exists for: the id handed back by
@@ -465,10 +468,8 @@ describe('cross-resolver integration — createApp → importBlueprint → publi
     expect(appRowAfterImport.workflowIds).toContain(imported.workflowId);
 
     // ── Step 4: publishWorkflow (agent exists → PUBLISHED) ─────────────────
-    const published = (await workflowHandler(
+    const published = (await invokeWorkflowHandler(
       makeEvent('publishWorkflow', { workflowId: imported.workflowId }),
-      mockContext,
-      jest.fn(),
     )) as TestRow;
 
     expect(published.status).toBe('PUBLISHED');
@@ -477,10 +478,8 @@ describe('cross-resolver integration — createApp → importBlueprint → publi
     ).toBe('PUBLISHED');
 
     // ── Step 5: startExecution ─────────────────────────────────────────────
-    const execution = (await executionHandler(
+    const execution = (await invokeExecutionHandler(
       makeEvent('startExecution', { workflowId: imported.workflowId }),
-      mockContext,
-      jest.fn(),
     )) as TestRow;
 
     expect(execution.executionId).toBeDefined();
@@ -520,10 +519,8 @@ describe('cross-resolver integration — createApp → importBlueprint → publi
     const { workflow } = await createAppAndImport();
 
     await expect(
-      workflowHandler(
+      invokeWorkflowHandler(
         makeEvent('publishWorkflow', { workflowId: workflow.workflowId }),
-        mockContext,
-        jest.fn(),
       ),
     ).rejects.toThrow(/agents that do not exist.*demo-echo-agent/);
 

--- a/backend/src/lambda/__tests__/execution-resolver.test.ts
+++ b/backend/src/lambda/__tests__/execution-resolver.test.ts
@@ -6,7 +6,6 @@ import { DynamoDBDocumentClient, GetCommand, PutCommand, UpdateCommand, QueryCom
 import { EventBridgeClient, PutEventsCommand } from '@aws-sdk/client-eventbridge';
 import { CognitoIdentityProviderClient, AdminGetUserCommand } from '@aws-sdk/client-cognito-identity-provider';
 import { mockClient } from 'aws-sdk-client-mock';
-import type { Context, Callback } from 'aws-lambda';
 
 const ddbMock = mockClient(DynamoDBDocumentClient);
 const ebMock = mockClient(EventBridgeClient);
@@ -28,12 +27,15 @@ function makeEvent(fieldName: string, args: Record<string, unknown>, sub = 'user
   } as unknown as HandlerEvent;
 }
 
-const mockContext = {} as Context;
-const mockCallback: Callback<unknown> = () => undefined;
+// aws-lambda's Handler type declares legacy required context and callback
+// parameters, but the implementation is a one-parameter async (event)
+// function that never uses them — invoke through the real signature
+// (single cast here) so calls don't pass superfluous arguments.
+const invokeHandler = handler as (event: HandlerEvent) => Promise<unknown>;
 
-/** Invokes the handler with stub context/callback and casts the result. */
+/** Invokes the handler and casts the result. */
 async function invoke<T = Record<string, unknown>>(event: HandlerEvent): Promise<T> {
-  return (await handler(event, mockContext, mockCallback)) as T;
+  return (await invokeHandler(event)) as T;
 }
 
 function mockCognitoOrg(orgId: string) {

--- a/backend/src/lambda/__tests__/node-shape.test.ts
+++ b/backend/src/lambda/__tests__/node-shape.test.ts
@@ -37,7 +37,6 @@ jest.mock('../../utils/appsync', () => ({
   getUserId: jest.fn().mockReturnValue('user-123'),
 }));
 
-import type { Context, Callback } from 'aws-lambda';
 import { handler } from '../workflow-resolver';
 import { SEED_BLUEPRINTS } from '../seed-blueprints';
 
@@ -51,8 +50,11 @@ function makeEvent(fieldName: string, args: Record<string, unknown>, sub = 'user
   } as unknown as HandlerEvent;
 }
 
-const mockContext = {} as Context;
-const mockCallback: Callback<unknown> = () => undefined;
+// aws-lambda's Handler type declares legacy required context and callback
+// parameters, but the implementation is a one-parameter async (event)
+// function that never uses them — invoke through the real signature
+// (single cast here) so calls don't pass superfluous arguments.
+const invokeHandler = handler as (event: HandlerEvent) => Promise<unknown>;
 
 function mockCognitoOrg(orgId: string) {
   cognitoMock.on(AdminGetUserCommand).resolves({
@@ -133,10 +135,8 @@ describe('canonical workflow node agentId shape', () => {
       });
 
       await expect(
-        handler(
+        invokeHandler(
           makeEvent('publishWorkflow', { workflowId: 'wf-shape-1' }),
-          mockContext,
-          mockCallback,
         ),
       ).rejects.toThrow(/missing agentId/i);
     });
@@ -164,10 +164,8 @@ describe('canonical workflow node agentId shape', () => {
       // check itself passes by checking the validation error message
       // does NOT mention "missing agentId".
       try {
-        await handler(
+        await invokeHandler(
           makeEvent('publishWorkflow', { workflowId: 'wf-shape-2' }),
-          mockContext,
-          mockCallback,
         );
       } catch (err) {
         expect(String((err as Error)?.message ?? err)).not.toMatch(/missing agentId/i);
@@ -194,10 +192,8 @@ describe('canonical workflow node agentId shape', () => {
       });
 
       try {
-        await handler(
+        await invokeHandler(
           makeEvent('publishWorkflow', { workflowId: 'wf-demo-echo' }),
-          mockContext,
-          mockCallback,
         );
       } catch (err) {
         expect(String((err as Error)?.message ?? err)).not.toMatch(
@@ -227,10 +223,8 @@ describe('canonical workflow node agentId shape', () => {
       });
 
       await expect(
-        handler(
+        invokeHandler(
           makeEvent('publishWorkflow', { workflowId: 'wf-shape-3' }),
-          mockContext,
-          mockCallback,
         ),
       ).rejects.toThrow(/missing agentId/i);
     });

--- a/backend/src/lambda/__tests__/registry-agent-authority-lifecycle.test.ts
+++ b/backend/src/lambda/__tests__/registry-agent-authority-lifecycle.test.ts
@@ -22,6 +22,7 @@ import {
   PutCommand,
   UpdateCommand,
 } from '@aws-sdk/lib-dynamodb';
+import type { PutCommandInput, UpdateCommandInput } from '@aws-sdk/lib-dynamodb';
 import {
   getAuthorityUnitsTable,
   grantFabricatorAuthority,
@@ -59,7 +60,7 @@ describe('registry-agent-authority-lifecycle (PR 6a)', () => {
 
       const calls = ddbMock.commandCalls(PutCommand);
       expect(calls).toHaveLength(1);
-      const input = calls[0].args[0].input as any;
+      const input = calls[0].args[0].input as PutCommandInput & { Item: Record<string, unknown> };
       expect(input.TableName).toBe('test-authority-units');
       expect(input.Item.unitId).toBe('fabricator-test-app-id-create-agents');
       expect(input.Item.registryId).toBe('test-app-id');
@@ -69,7 +70,7 @@ describe('registry-agent-authority-lifecycle (PR 6a)', () => {
     });
 
     test('swallows ConditionalCheckFailedException (idempotent on duplicate)', async () => {
-      const err: any = new Error('Conditional check failed');
+      const err = new Error('Conditional check failed');
       err.name = 'ConditionalCheckFailedException';
       ddbMock.on(PutCommand).rejects(err);
 
@@ -93,7 +94,7 @@ describe('registry-agent-authority-lifecycle (PR 6a)', () => {
 
       const calls = ddbMock.commandCalls(UpdateCommand);
       expect(calls).toHaveLength(1);
-      const input = calls[0].args[0].input as any;
+      const input = calls[0].args[0].input as UpdateCommandInput & { Key: Record<string, unknown> };
       expect(input.TableName).toBe('test-authority-units');
       expect(input.Key.unitId).toBe('fabricator-target-app-create-agents');
       expect(input.ConditionExpression).toContain('attribute_exists(unitId)');
@@ -104,7 +105,7 @@ describe('registry-agent-authority-lifecycle (PR 6a)', () => {
     });
 
     test('swallows ConditionalCheckFailedException on already-revoked row', async () => {
-      const err: any = new Error('Conditional check failed');
+      const err = new Error('Conditional check failed');
       err.name = 'ConditionalCheckFailedException';
       ddbMock.on(UpdateCommand).rejects(err);
 

--- a/backend/src/lambda/__tests__/registry-agent-record-resolver-access.test.ts
+++ b/backend/src/lambda/__tests__/registry-agent-record-resolver-access.test.ts
@@ -48,8 +48,12 @@ jest.mock('../app-access-control', () => ({
 import { handler } from '../registry-agent-record-resolver';
 
 type HandlerEvent = Parameters<typeof handler>[0];
-type HandlerContext = Parameters<typeof handler>[1];
-type HandlerCallback = Parameters<typeof handler>[2];
+
+// aws-lambda's Handler type declares legacy required context and callback
+// parameters, but the implementation is a one-parameter async (event)
+// function that never uses them — invoke through the real signature
+// (single cast here) so calls don't pass superfluous arguments.
+const invokeHandler = handler as (event: HandlerEvent) => Promise<unknown>;
 
 function makeEvent(fieldName: string, args: Record<string, unknown>) {
   return {
@@ -97,13 +101,11 @@ describe('registry-agent-record-resolver — access / auth surfaces', () => {
     test('succeeds and emits app.auth.config.set event', async () => {
       seedApp();
 
-      await handler(
+      await invokeHandler(
         makeEvent('setAppAuthConfig', {
           appId: 'app-1',
           authConfig: JSON.stringify({ provider: 'cognito', userPoolId: 'up-1' }),
         }),
-        {} as HandlerContext,
-        {} as HandlerCallback,
       );
 
       const entries = ebMock
@@ -116,13 +118,11 @@ describe('registry-agent-record-resolver — access / auth surfaces', () => {
 
     test('throws when app not found', async () => {
       await expect(
-        handler(
+        invokeHandler(
           makeEvent('setAppAuthConfig', {
             appId: 'nonexistent',
             authConfig: JSON.stringify({ provider: 'cognito' }),
           }),
-          {} as HandlerContext,
-          {} as HandlerCallback,
         ),
       ).rejects.toThrow('App not found');
     });
@@ -134,14 +134,12 @@ describe('registry-agent-record-resolver — access / auth surfaces', () => {
     test('succeeds and emits app.access.granted event with grantedBy user id', async () => {
       seedApp();
 
-      await handler(
+      await invokeHandler(
         makeEvent('grantAppAccess', {
           appId: 'app-1',
           userId: 'target-user',
           role: 'editor',
         }),
-        {} as HandlerContext,
-        {} as HandlerCallback,
       );
 
       const entries = ebMock
@@ -159,14 +157,12 @@ describe('registry-agent-record-resolver — access / auth surfaces', () => {
 
     test('throws when app not found', async () => {
       await expect(
-        handler(
+        invokeHandler(
           makeEvent('grantAppAccess', {
             appId: 'nonexistent',
             userId: 'target-user',
             role: 'editor',
           }),
-          {} as HandlerContext,
-          {} as HandlerCallback,
         ),
       ).rejects.toThrow('App not found');
     });
@@ -178,13 +174,11 @@ describe('registry-agent-record-resolver — access / auth surfaces', () => {
     test('succeeds and emits app.access.revoked event with revokedBy user id', async () => {
       seedApp();
 
-      await handler(
+      await invokeHandler(
         makeEvent('revokeAppAccess', {
           appId: 'app-1',
           userId: 'target-user',
         }),
-        {} as HandlerContext,
-        {} as HandlerCallback,
       );
 
       const entries = ebMock
@@ -201,13 +195,11 @@ describe('registry-agent-record-resolver — access / auth surfaces', () => {
 
     test('throws when app not found', async () => {
       await expect(
-        handler(
+        invokeHandler(
           makeEvent('revokeAppAccess', {
             appId: 'nonexistent',
             userId: 'target-user',
           }),
-          {} as HandlerContext,
-          {} as HandlerCallback,
         ),
       ).rejects.toThrow('App not found');
     });
@@ -223,10 +215,8 @@ describe('registry-agent-record-resolver — access / auth surfaces', () => {
       ];
       mockListAppAccessEntriesImpl.mockResolvedValueOnce(entries);
 
-      const result = await handler(
+      const result = await invokeHandler(
         makeEvent('listAppAccessEntries', { appId: 'app-1' }),
-        {} as HandlerContext,
-        {} as HandlerCallback,
       );
 
       expect(result).toEqual(entries);
@@ -242,10 +232,8 @@ describe('registry-agent-record-resolver — access / auth surfaces', () => {
     test('returns empty array when no access entries exist', async () => {
       mockListAppAccessEntriesImpl.mockResolvedValueOnce([]);
 
-      const result = await handler(
+      const result = await invokeHandler(
         makeEvent('listAppAccessEntries', { appId: 'app-empty' }),
-        {} as HandlerContext,
-        {} as HandlerCallback,
       );
 
       expect(result).toEqual([]);

--- a/backend/src/lambda/__tests__/registry-agent-record-resolver-access.test.ts
+++ b/backend/src/lambda/__tests__/registry-agent-record-resolver-access.test.ts
@@ -42,17 +42,21 @@ jest.mock('../../utils/appsync', () => ({
 
 const mockListAppAccessEntriesImpl = jest.fn();
 jest.mock('../app-access-control', () => ({
-  listAppAccessEntries: (...args: any[]) => mockListAppAccessEntriesImpl(...args),
+  listAppAccessEntries: (...args: unknown[]) => mockListAppAccessEntriesImpl(...args),
 }));
 
 import { handler } from '../registry-agent-record-resolver';
 
-function makeEvent(fieldName: string, args: any) {
+type HandlerEvent = Parameters<typeof handler>[0];
+type HandlerContext = Parameters<typeof handler>[1];
+type HandlerCallback = Parameters<typeof handler>[2];
+
+function makeEvent(fieldName: string, args: Record<string, unknown>) {
   return {
     info: { fieldName },
     arguments: args,
     identity: { sub: 'user-123', claims: { sub: 'user-123' } },
-  } as any;
+  } as unknown as HandlerEvent;
 }
 
 function seedApp(): void {
@@ -98,8 +102,8 @@ describe('registry-agent-record-resolver — access / auth surfaces', () => {
           appId: 'app-1',
           authConfig: JSON.stringify({ provider: 'cognito', userPoolId: 'up-1' }),
         }),
-        {} as any,
-        {} as any,
+        {} as HandlerContext,
+        {} as HandlerCallback,
       );
 
       const entries = ebMock
@@ -117,8 +121,8 @@ describe('registry-agent-record-resolver — access / auth surfaces', () => {
             appId: 'nonexistent',
             authConfig: JSON.stringify({ provider: 'cognito' }),
           }),
-          {} as any,
-          {} as any,
+          {} as HandlerContext,
+          {} as HandlerCallback,
         ),
       ).rejects.toThrow('App not found');
     });
@@ -136,8 +140,8 @@ describe('registry-agent-record-resolver — access / auth surfaces', () => {
           userId: 'target-user',
           role: 'editor',
         }),
-        {} as any,
-        {} as any,
+        {} as HandlerContext,
+        {} as HandlerCallback,
       );
 
       const entries = ebMock
@@ -161,8 +165,8 @@ describe('registry-agent-record-resolver — access / auth surfaces', () => {
             userId: 'target-user',
             role: 'editor',
           }),
-          {} as any,
-          {} as any,
+          {} as HandlerContext,
+          {} as HandlerCallback,
         ),
       ).rejects.toThrow('App not found');
     });
@@ -179,8 +183,8 @@ describe('registry-agent-record-resolver — access / auth surfaces', () => {
           appId: 'app-1',
           userId: 'target-user',
         }),
-        {} as any,
-        {} as any,
+        {} as HandlerContext,
+        {} as HandlerCallback,
       );
 
       const entries = ebMock
@@ -202,8 +206,8 @@ describe('registry-agent-record-resolver — access / auth surfaces', () => {
             appId: 'nonexistent',
             userId: 'target-user',
           }),
-          {} as any,
-          {} as any,
+          {} as HandlerContext,
+          {} as HandlerCallback,
         ),
       ).rejects.toThrow('App not found');
     });
@@ -221,8 +225,8 @@ describe('registry-agent-record-resolver — access / auth surfaces', () => {
 
       const result = await handler(
         makeEvent('listAppAccessEntries', { appId: 'app-1' }),
-        {} as any,
-        {} as any,
+        {} as HandlerContext,
+        {} as HandlerCallback,
       );
 
       expect(result).toEqual(entries);
@@ -240,8 +244,8 @@ describe('registry-agent-record-resolver — access / auth surfaces', () => {
 
       const result = await handler(
         makeEvent('listAppAccessEntries', { appId: 'app-empty' }),
-        {} as any,
-        {} as any,
+        {} as HandlerContext,
+        {} as HandlerCallback,
       );
 
       expect(result).toEqual([]);

--- a/backend/src/lambda/__tests__/registry-agent-record-resolver-apikeys.test.ts
+++ b/backend/src/lambda/__tests__/registry-agent-record-resolver-apikeys.test.ts
@@ -52,7 +52,12 @@ jest.mock('../app-api-key-management', () => ({
 import { handler } from '../registry-agent-record-resolver';
 
 type HandlerEvent = Parameters<typeof handler>[0];
-type HandlerContext = Parameters<typeof handler>[1];
+
+// aws-lambda's Handler type declares legacy required context and callback
+// parameters, but the implementation is a one-parameter async (event)
+// function that never uses them — invoke through the real signature
+// (single cast here) so calls don't pass superfluous arguments.
+const invokeHandler = handler as (event: HandlerEvent) => Promise<unknown>;
 
 function makeEvent(fieldName: string, args: Record<string, unknown>) {
   return {
@@ -88,10 +93,8 @@ describe('registry-agent-record-resolver — API key surfaces', () => {
       plaintext: 'plaintext-secret-abcdef',
     });
 
-    const result = await handler(
+    const result = await invokeHandler(
       makeEvent('createAppApiKey', { appId: 'app-1', name: 'Test Key' }),
-      {} as HandlerContext,
-      () => {},
     );
 
     expect(result).toHaveProperty('keyId', 'new-key-id');
@@ -118,10 +121,8 @@ describe('registry-agent-record-resolver — API key surfaces', () => {
       revokedKeyId: 'old-key',
     });
 
-    const result = await handler(
+    const result = await invokeHandler(
       makeEvent('rotateAppApiKey', { appId: 'app-1', keyId: 'old-key' }),
-      {} as HandlerContext,
-      () => {},
     );
 
     expect(result).not.toHaveProperty('newKey');
@@ -143,10 +144,8 @@ describe('registry-agent-record-resolver — API key surfaces', () => {
     };
     mockRevoke.mockResolvedValueOnce(revokedKey);
 
-    const result = await handler(
+    const result = await invokeHandler(
       makeEvent('revokeAppApiKey', { appId: 'app-1', keyId: 'target-key' }),
-      {} as HandlerContext,
-      () => {},
     );
 
     expect(result).toEqual(revokedKey);
@@ -164,10 +163,8 @@ describe('registry-agent-record-resolver — API key surfaces', () => {
       { keyId: 'k2', name: 'Key 2', prefix: 'bbbb2222', status: 'REVOKED', createdAt: '2024-02-01T00:00:00Z' },
     ]);
 
-    const result = await handler(
+    const result = await invokeHandler(
       makeEvent('listAppApiKeys', { appId: 'app-1' }),
-      {} as HandlerContext,
-      () => {},
     );
 
     expect(Array.isArray(result)).toBe(true);
@@ -193,10 +190,8 @@ describe('registry-agent-record-resolver — API key surfaces', () => {
       plaintext: 'pt',
     });
 
-    await handler(
+    await invokeHandler(
       makeEvent('createAppApiKey', { appId: 'app-9', name: 'K', expiresIn: 3600 }),
-      {} as HandlerContext,
-      () => {},
     );
 
     expect(mockCreate).toHaveBeenCalledWith(
@@ -211,10 +206,8 @@ describe('registry-agent-record-resolver — API key surfaces', () => {
   test('listAppApiKeys invokes impl with deps struct (no mutation of args)', async () => {
     mockList.mockResolvedValueOnce([]);
 
-    await handler(
+    await invokeHandler(
       makeEvent('listAppApiKeys', { appId: 'app-42' }),
-      {} as HandlerContext,
-      () => {},
     );
 
     expect(mockList).toHaveBeenCalledTimes(1);

--- a/backend/src/lambda/__tests__/registry-agent-record-resolver-apikeys.test.ts
+++ b/backend/src/lambda/__tests__/registry-agent-record-resolver-apikeys.test.ts
@@ -43,15 +43,18 @@ const mockRevoke = jest.fn();
 const mockRotate = jest.fn();
 const mockList = jest.fn();
 jest.mock('../app-api-key-management', () => ({
-  createAppApiKey: (...args: any[]) => mockCreate(...args),
-  revokeAppApiKey: (...args: any[]) => mockRevoke(...args),
-  rotateAppApiKey: (...args: any[]) => mockRotate(...args),
-  listAppApiKeys: (...args: any[]) => mockList(...args),
+  createAppApiKey: (...args: unknown[]) => mockCreate(...args),
+  revokeAppApiKey: (...args: unknown[]) => mockRevoke(...args),
+  rotateAppApiKey: (...args: unknown[]) => mockRotate(...args),
+  listAppApiKeys: (...args: unknown[]) => mockList(...args),
 }));
 
 import { handler } from '../registry-agent-record-resolver';
 
-function makeEvent(fieldName: string, args: Record<string, any>) {
+type HandlerEvent = Parameters<typeof handler>[0];
+type HandlerContext = Parameters<typeof handler>[1];
+
+function makeEvent(fieldName: string, args: Record<string, unknown>) {
   return {
     info: { fieldName, parentTypeName: 'Mutation', selectionSetList: [] },
     arguments: args,
@@ -60,7 +63,7 @@ function makeEvent(fieldName: string, args: Record<string, any>) {
     request: { headers: {} },
     prev: null,
     stash: {},
-  } as any;
+  } as unknown as HandlerEvent;
 }
 
 describe('registry-agent-record-resolver — API key surfaces', () => {
@@ -87,7 +90,7 @@ describe('registry-agent-record-resolver — API key surfaces', () => {
 
     const result = await handler(
       makeEvent('createAppApiKey', { appId: 'app-1', name: 'Test Key' }),
-      {} as any,
+      {} as HandlerContext,
       () => {},
     );
 
@@ -117,7 +120,7 @@ describe('registry-agent-record-resolver — API key surfaces', () => {
 
     const result = await handler(
       makeEvent('rotateAppApiKey', { appId: 'app-1', keyId: 'old-key' }),
-      {} as any,
+      {} as HandlerContext,
       () => {},
     );
 
@@ -142,7 +145,7 @@ describe('registry-agent-record-resolver — API key surfaces', () => {
 
     const result = await handler(
       makeEvent('revokeAppApiKey', { appId: 'app-1', keyId: 'target-key' }),
-      {} as any,
+      {} as HandlerContext,
       () => {},
     );
 
@@ -163,7 +166,7 @@ describe('registry-agent-record-resolver — API key surfaces', () => {
 
     const result = await handler(
       makeEvent('listAppApiKeys', { appId: 'app-1' }),
-      {} as any,
+      {} as HandlerContext,
       () => {},
     );
 
@@ -192,7 +195,7 @@ describe('registry-agent-record-resolver — API key surfaces', () => {
 
     await handler(
       makeEvent('createAppApiKey', { appId: 'app-9', name: 'K', expiresIn: 3600 }),
-      {} as any,
+      {} as HandlerContext,
       () => {},
     );
 
@@ -210,7 +213,7 @@ describe('registry-agent-record-resolver — API key surfaces', () => {
 
     await handler(
       makeEvent('listAppApiKeys', { appId: 'app-42' }),
-      {} as any,
+      {} as HandlerContext,
       () => {},
     );
 

--- a/backend/src/lambda/__tests__/registry-agent-record-resolver-binding-transition.test.ts
+++ b/backend/src/lambda/__tests__/registry-agent-record-resolver-binding-transition.test.ts
@@ -57,18 +57,18 @@ jest.mock('../../services/registry-service', () => {
       const base = getMockRegistryService();
       return {
         ...base,
-        resolveRecordId: (...args: any[]) => resolveRecordIdMock(...args),
-        getResource: (...args: any[]) => getResourceMock(...args),
-        updateResource: (...args: any[]) => updateResourceMock(...args),
+        resolveRecordId: (...args: unknown[]) => resolveRecordIdMock(...args),
+        getResource: (...args: unknown[]) => getResourceMock(...args),
+        updateResource: (...args: unknown[]) => updateResourceMock(...args),
       };
     }),
     getRegistryService: jest.fn(() => {
       const base = getMockRegistryService();
       return {
         ...base,
-        resolveRecordId: (...args: any[]) => resolveRecordIdMock(...args),
-        getResource: (...args: any[]) => getResourceMock(...args),
-        updateResource: (...args: any[]) => updateResourceMock(...args),
+        resolveRecordId: (...args: unknown[]) => resolveRecordIdMock(...args),
+        getResource: (...args: unknown[]) => getResourceMock(...args),
+        updateResource: (...args: unknown[]) => updateResourceMock(...args),
       };
     }),
     _resetRegistryService: jest.fn(),
@@ -150,12 +150,16 @@ function inactiveAgentRecord(recordId: string) {
   };
 }
 
-function makeEvent(fieldName: string, args: any) {
+type HandlerEvent = Parameters<typeof handler>[0];
+type HandlerContext = Parameters<typeof handler>[1];
+type HandlerCallback = Parameters<typeof handler>[2];
+
+function makeEvent(fieldName: string, args: Record<string, unknown>) {
   return {
     info: { fieldName },
     arguments: args,
     identity: { sub: 'user-123', claims: { sub: 'user-123' } },
-  } as any;
+  } as unknown as HandlerEvent;
 }
 
 // ---------------------------------------------------------------------------
@@ -175,7 +179,7 @@ describe('updateAgentBinding — READY transition agentId resolution', () => {
     // returned record, mimicking the real RegistryService. This is what
     // projectAgentApp consumes, so assertions can read the post-update
     // manifest via the normal projection path.
-    updateResourceMock.mockImplementation(async (_type: any, id: any, input: any) => ({
+    updateResourceMock.mockImplementation(async (_type: unknown, id: unknown, input: { customMetadata?: string }) => ({
       recordId: id,
       name: 'Test App',
       status: 'DRAFT',
@@ -226,8 +230,8 @@ describe('updateAgentBinding — READY transition agentId resolution', () => {
           status: 'READY',
         },
       }),
-      {} as any,
-      {} as any,
+      {} as HandlerContext,
+      {} as HandlerCallback,
     );
 
     expect(resolveRecordIdMock).toHaveBeenCalledWith('agent', AGENT_RECORD_ID);
@@ -274,8 +278,8 @@ describe('updateAgentBinding — READY transition agentId resolution', () => {
           status: 'READY',
         },
       }),
-      {} as any,
-      {} as any,
+      {} as HandlerContext,
+      {} as HandlerCallback,
     );
 
     // resolveRecordId was consulted for the binding's human name…
@@ -325,8 +329,8 @@ describe('updateAgentBinding — READY transition agentId resolution', () => {
             status: 'READY',
           },
         }),
-        {} as any,
-        {} as any,
+        {} as HandlerContext,
+        {} as HandlerCallback,
       ),
     ).rejects.toThrow(`Agent ${AGENT_NAME} not found`);
     // The agent getResource path must not be reached when resolution failed.
@@ -375,8 +379,8 @@ describe('updateAgentBinding — READY transition agentId resolution', () => {
             status: 'READY',
           },
         }),
-        {} as any,
-        {} as any,
+        {} as HandlerContext,
+        {} as HandlerCallback,
       ),
     ).rejects.toThrow('Agent must be active before it can be marked as ready');
   });
@@ -412,8 +416,8 @@ describe('updateAgentBinding — READY transition agentId resolution', () => {
             status: 'READY',
           },
         }),
-        {} as any,
-        {} as any,
+        {} as HandlerContext,
+        {} as HandlerCallback,
       ),
     ).rejects.toThrow('Agent must be active before it can be marked as ready');
   });
@@ -447,8 +451,8 @@ describe('updateAgentBinding — READY transition agentId resolution', () => {
           status: 'DESIGN',
         },
       }),
-      {} as any,
-      {} as any,
+      {} as HandlerContext,
+      {} as HandlerCallback,
     );
 
     expect(resolveRecordIdMock).not.toHaveBeenCalled();
@@ -487,7 +491,7 @@ describe('updateAgentBinding — modelOverride catalog validation', () => {
     resolveRecordIdMock.mockReset();
     getResourceMock.mockReset();
     updateResourceMock.mockReset();
-    updateResourceMock.mockImplementation(async (_type: any, id: any, input: any) => ({
+    updateResourceMock.mockImplementation(async (_type: unknown, id: unknown, input: { customMetadata?: string }) => ({
       recordId: id,
       name: 'Test App',
       status: 'DRAFT',

--- a/backend/src/lambda/__tests__/registry-agent-record-resolver-binding-transition.test.ts
+++ b/backend/src/lambda/__tests__/registry-agent-record-resolver-binding-transition.test.ts
@@ -151,8 +151,12 @@ function inactiveAgentRecord(recordId: string) {
 }
 
 type HandlerEvent = Parameters<typeof handler>[0];
-type HandlerContext = Parameters<typeof handler>[1];
-type HandlerCallback = Parameters<typeof handler>[2];
+
+// aws-lambda's Handler type declares legacy required context and callback
+// parameters, but the implementation is a one-parameter async (event)
+// function that never uses them — invoke through the real signature
+// (single cast here) so calls don't pass superfluous arguments.
+const invokeHandler = handler as (event: HandlerEvent) => Promise<unknown>;
 
 function makeEvent(fieldName: string, args: Record<string, unknown>) {
   return {
@@ -222,7 +226,7 @@ describe('updateAgentBinding — READY transition agentId resolution', () => {
       })
       .mockResolvedValueOnce(activeAgentRecord(AGENT_RECORD_ID));
 
-    const result = await handler(
+    const result = await invokeHandler(
       makeEvent('updateAgentBinding', {
         input: {
           appId: APP_RECORD_ID,
@@ -230,8 +234,6 @@ describe('updateAgentBinding — READY transition agentId resolution', () => {
           status: 'READY',
         },
       }),
-      {} as HandlerContext,
-      {} as HandlerCallback,
     );
 
     expect(resolveRecordIdMock).toHaveBeenCalledWith('agent', AGENT_RECORD_ID);
@@ -270,7 +272,7 @@ describe('updateAgentBinding — READY transition agentId resolution', () => {
       })
       .mockResolvedValueOnce(activeAgentRecord(AGENT_RECORD_ID));
 
-    await handler(
+    await invokeHandler(
       makeEvent('updateAgentBinding', {
         input: {
           appId: APP_RECORD_ID,
@@ -278,8 +280,6 @@ describe('updateAgentBinding — READY transition agentId resolution', () => {
           status: 'READY',
         },
       }),
-      {} as HandlerContext,
-      {} as HandlerCallback,
     );
 
     // resolveRecordId was consulted for the binding's human name…
@@ -321,7 +321,7 @@ describe('updateAgentBinding — READY transition agentId resolution', () => {
     });
 
     await expect(
-      handler(
+      invokeHandler(
         makeEvent('updateAgentBinding', {
           input: {
             appId: APP_RECORD_ID,
@@ -329,8 +329,6 @@ describe('updateAgentBinding — READY transition agentId resolution', () => {
             status: 'READY',
           },
         }),
-        {} as HandlerContext,
-        {} as HandlerCallback,
       ),
     ).rejects.toThrow(`Agent ${AGENT_NAME} not found`);
     // The agent getResource path must not be reached when resolution failed.
@@ -371,7 +369,7 @@ describe('updateAgentBinding — READY transition agentId resolution', () => {
       });
 
     await expect(
-      handler(
+      invokeHandler(
         makeEvent('updateAgentBinding', {
           input: {
             appId: APP_RECORD_ID,
@@ -379,8 +377,6 @@ describe('updateAgentBinding — READY transition agentId resolution', () => {
             status: 'READY',
           },
         }),
-        {} as HandlerContext,
-        {} as HandlerCallback,
       ),
     ).rejects.toThrow('Agent must be active before it can be marked as ready');
   });
@@ -408,7 +404,7 @@ describe('updateAgentBinding — READY transition agentId resolution', () => {
       .mockResolvedValueOnce(inactiveAgentRecord(AGENT_RECORD_ID));
 
     await expect(
-      handler(
+      invokeHandler(
         makeEvent('updateAgentBinding', {
           input: {
             appId: APP_RECORD_ID,
@@ -416,8 +412,6 @@ describe('updateAgentBinding — READY transition agentId resolution', () => {
             status: 'READY',
           },
         }),
-        {} as HandlerContext,
-        {} as HandlerCallback,
       ),
     ).rejects.toThrow('Agent must be active before it can be marked as ready');
   });
@@ -443,7 +437,7 @@ describe('updateAgentBinding — READY transition agentId resolution', () => {
       }),
     });
 
-    await handler(
+    await invokeHandler(
       makeEvent('updateAgentBinding', {
         input: {
           appId: APP_RECORD_ID,
@@ -451,8 +445,6 @@ describe('updateAgentBinding — READY transition agentId resolution', () => {
           status: 'DESIGN',
         },
       }),
-      {} as HandlerContext,
-      {} as HandlerCallback,
     );
 
     expect(resolveRecordIdMock).not.toHaveBeenCalled();
@@ -544,7 +536,7 @@ describe('updateAgentBinding — modelOverride catalog validation', () => {
       .on(GetCommand, { TableName: CATALOG_TABLE, Key: { modelKey: ENABLED_KEY } })
       .resolves({ Item: { modelKey: ENABLED_KEY, status: 'enabled' } });
 
-    const result = await handler(bindingEvent(ENABLED_KEY));
+    const result = await invokeHandler(bindingEvent(ENABLED_KEY));
 
     expect(ddbMock.commandCalls(GetCommand)).toHaveLength(1);
     expect(result).toMatchObject({
@@ -557,7 +549,7 @@ describe('updateAgentBinding — modelOverride catalog validation', () => {
     ddbMock.on(GetCommand).resolves({}); // no Item
 
     await expect(
-      handler(bindingEvent(UNKNOWN_KEY)),
+      invokeHandler(bindingEvent(UNKNOWN_KEY)),
     ).rejects.toThrow('not found in the model catalog');
     // Nothing persisted when validation fails.
     expect(updateResourceMock).not.toHaveBeenCalled();
@@ -570,7 +562,7 @@ describe('updateAgentBinding — modelOverride catalog validation', () => {
       .resolves({ Item: { modelKey: DISABLED_KEY, status: 'disabled' } });
 
     await expect(
-      handler(bindingEvent(DISABLED_KEY)),
+      invokeHandler(bindingEvent(DISABLED_KEY)),
     ).rejects.toThrow('is not enabled');
     expect(updateResourceMock).not.toHaveBeenCalled();
   });
@@ -578,7 +570,7 @@ describe('updateAgentBinding — modelOverride catalog validation', () => {
   test('(d) empty string clears the override without catalog validation', async () => {
     seedApp(LEGACY_KEY);
 
-    const result = await handler(bindingEvent(''));
+    const result = await invokeHandler(bindingEvent(''));
 
     expect(ddbMock.commandCalls(GetCommand)).toHaveLength(0);
     expect(result).toMatchObject({
@@ -589,7 +581,7 @@ describe('updateAgentBinding — modelOverride catalog validation', () => {
   test('(e) unchanged legacy value is grandfathered — no catalog validation', async () => {
     seedApp(LEGACY_KEY);
 
-    const result = await handler(bindingEvent(LEGACY_KEY));
+    const result = await invokeHandler(bindingEvent(LEGACY_KEY));
 
     expect(ddbMock.commandCalls(GetCommand)).toHaveLength(0);
     expect(result).toMatchObject({
@@ -602,7 +594,7 @@ describe('updateAgentBinding — modelOverride catalog validation', () => {
     const warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {});
     seedApp();
 
-    const result = await handler(bindingEvent('catalog-model-some-new'));
+    const result = await invokeHandler(bindingEvent('catalog-model-some-new'));
 
     // No catalog read attempted, mutation still persisted (non-breaking).
     expect(ddbMock.commandCalls(GetCommand)).toHaveLength(0);

--- a/backend/src/lambda/__tests__/registry-agent-record-resolver-components.test.ts
+++ b/backend/src/lambda/__tests__/registry-agent-record-resolver-components.test.ts
@@ -67,8 +67,12 @@ const VALID_SCHEMA = {
 };
 
 type HandlerEvent = Parameters<typeof handler>[0];
-type HandlerContext = Parameters<typeof handler>[1];
-type HandlerCallback = Parameters<typeof handler>[2];
+
+// aws-lambda's Handler type declares legacy required context and callback
+// parameters, but the implementation is a one-parameter async (event)
+// function that never uses them — invoke through the real signature
+// (single cast here) so calls don't pass superfluous arguments.
+const invokeHandler = handler as (event: HandlerEvent) => Promise<unknown>;
 
 function makeEvent(fieldName: string, args: Record<string, unknown>) {
   return {
@@ -212,7 +216,7 @@ describe('registry-agent-record-resolver — addAppComponent', () => {
     test('emits app.component.added event with agent component detail', async () => {
       seedApp();
 
-      await handler(
+      await invokeHandler(
         makeEvent('addAppComponent', {
           appId: 'app-1',
           component: {
@@ -220,8 +224,6 @@ describe('registry-agent-record-resolver — addAppComponent', () => {
             data: JSON.stringify({ agentId: 'agent-1' }),
           },
         }),
-        {} as HandlerContext,
-        {} as HandlerCallback,
       );
 
       const entries = ebMock
@@ -241,7 +243,7 @@ describe('registry-agent-record-resolver — addAppComponent', () => {
     test('accepts override fields without throwing', async () => {
       seedApp();
 
-      const result = await handler(
+      const result = await invokeHandler(
         makeEvent('addAppComponent', {
           appId: 'app-1',
           component: {
@@ -254,8 +256,6 @@ describe('registry-agent-record-resolver — addAppComponent', () => {
             }),
           },
         }),
-        {} as HandlerContext,
-        {} as HandlerCallback,
       );
 
       expect(result).toBeDefined();
@@ -267,7 +267,7 @@ describe('registry-agent-record-resolver — addAppComponent', () => {
     test('emits app.component.added event with permission component detail', async () => {
       seedApp();
 
-      await handler(
+      await invokeHandler(
         makeEvent('addAppComponent', {
           appId: 'app-1',
           component: {
@@ -280,8 +280,6 @@ describe('registry-agent-record-resolver — addAppComponent', () => {
             }),
           },
         }),
-        {} as HandlerContext,
-        {} as HandlerCallback,
       );
 
       const entries = ebMock
@@ -299,7 +297,7 @@ describe('registry-agent-record-resolver — addAppComponent', () => {
       seedApp();
 
       await expect(
-        handler(
+        invokeHandler(
           makeEvent('addAppComponent', {
             appId: 'app-1',
             component: {
@@ -311,8 +309,6 @@ describe('registry-agent-record-resolver — addAppComponent', () => {
               }),
             },
           }),
-          {} as HandlerContext,
-          {} as HandlerCallback,
         ),
       ).rejects.toThrow(/Permission validation failed/);
     });
@@ -321,7 +317,7 @@ describe('registry-agent-record-resolver — addAppComponent', () => {
   describe('error paths', () => {
     test('rejects when app not found', async () => {
       await expect(
-        handler(
+        invokeHandler(
           makeEvent('addAppComponent', {
             appId: 'nonexistent',
             component: {
@@ -329,8 +325,6 @@ describe('registry-agent-record-resolver — addAppComponent', () => {
               data: JSON.stringify({ agentId: 'agent-1' }),
             },
           }),
-          {} as HandlerContext,
-          {} as HandlerCallback,
         ),
       ).rejects.toThrow('App not found');
     });
@@ -339,13 +333,11 @@ describe('registry-agent-record-resolver — addAppComponent', () => {
       seedApp();
 
       await expect(
-        handler(
+        invokeHandler(
           makeEvent('addAppComponent', {
             appId: 'app-1',
             component: { type: 'unknown-type', data: JSON.stringify({ id: 'x' }) },
           }),
-          {} as HandlerContext,
-          {} as HandlerCallback,
         ),
       ).rejects.toThrow(/Unsupported component type/);
     });
@@ -356,7 +348,7 @@ describe('registry-agent-record-resolver — addAppComponent', () => {
       seedApp();
 
       await expect(
-        handler(
+        invokeHandler(
           makeEvent('addAppComponent', {
             appId: 'app-1',
             component: {
@@ -368,8 +360,6 @@ describe('registry-agent-record-resolver — addAppComponent', () => {
               }),
             },
           }),
-          {} as HandlerContext,
-          {} as HandlerCallback,
         ),
       ).rejects.toThrow('Bare wildcard');
     });
@@ -378,7 +368,7 @@ describe('registry-agent-record-resolver — addAppComponent', () => {
       seedApp();
 
       await expect(
-        handler(
+        invokeHandler(
           makeEvent('addAppComponent', {
             appId: 'app-1',
             component: {
@@ -390,8 +380,6 @@ describe('registry-agent-record-resolver — addAppComponent', () => {
               }),
             },
           }),
-          {} as HandlerContext,
-          {} as HandlerCallback,
         ),
       ).rejects.toThrow('Invalid IAM action format');
     });
@@ -399,7 +387,7 @@ describe('registry-agent-record-resolver — addAppComponent', () => {
     test('allows permission component with valid service-prefixed actions', async () => {
       seedApp();
 
-      const result = await handler(
+      const result = await invokeHandler(
         makeEvent('addAppComponent', {
           appId: 'app-1',
           component: {
@@ -411,8 +399,6 @@ describe('registry-agent-record-resolver — addAppComponent', () => {
             }),
           },
         }),
-        {} as HandlerContext,
-        {} as HandlerCallback,
       );
 
       expect(result).toBeDefined();
@@ -424,7 +410,7 @@ describe('registry-agent-record-resolver — addAppComponent', () => {
     test('returns app projection with agentBindings and permissions arrays present', async () => {
       seedApp();
 
-      const result = await handler(
+      const result = await invokeHandler(
         makeEvent('addAppComponent', {
           appId: 'app-1',
           component: {
@@ -432,8 +418,6 @@ describe('registry-agent-record-resolver — addAppComponent', () => {
             data: JSON.stringify({ agentId: 'agent-1' }),
           },
         }),
-        {} as HandlerContext,
-        {} as HandlerCallback,
       );
 
       expect(result.appId).toBe('app-1');
@@ -468,14 +452,12 @@ describe('registry-agent-record-resolver — removeAppComponent', () => {
   test('emits app.component.removed event for agent type', async () => {
     seedAppForRemove();
 
-    await handler(
+    await invokeHandler(
       makeEvent('removeAppComponent', {
         appId: 'app-1',
         componentType: 'agent',
         componentId: 'agent-1',
       }),
-      {} as HandlerContext,
-      {} as HandlerCallback,
     );
 
     const entries = ebMock
@@ -494,14 +476,12 @@ describe('registry-agent-record-resolver — removeAppComponent', () => {
   test('emits app.component.removed event for permission type', async () => {
     seedAppForRemove();
 
-    await handler(
+    await invokeHandler(
       makeEvent('removeAppComponent', {
         appId: 'app-1',
         componentType: 'permission',
         componentId: 'perm-1',
       }),
-      {} as HandlerContext,
-      {} as HandlerCallback,
     );
 
     const entries = ebMock
@@ -518,14 +498,12 @@ describe('registry-agent-record-resolver — removeAppComponent', () => {
   test('returns app unchanged when component does not exist (idempotent)', async () => {
     seedAppForRemove({ agentBindings: [] });
 
-    const result = await handler(
+    const result = await invokeHandler(
       makeEvent('removeAppComponent', {
         appId: 'app-1',
         componentType: 'agent',
         componentId: 'nonexistent-agent',
       }),
-      {} as HandlerContext,
-      {} as HandlerCallback,
     );
 
     expect(result).toBeDefined();
@@ -534,14 +512,12 @@ describe('registry-agent-record-resolver — removeAppComponent', () => {
 
   test('rejects when app not found', async () => {
     await expect(
-      handler(
+      invokeHandler(
         makeEvent('removeAppComponent', {
           appId: 'nonexistent',
           componentType: 'agent',
           componentId: 'agent-1',
         }),
-        {} as HandlerContext,
-        {} as HandlerCallback,
       ),
     ).rejects.toThrow('App not found');
   });
@@ -550,14 +526,12 @@ describe('registry-agent-record-resolver — removeAppComponent', () => {
     seedAppForRemove();
 
     await expect(
-      handler(
+      invokeHandler(
         makeEvent('removeAppComponent', {
           appId: 'app-1',
           componentType: 'unknown',
           componentId: 'x',
         }),
-        {} as HandlerContext,
-        {} as HandlerCallback,
       ),
     ).rejects.toThrow(/Unsupported component type/);
   });
@@ -578,7 +552,7 @@ describe('registry-agent-record-resolver — updateAgentBinding', () => {
     seedApp({ agentBindings: [] });
 
     await expect(
-      handler(
+      invokeHandler(
         makeEvent('updateAgentBinding', {
           input: {
             appId: 'app-1',
@@ -586,20 +560,16 @@ describe('registry-agent-record-resolver — updateAgentBinding', () => {
             systemPromptAddition: 'Be helpful',
           },
         }),
-        {} as HandlerContext,
-        {} as HandlerCallback,
       ),
     ).rejects.toThrow('Agent is not a component of this app');
   });
 
   test('throws when app does not exist', async () => {
     await expect(
-      handler(
+      invokeHandler(
         makeEvent('updateAgentBinding', {
           input: { appId: 'nonexistent', agentId: 'agent-1' },
         }),
-        {} as HandlerContext,
-        {} as HandlerCallback,
       ),
     ).rejects.toThrow('App not found');
   });
@@ -607,7 +577,7 @@ describe('registry-agent-record-resolver — updateAgentBinding', () => {
   test('updates systemPromptAddition without throwing and emits event', async () => {
     seedAppWithBinding();
 
-    const result = await handler(
+    const result = await invokeHandler(
       makeEvent('updateAgentBinding', {
         input: {
           appId: 'app-1',
@@ -615,8 +585,6 @@ describe('registry-agent-record-resolver — updateAgentBinding', () => {
           systemPromptAddition: 'Be helpful',
         },
       }),
-      {} as HandlerContext,
-      {} as HandlerCallback,
     );
 
     expect(result).toBeDefined();
@@ -638,7 +606,7 @@ describe('registry-agent-record-resolver — updateAgentBinding', () => {
     seedAppWithBinding();
     seedTargetAgent({ agentId: 'agent-1', state: 'active' });
 
-    const result = await handler(
+    const result = await invokeHandler(
       makeEvent('updateAgentBinding', {
         input: {
           appId: 'app-1',
@@ -646,8 +614,6 @@ describe('registry-agent-record-resolver — updateAgentBinding', () => {
           status: 'READY',
         },
       }),
-      {} as HandlerContext,
-      {} as HandlerCallback,
     );
 
     expect(result).toBeDefined();
@@ -657,7 +623,7 @@ describe('registry-agent-record-resolver — updateAgentBinding', () => {
     seedAppWithBinding();
 
     await expect(
-      handler(
+      invokeHandler(
         makeEvent('updateAgentBinding', {
           input: {
             appId: 'app-1',
@@ -665,8 +631,6 @@ describe('registry-agent-record-resolver — updateAgentBinding', () => {
             status: 'READY',
           },
         }),
-        {} as HandlerContext,
-        {} as HandlerCallback,
       ),
     ).rejects.toThrow('Agent must be active before it can be marked as ready');
   });
@@ -676,7 +640,7 @@ describe('registry-agent-record-resolver — updateAgentBinding', () => {
     seedTargetAgent({ agentId: 'agent-1', state: 'inactive' });
 
     await expect(
-      handler(
+      invokeHandler(
         makeEvent('updateAgentBinding', {
           input: {
             appId: 'app-1',
@@ -684,8 +648,6 @@ describe('registry-agent-record-resolver — updateAgentBinding', () => {
             status: 'READY',
           },
         }),
-        {} as HandlerContext,
-        {} as HandlerCallback,
       ),
     ).rejects.toThrow('Agent must be active before it can be marked as ready');
   });
@@ -693,7 +655,7 @@ describe('registry-agent-record-resolver — updateAgentBinding', () => {
   test('status change to DESIGN does not require target agent validation', async () => {
     seedAppWithBinding({ bindingStatus: 'READY' });
 
-    const result = await handler(
+    const result = await invokeHandler(
       makeEvent('updateAgentBinding', {
         input: {
           appId: 'app-1',
@@ -701,8 +663,6 @@ describe('registry-agent-record-resolver — updateAgentBinding', () => {
           status: 'DESIGN',
         },
       }),
-      {} as HandlerContext,
-      {} as HandlerCallback,
     );
 
     expect(result).toBeDefined();
@@ -711,7 +671,7 @@ describe('registry-agent-record-resolver — updateAgentBinding', () => {
   test('returns full app projection with agentBindings present', async () => {
     seedAppWithBinding();
 
-    const result = await handler(
+    const result = await invokeHandler(
       makeEvent('updateAgentBinding', {
         input: {
           appId: 'app-1',
@@ -719,8 +679,6 @@ describe('registry-agent-record-resolver — updateAgentBinding', () => {
           systemPromptAddition: 'Updated',
         },
       }),
-      {} as HandlerContext,
-      {} as HandlerCallback,
     );
 
     expect(result.appId).toBe('app-1');
@@ -744,14 +702,12 @@ describe('registry-agent-record-resolver — setAppConfigSchema', () => {
   test('stores valid JSON Schema and emits app.config.schema.set event', async () => {
     seedApp({ version: 3 });
 
-    const result = await handler(
+    const result = await invokeHandler(
       makeEvent('setAppConfigSchema', {
         appId: 'app-1',
         schema: JSON.stringify(VALID_SCHEMA),
         version: 3,
       }),
-      {} as HandlerContext,
-      {} as HandlerCallback,
     );
 
     expect(result).toBeDefined();
@@ -768,14 +724,12 @@ describe('registry-agent-record-resolver — setAppConfigSchema', () => {
     seedApp({ version: 3 });
 
     await expect(
-      handler(
+      invokeHandler(
         makeEvent('setAppConfigSchema', {
           appId: 'app-1',
           schema: JSON.stringify({ type: 'not-a-real-type' }),
           version: 3,
         }),
-        {} as HandlerContext,
-        {} as HandlerCallback,
       ),
     ).rejects.toThrow(/invalid.*schema/i);
   });
@@ -784,14 +738,12 @@ describe('registry-agent-record-resolver — setAppConfigSchema', () => {
     seedApp({ version: 3 });
 
     await expect(
-      handler(
+      invokeHandler(
         makeEvent('setAppConfigSchema', {
           appId: 'app-1',
           schema: JSON.stringify('just a string'),
           version: 3,
         }),
-        {} as HandlerContext,
-        {} as HandlerCallback,
       ),
     ).rejects.toThrow(/invalid.*schema/i);
   });
@@ -800,28 +752,24 @@ describe('registry-agent-record-resolver — setAppConfigSchema', () => {
     seedApp({ version: 5 });
 
     await expect(
-      handler(
+      invokeHandler(
         makeEvent('setAppConfigSchema', {
           appId: 'app-1',
           schema: JSON.stringify(VALID_SCHEMA),
           version: 3,
         }),
-        {} as HandlerContext,
-        {} as HandlerCallback,
       ),
     ).rejects.toThrow(/Conflict/i);
   });
 
   test('throws when app not found', async () => {
     await expect(
-      handler(
+      invokeHandler(
         makeEvent('setAppConfigSchema', {
           appId: 'nonexistent',
           schema: JSON.stringify(VALID_SCHEMA),
           version: 3,
         }),
-        {} as HandlerContext,
-        {} as HandlerCallback,
       ),
     ).rejects.toThrow('App not found');
   });
@@ -842,14 +790,12 @@ describe('registry-agent-record-resolver — setAppConfigValues', () => {
     seedApp({ version: 3, configSchema: VALID_SCHEMA });
     const values = { apiKey: 'sk-test-123', maxRetries: 3 };
 
-    await handler(
+    await invokeHandler(
       makeEvent('setAppConfigValues', {
         appId: 'app-1',
         values: JSON.stringify(values),
         version: 3,
       }),
-      {} as HandlerContext,
-      {} as HandlerCallback,
     );
 
     const entries = ebMock
@@ -863,14 +809,12 @@ describe('registry-agent-record-resolver — setAppConfigValues', () => {
     const values = { anything: 'goes', nested: { deep: true } };
     seedApp({ version: 3, configSchema: null });
 
-    const result = await handler(
+    const result = await invokeHandler(
       makeEvent('setAppConfigValues', {
         appId: 'app-1',
         values: JSON.stringify(values),
         version: 3,
       }),
-      {} as HandlerContext,
-      {} as HandlerCallback,
     );
 
     expect(result).toBeDefined();
@@ -880,14 +824,12 @@ describe('registry-agent-record-resolver — setAppConfigValues', () => {
     seedApp({ version: 3, configSchema: VALID_SCHEMA });
 
     await expect(
-      handler(
+      invokeHandler(
         makeEvent('setAppConfigValues', {
           appId: 'app-1',
           values: JSON.stringify({ maxRetries: 3 }),
           version: 3,
         }),
-        {} as HandlerContext,
-        {} as HandlerCallback,
       ),
     ).rejects.toThrow(/validation/i);
   });
@@ -896,14 +838,12 @@ describe('registry-agent-record-resolver — setAppConfigValues', () => {
     seedApp({ version: 3, configSchema: VALID_SCHEMA });
 
     await expect(
-      handler(
+      invokeHandler(
         makeEvent('setAppConfigValues', {
           appId: 'app-1',
           values: JSON.stringify({ apiKey: 12345, maxRetries: 3 }),
           version: 3,
         }),
-        {} as HandlerContext,
-        {} as HandlerCallback,
       ),
     ).rejects.toThrow(/validation/i);
   });
@@ -912,28 +852,24 @@ describe('registry-agent-record-resolver — setAppConfigValues', () => {
     seedApp({ version: 5 });
 
     await expect(
-      handler(
+      invokeHandler(
         makeEvent('setAppConfigValues', {
           appId: 'app-1',
           values: JSON.stringify({ apiKey: 'sk-test-123' }),
           version: 3,
         }),
-        {} as HandlerContext,
-        {} as HandlerCallback,
       ),
     ).rejects.toThrow(/Conflict/i);
   });
 
   test('throws when app not found', async () => {
     await expect(
-      handler(
+      invokeHandler(
         makeEvent('setAppConfigValues', {
           appId: 'nonexistent',
           values: JSON.stringify({ apiKey: 'test' }),
           version: 3,
         }),
-        {} as HandlerContext,
-        {} as HandlerCallback,
       ),
     ).rejects.toThrow('App not found');
   });

--- a/backend/src/lambda/__tests__/registry-agent-record-resolver-components.test.ts
+++ b/backend/src/lambda/__tests__/registry-agent-record-resolver-components.test.ts
@@ -66,22 +66,26 @@ const VALID_SCHEMA = {
   required: ['apiKey'],
 };
 
-function makeEvent(fieldName: string, args: any) {
+type HandlerEvent = Parameters<typeof handler>[0];
+type HandlerContext = Parameters<typeof handler>[1];
+type HandlerCallback = Parameters<typeof handler>[2];
+
+function makeEvent(fieldName: string, args: Record<string, unknown>) {
   return {
     info: { fieldName },
     arguments: args,
     identity: { sub: 'user-123', claims: { sub: 'user-123' } },
-  } as any;
+  } as unknown as HandlerEvent;
 }
 
 function seedApp(
   opts: {
     appId?: string;
-    agentBindings?: any[];
-    permissions?: any[];
+    agentBindings?: unknown[];
+    permissions?: unknown[];
     version?: number;
-    configSchema?: any;
-    configValues?: any;
+    configSchema?: unknown;
+    configValues?: unknown;
   } = {},
 ) {
   const appId = opts.appId ?? 'app-1';
@@ -216,8 +220,8 @@ describe('registry-agent-record-resolver — addAppComponent', () => {
             data: JSON.stringify({ agentId: 'agent-1' }),
           },
         }),
-        {} as any,
-        {} as any,
+        {} as HandlerContext,
+        {} as HandlerCallback,
       );
 
       const entries = ebMock
@@ -250,8 +254,8 @@ describe('registry-agent-record-resolver — addAppComponent', () => {
             }),
           },
         }),
-        {} as any,
-        {} as any,
+        {} as HandlerContext,
+        {} as HandlerCallback,
       );
 
       expect(result).toBeDefined();
@@ -276,8 +280,8 @@ describe('registry-agent-record-resolver — addAppComponent', () => {
             }),
           },
         }),
-        {} as any,
-        {} as any,
+        {} as HandlerContext,
+        {} as HandlerCallback,
       );
 
       const entries = ebMock
@@ -307,8 +311,8 @@ describe('registry-agent-record-resolver — addAppComponent', () => {
               }),
             },
           }),
-          {} as any,
-          {} as any,
+          {} as HandlerContext,
+          {} as HandlerCallback,
         ),
       ).rejects.toThrow(/Permission validation failed/);
     });
@@ -325,8 +329,8 @@ describe('registry-agent-record-resolver — addAppComponent', () => {
               data: JSON.stringify({ agentId: 'agent-1' }),
             },
           }),
-          {} as any,
-          {} as any,
+          {} as HandlerContext,
+          {} as HandlerCallback,
         ),
       ).rejects.toThrow('App not found');
     });
@@ -340,8 +344,8 @@ describe('registry-agent-record-resolver — addAppComponent', () => {
             appId: 'app-1',
             component: { type: 'unknown-type', data: JSON.stringify({ id: 'x' }) },
           }),
-          {} as any,
-          {} as any,
+          {} as HandlerContext,
+          {} as HandlerCallback,
         ),
       ).rejects.toThrow(/Unsupported component type/);
     });
@@ -364,8 +368,8 @@ describe('registry-agent-record-resolver — addAppComponent', () => {
               }),
             },
           }),
-          {} as any,
-          {} as any,
+          {} as HandlerContext,
+          {} as HandlerCallback,
         ),
       ).rejects.toThrow('Bare wildcard');
     });
@@ -386,8 +390,8 @@ describe('registry-agent-record-resolver — addAppComponent', () => {
               }),
             },
           }),
-          {} as any,
-          {} as any,
+          {} as HandlerContext,
+          {} as HandlerCallback,
         ),
       ).rejects.toThrow('Invalid IAM action format');
     });
@@ -407,8 +411,8 @@ describe('registry-agent-record-resolver — addAppComponent', () => {
             }),
           },
         }),
-        {} as any,
-        {} as any,
+        {} as HandlerContext,
+        {} as HandlerCallback,
       );
 
       expect(result).toBeDefined();
@@ -428,8 +432,8 @@ describe('registry-agent-record-resolver — addAppComponent', () => {
             data: JSON.stringify({ agentId: 'agent-1' }),
           },
         }),
-        {} as any,
-        {} as any,
+        {} as HandlerContext,
+        {} as HandlerCallback,
       );
 
       expect(result.appId).toBe('app-1');
@@ -450,7 +454,7 @@ describe('registry-agent-record-resolver — removeAppComponent', () => {
     ebMock.on(PutEventsCommand).resolves({});
   });
 
-  function seedAppForRemove(opts: { agentBindings?: any[]; permissions?: any[] } = {}) {
+  function seedAppForRemove(opts: { agentBindings?: unknown[]; permissions?: unknown[] } = {}) {
     seedApp({
       agentBindings: opts.agentBindings ?? [
         { agentId: 'agent-1', status: 'DESIGN', addedAt: '2024-01-01T00:00:00Z' },
@@ -470,8 +474,8 @@ describe('registry-agent-record-resolver — removeAppComponent', () => {
         componentType: 'agent',
         componentId: 'agent-1',
       }),
-      {} as any,
-      {} as any,
+      {} as HandlerContext,
+      {} as HandlerCallback,
     );
 
     const entries = ebMock
@@ -496,8 +500,8 @@ describe('registry-agent-record-resolver — removeAppComponent', () => {
         componentType: 'permission',
         componentId: 'perm-1',
       }),
-      {} as any,
-      {} as any,
+      {} as HandlerContext,
+      {} as HandlerCallback,
     );
 
     const entries = ebMock
@@ -520,8 +524,8 @@ describe('registry-agent-record-resolver — removeAppComponent', () => {
         componentType: 'agent',
         componentId: 'nonexistent-agent',
       }),
-      {} as any,
-      {} as any,
+      {} as HandlerContext,
+      {} as HandlerCallback,
     );
 
     expect(result).toBeDefined();
@@ -536,8 +540,8 @@ describe('registry-agent-record-resolver — removeAppComponent', () => {
           componentType: 'agent',
           componentId: 'agent-1',
         }),
-        {} as any,
-        {} as any,
+        {} as HandlerContext,
+        {} as HandlerCallback,
       ),
     ).rejects.toThrow('App not found');
   });
@@ -552,8 +556,8 @@ describe('registry-agent-record-resolver — removeAppComponent', () => {
           componentType: 'unknown',
           componentId: 'x',
         }),
-        {} as any,
-        {} as any,
+        {} as HandlerContext,
+        {} as HandlerCallback,
       ),
     ).rejects.toThrow(/Unsupported component type/);
   });
@@ -582,8 +586,8 @@ describe('registry-agent-record-resolver — updateAgentBinding', () => {
             systemPromptAddition: 'Be helpful',
           },
         }),
-        {} as any,
-        {} as any,
+        {} as HandlerContext,
+        {} as HandlerCallback,
       ),
     ).rejects.toThrow('Agent is not a component of this app');
   });
@@ -594,8 +598,8 @@ describe('registry-agent-record-resolver — updateAgentBinding', () => {
         makeEvent('updateAgentBinding', {
           input: { appId: 'nonexistent', agentId: 'agent-1' },
         }),
-        {} as any,
-        {} as any,
+        {} as HandlerContext,
+        {} as HandlerCallback,
       ),
     ).rejects.toThrow('App not found');
   });
@@ -611,8 +615,8 @@ describe('registry-agent-record-resolver — updateAgentBinding', () => {
           systemPromptAddition: 'Be helpful',
         },
       }),
-      {} as any,
-      {} as any,
+      {} as HandlerContext,
+      {} as HandlerCallback,
     );
 
     expect(result).toBeDefined();
@@ -642,8 +646,8 @@ describe('registry-agent-record-resolver — updateAgentBinding', () => {
           status: 'READY',
         },
       }),
-      {} as any,
-      {} as any,
+      {} as HandlerContext,
+      {} as HandlerCallback,
     );
 
     expect(result).toBeDefined();
@@ -661,8 +665,8 @@ describe('registry-agent-record-resolver — updateAgentBinding', () => {
             status: 'READY',
           },
         }),
-        {} as any,
-        {} as any,
+        {} as HandlerContext,
+        {} as HandlerCallback,
       ),
     ).rejects.toThrow('Agent must be active before it can be marked as ready');
   });
@@ -680,8 +684,8 @@ describe('registry-agent-record-resolver — updateAgentBinding', () => {
             status: 'READY',
           },
         }),
-        {} as any,
-        {} as any,
+        {} as HandlerContext,
+        {} as HandlerCallback,
       ),
     ).rejects.toThrow('Agent must be active before it can be marked as ready');
   });
@@ -697,8 +701,8 @@ describe('registry-agent-record-resolver — updateAgentBinding', () => {
           status: 'DESIGN',
         },
       }),
-      {} as any,
-      {} as any,
+      {} as HandlerContext,
+      {} as HandlerCallback,
     );
 
     expect(result).toBeDefined();
@@ -715,8 +719,8 @@ describe('registry-agent-record-resolver — updateAgentBinding', () => {
           systemPromptAddition: 'Updated',
         },
       }),
-      {} as any,
-      {} as any,
+      {} as HandlerContext,
+      {} as HandlerCallback,
     );
 
     expect(result.appId).toBe('app-1');
@@ -746,8 +750,8 @@ describe('registry-agent-record-resolver — setAppConfigSchema', () => {
         schema: JSON.stringify(VALID_SCHEMA),
         version: 3,
       }),
-      {} as any,
-      {} as any,
+      {} as HandlerContext,
+      {} as HandlerCallback,
     );
 
     expect(result).toBeDefined();
@@ -770,8 +774,8 @@ describe('registry-agent-record-resolver — setAppConfigSchema', () => {
           schema: JSON.stringify({ type: 'not-a-real-type' }),
           version: 3,
         }),
-        {} as any,
-        {} as any,
+        {} as HandlerContext,
+        {} as HandlerCallback,
       ),
     ).rejects.toThrow(/invalid.*schema/i);
   });
@@ -786,8 +790,8 @@ describe('registry-agent-record-resolver — setAppConfigSchema', () => {
           schema: JSON.stringify('just a string'),
           version: 3,
         }),
-        {} as any,
-        {} as any,
+        {} as HandlerContext,
+        {} as HandlerCallback,
       ),
     ).rejects.toThrow(/invalid.*schema/i);
   });
@@ -802,8 +806,8 @@ describe('registry-agent-record-resolver — setAppConfigSchema', () => {
           schema: JSON.stringify(VALID_SCHEMA),
           version: 3,
         }),
-        {} as any,
-        {} as any,
+        {} as HandlerContext,
+        {} as HandlerCallback,
       ),
     ).rejects.toThrow(/Conflict/i);
   });
@@ -816,8 +820,8 @@ describe('registry-agent-record-resolver — setAppConfigSchema', () => {
           schema: JSON.stringify(VALID_SCHEMA),
           version: 3,
         }),
-        {} as any,
-        {} as any,
+        {} as HandlerContext,
+        {} as HandlerCallback,
       ),
     ).rejects.toThrow('App not found');
   });
@@ -844,8 +848,8 @@ describe('registry-agent-record-resolver — setAppConfigValues', () => {
         values: JSON.stringify(values),
         version: 3,
       }),
-      {} as any,
-      {} as any,
+      {} as HandlerContext,
+      {} as HandlerCallback,
     );
 
     const entries = ebMock
@@ -865,8 +869,8 @@ describe('registry-agent-record-resolver — setAppConfigValues', () => {
         values: JSON.stringify(values),
         version: 3,
       }),
-      {} as any,
-      {} as any,
+      {} as HandlerContext,
+      {} as HandlerCallback,
     );
 
     expect(result).toBeDefined();
@@ -882,8 +886,8 @@ describe('registry-agent-record-resolver — setAppConfigValues', () => {
           values: JSON.stringify({ maxRetries: 3 }),
           version: 3,
         }),
-        {} as any,
-        {} as any,
+        {} as HandlerContext,
+        {} as HandlerCallback,
       ),
     ).rejects.toThrow(/validation/i);
   });
@@ -898,8 +902,8 @@ describe('registry-agent-record-resolver — setAppConfigValues', () => {
           values: JSON.stringify({ apiKey: 12345, maxRetries: 3 }),
           version: 3,
         }),
-        {} as any,
-        {} as any,
+        {} as HandlerContext,
+        {} as HandlerCallback,
       ),
     ).rejects.toThrow(/validation/i);
   });
@@ -914,8 +918,8 @@ describe('registry-agent-record-resolver — setAppConfigValues', () => {
           values: JSON.stringify({ apiKey: 'sk-test-123' }),
           version: 3,
         }),
-        {} as any,
-        {} as any,
+        {} as HandlerContext,
+        {} as HandlerCallback,
       ),
     ).rejects.toThrow(/Conflict/i);
   });
@@ -928,8 +932,8 @@ describe('registry-agent-record-resolver — setAppConfigValues', () => {
           values: JSON.stringify({ apiKey: 'test' }),
           version: 3,
         }),
-        {} as any,
-        {} as any,
+        {} as HandlerContext,
+        {} as HandlerCallback,
       ),
     ).rejects.toThrow('App not found');
   });

--- a/backend/src/lambda/__tests__/registry-agent-record-resolver-crud.test.ts
+++ b/backend/src/lambda/__tests__/registry-agent-record-resolver-crud.test.ts
@@ -65,18 +65,21 @@ jest.mock('../../utils/appsync-publish', () => ({
 import { handler } from '../registry-agent-record-resolver';
 import { APP_META_SORT_VALUE } from '../../utils/apps-table-meta';
 import type { Context } from 'aws-lambda';
+import type { QueryCommandInput, ScanCommandInput } from '@aws-sdk/lib-dynamodb';
+
+type HandlerEvent = Parameters<typeof handler>[0];
 
 // Typed Lambda invocation stub — the resolver ignores context/callback, so a
 // cast-through-unknown Context (plus a jest.fn() callback) keeps handler calls
 // type-correct without `any` (mirrors seed-blueprints.test.ts convention).
 const mockContext = {} as unknown as Context;
 
-function makeEvent(fieldName: string, args: any, sub = 'user-123') {
+function makeEvent(fieldName: string, args: Record<string, unknown>, sub = 'user-123') {
   return {
     info: { fieldName },
     arguments: args,
     identity: { sub, claims: { sub } },
-  } as any;
+  } as unknown as HandlerEvent;
 }
 
 /**
@@ -84,7 +87,7 @@ function makeEvent(fieldName: string, args: any, sub = 'user-123') {
  * `listApps` "All Organizations" gate introduced by Phase 1 org-scoping.
  * Mirrors `makeEvent` but sets `custom:role = 'admin'` on the identity.
  */
-function makeAdminEvent(fieldName: string, args: any, sub = 'user-123') {
+function makeAdminEvent(fieldName: string, args: Record<string, unknown>, sub = 'user-123') {
   return {
     info: { fieldName },
     arguments: args,
@@ -93,7 +96,7 @@ function makeAdminEvent(fieldName: string, args: any, sub = 'user-123') {
       'custom:role': 'admin',
       claims: { sub, 'custom:role': 'admin' },
     },
-  } as any;
+  } as unknown as HandlerEvent;
 }
 
 function seedApp(
@@ -101,7 +104,7 @@ function seedApp(
     status?: string;
     version?: number;
     orgId?: string;
-    manifest?: Record<string, any>;
+    manifest?: Record<string, unknown>;
   } = {},
 ): void {
   seedMockRegistry('agent', 'app-1', {
@@ -178,7 +181,7 @@ describe('registry-agent-record-resolver — CRUD', () => {
   // is no longer relevant to the listApps read path.
 
   /** Build a metadata row as it would appear in the AppsTable / OrgIndex. */
-  function metaRow(over: Partial<Record<string, any>> = {}): Record<string, any> {
+  function metaRow(over: Partial<Record<string, unknown>> = {}): Record<string, unknown> {
     return {
       appId: 'app-1',
       sortId: APP_META_SORT_VALUE,
@@ -214,7 +217,7 @@ describe('registry-agent-record-resolver — CRUD', () => {
       );
 
       expect(result.items).toHaveLength(3);
-      const ids = result.items.map((a: any) => a.appId).sort();
+      const ids = result.items.map((a: { appId: string }) => a.appId).sort();
       expect(ids).toEqual(['app-1', 'app-2', 'app-3']);
       expect(result.nextToken).toBeNull();
 
@@ -234,7 +237,7 @@ describe('registry-agent-record-resolver — CRUD', () => {
 
       const scanCalls = ddbMock.commandCalls(ScanCommand);
       expect(scanCalls.length).toBe(1);
-      const input = scanCalls[0].args[0].input as any;
+      const input = scanCalls[0].args[0].input as ScanCommandInput;
       expect(input.TableName).toBe('citadel-apps-test');
       expect(input.FilterExpression).toBe('sortId = :meta');
       expect(input.ExpressionAttributeValues[':meta']).toBe(APP_META_SORT_VALUE);
@@ -285,7 +288,7 @@ describe('registry-agent-record-resolver — CRUD', () => {
       );
 
       expect(result.items).toHaveLength(2);
-      const ids = result.items.map((a: any) => a.appId).sort();
+      const ids = result.items.map((a: { appId: string }) => a.appId).sort();
       expect(ids).toEqual(['app-1', 'app-2']);
       for (const app of result.items) {
         expect(app.orgId).toBe('org-1');
@@ -294,7 +297,7 @@ describe('registry-agent-record-resolver — CRUD', () => {
       // Org-scoped path must use Query against OrgIndex, not Scan.
       const queryCalls = ddbMock.commandCalls(QueryCommand);
       expect(queryCalls.length).toBe(1);
-      const input = queryCalls[0].args[0].input as any;
+      const input = queryCalls[0].args[0].input as QueryCommandInput;
       expect(input.TableName).toBe('citadel-apps-test');
       expect(input.IndexName).toBe('OrgIndex');
       expect(input.KeyConditionExpression).toBe('orgId = :org');
@@ -399,15 +402,15 @@ describe('registry-agent-record-resolver — CRUD', () => {
       );
 
       expect(result.items).toHaveLength(2);
-      expect(result.items.map((a: any) => a.appId)).toEqual(['app-1', 'app-2']);
+      expect(result.items.map((a: { appId: string }) => a.appId)).toEqual(['app-1', 'app-2']);
       // External cursor is not surfaced — pagination is fully drained internally.
       expect(result.nextToken).toBeNull();
 
       const queryCalls = ddbMock.commandCalls(QueryCommand);
       expect(queryCalls.length).toBe(2);
       // First call has no cursor; second call carries the page1 cursor.
-      expect((queryCalls[0].args[0].input as any).ExclusiveStartKey).toBeUndefined();
-      expect((queryCalls[1].args[0].input as any).ExclusiveStartKey).toEqual(page1Cursor);
+      expect((queryCalls[0].args[0].input as QueryCommandInput).ExclusiveStartKey).toBeUndefined();
+      expect((queryCalls[1].args[0].input as QueryCommandInput).ExclusiveStartKey).toEqual(page1Cursor);
     });
   });
 

--- a/backend/src/lambda/__tests__/registry-agent-record-resolver-crud.test.ts
+++ b/backend/src/lambda/__tests__/registry-agent-record-resolver-crud.test.ts
@@ -64,15 +64,15 @@ jest.mock('../../utils/appsync-publish', () => ({
 
 import { handler } from '../registry-agent-record-resolver';
 import { APP_META_SORT_VALUE } from '../../utils/apps-table-meta';
-import type { Context } from 'aws-lambda';
 import type { QueryCommandInput, ScanCommandInput } from '@aws-sdk/lib-dynamodb';
 
 type HandlerEvent = Parameters<typeof handler>[0];
 
-// Typed Lambda invocation stub — the resolver ignores context/callback, so a
-// cast-through-unknown Context (plus a jest.fn() callback) keeps handler calls
-// type-correct without `any` (mirrors seed-blueprints.test.ts convention).
-const mockContext = {} as unknown as Context;
+// aws-lambda's Handler type declares legacy required context and callback
+// parameters, but the implementation is a one-parameter async (event)
+// function that never uses them — invoke through the real signature
+// (single cast here) so calls don't pass superfluous arguments.
+const invokeHandler = handler as (event: HandlerEvent) => Promise<unknown>;
 
 function makeEvent(fieldName: string, args: Record<string, unknown>, sub = 'user-123') {
   return {
@@ -162,10 +162,8 @@ describe('registry-agent-record-resolver — CRUD', () => {
     test('returns item when caller orgId matches', async () => {
       seedApp({ orgId: 'org-1' });
 
-      const result = await handler(
+      const result = await invokeHandler(
         makeEvent('getApp', { appId: 'app-1' }),
-        mockContext,
-        jest.fn(),
       );
 
       expect(result.appId).toBe('app-1');
@@ -210,10 +208,8 @@ describe('registry-agent-record-resolver — CRUD', () => {
         LastEvaluatedKey: undefined,
       });
 
-      const result = await handler(
+      const result = await invokeHandler(
         makeAdminEvent('listApps', { orgId: 'All Organizations' }),
-        mockContext,
-        jest.fn(),
       );
 
       expect(result.items).toHaveLength(3);
@@ -229,10 +225,8 @@ describe('registry-agent-record-resolver — CRUD', () => {
     test('Scan is filtered to metadata rows only via FilterExpression', async () => {
       ddbMock.on(ScanCommand).resolves({ Items: [], LastEvaluatedKey: undefined });
 
-      await handler(
+      await invokeHandler(
         makeAdminEvent('listApps', { orgId: 'All Organizations' }),
-        mockContext,
-        jest.fn(),
       );
 
       const scanCalls = ddbMock.commandCalls(ScanCommand);
@@ -246,10 +240,8 @@ describe('registry-agent-record-resolver — CRUD', () => {
     test('returns empty items array when AppsTable is empty (admin caller)', async () => {
       ddbMock.on(ScanCommand).resolves({ Items: [], LastEvaluatedKey: undefined });
 
-      const result = await handler(
+      const result = await invokeHandler(
         makeAdminEvent('listApps', { orgId: 'All Organizations' }),
-        mockContext,
-        jest.fn(),
       );
 
       expect(result.items).toEqual([]);
@@ -258,10 +250,8 @@ describe('registry-agent-record-resolver — CRUD', () => {
 
     test('rejects non-admin callers with an "Only admins …" error (no DDB call)', async () => {
       await expect(
-        handler(
+        invokeHandler(
           makeEvent('listApps', { orgId: 'All Organizations' }),
-          mockContext,
-          jest.fn(),
         ),
       ).rejects.toThrow(/Only admins/i);
 
@@ -281,10 +271,8 @@ describe('registry-agent-record-resolver — CRUD', () => {
         LastEvaluatedKey: undefined,
       });
 
-      const result = await handler(
+      const result = await invokeHandler(
         makeEvent('listApps', { orgId: 'org-1' }),
-        mockContext,
-        jest.fn(),
       );
 
       expect(result.items).toHaveLength(2);
@@ -312,10 +300,8 @@ describe('registry-agent-record-resolver — CRUD', () => {
     test('returns empty items when OrgIndex Query returns no rows', async () => {
       ddbMock.on(QueryCommand).resolves({ Items: [], LastEvaluatedKey: undefined });
 
-      const result = await handler(
+      const result = await invokeHandler(
         makeEvent('listApps', { orgId: 'org-other' }),
-        mockContext,
-        jest.fn(),
       );
 
       expect(result.items).toEqual([]);
@@ -337,10 +323,8 @@ describe('registry-agent-record-resolver — CRUD', () => {
         LastEvaluatedKey: undefined,
       });
 
-      const result = await handler(
+      const result = await invokeHandler(
         makeEvent('listApps', { orgId: 'org-1' }),
-        mockContext,
-        jest.fn(),
       );
 
       expect(result.items).toHaveLength(1);
@@ -361,10 +345,8 @@ describe('registry-agent-record-resolver — CRUD', () => {
         LastEvaluatedKey: undefined,
       });
 
-      const result = await handler(
+      const result = await invokeHandler(
         makeEvent('listApps', { orgId: 'org-1' }),
-        mockContext,
-        jest.fn(),
       );
 
       expect(result.items).toHaveLength(1);
@@ -395,10 +377,8 @@ describe('registry-agent-record-resolver — CRUD', () => {
           LastEvaluatedKey: undefined,
         });
 
-      const result = await handler(
+      const result = await invokeHandler(
         makeEvent('listApps', { orgId: 'org-1' }),
-        mockContext,
-        jest.fn(),
       );
 
       expect(result.items).toHaveLength(2);
@@ -418,7 +398,7 @@ describe('registry-agent-record-resolver — CRUD', () => {
 
   describe('createApp', () => {
     test('sets version=1, status=DRAFT, workflowIds=[], generates UUID', async () => {
-      const result = await handler(
+      const result = await invokeHandler(
         makeEvent('createApp', {
           input: {
             name: 'New App',
@@ -426,8 +406,6 @@ describe('registry-agent-record-resolver — CRUD', () => {
             orgId: 'org-1',
           },
         }),
-        mockContext,
-        jest.fn(),
       );
 
       expect(result).toMatchObject({
@@ -441,12 +419,10 @@ describe('registry-agent-record-resolver — CRUD', () => {
     });
 
     test('emits app.created event', async () => {
-      await handler(
+      await invokeHandler(
         makeEvent('createApp', {
           input: { name: 'EB Test App', orgId: 'org-1' },
         }),
-        mockContext,
-        jest.fn(),
       );
 
       const ebCalls = ebMock.commandCalls(PutEventsCommand);
@@ -466,12 +442,10 @@ describe('registry-agent-record-resolver — CRUD', () => {
       seedApp({ version: 1, orgId: 'org-1' });
 
       await expect(
-        handler(
+        invokeHandler(
           makeEvent('updateApp', {
             input: { appId: 'app-1', version: 1, name: 'Updated Name' },
           }),
-          mockContext,
-          jest.fn(),
         ),
       ).resolves.toBeDefined();
 
@@ -487,12 +461,10 @@ describe('registry-agent-record-resolver — CRUD', () => {
       seedApp({ version: 3 });
 
       await expect(
-        handler(
+        invokeHandler(
           makeEvent('updateApp', {
             input: { appId: 'app-1', name: 'Stale', version: 1 },
           }),
-          mockContext,
-          jest.fn(),
         ),
       ).rejects.toThrow(/Conflict/);
     });
@@ -500,12 +472,10 @@ describe('registry-agent-record-resolver — CRUD', () => {
     test('emits app.updated event', async () => {
       seedApp({ version: 1 });
 
-      await handler(
+      await invokeHandler(
         makeEvent('updateApp', {
           input: { appId: 'app-1', name: 'Updated', version: 1 },
         }),
-        mockContext,
-        jest.fn(),
       );
 
       const ebCalls = ebMock.commandCalls(PutEventsCommand);
@@ -523,10 +493,8 @@ describe('registry-agent-record-resolver — CRUD', () => {
     test('deletes and emits app.deleted', async () => {
       seedApp({ manifest: { workflowIds: ['wf-1', 'wf-2'] } });
 
-      const result = await handler(
+      const result = await invokeHandler(
         makeEvent('deleteApp', { appId: 'app-1' }),
-        mockContext,
-        jest.fn(),
       );
 
       expect(result.success).toBe(true);
@@ -542,10 +510,8 @@ describe('registry-agent-record-resolver — CRUD', () => {
     test('emits app.deleted event on simple delete', async () => {
       seedApp();
 
-      await handler(
+      await invokeHandler(
         makeEvent('deleteApp', { appId: 'app-1' }),
-        mockContext,
-        jest.fn(),
       );
 
       const ebCalls = ebMock.commandCalls(PutEventsCommand);
@@ -561,7 +527,7 @@ describe('registry-agent-record-resolver — CRUD', () => {
 
   describe('sourceProjectId propagation (US-ARB-017)', () => {
     test('projects sourceProjectId onto createApp result when provided', async () => {
-      const result = await handler(
+      const result = await invokeHandler(
         makeEvent('createApp', {
           input: {
             name: 'Governed App',
@@ -570,8 +536,6 @@ describe('registry-agent-record-resolver — CRUD', () => {
             sourceProjectId: 'proj-1',
           },
         }),
-        mockContext,
-        jest.fn(),
       );
 
       expect(result.sourceProjectId).toBe('proj-1');
@@ -581,7 +545,7 @@ describe('registry-agent-record-resolver — CRUD', () => {
     });
 
     test('returns sourceProjectId as null when not provided', async () => {
-      const result = await handler(
+      const result = await invokeHandler(
         makeEvent('createApp', {
           input: {
             name: 'Ungoverned App',
@@ -589,8 +553,6 @@ describe('registry-agent-record-resolver — CRUD', () => {
             orgId: 'org-1',
           },
         }),
-        mockContext,
-        jest.fn(),
       );
 
       expect(result.sourceProjectId == null).toBe(true);
@@ -600,7 +562,7 @@ describe('registry-agent-record-resolver — CRUD', () => {
       seedApp({ version: 1 });
 
       await expect(
-        handler(
+        invokeHandler(
           makeEvent('updateApp', {
             input: {
               appId: 'app-1',
@@ -608,8 +570,6 @@ describe('registry-agent-record-resolver — CRUD', () => {
               sourceProjectId: 'proj-2',
             },
           }),
-          mockContext,
-          jest.fn(),
         ),
       ).resolves.toBeDefined();
 
@@ -625,7 +585,7 @@ describe('registry-agent-record-resolver — CRUD', () => {
       seedApp({ version: 1 });
 
       await expect(
-        handler(
+        invokeHandler(
           makeEvent('updateApp', {
             input: {
               appId: 'app-1',
@@ -633,8 +593,6 @@ describe('registry-agent-record-resolver — CRUD', () => {
               version: 1,
             },
           }),
-          mockContext,
-          jest.fn(),
         ),
       ).resolves.toBeDefined();
 

--- a/backend/src/lambda/__tests__/registry-agent-record-resolver-description-default.test.ts
+++ b/backend/src/lambda/__tests__/registry-agent-record-resolver-description-default.test.ts
@@ -83,9 +83,6 @@ jest.mock('../../utils/appsync-publish', () => ({
 
 import { getRegistryService } from '../../services/registry-service';
 import { handler } from '../registry-agent-record-resolver';
-import type { Context } from 'aws-lambda';
-
-const mockContext = {} as unknown as Context;
 
 const registry = getRegistryService() as unknown as {
   createResource: jest.Mock;
@@ -93,6 +90,12 @@ const registry = getRegistryService() as unknown as {
 };
 
 type HandlerEvent = Parameters<typeof handler>[0];
+
+// aws-lambda's Handler type declares legacy required context and callback
+// parameters, but the implementation is a one-parameter async (event)
+// function that never uses them — invoke through the real signature
+// (single cast here) so calls don't pass superfluous arguments.
+const invokeHandler = handler as (event: HandlerEvent) => Promise<unknown>;
 
 function makeEvent(fieldName: string, args: Record<string, unknown>, sub = 'user-123'): HandlerEvent {
   return {
@@ -195,12 +198,10 @@ describe('registry-agent-record-resolver — description defaulting', () => {
 
   describe('createApp', () => {
     test('defaults the registry description to the app name when description is omitted (Import Blueprint New App regression)', async () => {
-      await handler(
+      await invokeHandler(
         makeEvent('createApp', {
           input: { name: 'My New App', orgId: 'org-1' },
         }),
-        mockContext,
-        jest.fn(),
       );
 
       const created = lastCreateResourceInput();
@@ -208,12 +209,10 @@ describe('registry-agent-record-resolver — description defaulting', () => {
     });
 
     test('defaults a blank (whitespace-only) description to the app name', async () => {
-      await handler(
+      await invokeHandler(
         makeEvent('createApp', {
           input: { name: 'My New App', orgId: 'org-1', description: '   ' },
         }),
-        mockContext,
-        jest.fn(),
       );
 
       const created = lastCreateResourceInput();
@@ -221,19 +220,17 @@ describe('registry-agent-record-resolver — description defaulting', () => {
     });
 
     test('mirrors the defaulted description to the AppsTable #META row (registry/mirror consistency)', async () => {
-      await handler(
+      await invokeHandler(
         makeEvent('createApp', {
           input: { name: 'My New App', orgId: 'org-1' },
         }),
-        mockContext,
-        jest.fn(),
       );
 
       expect(lastMetaDescriptionWrite()).toBe('My New App');
     });
 
     test('passes a provided non-empty description to the registry verbatim', async () => {
-      await handler(
+      await invokeHandler(
         makeEvent('createApp', {
           input: {
             name: 'My New App',
@@ -241,8 +238,6 @@ describe('registry-agent-record-resolver — description defaulting', () => {
             description: 'Hand-written description',
           },
         }),
-        mockContext,
-        jest.fn(),
       );
 
       const created = lastCreateResourceInput();
@@ -257,12 +252,10 @@ describe('registry-agent-record-resolver — description defaulting', () => {
     test('never forwards an explicit-blank description to the registry — defaults to the app name', async () => {
       seedApp({ name: 'Legacy App' });
 
-      await handler(
+      await invokeHandler(
         makeEvent('updateApp', {
           input: { appId: 'app-1', version: 1, description: '' },
         }),
-        mockContext,
-        jest.fn(),
       );
 
       const updated = lastUpdateResourceInput();
@@ -272,12 +265,10 @@ describe('registry-agent-record-resolver — description defaulting', () => {
     test('defaults to the app name when description is omitted and the existing record description is blank (legacy record)', async () => {
       seedApp({ name: 'Legacy App', description: '' });
 
-      await handler(
+      await invokeHandler(
         makeEvent('updateApp', {
           input: { appId: 'app-1', version: 1, name: 'Renamed App' },
         }),
-        mockContext,
-        jest.fn(),
       );
 
       const updated = lastUpdateResourceInput();
@@ -287,12 +278,10 @@ describe('registry-agent-record-resolver — description defaulting', () => {
     test('mirrors the defaulted description to the AppsTable #META row when the caller sent a blank description', async () => {
       seedApp({ name: 'Legacy App' });
 
-      await handler(
+      await invokeHandler(
         makeEvent('updateApp', {
           input: { appId: 'app-1', version: 1, description: '   ' },
         }),
-        mockContext,
-        jest.fn(),
       );
 
       expect(lastMetaDescriptionWrite()).toBe('Legacy App');
@@ -301,12 +290,10 @@ describe('registry-agent-record-resolver — description defaulting', () => {
     test('preserves a provided non-empty description verbatim', async () => {
       seedApp({ name: 'Legacy App' });
 
-      await handler(
+      await invokeHandler(
         makeEvent('updateApp', {
           input: { appId: 'app-1', version: 1, description: 'Updated by hand' },
         }),
-        mockContext,
-        jest.fn(),
       );
 
       const updated = lastUpdateResourceInput();
@@ -317,12 +304,10 @@ describe('registry-agent-record-resolver — description defaulting', () => {
     test('keeps the existing non-blank description when the caller omits it', async () => {
       seedApp({ name: 'Legacy App', description: 'Existing description' });
 
-      await handler(
+      await invokeHandler(
         makeEvent('updateApp', {
           input: { appId: 'app-1', version: 1, name: 'Renamed App' },
         }),
-        mockContext,
-        jest.fn(),
       );
 
       const updated = lastUpdateResourceInput();

--- a/backend/src/lambda/__tests__/registry-agent-record-resolver-identity.test.ts
+++ b/backend/src/lambda/__tests__/registry-agent-record-resolver-identity.test.ts
@@ -139,7 +139,6 @@ jest.mock('../../utils/appsync-publish', () => ({
 }));
 
 import { handler } from '../registry-agent-record-resolver';
-import type { Context } from 'aws-lambda';
 
 import * as registryServiceMockedModule from '../../services/registry-service';
 
@@ -162,9 +161,13 @@ const registryMock = registryServiceMockedModule as unknown as {
   __reset: () => void;
 };
 
-const mockContext = {} as unknown as Context;
-
 type HandlerEvent = Parameters<typeof handler>[0];
+
+// aws-lambda's Handler type declares legacy required context and callback
+// parameters, but the implementation is a one-parameter async (event)
+// function that never uses them — invoke through the real signature
+// (single cast here) so calls don't pass superfluous arguments.
+const invokeHandler = handler as (event: HandlerEvent) => Promise<unknown>;
 
 function makeEvent(fieldName: string, args: Record<string, unknown>, sub = 'user-123'): HandlerEvent {
   return {
@@ -236,12 +239,10 @@ describe('registry-agent-record-resolver — appId identity chain', () => {
 
   describe('createApp', () => {
     test('returns the registry-assigned recordId as appId, not the original UUID from customDescriptorContent', async () => {
-      const result = (await handler(
+      const result = (await invokeHandler(
         makeEvent('createApp', {
           input: { name: 'New App', description: 'A test app', orgId: 'org-1' },
         }),
-        mockContext,
-        jest.fn(),
       )) as Record<string, unknown>;
 
       // The persisted record's descriptor still embeds the original UUID.
@@ -257,12 +258,10 @@ describe('registry-agent-record-resolver — appId identity chain', () => {
     });
 
     test('returned appId agrees with the AppsTable #META mirror key', async () => {
-      const result = (await handler(
+      const result = (await invokeHandler(
         makeEvent('createApp', {
           input: { name: 'New App', description: 'A test app', orgId: 'org-1' },
         }),
-        mockContext,
-        jest.fn(),
       )) as Record<string, unknown>;
 
       const calls = metaUpdateCalls();
@@ -279,12 +278,10 @@ describe('registry-agent-record-resolver — appId identity chain', () => {
       const errorSpy = jest.spyOn(console, 'error').mockImplementation(() => undefined);
       const warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => undefined);
       try {
-        await handler(
+        await invokeHandler(
           makeEvent('createApp', {
             input: { name: 'New App', description: 'A test app', orgId: 'org-1' },
           }),
-          mockContext,
-          jest.fn(),
         );
 
         const mirrorFailureLogs = errorSpy.mock.calls.filter(
@@ -309,40 +306,32 @@ describe('registry-agent-record-resolver — appId identity chain', () => {
   describe('sibling mutation paths return recordId when the descriptor embeds a stale UUID', () => {
     test('updateApp', async () => {
       seedAppWithStaleDescriptorId();
-      const result = (await handler(
+      const result = (await invokeHandler(
         makeEvent('updateApp', { input: { appId: 'app-1', name: 'Renamed' } }),
-        mockContext,
-        jest.fn(),
       )) as Record<string, unknown>;
       expect(result.appId).toBe('app-1');
     });
 
     test('bindWorkflowToApp (new binding)', async () => {
       seedAppWithStaleDescriptorId();
-      const result = (await handler(
+      const result = (await invokeHandler(
         makeEvent('bindWorkflowToApp', { appId: 'app-1', workflowId: 'wf-1' }),
-        mockContext,
-        jest.fn(),
       )) as Record<string, unknown>;
       expect(result.appId).toBe('app-1');
     });
 
     test('bindWorkflowToApp (idempotent early return)', async () => {
       seedAppWithStaleDescriptorId({ workflowIds: ['wf-1'] });
-      const result = (await handler(
+      const result = (await invokeHandler(
         makeEvent('bindWorkflowToApp', { appId: 'app-1', workflowId: 'wf-1' }),
-        mockContext,
-        jest.fn(),
       )) as Record<string, unknown>;
       expect(result.appId).toBe('app-1');
     });
 
     test('unbindWorkflowFromApp', async () => {
       seedAppWithStaleDescriptorId({ workflowIds: ['wf-1'] });
-      const result = (await handler(
+      const result = (await invokeHandler(
         makeEvent('unbindWorkflowFromApp', { appId: 'app-1', workflowId: 'wf-1' }),
-        mockContext,
-        jest.fn(),
       )) as Record<string, unknown>;
       expect(result.appId).toBe('app-1');
     });
@@ -351,25 +340,21 @@ describe('registry-agent-record-resolver — appId identity chain', () => {
       seedAppWithStaleDescriptorId({
         agentBindings: [{ agentId: 'agent-x', status: 'DESIGN' }],
       });
-      const result = (await handler(
+      const result = (await invokeHandler(
         makeEvent('updateAgentBinding', {
           input: { appId: 'app-1', agentId: 'agent-x', systemPromptAddition: 'hi' },
         }),
-        mockContext,
-        jest.fn(),
       )) as Record<string, unknown>;
       expect(result.appId).toBe('app-1');
     });
 
     test('addAppComponent', async () => {
       seedAppWithStaleDescriptorId();
-      const result = (await handler(
+      const result = (await invokeHandler(
         makeEvent('addAppComponent', {
           appId: 'app-1',
           component: { type: 'agent', data: JSON.stringify({ agentId: 'agent-y' }) },
         }),
-        mockContext,
-        jest.fn(),
       )) as Record<string, unknown>;
       expect(result.appId).toBe('app-1');
     });
@@ -378,65 +363,55 @@ describe('registry-agent-record-resolver — appId identity chain', () => {
       seedAppWithStaleDescriptorId({
         agentBindings: [{ agentId: 'agent-x', status: 'DESIGN' }],
       });
-      const result = (await handler(
+      const result = (await invokeHandler(
         makeEvent('removeAppComponent', {
           appId: 'app-1',
           componentType: 'agent',
           componentId: 'agent-x',
         }),
-        mockContext,
-        jest.fn(),
       )) as Record<string, unknown>;
       expect(result.appId).toBe('app-1');
     });
 
     test('setAppConfigSchema', async () => {
       seedAppWithStaleDescriptorId();
-      const result = (await handler(
+      const result = (await invokeHandler(
         makeEvent('setAppConfigSchema', {
           appId: 'app-1',
           schema: JSON.stringify({ type: 'object' }),
           version: 1,
         }),
-        mockContext,
-        jest.fn(),
       )) as Record<string, unknown>;
       expect(result.appId).toBe('app-1');
     });
 
     test('setAppConfigValues', async () => {
       seedAppWithStaleDescriptorId();
-      const result = (await handler(
+      const result = (await invokeHandler(
         makeEvent('setAppConfigValues', {
           appId: 'app-1',
           values: JSON.stringify({}),
           version: 1,
         }),
-        mockContext,
-        jest.fn(),
       )) as Record<string, unknown>;
       expect(result.appId).toBe('app-1');
     });
 
     test('setAppAuthConfig', async () => {
       seedAppWithStaleDescriptorId();
-      const result = (await handler(
+      const result = (await invokeHandler(
         makeEvent('setAppAuthConfig', {
           appId: 'app-1',
           authConfig: JSON.stringify({ mode: 'NONE' }),
         }),
-        mockContext,
-        jest.fn(),
       )) as Record<string, unknown>;
       expect(result.appId).toBe('app-1');
     });
 
     test('grantAppAccess', async () => {
       seedAppWithStaleDescriptorId();
-      const result = (await handler(
+      const result = (await invokeHandler(
         makeEvent('grantAppAccess', { appId: 'app-1', userId: 'user-2', role: 'viewer' }),
-        mockContext,
-        jest.fn(),
       )) as Record<string, unknown>;
       expect(result.appId).toBe('app-1');
     });
@@ -445,10 +420,8 @@ describe('registry-agent-record-resolver — appId identity chain', () => {
       seedAppWithStaleDescriptorId({
         access: { 'user-2': { role: 'viewer', grantedAt: 'x', grantedBy: 'y' } },
       });
-      const result = (await handler(
+      const result = (await invokeHandler(
         makeEvent('revokeAppAccess', { appId: 'app-1', userId: 'user-2' }),
-        mockContext,
-        jest.fn(),
       )) as Record<string, unknown>;
       expect(result.appId).toBe('app-1');
     });

--- a/backend/src/lambda/__tests__/registry-agent-record-resolver-meta-writes.test.ts
+++ b/backend/src/lambda/__tests__/registry-agent-record-resolver-meta-writes.test.ts
@@ -57,12 +57,16 @@ jest.mock('../../utils/appsync-publish', () => ({
 import { handler } from '../registry-agent-record-resolver';
 import { APP_META_SORT_VALUE } from '../../utils/apps-table-meta';
 
-function makeEvent(fieldName: string, args: any, sub = 'user-123') {
+type HandlerEvent = Parameters<typeof handler>[0];
+type HandlerContext = Parameters<typeof handler>[1];
+type HandlerCallback = Parameters<typeof handler>[2];
+
+function makeEvent(fieldName: string, args: Record<string, unknown>, sub = 'user-123') {
   return {
     info: { fieldName },
     arguments: args,
     identity: { sub, claims: { sub } },
-  } as any;
+  } as unknown as HandlerEvent;
 }
 
 function seedApp(opts: { version?: number; orgId?: string } = {}): void {
@@ -120,8 +124,8 @@ describe('registry-agent-record-resolver — AppsTable #META mirror writes', () 
             orgId: 'org-1',
           },
         }),
-        {} as any,
-        {} as any,
+        {} as HandlerContext,
+        {} as HandlerCallback,
       );
 
       // upsertAppMeta is now an UpdateCommand (not a Put) so it preserves
@@ -130,12 +134,12 @@ describe('registry-agent-record-resolver — AppsTable #META mirror writes', () 
       const metaUpdate = updateCalls.find(
         (c) =>
           c.args[0].input.TableName === 'citadel-apps-test' &&
-          (c.args[0].input.Key as any)?.appId === result.appId &&
+          (c.args[0].input.Key as Record<string, unknown> | undefined)?.appId === result.appId &&
           // Key must be appId only — no sortId in the key.
-          (c.args[0].input.Key as any)?.sortId === undefined,
+          (c.args[0].input.Key as Record<string, unknown> | undefined)?.sortId === undefined,
       );
       expect(metaUpdate).toBeDefined();
-      const values = metaUpdate!.args[0].input.ExpressionAttributeValues as any;
+      const values = metaUpdate!.args[0].input.ExpressionAttributeValues as Record<string, unknown>;
       expect(values[':v_orgId']).toBe('org-1');
       expect(values[':v_name']).toBe('New App');
       expect(values[':v_status']).toBe('DRAFT');
@@ -158,8 +162,8 @@ describe('registry-agent-record-resolver — AppsTable #META mirror writes', () 
         makeEvent('updateApp', {
           input: { appId: 'app-1', version: 1, name: 'Renamed' },
         }),
-        {} as any,
-        {} as any,
+        {} as HandlerContext,
+        {} as HandlerCallback,
       );
 
       const updateCalls = ddbMock.commandCalls(UpdateCommand);
@@ -169,12 +173,12 @@ describe('registry-agent-record-resolver — AppsTable #META mirror writes', () 
       const metaUpdate = updateCalls.find(
         (c) =>
           c.args[0].input.TableName === 'citadel-apps-test' &&
-          (c.args[0].input.Key as any)?.appId === 'app-1' &&
-          (c.args[0].input.Key as any)?.sortId === undefined,
+          (c.args[0].input.Key as Record<string, unknown> | undefined)?.appId === 'app-1' &&
+          (c.args[0].input.Key as Record<string, unknown> | undefined)?.sortId === undefined,
       );
       expect(metaUpdate).toBeDefined();
 
-      const values = metaUpdate!.args[0].input.ExpressionAttributeValues as any;
+      const values = metaUpdate!.args[0].input.ExpressionAttributeValues as Record<string, unknown>;
       // name was provided -> mirrored. status/description/routingConfig were
       // NOT provided -> must NOT be in the update.
       expect(values[':v_name']).toBe('Renamed');
@@ -193,21 +197,21 @@ describe('registry-agent-record-resolver — AppsTable #META mirror writes', () 
         makeEvent('updateApp', {
           input: { appId: 'app-1', version: 1, status: 'APPROVED' },
         }),
-        {} as any,
-        {} as any,
+        {} as HandlerContext,
+        {} as HandlerCallback,
       );
 
       const updateCalls = ddbMock.commandCalls(UpdateCommand);
       const metaUpdate = updateCalls.find(
         (c) =>
           c.args[0].input.TableName === 'citadel-apps-test' &&
-          (c.args[0].input.Key as any)?.appId === 'app-1' &&
-          (c.args[0].input.Key as any)?.sortId === undefined &&
-          (c.args[0].input.ExpressionAttributeValues as any)?.[':v_status'] !==
+          (c.args[0].input.Key as Record<string, unknown> | undefined)?.appId === 'app-1' &&
+          (c.args[0].input.Key as Record<string, unknown> | undefined)?.sortId === undefined &&
+          (c.args[0].input.ExpressionAttributeValues as Record<string, unknown> | undefined)?.[':v_status'] !==
             undefined,
       );
       expect(metaUpdate).toBeDefined();
-      const values = metaUpdate!.args[0].input.ExpressionAttributeValues as any;
+      const values = metaUpdate!.args[0].input.ExpressionAttributeValues as Record<string, unknown>;
       expect(values[':v_status']).toBe('APPROVED');
       expect(values[':v_version']).toBe(2);
     });
@@ -219,17 +223,17 @@ describe('registry-agent-record-resolver — AppsTable #META mirror writes', () 
 
       await handler(
         makeEvent('deleteApp', { appId: 'app-1' }),
-        {} as any,
-        {} as any,
+        {} as HandlerContext,
+        {} as HandlerCallback,
       );
 
       const deleteCalls = ddbMock.commandCalls(DeleteCommand);
       const metaDelete = deleteCalls.find(
         (c) =>
           c.args[0].input.TableName === 'citadel-apps-test' &&
-          (c.args[0].input.Key as any)?.appId === 'app-1' &&
+          (c.args[0].input.Key as Record<string, unknown> | undefined)?.appId === 'app-1' &&
           // Key must be appId only — AppsTable has no sort key.
-          (c.args[0].input.Key as any)?.sortId === undefined,
+          (c.args[0].input.Key as Record<string, unknown> | undefined)?.sortId === undefined,
       );
       expect(metaDelete).toBeDefined();
     });
@@ -245,8 +249,8 @@ describe('registry-agent-record-resolver — AppsTable #META mirror writes', () 
           makeEvent('createApp', {
             input: { name: 'New App', orgId: 'org-1' },
           }),
-          {} as any,
-          {} as any,
+          {} as HandlerContext,
+          {} as HandlerCallback,
         ),
       ).resolves.toBeDefined();
     });
@@ -258,8 +262,8 @@ describe('registry-agent-record-resolver — AppsTable #META mirror writes', () 
       await expect(
         handler(
           makeEvent('deleteApp', { appId: 'app-1' }),
-          {} as any,
-          {} as any,
+          {} as HandlerContext,
+          {} as HandlerCallback,
         ),
       ).resolves.toBeDefined();
     });

--- a/backend/src/lambda/__tests__/registry-agent-record-resolver-meta-writes.test.ts
+++ b/backend/src/lambda/__tests__/registry-agent-record-resolver-meta-writes.test.ts
@@ -58,8 +58,12 @@ import { handler } from '../registry-agent-record-resolver';
 import { APP_META_SORT_VALUE } from '../../utils/apps-table-meta';
 
 type HandlerEvent = Parameters<typeof handler>[0];
-type HandlerContext = Parameters<typeof handler>[1];
-type HandlerCallback = Parameters<typeof handler>[2];
+
+// aws-lambda's Handler type declares legacy required context and callback
+// parameters, but the implementation is a one-parameter async (event)
+// function that never uses them — invoke through the real signature
+// (single cast here) so calls don't pass superfluous arguments.
+const invokeHandler = handler as (event: HandlerEvent) => Promise<unknown>;
 
 function makeEvent(fieldName: string, args: Record<string, unknown>, sub = 'user-123') {
   return {
@@ -116,7 +120,7 @@ describe('registry-agent-record-resolver — AppsTable #META mirror writes', () 
 
   describe('createApp', () => {
     test('writes an UpdateCommand for the metadata row with full projection', async () => {
-      const result = await handler(
+      const result = await invokeHandler(
         makeEvent('createApp', {
           input: {
             name: 'New App',
@@ -124,8 +128,6 @@ describe('registry-agent-record-resolver — AppsTable #META mirror writes', () 
             orgId: 'org-1',
           },
         }),
-        {} as HandlerContext,
-        {} as HandlerCallback,
       );
 
       // upsertAppMeta is now an UpdateCommand (not a Put) so it preserves
@@ -158,12 +160,10 @@ describe('registry-agent-record-resolver — AppsTable #META mirror writes', () 
     test('writes an UpdateCommand for the metadata row with only the changed fields', async () => {
       seedApp({ version: 1 });
 
-      await handler(
+      await invokeHandler(
         makeEvent('updateApp', {
           input: { appId: 'app-1', version: 1, name: 'Renamed' },
         }),
-        {} as HandlerContext,
-        {} as HandlerCallback,
       );
 
       const updateCalls = ddbMock.commandCalls(UpdateCommand);
@@ -193,12 +193,10 @@ describe('registry-agent-record-resolver — AppsTable #META mirror writes', () 
     test('mirrors a status change', async () => {
       seedApp({ version: 1 });
 
-      await handler(
+      await invokeHandler(
         makeEvent('updateApp', {
           input: { appId: 'app-1', version: 1, status: 'APPROVED' },
         }),
-        {} as HandlerContext,
-        {} as HandlerCallback,
       );
 
       const updateCalls = ddbMock.commandCalls(UpdateCommand);
@@ -221,10 +219,8 @@ describe('registry-agent-record-resolver — AppsTable #META mirror writes', () 
     test('writes a DeleteCommand for the metadata row keyed on appId only', async () => {
       seedApp();
 
-      await handler(
+      await invokeHandler(
         makeEvent('deleteApp', { appId: 'app-1' }),
-        {} as HandlerContext,
-        {} as HandlerCallback,
       );
 
       const deleteCalls = ddbMock.commandCalls(DeleteCommand);
@@ -245,12 +241,10 @@ describe('registry-agent-record-resolver — AppsTable #META mirror writes', () 
 
       // Helper swallows the error → handler must still resolve.
       await expect(
-        handler(
+        invokeHandler(
           makeEvent('createApp', {
             input: { name: 'New App', orgId: 'org-1' },
           }),
-          {} as HandlerContext,
-          {} as HandlerCallback,
         ),
       ).resolves.toBeDefined();
     });
@@ -260,10 +254,8 @@ describe('registry-agent-record-resolver — AppsTable #META mirror writes', () 
       ddbMock.on(DeleteCommand).rejects(new Error('AppsTable down'));
 
       await expect(
-        handler(
+        invokeHandler(
           makeEvent('deleteApp', { appId: 'app-1' }),
-          {} as HandlerContext,
-          {} as HandlerCallback,
         ),
       ).resolves.toBeDefined();
     });

--- a/backend/src/lambda/__tests__/registry-agent-record-resolver-status-events.test.ts
+++ b/backend/src/lambda/__tests__/registry-agent-record-resolver-status-events.test.ts
@@ -53,12 +53,16 @@ jest.mock('uuid', () => ({
 
 import { handler } from '../registry-agent-record-resolver';
 
-function makeEvent(fieldName: string, args: any) {
+type HandlerEvent = Parameters<typeof handler>[0];
+type HandlerContext = Parameters<typeof handler>[1];
+type HandlerCallback = Parameters<typeof handler>[2];
+
+function makeEvent(fieldName: string, args: Record<string, unknown>) {
   return {
     info: { fieldName },
     arguments: args,
     identity: { sub: 'user-123', claims: { sub: 'user-123' } },
-  } as any;
+  } as unknown as HandlerEvent;
 }
 
 function seedApp(status: string, version: number = 1, orgId: string = 'org-1') {
@@ -112,8 +116,8 @@ describe('registry-agent-record-resolver — status transition events', () => {
       makeEvent('updateApp', {
         input: { appId: 'app-1', status: 'APPROVED', version: 1 },
       }),
-      {} as any,
-      {} as any,
+      {} as HandlerContext,
+      {} as HandlerCallback,
     );
 
     const ebCalls = ebMock.commandCalls(PutEventsCommand);
@@ -143,8 +147,8 @@ describe('registry-agent-record-resolver — status transition events', () => {
       makeEvent('updateApp', {
         input: { appId: 'app-1', status: 'DEPRECATED', version: 1 },
       }),
-      {} as any,
-      {} as any,
+      {} as HandlerContext,
+      {} as HandlerCallback,
     );
 
     const ebCalls = ebMock.commandCalls(PutEventsCommand);
@@ -166,8 +170,8 @@ describe('registry-agent-record-resolver — status transition events', () => {
       makeEvent('updateApp', {
         input: { appId: 'app-1', status: 'DRAFT', version: 3 },
       }),
-      {} as any,
-      {} as any,
+      {} as HandlerContext,
+      {} as HandlerCallback,
     );
 
     const ebCalls = ebMock.commandCalls(PutEventsCommand);
@@ -189,8 +193,8 @@ describe('registry-agent-record-resolver — status transition events', () => {
       makeEvent('updateApp', {
         input: { appId: 'app-1', status: 'DRAFT', version: 3 },
       }),
-      {} as any,
-      {} as any,
+      {} as HandlerContext,
+      {} as HandlerCallback,
     );
 
     const ebCalls = ebMock.commandCalls(PutEventsCommand);
@@ -211,8 +215,8 @@ describe('registry-agent-record-resolver — status transition events', () => {
       makeEvent('updateApp', {
         input: { appId: 'app-1', name: 'Updated Name', version: 1 },
       }),
-      {} as any,
-      {} as any,
+      {} as HandlerContext,
+      {} as HandlerCallback,
     );
 
     const ebCalls = ebMock.commandCalls(PutEventsCommand);
@@ -230,8 +234,8 @@ describe('registry-agent-record-resolver — status transition events', () => {
       makeEvent('updateApp', {
         input: { appId: 'app-1', status: 'DRAFT', name: 'Updated', version: 1 },
       }),
-      {} as any,
-      {} as any,
+      {} as HandlerContext,
+      {} as HandlerCallback,
     );
 
     const ebCalls = ebMock.commandCalls(PutEventsCommand);
@@ -249,8 +253,8 @@ describe('registry-agent-record-resolver — status transition events', () => {
       makeEvent('updateApp', {
         input: { appId: 'app-1', status: 'APPROVED', version: 1 },
       }),
-      {} as any,
-      {} as any,
+      {} as HandlerContext,
+      {} as HandlerCallback,
     );
 
     expect(mockPublishAppStatusEvent).toHaveBeenCalledTimes(1);
@@ -271,8 +275,8 @@ describe('registry-agent-record-resolver — status transition events', () => {
       makeEvent('updateApp', {
         input: { appId: 'app-1', name: 'Updated Name', version: 1 },
       }),
-      {} as any,
-      {} as any,
+      {} as HandlerContext,
+      {} as HandlerCallback,
     );
 
     expect(mockPublishAppStatusEvent).not.toHaveBeenCalled();
@@ -287,8 +291,8 @@ describe('registry-agent-record-resolver — status transition events', () => {
       makeEvent('updateApp', {
         input: { appId: 'app-1', status: 'DRAFT', version: 3 },
       }),
-      {} as any,
-      {} as any,
+      {} as HandlerContext,
+      {} as HandlerCallback,
     );
 
     expect(result).toBeDefined();
@@ -305,8 +309,8 @@ describe('registry-agent-record-resolver — status transition events', () => {
 
     const result = await handler(
       makeEvent('publishAppStatusEvent', { input }),
-      {} as any,
-      {} as any,
+      {} as HandlerContext,
+      {} as HandlerCallback,
     );
 
     expect(result).toEqual(input);

--- a/backend/src/lambda/__tests__/registry-agent-record-resolver-status-events.test.ts
+++ b/backend/src/lambda/__tests__/registry-agent-record-resolver-status-events.test.ts
@@ -54,8 +54,12 @@ jest.mock('uuid', () => ({
 import { handler } from '../registry-agent-record-resolver';
 
 type HandlerEvent = Parameters<typeof handler>[0];
-type HandlerContext = Parameters<typeof handler>[1];
-type HandlerCallback = Parameters<typeof handler>[2];
+
+// aws-lambda's Handler type declares legacy required context and callback
+// parameters, but the implementation is a one-parameter async (event)
+// function that never uses them — invoke through the real signature
+// (single cast here) so calls don't pass superfluous arguments.
+const invokeHandler = handler as (event: HandlerEvent) => Promise<unknown>;
 
 function makeEvent(fieldName: string, args: Record<string, unknown>) {
   return {
@@ -112,12 +116,10 @@ describe('registry-agent-record-resolver — status transition events', () => {
   test('emits app.status.draft_to_approved on DRAFT→APPROVED transition', async () => {
     seedApp('DRAFT', 1);
 
-    await handler(
+    await invokeHandler(
       makeEvent('updateApp', {
         input: { appId: 'app-1', status: 'APPROVED', version: 1 },
       }),
-      {} as HandlerContext,
-      {} as HandlerCallback,
     );
 
     const ebCalls = ebMock.commandCalls(PutEventsCommand);
@@ -143,12 +145,10 @@ describe('registry-agent-record-resolver — status transition events', () => {
   test('emits app.status.approved_to_deprecated on APPROVED→DEPRECATED transition', async () => {
     seedApp('APPROVED', 1);
 
-    await handler(
+    await invokeHandler(
       makeEvent('updateApp', {
         input: { appId: 'app-1', status: 'DEPRECATED', version: 1 },
       }),
-      {} as HandlerContext,
-      {} as HandlerCallback,
     );
 
     const ebCalls = ebMock.commandCalls(PutEventsCommand);
@@ -166,12 +166,10 @@ describe('registry-agent-record-resolver — status transition events', () => {
   test('emits app.status.deprecated_to_draft on DEPRECATED→DRAFT transition', async () => {
     seedApp('DEPRECATED', 3);
 
-    await handler(
+    await invokeHandler(
       makeEvent('updateApp', {
         input: { appId: 'app-1', status: 'DRAFT', version: 3 },
       }),
-      {} as HandlerContext,
-      {} as HandlerCallback,
     );
 
     const ebCalls = ebMock.commandCalls(PutEventsCommand);
@@ -189,12 +187,10 @@ describe('registry-agent-record-resolver — status transition events', () => {
   test('status event timestamp is valid ISO 8601', async () => {
     seedApp('DEPRECATED', 3);
 
-    await handler(
+    await invokeHandler(
       makeEvent('updateApp', {
         input: { appId: 'app-1', status: 'DRAFT', version: 3 },
       }),
-      {} as HandlerContext,
-      {} as HandlerCallback,
     );
 
     const ebCalls = ebMock.commandCalls(PutEventsCommand);
@@ -211,12 +207,10 @@ describe('registry-agent-record-resolver — status transition events', () => {
   test('does not emit status transition event for non-status updates', async () => {
     seedApp('DRAFT', 1);
 
-    await handler(
+    await invokeHandler(
       makeEvent('updateApp', {
         input: { appId: 'app-1', name: 'Updated Name', version: 1 },
       }),
-      {} as HandlerContext,
-      {} as HandlerCallback,
     );
 
     const ebCalls = ebMock.commandCalls(PutEventsCommand);
@@ -230,12 +224,10 @@ describe('registry-agent-record-resolver — status transition events', () => {
   test('does not emit status transition event when status is unchanged', async () => {
     seedApp('DRAFT', 1);
 
-    await handler(
+    await invokeHandler(
       makeEvent('updateApp', {
         input: { appId: 'app-1', status: 'DRAFT', name: 'Updated', version: 1 },
       }),
-      {} as HandlerContext,
-      {} as HandlerCallback,
     );
 
     const ebCalls = ebMock.commandCalls(PutEventsCommand);
@@ -249,12 +241,10 @@ describe('registry-agent-record-resolver — status transition events', () => {
   test('calls publishAppStatusEvent for DRAFT→APPROVED transition', async () => {
     seedApp('DRAFT', 1);
 
-    await handler(
+    await invokeHandler(
       makeEvent('updateApp', {
         input: { appId: 'app-1', status: 'APPROVED', version: 1 },
       }),
-      {} as HandlerContext,
-      {} as HandlerCallback,
     );
 
     expect(mockPublishAppStatusEvent).toHaveBeenCalledTimes(1);
@@ -271,12 +261,10 @@ describe('registry-agent-record-resolver — status transition events', () => {
   test('does not call publishAppStatusEvent for non-status updates', async () => {
     seedApp('DRAFT', 1);
 
-    await handler(
+    await invokeHandler(
       makeEvent('updateApp', {
         input: { appId: 'app-1', name: 'Updated Name', version: 1 },
       }),
-      {} as HandlerContext,
-      {} as HandlerCallback,
     );
 
     expect(mockPublishAppStatusEvent).not.toHaveBeenCalled();
@@ -287,12 +275,10 @@ describe('registry-agent-record-resolver — status transition events', () => {
 
     seedApp('DEPRECATED', 3);
 
-    const result = await handler(
+    const result = await invokeHandler(
       makeEvent('updateApp', {
         input: { appId: 'app-1', status: 'DRAFT', version: 3 },
       }),
-      {} as HandlerContext,
-      {} as HandlerCallback,
     );
 
     expect(result).toBeDefined();
@@ -307,10 +293,8 @@ describe('registry-agent-record-resolver — status transition events', () => {
       timestamp: '2025-05-08T10:00:00.000Z',
     };
 
-    const result = await handler(
+    const result = await invokeHandler(
       makeEvent('publishAppStatusEvent', { input }),
-      {} as HandlerContext,
-      {} as HandlerCallback,
     );
 
     expect(result).toEqual(input);

--- a/backend/src/lambda/__tests__/registry-agent-record-resolver-workflows.test.ts
+++ b/backend/src/lambda/__tests__/registry-agent-record-resolver-workflows.test.ts
@@ -43,8 +43,12 @@ jest.mock('../../utils/appsync-publish', () => ({
 import { handler } from '../registry-agent-record-resolver';
 
 type HandlerEvent = Parameters<typeof handler>[0];
-type HandlerContext = Parameters<typeof handler>[1];
-type HandlerCallback = Parameters<typeof handler>[2];
+
+// aws-lambda's Handler type declares legacy required context and callback
+// parameters, but the implementation is a one-parameter async (event)
+// function that never uses them — invoke through the real signature
+// (single cast here) so calls don't pass superfluous arguments.
+const invokeHandler = handler as (event: HandlerEvent) => Promise<unknown>;
 
 function makeEvent(fieldName: string, args: Record<string, unknown>) {
   return {
@@ -105,13 +109,11 @@ describe('registry-agent-record-resolver — workflow binding', () => {
       seedApp({ manifest: { workflowIds: ['wf-existing'] } });
 
       await expect(
-        handler(
+        invokeHandler(
           makeEvent('bindWorkflowToApp', {
             appId: 'app-1',
             workflowId: 'wf-new',
           }),
-          {} as HandlerContext,
-          {} as HandlerCallback,
         ),
       ).resolves.toBeDefined();
 
@@ -127,13 +129,11 @@ describe('registry-agent-record-resolver — workflow binding', () => {
       seedApp({ manifest: { workflowIds: ['wf-1'] } });
 
       await expect(
-        handler(
+        invokeHandler(
           makeEvent('bindWorkflowToApp', {
             appId: 'app-1',
             workflowId: 'wf-1',
           }),
-          {} as HandlerContext,
-          {} as HandlerCallback,
         ),
       ).resolves.toBeDefined();
 
@@ -142,13 +142,11 @@ describe('registry-agent-record-resolver — workflow binding', () => {
 
     test('throws when app not found', async () => {
       await expect(
-        handler(
+        invokeHandler(
           makeEvent('bindWorkflowToApp', {
             appId: 'nonexistent',
             workflowId: 'wf-1',
           }),
-          {} as HandlerContext,
-          {} as HandlerCallback,
         ),
       ).rejects.toThrow('App not found');
     });
@@ -161,13 +159,11 @@ describe('registry-agent-record-resolver — workflow binding', () => {
       seedApp({ manifest: { workflowIds: ['wf-1', 'wf-2'] } });
 
       await expect(
-        handler(
+        invokeHandler(
           makeEvent('unbindWorkflowFromApp', {
             appId: 'app-1',
             workflowId: 'wf-1',
           }),
-          {} as HandlerContext,
-          {} as HandlerCallback,
         ),
       ).resolves.toBeDefined();
 
@@ -181,13 +177,11 @@ describe('registry-agent-record-resolver — workflow binding', () => {
 
     test('throws when app not found', async () => {
       await expect(
-        handler(
+        invokeHandler(
           makeEvent('unbindWorkflowFromApp', {
             appId: 'nonexistent',
             workflowId: 'wf-1',
           }),
-          {} as HandlerContext,
-          {} as HandlerCallback,
         ),
       ).rejects.toThrow('App not found');
     });

--- a/backend/src/lambda/__tests__/registry-agent-record-resolver-workflows.test.ts
+++ b/backend/src/lambda/__tests__/registry-agent-record-resolver-workflows.test.ts
@@ -42,16 +42,20 @@ jest.mock('../../utils/appsync-publish', () => ({
 
 import { handler } from '../registry-agent-record-resolver';
 
-function makeEvent(fieldName: string, args: any) {
+type HandlerEvent = Parameters<typeof handler>[0];
+type HandlerContext = Parameters<typeof handler>[1];
+type HandlerCallback = Parameters<typeof handler>[2];
+
+function makeEvent(fieldName: string, args: Record<string, unknown>) {
   return {
     info: { fieldName },
     arguments: args,
     identity: { sub: 'user-123', claims: { sub: 'user-123' } },
-  } as any;
+  } as unknown as HandlerEvent;
 }
 
 function seedApp(
-  opts: { manifest?: Record<string, any> } = {},
+  opts: { manifest?: Record<string, unknown> } = {},
 ): void {
   seedMockRegistry('agent', 'app-1', {
     name: 'Test App',
@@ -106,8 +110,8 @@ describe('registry-agent-record-resolver — workflow binding', () => {
             appId: 'app-1',
             workflowId: 'wf-new',
           }),
-          {} as any,
-          {} as any,
+          {} as HandlerContext,
+          {} as HandlerCallback,
         ),
       ).resolves.toBeDefined();
 
@@ -128,8 +132,8 @@ describe('registry-agent-record-resolver — workflow binding', () => {
             appId: 'app-1',
             workflowId: 'wf-1',
           }),
-          {} as any,
-          {} as any,
+          {} as HandlerContext,
+          {} as HandlerCallback,
         ),
       ).resolves.toBeDefined();
 
@@ -143,8 +147,8 @@ describe('registry-agent-record-resolver — workflow binding', () => {
             appId: 'nonexistent',
             workflowId: 'wf-1',
           }),
-          {} as any,
-          {} as any,
+          {} as HandlerContext,
+          {} as HandlerCallback,
         ),
       ).rejects.toThrow('App not found');
     });
@@ -162,8 +166,8 @@ describe('registry-agent-record-resolver — workflow binding', () => {
             appId: 'app-1',
             workflowId: 'wf-1',
           }),
-          {} as any,
-          {} as any,
+          {} as HandlerContext,
+          {} as HandlerCallback,
         ),
       ).resolves.toBeDefined();
 
@@ -182,8 +186,8 @@ describe('registry-agent-record-resolver — workflow binding', () => {
             appId: 'nonexistent',
             workflowId: 'wf-1',
           }),
-          {} as any,
-          {} as any,
+          {} as HandlerContext,
+          {} as HandlerCallback,
         ),
       ).rejects.toThrow('App not found');
     });

--- a/backend/src/lambda/__tests__/registry-sync.test.ts
+++ b/backend/src/lambda/__tests__/registry-sync.test.ts
@@ -27,7 +27,7 @@ import {
   sendToDlq,
   emitSyncFailureMetric,
 } from '../registry-sync';
-import type { RegistryEvent } from '../registry-sync';
+import type { RegistryEvent, RegistryResourcePayload, ResourceType } from '../registry-sync';
 
 // ---------------------------------------------------------------------------
 // Mocks
@@ -57,7 +57,14 @@ afterEach(() => {
 // Helpers
 // ---------------------------------------------------------------------------
 
-function makeEvent(overrides: Partial<RegistryEvent> & { detail?: any } = {}): RegistryEvent {
+/** Loosely-typed overrides so tests can build deliberately malformed events. */
+interface EventOverrides {
+  source?: string;
+  'detail-type'?: string;
+  detail?: Record<string, unknown>;
+}
+
+function makeEvent(overrides: EventOverrides = {}): RegistryEvent {
   return {
     source: 'aws.bedrock-agentcore',
     'detail-type': 'AgentCore Registry Resource Change',
@@ -73,7 +80,7 @@ function makeEvent(overrides: Partial<RegistryEvent> & { detail?: any } = {}): R
   } as RegistryEvent;
 }
 
-function makeAgentResource(overrides: Record<string, any> = {}): Record<string, any> {
+function makeAgentResource(overrides: RegistryResourcePayload = {}): RegistryResourcePayload {
   return {
     description: JSON.stringify({ name: 'TestAgent', filename: 'test.py' }),
     customDescriptorContent: JSON.stringify({
@@ -89,7 +96,7 @@ function makeAgentResource(overrides: Record<string, any> = {}): Record<string, 
   };
 }
 
-function makeToolResource(overrides: Record<string, any> = {}): Record<string, any> {
+function makeToolResource(overrides: RegistryResourcePayload = {}): RegistryResourcePayload {
   return {
     description: JSON.stringify({ name: 'TestTool', filename: 'tool.py' }),
     customDescriptorContent: JSON.stringify({
@@ -120,11 +127,11 @@ describe('validateEvent', () => {
   });
 
   test('rejects wrong source', () => {
-    expect(validateEvent(makeEvent({ source: 'aws.s3' } as any))).toContain('Unexpected event source');
+    expect(validateEvent(makeEvent({ source: 'aws.s3' }))).toContain('Unexpected event source');
   });
 
   test('rejects wrong detail-type', () => {
-    expect(validateEvent(makeEvent({ 'detail-type': 'SomethingElse' } as any))).toContain('Unexpected detail-type');
+    expect(validateEvent(makeEvent({ 'detail-type': 'SomethingElse' }))).toContain('Unexpected detail-type');
   });
 
   test('rejects missing detail', () => {
@@ -176,7 +183,7 @@ describe('getTableForResourceType', () => {
   });
 
   test('throws for unknown resourceType', () => {
-    expect(() => getTableForResourceType('widget' as any)).toThrow('Unknown resourceType');
+    expect(() => getTableForResourceType('widget' as unknown as ResourceType)).toThrow('Unknown resourceType');
   });
 });
 
@@ -368,7 +375,7 @@ describe('handleCreateOrUpdate', () => {
 
   test('propagates DynamoDB errors (non-conditional)', async () => {
     const error = new Error('DynamoDB failure');
-    (error as any).name = 'InternalServerError';
+    error.name = 'InternalServerError';
     ddbMock.on(PutCommand).rejects(error);
 
     await expect(
@@ -470,7 +477,7 @@ describe('handleStatusChanged', () => {
 
   test('propagates DynamoDB errors (non-conditional)', async () => {
     const error = new Error('Update failed');
-    (error as any).name = 'InternalServerError';
+    error.name = 'InternalServerError';
     ddbMock.on(UpdateCommand).rejects(error);
 
     await expect(
@@ -594,7 +601,7 @@ describe('handler — cache operations', () => {
 
   test('ConditionalCheckFailedException is swallowed (idempotency)', async () => {
     const error = new Error('Conditional check failed');
-    (error as any).name = 'ConditionalCheckFailedException';
+    error.name = 'ConditionalCheckFailedException';
     ddbMock.on(PutCommand).rejects(error);
 
     const event = makeEvent({
@@ -612,7 +619,7 @@ describe('handler — cache operations', () => {
 
   test('ConditionalCheckFailedException on STATUS_CHANGED is swallowed', async () => {
     const error = new Error('Conditional check failed');
-    (error as any).name = 'ConditionalCheckFailedException';
+    error.name = 'ConditionalCheckFailedException';
     ddbMock.on(UpdateCommand).rejects(error);
 
     const event = makeEvent({
@@ -629,7 +636,7 @@ describe('handler — cache operations', () => {
 
   test('non-conditional DynamoDB errors propagate and route to DLQ', async () => {
     const error = new Error('DynamoDB is down');
-    (error as any).name = 'InternalServerError';
+    error.name = 'InternalServerError';
     ddbMock.on(PutCommand).rejects(error);
 
     const event = makeEvent({
@@ -646,7 +653,7 @@ describe('handler — cache operations', () => {
   });
 
   test('malformed event sends to DLQ then throws', async () => {
-    const badEvent = { source: 'aws.s3', 'detail-type': 'wrong', detail: {} } as any;
+    const badEvent = { source: 'aws.s3', 'detail-type': 'wrong', detail: {} } as unknown as RegistryEvent;
     await expect(handler(badEvent)).rejects.toThrow('Malformed registry sync event');
 
     // Verify DLQ was called
@@ -719,7 +726,7 @@ describe('emitSyncFailureMetric', () => {
 describe('handler — DLQ routing and metrics', () => {
   test('DynamoDB write failure sends to DLQ and emits SyncFailure metric', async () => {
     const error = new Error('DynamoDB is down');
-    (error as any).name = 'InternalServerError';
+    error.name = 'InternalServerError';
     ddbMock.on(PutCommand).rejects(error);
 
     const event = makeEvent({
@@ -749,7 +756,7 @@ describe('handler — DLQ routing and metrics', () => {
 
   test('DynamoDB delete failure sends to DLQ and emits metric', async () => {
     const error = new Error('Delete failed');
-    (error as any).name = 'InternalServerError';
+    error.name = 'InternalServerError';
     ddbMock.on(DeleteCommand).rejects(error);
 
     const event = makeEvent({
@@ -767,7 +774,7 @@ describe('handler — DLQ routing and metrics', () => {
 
   test('DynamoDB update failure sends to DLQ and emits metric', async () => {
     const error = new Error('Update failed');
-    (error as any).name = 'InternalServerError';
+    error.name = 'InternalServerError';
     ddbMock.on(UpdateCommand).rejects(error);
 
     const event = makeEvent({
@@ -786,7 +793,7 @@ describe('handler — DLQ routing and metrics', () => {
 
   test('ConditionalCheckFailedException does NOT send to DLQ or emit metric', async () => {
     const error = new Error('Conditional check failed');
-    (error as any).name = 'ConditionalCheckFailedException';
+    error.name = 'ConditionalCheckFailedException';
     ddbMock.on(PutCommand).rejects(error);
 
     const event = makeEvent({
@@ -804,7 +811,7 @@ describe('handler — DLQ routing and metrics', () => {
   });
 
   test('malformed event sends to DLQ but does NOT emit SyncFailure metric', async () => {
-    const badEvent = { source: 'aws.s3', 'detail-type': 'wrong', detail: {} } as any;
+    const badEvent = { source: 'aws.s3', 'detail-type': 'wrong', detail: {} } as unknown as RegistryEvent;
     await expect(handler(badEvent)).rejects.toThrow('Malformed registry sync event');
 
     // DLQ should be called
@@ -815,7 +822,7 @@ describe('handler — DLQ routing and metrics', () => {
 
   test('handler still throws even if DLQ send fails', async () => {
     const ddbError = new Error('DynamoDB is down');
-    (ddbError as any).name = 'InternalServerError';
+    ddbError.name = 'InternalServerError';
     ddbMock.on(PutCommand).rejects(ddbError);
     sqsMock.on(SendMessageCommand).rejects(new Error('SQS also down'));
 

--- a/backend/src/lambda/__tests__/workflow-progress-fanout.test.ts
+++ b/backend/src/lambda/__tests__/workflow-progress-fanout.test.ts
@@ -34,7 +34,6 @@ jest.mock('@aws-sdk/client-cloudwatch', () => ({
     .mockImplementation((input: unknown) => ({ __command: 'PutMetricData', input })),
 }));
 
-import type { Context, Callback } from 'aws-lambda';
 import { handler } from '../workflow-progress-fanout';
 
 type HandlerEvent = Parameters<typeof handler>[0];
@@ -53,8 +52,11 @@ function makeEventBridgeEvent(detailType: string, detail: Record<string, unknown
   } as unknown as HandlerEvent;
 }
 
-const mockContext = {} as Context;
-const mockCallback: Callback<void> = () => undefined;
+// aws-lambda's Handler type declares legacy required context and callback
+// parameters, but the implementation is a one-parameter async (event)
+// function that never uses them — invoke through the real signature
+// (single cast here) so calls don't pass superfluous arguments.
+const invokeHandler = handler as (event: HandlerEvent) => Promise<unknown>;
 
 describe('workflow-progress-fanout', () => {
   beforeAll(() => {
@@ -101,8 +103,8 @@ describe('workflow-progress-fanout', () => {
         timestamp: '2024-01-15T10:30:00Z',
       };
 
-      await handler(
-        makeEventBridgeEvent('workflow.node.started', detail), mockContext, mockCallback
+      await invokeHandler(
+        makeEventBridgeEvent('workflow.node.started', detail)
       );
 
       // Verify fetch was called
@@ -135,8 +137,8 @@ describe('workflow-progress-fanout', () => {
         timestamp: '2024-01-15T10:30:00Z',
       };
 
-      await handler(
-        makeEventBridgeEvent('workflow.started', detail), mockContext, mockCallback
+      await invokeHandler(
+        makeEventBridgeEvent('workflow.started', detail)
       );
 
       // Verify SignatureV4.sign was called to sign the request
@@ -174,8 +176,8 @@ describe('workflow-progress-fanout', () => {
         timestamp: '2024-01-15T10:30:00Z',
       };
 
-      await handler(
-        makeEventBridgeEvent(eventType, detail), mockContext, mockCallback
+      await invokeHandler(
+        makeEventBridgeEvent(eventType, detail)
       );
 
       expect(mockFetch).toHaveBeenCalledTimes(1);
@@ -203,8 +205,8 @@ describe('workflow-progress-fanout', () => {
       };
 
       await expect(
-        handler(
-          makeEventBridgeEvent('workflow.failed', detail), mockContext, mockCallback
+        invokeHandler(
+          makeEventBridgeEvent('workflow.failed', detail)
         ),
       ).rejects.toThrow(/AppSync mutation failed/);
     });
@@ -226,8 +228,8 @@ describe('workflow-progress-fanout', () => {
       };
 
       await expect(
-        handler(
-          makeEventBridgeEvent('workflow.node.completed', detail), mockContext, mockCallback
+        invokeHandler(
+          makeEventBridgeEvent('workflow.node.completed', detail)
         ),
       ).rejects.toThrow(/AppSync mutation failed/);
     });
@@ -246,8 +248,8 @@ describe('workflow-progress-fanout', () => {
       };
 
       await expect(
-        handler(
-          makeEventBridgeEvent('workflow.completed', detail), mockContext, mockCallback
+        invokeHandler(
+          makeEventBridgeEvent('workflow.completed', detail)
         ),
       ).resolves.toBeUndefined();
     });
@@ -271,7 +273,7 @@ describe('workflow-progress-fanout', () => {
       };
 
       await expect(
-        handler(makeEventBridgeEvent('workflow.node.failed', detail), mockContext, mockCallback),
+        invokeHandler(makeEventBridgeEvent('workflow.node.failed', detail)),
       ).rejects.toThrow(/AppSync mutation failed/);
 
       // At least one structured error log carries the executionId.
@@ -296,7 +298,7 @@ describe('workflow-progress-fanout', () => {
       };
 
       await expect(
-        handler(makeEventBridgeEvent('workflow.failed', detail), mockContext, mockCallback),
+        invokeHandler(makeEventBridgeEvent('workflow.failed', detail)),
       ).rejects.toThrow(/AppSync mutation failed/);
 
       expect(mockCwSend).toHaveBeenCalledTimes(1);
@@ -313,7 +315,7 @@ describe('workflow-progress-fanout', () => {
         timestamp: '2024-01-15T10:30:00Z',
       };
 
-      await handler(makeEventBridgeEvent('workflow.started', detail), mockContext, mockCallback);
+      await invokeHandler(makeEventBridgeEvent('workflow.started', detail));
 
       expect(mockCwSend).not.toHaveBeenCalled();
     });
@@ -329,7 +331,7 @@ describe('workflow-progress-fanout', () => {
       };
 
       await expect(
-        handler(makeEventBridgeEvent('workflow.failed', detail), mockContext, mockCallback),
+        invokeHandler(makeEventBridgeEvent('workflow.failed', detail)),
       ).rejects.toThrow(/AppSync mutation failed/);
     });
   });
@@ -345,8 +347,8 @@ describe('workflow-progress-fanout', () => {
         // no nodeId, status, output, error
       };
 
-      await handler(
-        makeEventBridgeEvent('workflow.started', detail), mockContext, mockCallback
+      await invokeHandler(
+        makeEventBridgeEvent('workflow.started', detail)
       );
 
       const body = JSON.parse(mockFetch.mock.calls[0][1].body);

--- a/backend/src/lambda/__tests__/workflow-resolver.test.ts
+++ b/backend/src/lambda/__tests__/workflow-resolver.test.ts
@@ -6,7 +6,6 @@ import { DynamoDBDocumentClient, GetCommand, PutCommand, UpdateCommand, QueryCom
 import { EventBridgeClient, PutEventsCommand } from '@aws-sdk/client-eventbridge';
 import { CognitoIdentityProviderClient, AdminGetUserCommand } from '@aws-sdk/client-cognito-identity-provider';
 import { mockClient } from 'aws-sdk-client-mock';
-import type { Context, Callback } from 'aws-lambda';
 
 const ddbMock = mockClient(DynamoDBDocumentClient);
 const ebMock = mockClient(EventBridgeClient);
@@ -28,12 +27,15 @@ function makeEvent(fieldName: string, args: Record<string, unknown>, sub = 'user
   } as unknown as HandlerEvent;
 }
 
-const mockContext = {} as Context;
-const mockCallback: Callback<unknown> = () => undefined;
+// aws-lambda's Handler type declares legacy required context and callback
+// parameters, but the implementation is a one-parameter async (event)
+// function that never uses them — invoke through the real signature
+// (single cast here) so calls don't pass superfluous arguments.
+const invokeHandler = handler as (event: HandlerEvent) => Promise<unknown>;
 
-/** Invokes the handler with stub context/callback and casts the result. */
+/** Invokes the handler and casts the result. */
 async function invoke<T = Record<string, unknown>>(event: HandlerEvent): Promise<T> {
-  return (await handler(event, mockContext, mockCallback)) as T;
+  return (await invokeHandler(event)) as T;
 }
 
 /** Helper: configure Cognito mock to return orgId for user */

--- a/backend/src/lambda/adapters/__tests__/registry.property.test.ts
+++ b/backend/src/lambda/adapters/__tests__/registry.property.test.ts
@@ -94,7 +94,7 @@ jest.mock('@databricks/sql', () => ({
 }));
 
 // All valid DataStoreType enum values and their expected adapter class
-const TYPE_TO_CLASS: Array<[string, any]> = [
+const TYPE_TO_CLASS: Array<[string, new (...args: never[]) => unknown]> = [
   ['S3', S3Adapter],
   ['DYNAMODB', DynamoDBAdapter],
   ['RDS_POSTGRESQL', RdsAdapter],

--- a/backend/src/lambda/registry-provisioner.ts
+++ b/backend/src/lambda/registry-provisioner.ts
@@ -82,7 +82,7 @@ export async function handler(event: CloudFormationCustomResourceEvent): Promise
       }
 
       case 'Update': {
-        const physicalId = (event as any).PhysicalResourceId as string;
+        const physicalId = event.PhysicalResourceId;
 
         // Check if the existing registry is still alive
         let registryArn = physicalId;
@@ -121,7 +121,7 @@ export async function handler(event: CloudFormationCustomResourceEvent): Promise
       }
 
       case 'Delete': {
-        const physicalId = (event as any).PhysicalResourceId as string;
+        const physicalId = event.PhysicalResourceId;
         const registryId = physicalId.split('/').pop()!;
 
         try {
@@ -143,7 +143,7 @@ export async function handler(event: CloudFormationCustomResourceEvent): Promise
       event,
       'FAILED',
       {},
-      (event as any).PhysicalResourceId ?? event.LogicalResourceId,
+      (event as { PhysicalResourceId?: string }).PhysicalResourceId ?? event.LogicalResourceId,
       err instanceof Error ? err.message : String(err),
     );
   }

--- a/backend/src/lambda/registry-sync.ts
+++ b/backend/src/lambda/registry-sync.ts
@@ -45,11 +45,23 @@ const cwClient = new CloudWatchClient({});
 export type ResourceType = 'agent' | 'tool';
 export type EventType = 'CREATED' | 'UPDATED' | 'DELETED' | 'STATUS_CHANGED';
 
+/**
+ * Registry resource payload carried in EventBridge event details. Known fields
+ * are typed; everything else is passed through untyped (index signature).
+ */
+export interface RegistryResourcePayload {
+  [key: string]: unknown;
+  description?: string;
+  customDescriptorContent?: string | null;
+  createdAt?: string | number;
+  updatedAt?: string | number;
+}
+
 export interface RegistryEventDetail {
   resourceId: string;
   resourceType: ResourceType;
   eventType: EventType;
-  resource?: Record<string, any>;
+  resource?: RegistryResourcePayload;
   previousStatus?: string;
   newStatus?: string;
 }
@@ -60,12 +72,25 @@ export interface RegistryEvent {
   detail: RegistryEventDetail;
 }
 
+/**
+ * Structural view of a not-yet-validated event as seen by validateEvent.
+ * All fields are unknown until validation succeeds.
+ */
+export interface UnvalidatedEventDetail {
+  [key: string]: unknown;
+}
+
+export interface UnvalidatedEvent {
+  [key: string]: unknown;
+  detail?: UnvalidatedEventDetail | null;
+}
+
 // ---------------------------------------------------------------------------
 // Validation
 // ---------------------------------------------------------------------------
 
-const VALID_RESOURCE_TYPES: ReadonlySet<string> = new Set(['agent', 'tool']);
-const VALID_EVENT_TYPES: ReadonlySet<string> = new Set([
+const VALID_RESOURCE_TYPES: ReadonlySet<unknown> = new Set(['agent', 'tool']);
+const VALID_EVENT_TYPES: ReadonlySet<unknown> = new Set([
   'CREATED',
   'UPDATED',
   'DELETED',
@@ -76,7 +101,9 @@ const VALID_EVENT_TYPES: ReadonlySet<string> = new Set([
  * Validates the incoming EventBridge event structure.
  * Returns an error message string if invalid, or null if valid.
  */
-export function validateEvent(event: any): string | null {
+export function validateEvent(
+  event: RegistryEvent | UnvalidatedEvent | null | undefined,
+): string | null {
   if (!event) {
     return 'Event is null or undefined';
   }
@@ -160,15 +187,15 @@ const AGENT_METADATA_DEFAULTS = {
   icon: '',
   state: 'active' as string,
   appId: undefined as string | undefined,
-  manifest: undefined as Record<string, any> | undefined,
+  manifest: undefined as Record<string, unknown> | undefined,
 };
 
 const TOOL_METADATA_DEFAULTS = {
   categories: [] as string[],
   icon: '',
   state: 'active' as string,
-  integrationBindings: undefined as any[] | undefined,
-  dataStoreBindings: undefined as any[] | undefined,
+  integrationBindings: undefined as unknown[] | undefined,
+  dataStoreBindings: undefined as unknown[] | undefined,
   appId: undefined as string | undefined,
 };
 
@@ -214,13 +241,44 @@ function getKeyForResource(
 // ---------------------------------------------------------------------------
 
 /**
+ * DynamoDB item shape for an agent cache record.
+ */
+export type AgentCacheRecord = {
+  agentId: string;
+  config: string;
+  state: string;
+  categories: string[];
+  icon: string;
+  appId: string | undefined;
+  manifest: Record<string, unknown> | undefined;
+  createdAt: string;
+  updatedAt: string;
+};
+
+/**
+ * DynamoDB item shape for a tool cache record.
+ */
+export type ToolCacheRecord = {
+  toolId: string;
+  config: string;
+  state: string;
+  categories: string[];
+  icon: string;
+  integrationBindings: unknown[] | undefined;
+  dataStoreBindings: unknown[] | undefined;
+  appId: string | undefined;
+  createdAt: string;
+  updatedAt: string;
+};
+
+/**
  * Builds a DynamoDB item for an agent cache record from the Registry event
  * resource payload.
  */
 export function buildAgentCacheRecord(
   resourceId: string,
-  resource: Record<string, any>,
-): Record<string, any> {
+  resource: RegistryResourcePayload,
+): AgentCacheRecord {
   const meta = deserializeCustomMetadata(
     resource.customDescriptorContent ?? null,
     AGENT_METADATA_DEFAULTS,
@@ -249,8 +307,8 @@ export function buildAgentCacheRecord(
  */
 export function buildToolCacheRecord(
   resourceId: string,
-  resource: Record<string, any>,
-): Record<string, any> {
+  resource: RegistryResourcePayload,
+): ToolCacheRecord {
   const meta = deserializeCustomMetadata(
     resource.customDescriptorContent ?? null,
     TOOL_METADATA_DEFAULTS,
@@ -287,7 +345,7 @@ export async function handleCreateOrUpdate(
   tableName: string,
   resourceType: ResourceType,
   resourceId: string,
-  resource: Record<string, any>,
+  resource: RegistryResourcePayload,
 ): Promise<void> {
   const item =
     resourceType === 'agent'

--- a/backend/src/lambda/seed-blueprints/__tests__/seed-blueprints.test.ts
+++ b/backend/src/lambda/seed-blueprints/__tests__/seed-blueprints.test.ts
@@ -64,6 +64,15 @@ const mockContext: Context = {
   succeed: jest.fn(),
 };
 
+// aws-lambda's Handler type declares a legacy required callback third
+// parameter, but the implementation is a two-parameter async
+// (event, context) function that never uses it — invoke through the real
+// signature (single cast here) so calls don't pass a superfluous callback.
+const invokeHandler = handler as (
+  event: CloudFormationCustomResourceEvent,
+  context: Context,
+) => Promise<void>;
+
 describe('seed-blueprints Lambda', () => {
   beforeAll(() => {
     process.env.WORKFLOWS_TABLE = 'citadel-workflows-test';
@@ -193,7 +202,7 @@ describe('seed-blueprints Lambda', () => {
     test('blueprints are created with isBlueprint="true" and status=PUBLISHED', async () => {
       ddbMock.on(PutCommand).resolves({});
 
-      await handler(makeEvent('Create'), mockContext, jest.fn());
+      await invokeHandler(makeEvent('Create'), mockContext);
 
       const putCalls = ddbMock.commandCalls(PutCommand);
       expect(putCalls).toHaveLength(5);
@@ -212,7 +221,7 @@ describe('seed-blueprints Lambda', () => {
     test('PutCommand uses ConditionExpression for idempotency', async () => {
       ddbMock.on(PutCommand).resolves({});
 
-      await handler(makeEvent('Create'), mockContext, jest.fn());
+      await invokeHandler(makeEvent('Create'), mockContext);
 
       const putCalls = ddbMock.commandCalls(PutCommand);
       for (const call of putCalls) {
@@ -229,14 +238,14 @@ describe('seed-blueprints Lambda', () => {
 
       // Should not throw — idempotent behavior
       await expect(
-        handler(makeEvent('Update'), mockContext, jest.fn()),
+        invokeHandler(makeEvent('Update'), mockContext),
       ).resolves.not.toThrow();
     });
 
     test('uses deterministic workflowId based on blueprint name', async () => {
       ddbMock.on(PutCommand).resolves({});
 
-      await handler(makeEvent('Create'), mockContext, jest.fn());
+      await invokeHandler(makeEvent('Create'), mockContext);
       const firstCallIds = ddbMock.commandCalls(PutCommand).map(
         (c) => c.args[0].input.Item!.workflowId,
       );
@@ -244,7 +253,7 @@ describe('seed-blueprints Lambda', () => {
       ddbMock.reset();
       ddbMock.on(PutCommand).resolves({});
 
-      await handler(makeEvent('Create'), mockContext, jest.fn());
+      await invokeHandler(makeEvent('Create'), mockContext);
       const secondCallIds = ddbMock.commandCalls(PutCommand).map(
         (c) => c.args[0].input.Item!.workflowId,
       );
@@ -256,7 +265,7 @@ describe('seed-blueprints Lambda', () => {
     test('uses WORKFLOWS_TABLE env var and writes all 5 blueprints', async () => {
       ddbMock.on(PutCommand).resolves({});
 
-      await handler(makeEvent('Create'), mockContext, jest.fn());
+      await invokeHandler(makeEvent('Create'), mockContext);
 
       // Verify all 5 blueprints were written
       const putCalls = ddbMock.commandCalls(PutCommand);
@@ -274,7 +283,7 @@ describe('seed-blueprints Lambda', () => {
     test('definition is stored as serialized JSON string', async () => {
       ddbMock.on(PutCommand).resolves({});
 
-      await handler(makeEvent('Create'), mockContext, jest.fn());
+      await invokeHandler(makeEvent('Create'), mockContext);
 
       const putCalls = ddbMock.commandCalls(PutCommand);
       for (const call of putCalls) {
@@ -290,7 +299,7 @@ describe('seed-blueprints Lambda', () => {
     test('metadata is stored as serialized JSON string with category and isSystem', async () => {
       ddbMock.on(PutCommand).resolves({});
 
-      await handler(makeEvent('Create'), mockContext, jest.fn());
+      await invokeHandler(makeEvent('Create'), mockContext);
 
       const putCalls = ddbMock.commandCalls(PutCommand);
       for (const call of putCalls) {
@@ -307,7 +316,7 @@ describe('seed-blueprints Lambda', () => {
 
   describe('Delete request type', () => {
     test('does nothing on Delete — no DynamoDB calls', async () => {
-      await handler(makeEvent('Delete'), mockContext, jest.fn());
+      await invokeHandler(makeEvent('Delete'), mockContext);
 
       const putCalls = ddbMock.commandCalls(PutCommand);
       expect(putCalls).toHaveLength(0);
@@ -321,7 +330,7 @@ describe('seed-blueprints Lambda', () => {
       ddbMock.on(PutCommand).rejects(new Error('InternalServerError'));
 
       await expect(
-        handler(makeEvent('Create'), mockContext, jest.fn()),
+        invokeHandler(makeEvent('Create'), mockContext),
       ).rejects.toThrow('InternalServerError');
     });
   });

--- a/backend/src/services/__tests__/registry-service-crud.test.ts
+++ b/backend/src/services/__tests__/registry-service-crud.test.ts
@@ -101,7 +101,7 @@ describe('RegistryService CRUD operations', () => {
         status: 'DRAFT',
       });
       // Get fails with 404
-      const err = new Error('Not found') as any;
+      const err = new Error('Not found') as Error & { $metadata?: { httpStatusCode?: number } };
       err.name = 'ResourceNotFoundException';
       err.$metadata = { httpStatusCode: 404 };
       sdkMock.on(GetRegistryRecordCommand).rejects(err);
@@ -146,7 +146,7 @@ describe('RegistryService CRUD operations', () => {
     });
 
     it('returns null on ResourceNotFoundException', async () => {
-      const err = new Error('Not found') as any;
+      const err = new Error('Not found') as Error & { $metadata?: { httpStatusCode?: number } };
       err.name = 'ResourceNotFoundException';
       err.$metadata = { httpStatusCode: 404 };
       sdkMock.on(GetRegistryRecordCommand).rejects(err);
@@ -157,7 +157,7 @@ describe('RegistryService CRUD operations', () => {
     });
 
     it('returns null on 404 status code', async () => {
-      const err = new Error('Not found') as any;
+      const err = new Error('Not found') as Error & { $metadata?: { httpStatusCode?: number } };
       err.name = 'SomeOtherError';
       err.$metadata = { httpStatusCode: 404 };
       sdkMock.on(GetRegistryRecordCommand).rejects(err);
@@ -168,7 +168,7 @@ describe('RegistryService CRUD operations', () => {
     });
 
     it('throws non-404 errors', async () => {
-      const err = new Error('Access denied') as any;
+      const err = new Error('Access denied') as Error & { $metadata?: { httpStatusCode?: number } };
       err.name = 'AccessDeniedException';
       err.$metadata = { httpStatusCode: 403 };
       sdkMock.on(GetRegistryRecordCommand).rejects(err);
@@ -281,7 +281,7 @@ describe('RegistryService CRUD operations', () => {
     });
 
     it('throws on non-transient errors', async () => {
-      const err = new Error('Not found') as any;
+      const err = new Error('Not found') as Error & { $metadata?: { httpStatusCode?: number } };
       err.name = 'ResourceNotFoundException';
       err.$metadata = { httpStatusCode: 404 };
       sdkMock.on(DeleteRegistryRecordCommand).rejects(err);
@@ -395,7 +395,7 @@ describe('RegistryService CRUD operations', () => {
     it('returns empty array when registryRecords field is undefined', async () => {
       sdkMock.on(ListRegistryRecordsCommand).resolves({
         nextToken: undefined,
-      } as any);
+      });
 
       const results = await service.listResources('tool');
 
@@ -407,7 +407,7 @@ describe('RegistryService CRUD operations', () => {
 
   describe('retry with exponential backoff', () => {
     it('retries on 5xx errors and succeeds on subsequent attempt', async () => {
-      const serverError = new Error('Internal Server Error') as any;
+      const serverError = new Error('Internal Server Error') as Error & { $metadata?: { httpStatusCode?: number } };
       serverError.$metadata = { httpStatusCode: 500 };
 
       sdkMock
@@ -431,7 +431,7 @@ describe('RegistryService CRUD operations', () => {
     });
 
     it('retries on ThrottlingException', async () => {
-      const throttleError = new Error('Rate exceeded') as any;
+      const throttleError = new Error('Rate exceeded');
       throttleError.name = 'ThrottlingException';
 
       // First call to CreateRegistryRecordCommand throttles, second succeeds
@@ -463,7 +463,7 @@ describe('RegistryService CRUD operations', () => {
     });
 
     it('retries on ServiceUnavailableException', async () => {
-      const unavailableError = new Error('Service unavailable') as any;
+      const unavailableError = new Error('Service unavailable');
       unavailableError.name = 'ServiceUnavailableException';
 
       sdkMock
@@ -477,7 +477,7 @@ describe('RegistryService CRUD operations', () => {
     });
 
     it('throws after exhausting all 3 retry attempts', async () => {
-      const serverError = new Error('Persistent failure') as any;
+      const serverError = new Error('Persistent failure') as Error & { $metadata?: { httpStatusCode?: number } };
       serverError.$metadata = { httpStatusCode: 503 };
 
       sdkMock.on(GetRegistryRecordCommand).rejects(serverError);
@@ -491,7 +491,7 @@ describe('RegistryService CRUD operations', () => {
     });
 
     it('does not retry on non-transient errors (4xx)', async () => {
-      const clientError = new Error('Bad request') as any;
+      const clientError = new Error('Bad request') as Error & { $metadata?: { httpStatusCode?: number } };
       clientError.name = 'ValidationException';
       clientError.$metadata = { httpStatusCode: 400 };
 
@@ -509,7 +509,7 @@ describe('RegistryService CRUD operations', () => {
     });
 
     it('does not retry on AccessDeniedException', async () => {
-      const authError = new Error('Access denied') as any;
+      const authError = new Error('Access denied') as Error & { $metadata?: { httpStatusCode?: number } };
       authError.name = 'AccessDeniedException';
       authError.$metadata = { httpStatusCode: 403 };
 
@@ -523,7 +523,7 @@ describe('RegistryService CRUD operations', () => {
     });
 
     it('retries on InternalServerException by name', async () => {
-      const internalError = new Error('Internal error') as any;
+      const internalError = new Error('Internal error');
       internalError.name = 'InternalServerException';
 
       sdkMock

--- a/backend/src/services/__tests__/registry-service-search.test.ts
+++ b/backend/src/services/__tests__/registry-service-search.test.ts
@@ -19,7 +19,7 @@ import { RegistryService } from '../registry-service';
 const sdkMock = mockClient(BedrockAgentCoreControlClient);
 
 /** Helper to build a minimal RegistryRecordSummary-like object for mocks. */
-function makeSummary(overrides: Record<string, any>) {
+function makeSummary(overrides: Record<string, unknown>) {
   return {
     recordArn: 'arn:mock',
     registryArn: 'arn:reg',
@@ -139,7 +139,7 @@ describe('RegistryService searchResources', () => {
   it('returns empty array when registryRecords field is undefined', async () => {
     sdkMock.on(ListRegistryRecordsCommand).resolves({
       nextToken: undefined,
-    } as any);
+    });
 
     const results = await service.searchResources('agent', 'missing');
 
@@ -147,7 +147,7 @@ describe('RegistryService searchResources', () => {
   });
 
   it('retries on transient 5xx errors', async () => {
-    const serverError = new Error('Internal Server Error') as any;
+    const serverError = new Error('Internal Server Error') as Error & { $metadata?: { httpStatusCode?: number } };
     serverError.$metadata = { httpStatusCode: 500 };
 
     sdkMock
@@ -166,7 +166,7 @@ describe('RegistryService searchResources', () => {
   });
 
   it('throws non-transient errors without retry', async () => {
-    const clientError = new Error('Access denied') as any;
+    const clientError = new Error('Access denied') as Error & { $metadata?: { httpStatusCode?: number } };
     clientError.name = 'AccessDeniedException';
     clientError.$metadata = { httpStatusCode: 403 };
 

--- a/backend/src/services/registry-service.ts
+++ b/backend/src/services/registry-service.ts
@@ -50,6 +50,15 @@ export interface RegistryServiceConfig {
 
 export type BindingDirection = 'INPUT' | 'OUTPUT' | 'BIDIRECTIONAL';
 
+/**
+ * Structural view of an AWS SDK error for transient/not-found checks.
+ * Used to inspect caught `unknown` errors without asserting a full class.
+ */
+interface AwsErrorLike {
+  name?: string;
+  $metadata?: { httpStatusCode?: number };
+}
+
 export interface IntegrationBinding {
   integrationId: string;
   integrationType: string;
@@ -281,7 +290,7 @@ export interface AgentCustomMetadata {
   icon: string;
   state: 'active' | 'inactive' | 'maintenance';
   appId?: string;
-  manifest?: Record<string, any>;
+  manifest?: Record<string, unknown>;
   orgId?: string;
   /** Present only on imported agents (US-IMP-001). Absent ⇒ AGENTCORE_RUNTIME. */
   invocation?: AgentInvocationBlock;
@@ -413,12 +422,12 @@ export interface AgentConfig {
   agentId: string;
   name?: string;
   orgId: string;
-  config: any;
+  config: string;
   state: string;
   categories?: string[];
   createdAt?: string;
   updatedAt?: string;
-  manifest?: Record<string, any>;
+  manifest?: Record<string, unknown>;
   /**
    * UNTRUSTED, LLM-proposed manifest surfaced READ-ONLY for review UIs
    * (Tier-3 agent import). Present only while a proposal is pending/failed;
@@ -442,7 +451,7 @@ export interface AgentConfig {
 export interface ToolConfig {
   toolId: string;
   orgId: string;
-  config: any;
+  config: string;
   state: string;
   categories?: string[];
   integrationBindings?: IntegrationBinding[] | null;
@@ -587,11 +596,11 @@ export class RegistryService {
   }
 
   /** Returns true if the error is transient (5xx, timeout, network). */
-  private isTransientError(err: any): boolean {
-    const statusCode = err?.$metadata?.httpStatusCode;
+  private isTransientError(err: unknown): boolean {
+    const statusCode = (err as AwsErrorLike)?.$metadata?.httpStatusCode;
     if (statusCode && statusCode >= 500) return true;
 
-    const name = err?.name ?? '';
+    const name = (err as AwsErrorLike)?.name ?? '';
     if (
       name === 'TimeoutError' ||
       name === 'NetworkingError' ||
@@ -727,10 +736,10 @@ export class RegistryService {
         createdAt: result.createdAt,
         updatedAt: result.updatedAt,
       };
-    } catch (err: any) {
+    } catch (err: unknown) {
       if (
-        err.name === 'ResourceNotFoundException' ||
-        err?.$metadata?.httpStatusCode === 404
+        (err as AwsErrorLike).name === 'ResourceNotFoundException' ||
+        (err as AwsErrorLike)?.$metadata?.httpStatusCode === 404
       ) {
         return null;
       }
@@ -1194,11 +1203,11 @@ export class RegistryService {
    * "[Binding]" (optional list) shape.
    */
   private static sanitizeIntegrationBindings(
-    bindings: any,
+    bindings: unknown,
   ): IntegrationBinding[] | null {
     if (!Array.isArray(bindings) || bindings.length === 0) return null;
     const cleaned = bindings.filter(
-      (b: any) =>
+      (b: { integrationId?: unknown; integrationType?: unknown } | null | undefined) =>
         b &&
         typeof b.integrationId === 'string' && b.integrationId.length > 0 &&
         typeof b.integrationType === 'string' && b.integrationType.length > 0,
@@ -1207,11 +1216,11 @@ export class RegistryService {
   }
 
   private static sanitizeDataStoreBindings(
-    bindings: any,
+    bindings: unknown,
   ): DataStoreBinding[] | null {
     if (!Array.isArray(bindings) || bindings.length === 0) return null;
     const cleaned = bindings.filter(
-      (b: any) =>
+      (b: { dataStoreId?: unknown; dataStoreType?: unknown } | null | undefined) =>
         b &&
         typeof b.dataStoreId === 'string' && b.dataStoreId.length > 0 &&
         typeof b.dataStoreType === 'string' && b.dataStoreType.length > 0,


### PR DESCRIPTION
## Summary

Lint-debt burn-down, using ratcheting approach: the `registry*` file cluster.

- Eliminates all 273 `no-explicit-any` / `require-imports` warnings across 16 registry files
- 13 test files: typed fixtures and `aws-sdk-client-mock` generics — assertions and per-suite test counts unchanged
- 3 source files (`registry-sync.ts`, `registry-service.ts`, `registry-provisioner.ts`): strictly type-only changes
- Ratchets `--max-warnings` 1997 → 1724 so the gain cannot regress
- No `eslint-disable` comments introduced

## Testing

- Full backend suite green; all registry suites pass with unchanged counts; `npm run build` passes
- `npx eslint 'src/**/registry*'` reports 0 problems