### PR TITLE
fix(lint): type governance, project and credential clusters, cap to 1476

### DIFF
--- a/backend/package.json
+++ b/backend/package.json
@@ -11,7 +11,7 @@
     "watch": "tsc -w",
     "test": "jest",
     "test:integration": "jest --config jest.integration.config.js",
-    "lint": "eslint \"src/**/*.ts\" --max-warnings 1724",
+    "lint": "eslint \"src/**/*.ts\" --max-warnings 1476",
     "lint:fix": "eslint \"src/**/*.ts\" --fix",
     "format": "prettier --write \"src/**/*.ts\"",
     "cdk:synth": "cdk synth",

--- a/backend/src/lambda/__tests__/governance-finding-fanout.test.ts
+++ b/backend/src/lambda/__tests__/governance-finding-fanout.test.ts
@@ -9,7 +9,7 @@
 
 // Mock global fetch before any imports (handler uses node 18+ global fetch).
 const mockFetch = jest.fn();
-(global as any).fetch = mockFetch;
+global.fetch = mockFetch as unknown as typeof fetch;
 
 // Mock SignatureV4 + Sha256 + credential provider so the signer never
 // reaches AWS in unit tests.
@@ -28,6 +28,11 @@ jest.mock('@aws-sdk/credential-provider-node', () => ({
   defaultProvider: jest.fn().mockReturnValue('mock-credentials'),
 }));
 
+import type {
+  AttributeValue,
+  DynamoDBRecord,
+  DynamoDBStreamEvent,
+} from 'aws-lambda';
 import { mockClient } from 'aws-sdk-client-mock';
 import {
   CloudWatchClient,
@@ -39,6 +44,12 @@ import {
   projectRow,
   __resetForTest,
 } from '../governance-finding-fanout';
+
+// aws-lambda's DynamoDBStreamHandler type declares legacy required context
+// and callback parameters, but the implementation is a one-parameter async
+// (event) function that never uses them — invoke through the real signature
+// (single cast here) so calls don't pass superfluous arguments.
+const invokeHandler = handler as (event: DynamoDBStreamEvent) => Promise<void>;
 
 const cwMock = mockClient(CloudWatchClient);
 
@@ -56,9 +67,9 @@ function BOOL(v: boolean) {
 
 function makeRecord(opts: {
   eventName?: 'INSERT' | 'MODIFY' | 'REMOVE';
-  newImage?: Record<string, any>;
+  newImage?: Record<string, AttributeValue>;
   eventID?: string;
-}) {
+}): DynamoDBRecord {
   return {
     eventID: opts.eventID ?? 'rec-1',
     eventName: opts.eventName ?? 'INSERT',
@@ -73,7 +84,7 @@ function makeRecord(opts: {
       SizeBytes: 100,
       StreamViewType: 'NEW_AND_OLD_IMAGES',
     },
-  } as any;
+  };
 }
 
 const validNewImage = {
@@ -194,10 +205,8 @@ describe('projectRow', () => {
 
 describe('governance-finding-fanout handler', () => {
   test('projects an INSERT record and POSTs the publishGovernanceFinding mutation', async () => {
-    await handler(
-      { Records: [makeRecord({ newImage: validNewImage })] } as any,
-      {} as any,
-      {} as any,
+    await invokeHandler(
+      { Records: [makeRecord({ newImage: validNewImage })] },
     );
 
     expect(mockSign).toHaveBeenCalledTimes(1);
@@ -232,14 +241,12 @@ describe('governance-finding-fanout handler', () => {
   });
 
   test('skips MODIFY records (defence-in-depth past the EventSourceMapping filter)', async () => {
-    await handler(
+    await invokeHandler(
       {
         Records: [
           makeRecord({ eventName: 'MODIFY', newImage: validNewImage }),
         ],
-      } as any,
-      {} as any,
-      {} as any,
+      },
     );
 
     expect(mockFetch).not.toHaveBeenCalled();
@@ -247,24 +254,20 @@ describe('governance-finding-fanout handler', () => {
   });
 
   test('skips REMOVE records', async () => {
-    await handler(
+    await invokeHandler(
       {
         Records: [
           makeRecord({ eventName: 'REMOVE', newImage: undefined }),
         ],
-      } as any,
-      {} as any,
-      {} as any,
+      },
     );
 
     expect(mockFetch).not.toHaveBeenCalled();
   });
 
   test('skips records with missing NewImage and does not metricise', async () => {
-    await handler(
-      { Records: [makeRecord({ newImage: undefined })] } as any,
-      {} as any,
-      {} as any,
+    await invokeHandler(
+      { Records: [makeRecord({ newImage: undefined })] },
     );
     expect(mockFetch).not.toHaveBeenCalled();
     expect(cwMock.commandCalls(PutMetricDataCommand)).toHaveLength(0);
@@ -278,10 +281,8 @@ describe('governance-finding-fanout handler', () => {
       timestamp: N(1715000000),
     };
 
-    await handler(
-      { Records: [makeRecord({ newImage: malformed })] } as any,
-      {} as any,
-      {} as any,
+    await invokeHandler(
+      { Records: [makeRecord({ newImage: malformed })] },
     );
 
     // No AppSync call (projectRow returned null).
@@ -305,10 +306,8 @@ describe('governance-finding-fanout handler — failure paths', () => {
     mockFetch.mockResolvedValue({ ok: false, status: 500 });
 
     await expect(
-      handler(
-        { Records: [makeRecord({ newImage: validNewImage })] } as any,
-        {} as any,
-        {} as any,
+      invokeHandler(
+        { Records: [makeRecord({ newImage: validNewImage })] },
       ),
     ).resolves.toBeUndefined();
 
@@ -322,10 +321,8 @@ describe('governance-finding-fanout handler — failure paths', () => {
     mockFetch.mockResolvedValue({ ok: false, status: 400 });
 
     await expect(
-      handler(
-        { Records: [makeRecord({ newImage: validNewImage })] } as any,
-        {} as any,
-        {} as any,
+      invokeHandler(
+        { Records: [makeRecord({ newImage: validNewImage })] },
       ),
     ).resolves.toBeUndefined();
 
@@ -340,15 +337,13 @@ describe('governance-finding-fanout handler — failure paths', () => {
     });
 
     await expect(
-      handler(
+      invokeHandler(
         {
           Records: [
             makeRecord({ eventID: 'rec-a', newImage: validNewImage }),
             makeRecord({ eventID: 'rec-b', newImage: validNewImage }),
           ],
-        } as any,
-        {} as any,
-        {} as any,
+        },
       ),
     ).resolves.toBeUndefined();
 
@@ -363,10 +358,8 @@ describe('governance-finding-fanout handler — failure paths', () => {
     cwMock.on(PutMetricDataCommand).rejects(new Error('cw down'));
 
     await expect(
-      handler(
-        { Records: [makeRecord({ newImage: validNewImage })] } as any,
-        {} as any,
-        {} as any,
+      invokeHandler(
+        { Records: [makeRecord({ newImage: validNewImage })] },
       ),
     ).resolves.toBeUndefined();
   });
@@ -378,16 +371,14 @@ describe('governance-finding-fanout handler — failure paths', () => {
       .mockResolvedValueOnce({ ok: false, status: 502 })
       .mockResolvedValueOnce({ ok: true, status: 200 });
 
-    await handler(
+    await invokeHandler(
       {
         Records: [
           makeRecord({ eventID: 'r-1', newImage: validNewImage }),
           makeRecord({ eventID: 'r-2', newImage: validNewImage }),
           makeRecord({ eventID: 'r-3', newImage: validNewImage }),
         ],
-      } as any,
-      {} as any,
-      {} as any,
+      },
     );
 
     expect(mockFetch).toHaveBeenCalledTimes(3);
@@ -399,10 +390,8 @@ describe('governance-finding-fanout handler — failure paths', () => {
     delete process.env.APPSYNC_ENDPOINT;
 
     await expect(
-      handler(
-        { Records: [makeRecord({ newImage: validNewImage })] } as any,
-        {} as any,
-        {} as any,
+      invokeHandler(
+        { Records: [makeRecord({ newImage: validNewImage })] },
       ),
     ).resolves.toBeUndefined();
 
@@ -416,7 +405,7 @@ describe('governance-finding-fanout handler — failure paths', () => {
 
   test('handles an empty Records array', async () => {
     await expect(
-      handler({ Records: [] } as any, {} as any, {} as any),
+      invokeHandler({ Records: [] }),
     ).resolves.toBeUndefined();
     expect(mockFetch).not.toHaveBeenCalled();
   });

--- a/backend/src/lambda/__tests__/governance-graph-snapshot-on-change.test.ts
+++ b/backend/src/lambda/__tests__/governance-graph-snapshot-on-change.test.ts
@@ -20,12 +20,13 @@ process.env.CASE_LAW_TABLE = 'citadel-case-law-test';
 process.env.GRAPH_SNAPSHOTS_TABLE =
   'citadel-governance-graph-snapshots-test';
 
-import type { DynamoDBStreamEvent } from 'aws-lambda';
+import type { DynamoDBRecord, DynamoDBStreamEvent } from 'aws-lambda';
 import { mockClient } from 'aws-sdk-client-mock';
 import {
   DynamoDBDocumentClient,
   PutCommand,
   ScanCommand,
+  type ScanCommandInput,
 } from '@aws-sdk/lib-dynamodb';
 import { SSMClient, GetParameterCommand } from '@aws-sdk/client-ssm';
 import {
@@ -58,9 +59,24 @@ function stubSettings(value: string): void {
   });
 }
 
+/** Shape of the snapshot row the handler writes — typed view for assertions. */
+interface SnapshotRow {
+  snapshotId: string;
+  kind: string;
+  trigger: string;
+  timestamp: number;
+  expiresAt: number;
+  env: string;
+  partial: boolean;
+  authorityUnits: Array<Record<string, unknown>>;
+  compositionContracts: Array<Record<string, unknown>>;
+  constitutionalLayers: Array<Record<string, unknown>>;
+  caseLaw: Array<Record<string, unknown>>;
+}
+
 /** Build a minimal DynamoDB stream event with N synthetic records. */
 function streamEvent(n: number, eventName: 'INSERT' | 'MODIFY' | 'REMOVE' = 'MODIFY'): DynamoDBStreamEvent {
-  const records = Array.from({ length: n }, (_, i) => ({
+  const records: DynamoDBRecord[] = Array.from({ length: n }, (_, i) => ({
     eventID: `evt-${i}`,
     eventName,
     eventVersion: '1.1',
@@ -75,12 +91,12 @@ function streamEvent(n: number, eventName: 'INSERT' | 'MODIFY' | 'REMOVE' = 'MOD
       StreamViewType: 'NEW_AND_OLD_IMAGES',
     },
   }));
-  return { Records: records as any };
+  return { Records: records };
 }
 
 describe('governance-graph-snapshot-on-change handler', () => {
   test('empty event — returns ok with reason=empty, no scans, no put, no metric', async () => {
-    const result = await handler({ Records: [] } as any);
+    const result = await handler({ Records: [] });
 
     expect(result.ok).toBe(true);
     expect(result.snapshotId).toBeNull();
@@ -112,7 +128,7 @@ describe('governance-graph-snapshot-on-change handler', () => {
     stubSettings(
       '{"enabled":true,"retentionDays":7,"captureMode":"on-change"}',
     );
-    ddbMock.on(ScanCommand).callsFake((input: any) => {
+    ddbMock.on(ScanCommand).callsFake((input: ScanCommandInput) => {
       const t: string = input?.TableName ?? '';
       if (t === 'citadel-authority-units-test') {
         return Promise.resolve({ Items: [{ unitId: 'u-1' }] });
@@ -140,7 +156,7 @@ describe('governance-graph-snapshot-on-change handler', () => {
 
     const scanCalls = ddbMock.commandCalls(ScanCommand);
     const tables = new Set(
-      scanCalls.map((c) => (c.args[0].input as any).TableName),
+      scanCalls.map((c) => c.args[0].input.TableName),
     );
     expect(tables).toContain('citadel-authority-units-test');
     expect(tables).toContain('citadel-composition-contracts-test');
@@ -149,7 +165,7 @@ describe('governance-graph-snapshot-on-change handler', () => {
 
     const puts = ddbMock.commandCalls(PutCommand);
     expect(puts).toHaveLength(1);
-    const item = puts[0].args[0].input.Item as any;
+    const item = puts[0].args[0].input.Item as unknown as SnapshotRow;
     expect(item.kind).toBe('full');
     expect(item.trigger).toBe('OnChange');
     expect(item.snapshotId).toBe(result.snapshotId);
@@ -192,7 +208,7 @@ describe('governance-graph-snapshot-on-change handler', () => {
 
     const puts = ddbMock.commandCalls(PutCommand);
     expect(puts).toHaveLength(1);
-    expect((puts[0].args[0].input as any).TableName).toBe(
+    expect(puts[0].args[0].input.TableName).toBe(
       'citadel-governance-graph-snapshots-test',
     );
   });
@@ -212,11 +228,11 @@ describe('governance-graph-snapshot-on-change handler', () => {
     expect(md.MetricName).toBe('Count');
     expect(md.Value).toBe(1);
     const dims = md.Dimensions ?? [];
-    const triggerDim = dims.find((d: any) => d.Name === 'Trigger');
+    const triggerDim = dims.find((d) => d.Name === 'Trigger');
     expect(triggerDim?.Value).toBe('OnChange');
-    const statusDim = dims.find((d: any) => d.Name === 'Status');
+    const statusDim = dims.find((d) => d.Name === 'Status');
     expect(statusDim?.Value).toBe('Success');
-    const partialDim = dims.find((d: any) => d.Name === 'Partial');
+    const partialDim = dims.find((d) => d.Name === 'Partial');
     expect(partialDim?.Value).toBe('false');
   });
 
@@ -224,7 +240,7 @@ describe('governance-graph-snapshot-on-change handler', () => {
     stubSettings(
       '{"enabled":true,"retentionDays":30,"captureMode":"on-change"}',
     );
-    ddbMock.on(ScanCommand).callsFake((input: any) => {
+    ddbMock.on(ScanCommand).callsFake((input: ScanCommandInput) => {
       const t: string = input?.TableName ?? '';
       if (t === 'citadel-case-law-test') {
         return Promise.reject(new Error('throttled'));
@@ -240,7 +256,7 @@ describe('governance-graph-snapshot-on-change handler', () => {
 
     const puts = ddbMock.commandCalls(PutCommand);
     expect(puts).toHaveLength(1);
-    const item = puts[0].args[0].input.Item as any;
+    const item = puts[0].args[0].input.Item as unknown as SnapshotRow;
     expect(item.partial).toBe(true);
     expect(item.caseLaw).toEqual([]);
 
@@ -249,9 +265,9 @@ describe('governance-graph-snapshot-on-change handler', () => {
     expect(metrics).toHaveLength(1);
     const md = metrics[0].args[0].input.MetricData![0];
     const dims = md.Dimensions ?? [];
-    const statusDim = dims.find((d: any) => d.Name === 'Status');
+    const statusDim = dims.find((d) => d.Name === 'Status');
     expect(statusDim?.Value).toBe('Success');
-    const partialDim = dims.find((d: any) => d.Name === 'Partial');
+    const partialDim = dims.find((d) => d.Name === 'Partial');
     expect(partialDim?.Value).toBe('true');
   });
 
@@ -270,7 +286,7 @@ describe('governance-graph-snapshot-on-change handler', () => {
     expect(metrics).toHaveLength(1);
     const md = metrics[0].args[0].input.MetricData![0];
     const dims = md.Dimensions ?? [];
-    const statusDim = dims.find((d: any) => d.Name === 'Status');
+    const statusDim = dims.find((d) => d.Name === 'Status');
     expect(statusDim?.Value).toBe('Failure');
   });
 
@@ -287,7 +303,7 @@ describe('governance-graph-snapshot-on-change handler', () => {
     expect(metrics).toHaveLength(1);
     const md = metrics[0].args[0].input.MetricData![0];
     const dims = md.Dimensions ?? [];
-    const statusDim = dims.find((d: any) => d.Name === 'Status');
+    const statusDim = dims.find((d) => d.Name === 'Status');
     expect(statusDim?.Value).toBe('Failure');
   });
 
@@ -326,7 +342,7 @@ describe('governance-graph-snapshot-on-change handler', () => {
 
     const puts = ddbMock.commandCalls(PutCommand);
     expect(puts).toHaveLength(1);
-    const item = puts[0].args[0].input.Item as any;
+    const item = puts[0].args[0].input.Item as unknown as SnapshotRow;
     expect(item.trigger).toBe('OnChange');
   });
 });

--- a/backend/src/lambda/__tests__/governance-graph-snapshot.test.ts
+++ b/backend/src/lambda/__tests__/governance-graph-snapshot.test.ts
@@ -22,6 +22,7 @@ import {
   DynamoDBDocumentClient,
   PutCommand,
   ScanCommand,
+  type ScanCommandInput,
 } from '@aws-sdk/lib-dynamodb';
 import { SSMClient, GetParameterCommand } from '@aws-sdk/client-ssm';
 import {
@@ -53,6 +54,20 @@ function stubSettings(value: string) {
   });
 }
 
+/** Shape of the snapshot row the handler writes — typed view for assertions. */
+interface SnapshotRow {
+  snapshotId: string;
+  kind: string;
+  timestamp: number;
+  expiresAt: number;
+  env: string;
+  partial: boolean;
+  authorityUnits: Array<Record<string, unknown>>;
+  compositionContracts: Array<Record<string, unknown>>;
+  constitutionalLayers: Array<Record<string, unknown>>;
+  caseLaw: Array<Record<string, unknown>>;
+}
+
 describe('governance-graph-snapshot handler', () => {
   test('skips early when settings.enabled === false', async () => {
     stubSettings(
@@ -82,7 +97,7 @@ describe('governance-graph-snapshot handler', () => {
     const scanCalls = ddbMock.commandCalls(ScanCommand);
     expect(scanCalls.length).toBeGreaterThanOrEqual(4);
     const tables = new Set(
-      scanCalls.map((c) => (c.args[0].input as any).TableName),
+      scanCalls.map((c) => c.args[0].input.TableName),
     );
     expect(tables).toContain('citadel-authority-units-test');
     expect(tables).toContain('citadel-composition-contracts-test');
@@ -94,7 +109,7 @@ describe('governance-graph-snapshot handler', () => {
     stubSettings(
       '{"enabled":true,"retentionDays":7,"captureMode":"daily"}',
     );
-    ddbMock.on(ScanCommand).callsFake((input: any) => {
+    ddbMock.on(ScanCommand).callsFake((input: ScanCommandInput) => {
       const t: string = input?.TableName ?? '';
       if (t === 'citadel-authority-units-test') {
         return Promise.resolve({ Items: [{ unitId: 'u-1' }] });
@@ -122,7 +137,7 @@ describe('governance-graph-snapshot handler', () => {
     // Inspect the snapshot row written.
     const puts = ddbMock.commandCalls(PutCommand);
     expect(puts).toHaveLength(1);
-    const item = puts[0].args[0].input.Item as any;
+    const item = puts[0].args[0].input.Item as unknown as SnapshotRow;
     expect(item.kind).toBe('full');
     expect(item.snapshotId).toBe(result.snapshotId);
     expect(item.timestamp).toBeGreaterThanOrEqual(before);
@@ -146,7 +161,7 @@ describe('governance-graph-snapshot handler', () => {
 
     const puts = ddbMock.commandCalls(PutCommand);
     expect(puts).toHaveLength(1);
-    expect((puts[0].args[0].input as any).TableName).toBe(
+    expect(puts[0].args[0].input.TableName).toBe(
       'citadel-governance-graph-snapshots-test',
     );
   });
@@ -166,9 +181,9 @@ describe('governance-graph-snapshot handler', () => {
     expect(md.MetricName).toBe('Count');
     expect(md.Value).toBe(1);
     const dims = md.Dimensions ?? [];
-    const statusDim = dims.find((d: any) => d.Name === 'Status');
+    const statusDim = dims.find((d) => d.Name === 'Status');
     expect(statusDim?.Value).toBe('Success');
-    const partialDim = dims.find((d: any) => d.Name === 'Partial');
+    const partialDim = dims.find((d) => d.Name === 'Partial');
     expect(partialDim?.Value).toBe('false');
   });
 
@@ -176,7 +191,7 @@ describe('governance-graph-snapshot handler', () => {
     stubSettings(
       '{"enabled":true,"retentionDays":30,"captureMode":"daily"}',
     );
-    ddbMock.on(ScanCommand).callsFake((input: any) => {
+    ddbMock.on(ScanCommand).callsFake((input: ScanCommandInput) => {
       const t: string = input?.TableName ?? '';
       if (t === 'citadel-case-law-test') {
         return Promise.reject(new Error('throttled'));
@@ -193,7 +208,7 @@ describe('governance-graph-snapshot handler', () => {
     // Snapshot row records partial:true and an empty caseLaw array.
     const puts = ddbMock.commandCalls(PutCommand);
     expect(puts).toHaveLength(1);
-    const item = puts[0].args[0].input.Item as any;
+    const item = puts[0].args[0].input.Item as unknown as SnapshotRow;
     expect(item.partial).toBe(true);
     expect(item.caseLaw).toEqual([]);
 
@@ -203,9 +218,9 @@ describe('governance-graph-snapshot handler', () => {
     expect(metrics).toHaveLength(1);
     const dims =
       metrics[0].args[0].input.MetricData![0].Dimensions ?? [];
-    const statusDim = dims.find((d: any) => d.Name === 'Status');
+    const statusDim = dims.find((d) => d.Name === 'Status');
     expect(statusDim?.Value).toBe('Success');
-    const partialDim = dims.find((d: any) => d.Name === 'Partial');
+    const partialDim = dims.find((d) => d.Name === 'Partial');
     expect(partialDim?.Value).toBe('true');
   });
 
@@ -228,7 +243,7 @@ describe('governance-graph-snapshot handler', () => {
     expect(metrics).toHaveLength(1);
     const dims =
       metrics[0].args[0].input.MetricData![0].Dimensions ?? [];
-    const statusDim = dims.find((d: any) => d.Name === 'Status');
+    const statusDim = dims.find((d) => d.Name === 'Status');
     expect(statusDim?.Value).toBe('Failure');
   });
 
@@ -276,7 +291,7 @@ describe('governance-graph-snapshot handler', () => {
     const scanCalls = ddbMock.commandCalls(ScanCommand);
     expect(scanCalls.length).toBeGreaterThanOrEqual(4);
     const tables = new Set(
-      scanCalls.map((c) => (c.args[0].input as any).TableName),
+      scanCalls.map((c) => c.args[0].input.TableName),
     );
     expect(tables).toContain('citadel-authority-units-test');
     expect(tables).toContain('citadel-composition-contracts-test');

--- a/backend/src/lambda/__tests__/governance-notifier.test.ts
+++ b/backend/src/lambda/__tests__/governance-notifier.test.ts
@@ -10,7 +10,7 @@
 
 // Mock global fetch before any imports (handler uses node 18+ global fetch).
 const mockFetch = jest.fn();
-(global as any).fetch = mockFetch;
+global.fetch = mockFetch as unknown as typeof fetch;
 
 const mockSign = jest.fn();
 jest.mock('@smithy/signature-v4', () => ({

--- a/backend/src/lambda/__tests__/governance-ui-resolver.test.ts
+++ b/backend/src/lambda/__tests__/governance-ui-resolver.test.ts
@@ -26,8 +26,16 @@ import {
   PutCommand,
   QueryCommand,
   ScanCommand,
+  type ScanCommandInput,
 } from '@aws-sdk/lib-dynamodb';
-import { SSMClient, GetParameterCommand, GetParameterHistoryCommand, PutParameterCommand } from '@aws-sdk/client-ssm';
+import {
+  SSMClient,
+  GetParameterCommand,
+  GetParameterHistoryCommand,
+  PutParameterCommand,
+  type GetParameterCommandInput,
+  type PutParameterCommandInput,
+} from '@aws-sdk/client-ssm';
 import {
   CloudWatchClient,
   GetMetricStatisticsCommand,
@@ -40,6 +48,8 @@ import {
   IAMClient,
   GetRoleCommand,
   GetRolePolicyCommand,
+  type GetRoleCommandInput,
+  type GetRolePolicyCommandInput,
 } from '@aws-sdk/client-iam';
 import {
   STSClient,
@@ -207,7 +217,9 @@ interface PartialEvent {
   identity?: Record<string, unknown>;
 }
 
-function makeEvent({ fieldName, args = {}, identity = {} }: PartialEvent): any {
+type HandlerEvent = Parameters<typeof handler>[0];
+
+function makeEvent({ fieldName, args = {}, identity = {} }: PartialEvent): HandlerEvent {
   return {
     arguments: args,
     identity,
@@ -216,7 +228,7 @@ function makeEvent({ fieldName, args = {}, identity = {} }: PartialEvent): any {
     source: null,
     prev: null,
     stash: {},
-  };
+  } as unknown as HandlerEvent;
 }
 
 function makeDdbRow(overrides: Record<string, unknown> = {}): Record<string, unknown> {
@@ -480,7 +492,7 @@ describe('getReconcilerStatus', () => {
   test('returns zero defaults when SSM throws ParameterNotFound', async () => {
     isAdminFromEventMock.mockReturnValue(true);
     const err = new Error('Parameter not found');
-    (err as any).name = 'ParameterNotFound';
+    err.name = 'ParameterNotFound';
     ssmMock.on(GetParameterCommand).rejects(err);
 
     const result = (await handler(
@@ -1194,7 +1206,7 @@ describe('getRolloutReadiness real checks (Wave 2.B)', () => {
     // ScanCommand responses (governance-ledger reads see ledger-shaped
     // rows; authority-units reads see makeUnits).
     const telOneOldTs = Math.floor(Date.now() / 1000) - 10 * 86_400;
-    ddbMock.on(ScanCommand).callsFake((input: any) => {
+    ddbMock.on(ScanCommand).callsFake((input: ScanCommandInput) => {
       if (input.TableName === 'citadel-governance-ledger-test') {
         if (input.Select === 'COUNT') {
           // tel-2: total >= 100, mismatches < 0.5%.
@@ -1690,7 +1702,7 @@ describe('setGovernanceMode', () => {
     targetMode?: string;
     acknowledgement?: string;
     reason?: string | null;
-  }): any {
+  }): HandlerEvent {
     return makeEvent({
       fieldName: 'setGovernanceMode',
       args: { input },
@@ -1715,7 +1727,7 @@ describe('setGovernanceMode', () => {
     putShouldFailOn?: 'enforce' | 'effective_at' | null;
   }) {
     const { currentMode, currentEffectiveAt, putShouldFailOn } = opts;
-    ssmMock.on(GetParameterCommand).callsFake((input: any) => {
+    ssmMock.on(GetParameterCommand).callsFake((input: GetParameterCommandInput) => {
       const name: string = input?.Name ?? '';
       if (name.includes('/enforce/')) {
         return Promise.resolve({ Parameter: { Value: currentMode } });
@@ -1725,7 +1737,7 @@ describe('setGovernanceMode', () => {
       }
       return Promise.resolve({});
     });
-    ssmMock.on(PutParameterCommand).callsFake((input: any) => {
+    ssmMock.on(PutParameterCommand).callsFake((input: PutParameterCommandInput) => {
       const name: string = input?.Name ?? '';
       if (putShouldFailOn === 'enforce' && name.includes('/enforce/')) {
         return Promise.reject(new Error('SSM enforce write failed'));
@@ -2047,7 +2059,7 @@ describe('markReadinessCheckVerified', () => {
     checkId?: string;
     expiresInDays?: number | null;
     note?: string | null;
-  }, identity: Record<string, unknown> = { sub: 'verifier-sub-1' }): any {
+  }, identity: Record<string, unknown> = { sub: 'verifier-sub-1' }): HandlerEvent {
     return makeEvent({
       fieldName: 'markReadinessCheckVerified',
       args: { input },
@@ -2219,7 +2231,7 @@ describe('getRolloutReadiness verification overlay (Wave 2.B.2)', () => {
   function stubSsmForManual(
     map: Record<string, { value?: string; throws?: boolean } | undefined>,
   ) {
-    ssmMock.on(GetParameterCommand).callsFake((input: any) => {
+    ssmMock.on(GetParameterCommand).callsFake((input: GetParameterCommandInput) => {
       const name: string = input?.Name ?? '';
       const m = name.match(
         /\/citadel\/governance\/readiness\/manual\/[^/]+\/([^/]+)$/,
@@ -2307,7 +2319,7 @@ describe('getRolloutReadiness verification overlay (Wave 2.B.2)', () => {
   test('2 manual verified + 8 real PASS → passCount = 10, stubCount = 1', async () => {
     // Real-check happy paths (data-1, data-2, data-3, tel-1, tel-2, tel-3, rb-1, rb-2):
     const telOneOldTs = Math.floor(Date.now() / 1000) - 10 * 86_400;
-    ddbMock.on(ScanCommand).callsFake((input: any) => {
+    ddbMock.on(ScanCommand).callsFake((input: ScanCommandInput) => {
       if (input.TableName === 'citadel-governance-ledger-test') {
         if (input.Select === 'COUNT') {
           // tel-2: total >= 100, mismatches < 0.5%.
@@ -2347,7 +2359,7 @@ describe('getRolloutReadiness verification overlay (Wave 2.B.2)', () => {
         expiresAt: futureExpiry,
         note: null,
       });
-    ssmMock.on(GetParameterCommand).callsFake((input: any) => {
+    ssmMock.on(GetParameterCommand).callsFake((input: GetParameterCommandInput) => {
       const name: string = input?.Name ?? '';
       if (name.endsWith('/enforce/dev')) {
         // rb-1 PASS path
@@ -2395,7 +2407,7 @@ describe('getRolloutReadiness verification overlay (Wave 2.B.2)', () => {
 
   test('all 3 manual verified + all 8 real PASS → passCount = 11, stubCount = 0', async () => {
     const telOneOldTs = Math.floor(Date.now() / 1000) - 10 * 86_400;
-    ddbMock.on(ScanCommand).callsFake((input: any) => {
+    ddbMock.on(ScanCommand).callsFake((input: ScanCommandInput) => {
       if (input.TableName === 'citadel-governance-ledger-test') {
         if (input.Select === 'COUNT') {
           const isMismatch =
@@ -2432,7 +2444,7 @@ describe('getRolloutReadiness verification overlay (Wave 2.B.2)', () => {
         expiresAt: futureExpiry,
         note: null,
       });
-    ssmMock.on(GetParameterCommand).callsFake((input: any) => {
+    ssmMock.on(GetParameterCommand).callsFake((input: GetParameterCommandInput) => {
       const name: string = input?.Name ?? '';
       if (name.endsWith('/enforce/dev')) {
         return Promise.resolve({ Parameter: { Value: 'permissive' } });
@@ -2478,7 +2490,7 @@ describe('getRolloutReadiness verification overlay (Wave 2.B.2)', () => {
         expiresAt: futureExpiry,
         note: null,
       });
-    ssmMock.on(GetParameterCommand).callsFake((input: any) => {
+    ssmMock.on(GetParameterCommand).callsFake((input: GetParameterCommandInput) => {
       const name: string = input?.Name ?? '';
       const m = name.match(
         /\/citadel\/governance\/readiness\/manual\/[^/]+\/([^/]+)$/,
@@ -2995,7 +3007,7 @@ describe('publishGovernanceFinding', () => {
         source: null,
         prev: null,
         stash: {},
-      } as any),
+      } as unknown as HandlerEvent),
     ).rejects.toThrow(/Forbidden: publishGovernanceFinding is IAM-only/);
   });
 
@@ -4637,7 +4649,7 @@ describe('constitutionalRule mutations (Wave 4.C.2)', () => {
   function adminMutEvent(
     fieldName: 'addConstitutionalRule' | 'updateConstitutionalRule' | 'deleteConstitutionalRule',
     input: Record<string, unknown>,
-  ): any {
+  ): HandlerEvent {
     return makeEvent({
       fieldName,
       args: { input },
@@ -4680,7 +4692,7 @@ describe('constitutionalRule mutations (Wave 4.C.2)', () => {
     async (fieldName, input) => {
       isAdminFromEventMock.mockReturnValue(false);
       await expect(
-        handler(adminMutEvent(fieldName as any, input as any)),
+        handler(adminMutEvent(fieldName, input)),
       ).rejects.toThrow('Forbidden: admin required');
     },
   );
@@ -4693,7 +4705,7 @@ describe('constitutionalRule mutations (Wave 4.C.2)', () => {
     '%s: acknowledgement string mismatch throws',
     async (fieldName, input) => {
       await expect(
-        handler(adminMutEvent(fieldName as any, input as any)),
+        handler(adminMutEvent(fieldName, input)),
       ).rejects.toThrow('Acknowledgement string mismatch');
     },
   );
@@ -4706,7 +4718,7 @@ describe('constitutionalRule mutations (Wave 4.C.2)', () => {
     async (fieldName, input) => {
       ddbMock.on(GetCommand).resolves({ Item: makeStoredLayerRow({ layerId: 'l1' }) });
       await expect(
-        handler(adminMutEvent(fieldName as any, input as any)),
+        handler(adminMutEvent(fieldName, input)),
       ).rejects.toThrow('Invalid operator: bogus');
     },
   );
@@ -5080,7 +5092,7 @@ describe('caseLaw mutations (Wave 4.D.2)', () => {
       | 'unrevokeCaseLaw'
       | 'updateCaseLawPrecedence',
     input: Record<string, unknown>,
-  ): any {
+  ): HandlerEvent {
     return makeEvent({
       fieldName,
       args: { input },
@@ -5126,7 +5138,7 @@ describe('caseLaw mutations (Wave 4.D.2)', () => {
     async (fieldName, input) => {
       isAdminFromEventMock.mockReturnValue(false);
       await expect(
-        handler(adminCaseLawEvent(fieldName as any, input as any)),
+        handler(adminCaseLawEvent(fieldName, input)),
       ).rejects.toThrow('Forbidden: admin required');
     },
   );
@@ -5142,7 +5154,7 @@ describe('caseLaw mutations (Wave 4.D.2)', () => {
     '%s: acknowledgement string mismatch throws',
     async (fieldName, input) => {
       await expect(
-        handler(adminCaseLawEvent(fieldName as any, input as any)),
+        handler(adminCaseLawEvent(fieldName, input)),
       ).rejects.toThrow('Acknowledgement string mismatch');
     },
   );
@@ -5162,7 +5174,7 @@ describe('caseLaw mutations (Wave 4.D.2)', () => {
     async (fieldName, input) => {
       ddbMock.on(GetCommand).resolves({ Item: undefined });
       await expect(
-        handler(adminCaseLawEvent(fieldName as any, input as any)),
+        handler(adminCaseLawEvent(fieldName, input)),
       ).rejects.toThrow('Case-law entry not found: missing');
     },
   );
@@ -5178,7 +5190,7 @@ describe('caseLaw mutations (Wave 4.D.2)', () => {
     '%s: empty caseId throws',
     async (fieldName, input) => {
       await expect(
-        handler(adminCaseLawEvent(fieldName as any, input as any)),
+        handler(adminCaseLawEvent(fieldName, input)),
       ).rejects.toThrow('caseId must be non-empty');
     },
   );
@@ -5237,7 +5249,7 @@ describe('caseLaw mutations (Wave 4.D.2)', () => {
     // mutation skipped the UpdateItem entirely.
     const sendSpy = jest.spyOn(
       DynamoDBDocumentClient.prototype,
-      'send' as any,
+      'send',
     );
 
     const result = (await handler(
@@ -5254,7 +5266,7 @@ describe('caseLaw mutations (Wave 4.D.2)', () => {
     // no second GetCommand for re-projection. Assert by inspecting
     // every call's command name.
     const sendCallNames = sendSpy.mock.calls.map(
-      (call) => (call[0] as any)?.constructor?.name ?? 'unknown',
+      (call) => (call[0] as object | undefined)?.constructor?.name ?? 'unknown',
     );
     expect(sendCallNames).toEqual(['GetCommand']);
 
@@ -5386,7 +5398,7 @@ describe('caseLaw mutations (Wave 4.D.2)', () => {
 
       const sendSpy = jest.spyOn(
         DynamoDBDocumentClient.prototype,
-        'send' as any,
+        'send',
       );
 
       await expect(
@@ -5417,7 +5429,7 @@ describe('caseLaw mutations (Wave 4.D.2)', () => {
     // Spy on send so we can assert the UpdateCommand was issued.
     const sendSpy = jest.spyOn(
       DynamoDBDocumentClient.prototype,
-      'send' as any,
+      'send',
     );
 
     const result = (await handler(
@@ -5433,7 +5445,7 @@ describe('caseLaw mutations (Wave 4.D.2)', () => {
     // The UpdateCommand was issued — the primary write succeeded; only
     // the audit event emit failed.
     const sendCallNames = sendSpy.mock.calls.map(
-      (call) => (call[0] as any)?.constructor?.name ?? 'unknown',
+      (call) => (call[0] as object | undefined)?.constructor?.name ?? 'unknown',
     );
     expect(sendCallNames).toContain('UpdateCommand');
     sendSpy.mockRestore();
@@ -5470,7 +5482,7 @@ describe('authorityGraphHistorySettings (Wave 4.E.A)', () => {
   const SETTINGS_PARAM_PREFIX =
     '/citadel/governance/authority-graph-history/';
 
-  function settingsEvent(fieldName: string, args?: any): any {
+  function settingsEvent(fieldName: string, args?: Record<string, unknown>): HandlerEvent {
     return makeEvent({
       fieldName,
       args: args ?? {},
@@ -5487,7 +5499,7 @@ describe('authorityGraphHistorySettings (Wave 4.E.A)', () => {
     // freshly written JSON (mirrors the real SSM behaviour).
     let liveValue: string | null =
       opts.storedValue === undefined ? null : opts.storedValue;
-    ssmMock.on(GetParameterCommand).callsFake((input: any) => {
+    ssmMock.on(GetParameterCommand).callsFake((input: GetParameterCommandInput) => {
       const name: string = input?.Name ?? '';
       if (name.startsWith(SETTINGS_PARAM_PREFIX)) {
         if (liveValue === null) {
@@ -5497,7 +5509,7 @@ describe('authorityGraphHistorySettings (Wave 4.E.A)', () => {
       }
       return Promise.resolve({});
     });
-    ssmMock.on(PutParameterCommand).callsFake((input: any) => {
+    ssmMock.on(PutParameterCommand).callsFake((input: PutParameterCommandInput) => {
       const name: string = input?.Name ?? '';
       if (name.startsWith(SETTINGS_PARAM_PREFIX)) {
         if (putShouldFail) {
@@ -5603,14 +5615,14 @@ describe('authorityGraphHistorySettings (Wave 4.E.A)', () => {
 
     const scanCalls = ddbMock.commandCalls(ScanCommand);
     expect(scanCalls).toHaveLength(1);
-    const scanInput: any = scanCalls[0].args[0].input;
+    const scanInput = scanCalls[0].args[0].input;
     expect(scanInput.TableName).toBe(
       'citadel-governance-graph-snapshots-test',
     );
     expect(scanInput.FilterExpression).toBe('#ts >= :since');
-    expect(scanInput.ExpressionAttributeNames['#ts']).toBe('timestamp');
+    expect(scanInput.ExpressionAttributeNames?.['#ts']).toBe('timestamp');
     // 30 days * 86400 seconds.
-    expect(typeof scanInput.ExpressionAttributeValues[':since']).toBe(
+    expect(typeof scanInput.ExpressionAttributeValues?.[':since']).toBe(
       'number',
     );
     expect(scanInput.Limit).toBe(5000);
@@ -5855,7 +5867,7 @@ describe('authorityGraphHistorySettings (Wave 4.E.A)', () => {
 // ---------------------------------------------------------------------------
 
 describe('listAuthorityGraphSnapshots (Wave 4.E.B)', () => {
-  function snapshotEvent(args?: any): any {
+  function snapshotEvent(args?: Record<string, unknown>): HandlerEvent {
     return makeEvent({
       fieldName: 'listAuthorityGraphSnapshots',
       args: args ?? {},
@@ -5893,15 +5905,15 @@ describe('listAuthorityGraphSnapshots (Wave 4.E.B)', () => {
     ddbMock.on(QueryCommand).resolves({ Items: [] });
     await handler(snapshotEvent());
     const call = ddbMock.commandCalls(QueryCommand)[0];
-    const input: any = call.args[0].input;
+    const input = call.args[0].input;
     expect(input.IndexName).toBe('kind-timestamp-index');
     expect(input.KeyConditionExpression).toBe(
       'kind = :full AND #ts BETWEEN :since AND :until',
     );
-    expect(input.ExpressionAttributeValues[':full']).toBe('full');
-    expect(input.ExpressionAttributeNames['#ts']).toBe('timestamp');
-    const sinceTs = input.ExpressionAttributeValues[':since'];
-    const untilTs = input.ExpressionAttributeValues[':until'];
+    expect(input.ExpressionAttributeValues?.[':full']).toBe('full');
+    expect(input.ExpressionAttributeNames?.['#ts']).toBe('timestamp');
+    const sinceTs = input.ExpressionAttributeValues?.[':since'] as number;
+    const untilTs = input.ExpressionAttributeValues?.[':until'] as number;
     expect(typeof sinceTs).toBe('number');
     expect(typeof untilTs).toBe('number');
     // 365 day default window.
@@ -6012,9 +6024,9 @@ describe('listAuthorityGraphSnapshots (Wave 4.E.B)', () => {
     const untilTs = Math.floor(Date.now() / 1000);
     const sinceTs = untilTs - 1000 * 86400; // 1000 days back, > 365 cap
     await handler(snapshotEvent({ sinceTs, untilTs }));
-    const input: any = ddbMock.commandCalls(QueryCommand)[0].args[0].input;
-    const effectiveSince = input.ExpressionAttributeValues[':since'];
-    const effectiveUntil = input.ExpressionAttributeValues[':until'];
+    const input = ddbMock.commandCalls(QueryCommand)[0].args[0].input;
+    const effectiveSince = input.ExpressionAttributeValues?.[':since'] as number;
+    const effectiveUntil = input.ExpressionAttributeValues?.[':until'] as number;
     expect(effectiveUntil - effectiveSince).toBe(365 * 86400);
   });
 
@@ -6032,7 +6044,7 @@ describe('listAuthorityGraphSnapshots (Wave 4.E.B)', () => {
 });
 
 describe('getAuthorityGraphSnapshot (Wave 4.E.B)', () => {
-  function snapshotEvent(snapshotId: string): any {
+  function snapshotEvent(snapshotId: string): HandlerEvent {
     return makeEvent({
       fieldName: 'getAuthorityGraphSnapshot',
       args: { snapshotId },
@@ -6939,7 +6951,7 @@ describe('getTrustPath', () => {
   test('datastore without crossAccountRoleArn → hops = [lambda, scoped]', async () => {
     isAdminFromEventMock.mockReturnValue(true);
     armSts();
-    iamMock.on(GetRoleCommand).callsFake(async (input: any) => ({
+    iamMock.on(GetRoleCommand).callsFake(async (input: GetRoleCommandInput) => ({
       Role: {
         RoleName: input.RoleName,
         AssumeRolePolicyDocument: makeTrustPolicy('arn:aws:iam::1:role/x'),
@@ -6949,7 +6961,7 @@ describe('getTrustPath', () => {
         CreateDate: new Date(),
       },
     }));
-    iamMock.on(GetRolePolicyCommand).callsFake(async (input: any) => ({
+    iamMock.on(GetRolePolicyCommand).callsFake(async (input: GetRolePolicyCommandInput) => ({
       RoleName: input.RoleName,
       PolicyName: 'DataStoreAccess',
       PolicyDocument: makeInlinePolicy(['s3:GetObject'], ['arn:aws:s3:::b/*']),
@@ -6976,7 +6988,7 @@ describe('getTrustPath', () => {
   test('datastore with crossAccountRoleArn → hops = [lambda, cross-account, scoped]', async () => {
     isAdminFromEventMock.mockReturnValue(true);
     armSts();
-    iamMock.on(GetRoleCommand).callsFake(async (input: any) => ({
+    iamMock.on(GetRoleCommand).callsFake(async (input: GetRoleCommandInput) => ({
       Role: {
         RoleName: input.RoleName,
         AssumeRolePolicyDocument: makeTrustPolicy('arn:aws:iam::1:role/x'),
@@ -7014,7 +7026,7 @@ describe('getTrustPath', () => {
   test('integration path queries by GSI and emits scoped role with citadel-int- prefix', async () => {
     isAdminFromEventMock.mockReturnValue(true);
     armSts();
-    iamMock.on(GetRoleCommand).callsFake(async (input: any) => ({
+    iamMock.on(GetRoleCommand).callsFake(async (input: GetRoleCommandInput) => ({
       Role: {
         RoleName: input.RoleName,
         AssumeRolePolicyDocument: makeTrustPolicy('arn:aws:iam::1:role/x'),
@@ -7051,7 +7063,7 @@ describe('getTrustPath', () => {
   test('agent path uses RegistryService and emits citadel-agent- prefix', async () => {
     isAdminFromEventMock.mockReturnValue(true);
     armSts();
-    iamMock.on(GetRoleCommand).callsFake(async (input: any) => ({
+    iamMock.on(GetRoleCommand).callsFake(async (input: GetRoleCommandInput) => ({
       Role: {
         RoleName: input.RoleName,
         AssumeRolePolicyDocument: makeTrustPolicy('arn:aws:iam::1:role/x'),
@@ -7090,9 +7102,9 @@ describe('getTrustPath', () => {
     isAdminFromEventMock.mockReturnValue(true);
     armSts();
     // Lambda role lookup succeeds; scoped role lookup throws NoSuchEntity.
-    iamMock.on(GetRoleCommand).callsFake(async (input: any) => {
+    iamMock.on(GetRoleCommand).callsFake(async (input: GetRoleCommandInput) => {
       if (input.RoleName === 'citadel-ds-ds-1') {
-        const err: any = new Error('NoSuchEntity');
+        const err = new Error('NoSuchEntity');
         err.name = 'NoSuchEntityException';
         throw err;
       }
@@ -7133,7 +7145,7 @@ describe('getTrustPath', () => {
   test('GetRolePolicy missing → hop has empty inlinePolicy + note', async () => {
     isAdminFromEventMock.mockReturnValue(true);
     armSts();
-    iamMock.on(GetRoleCommand).callsFake(async (input: any) => ({
+    iamMock.on(GetRoleCommand).callsFake(async (input: GetRoleCommandInput) => ({
       Role: {
         RoleName: input.RoleName,
         AssumeRolePolicyDocument: makeTrustPolicy('arn:aws:iam::1:role/x'),
@@ -7143,9 +7155,9 @@ describe('getTrustPath', () => {
         CreateDate: new Date(),
       },
     }));
-    iamMock.on(GetRolePolicyCommand).callsFake(async (input: any) => {
+    iamMock.on(GetRolePolicyCommand).callsFake(async (input: GetRolePolicyCommandInput) => {
       if (input.RoleName === 'citadel-ds-ds-1') {
-        const err: any = new Error('NoSuchEntity');
+        const err = new Error('NoSuchEntity');
         err.name = 'NoSuchEntityException';
         throw err;
       }
@@ -7178,7 +7190,7 @@ describe('getTrustPath', () => {
   test('totalActions / totalResources reflect inline policy contents', async () => {
     isAdminFromEventMock.mockReturnValue(true);
     armSts();
-    iamMock.on(GetRoleCommand).callsFake(async (input: any) => ({
+    iamMock.on(GetRoleCommand).callsFake(async (input: GetRoleCommandInput) => ({
       Role: {
         RoleName: input.RoleName,
         AssumeRolePolicyDocument: makeTrustPolicy('arn:aws:iam::1:role/x'),
@@ -7214,7 +7226,7 @@ describe('getTrustPath', () => {
   test('trust policy parses Principal.AWS array shape', async () => {
     isAdminFromEventMock.mockReturnValue(true);
     armSts();
-    iamMock.on(GetRoleCommand).callsFake(async (input: any) => ({
+    iamMock.on(GetRoleCommand).callsFake(async (input: GetRoleCommandInput) => ({
       Role: {
         RoleName: input.RoleName,
         AssumeRolePolicyDocument: makeTrustPolicy([
@@ -7252,7 +7264,7 @@ describe('getTrustPath', () => {
   test('5-min cache: same args within window avoid second GetRole call', async () => {
     isAdminFromEventMock.mockReturnValue(true);
     armSts();
-    iamMock.on(GetRoleCommand).callsFake(async (input: any) => ({
+    iamMock.on(GetRoleCommand).callsFake(async (input: GetRoleCommandInput) => ({
       Role: {
         RoleName: input.RoleName,
         AssumeRolePolicyDocument: makeTrustPolicy('arn:aws:iam::1:role/x'),
@@ -7298,7 +7310,7 @@ describe('getTrustPath', () => {
       ddbMock.on(GetCommand, { TableName: 'citadel-datastores-test' }).resolves({
         Item: { dataStoreId: 'ds-1' },
       });
-      iamMock.on(GetRoleCommand).callsFake(async (input: any) => ({
+      iamMock.on(GetRoleCommand).callsFake(async (input: GetRoleCommandInput) => ({
         Role: {
           RoleName: input.RoleName,
           AssumeRolePolicyDocument: makeTrustPolicy('arn:aws:iam::1:role/x'),
@@ -7464,7 +7476,7 @@ describe('getResourceIamDrift', () => {
       .resolves({
         Item: { dataStoreId: 'ds-1', type: 's3', config: {} },
       });
-    const noSuch: any = new Error('NoSuchEntity');
+    const noSuch = new Error('NoSuchEntity');
     noSuch.name = 'NoSuchEntityException';
     iamMock.on(GetRolePolicyCommand).rejects(noSuch);
 

--- a/backend/src/lambda/__tests__/project-resolver.test.ts
+++ b/backend/src/lambda/__tests__/project-resolver.test.ts
@@ -24,7 +24,13 @@ import { SSMClient, GetParameterCommand } from '@aws-sdk/client-ssm';
 import { mockClient } from 'aws-sdk-client-mock';
 import * as fc from 'fast-check';
 
-import { GovernanceArchetype, ProjectArchetypeStatus } from '../../types';
+import { GovernanceArchetype, ProjectArchetypeStatus, type Project } from '../../types';
+// Namespace imports so jest.spyOn can patch the sibling resolver modules the
+// phase-transition gates call at runtime (same module-registry objects the
+// previous require() calls returned).
+import * as adrResolver from '../adr-resolver';
+import * as execspecResolver from '../execspec-resolver';
+import * as assessmentResolver from '../agent-design-assessment-resolver';
 import { __resetGovernanceNotifierForTest } from '../../utils/notifier-base';
 import { __resetGovernanceFlagCacheForTest } from '../../utils/governance-flag';
 
@@ -42,11 +48,21 @@ jest.mock('uuid', () => ({ v4: jest.fn().mockReturnValue('project-uuid-1') }));
 // Import after mocks are registered
 import { handler } from '../project-resolver';
 
-const makeEvent = (fieldName: string, args: any) => ({
-  info: { fieldName },
-  arguments: args,
-  identity: { sub: 'user-123' },
-});
+type HandlerEvent = Parameters<typeof handler>[0];
+
+// aws-lambda's Handler type declares legacy required context and callback
+// parameters, but the implementation is a one-parameter async (event)
+// function that never uses them — invoke through the real signature
+// (single cast here) so calls don't pass superfluous arguments. Every
+// operation exercised in this file resolves a Project.
+const invokeHandler = handler as (event: HandlerEvent) => Promise<Project>;
+
+const makeEvent = (fieldName: string, args: Record<string, unknown>) =>
+  ({
+    info: { fieldName },
+    arguments: args,
+    identity: { sub: 'user-123' },
+  }) as unknown as HandlerEvent;
 
 describe('project-resolver — archetype attributes', () => {
   beforeEach(() => {
@@ -73,12 +89,10 @@ describe('project-resolver — archetype attributes', () => {
     test('new project is created with archetypeStatus=PENDING and no archetype/confidence', async () => {
       dynamoMock.on(PutCommand).resolves({});
 
-      const result = await handler(
+      const result = await invokeHandler(
         makeEvent('createProject', {
           input: { name: 'Legacy DB migration', description: 'Mono schema' },
-        }) as any,
-        {} as any,
-        {} as any
+        }),
       );
 
       // Response shape
@@ -89,7 +103,7 @@ describe('project-resolver — archetype attributes', () => {
       // Persisted shape — inspect the PutCommand payload
       const putCalls = dynamoMock.commandCalls(PutCommand);
       expect(putCalls).toHaveLength(1);
-      const persisted = putCalls[0].args[0].input.Item as any;
+      const persisted = putCalls[0].args[0].input.Item as Record<string, unknown>;
       expect(persisted.archetypeStatus).toBe('PENDING');
       expect(persisted.archetype).toBeUndefined();
       expect(persisted.archetypeConfidence).toBeUndefined();
@@ -121,7 +135,7 @@ describe('project-resolver — archetype attributes', () => {
         },
       });
 
-      const result = await handler(
+      const result = await invokeHandler(
         makeEvent('updateProject', {
           id: 'proj-1',
           input: {
@@ -129,9 +143,7 @@ describe('project-resolver — archetype attributes', () => {
             archetypeConfidence: 0.85,
             archetypeStatus: 'CLASSIFIED',
           },
-        }) as any,
-        {} as any,
-        {} as any
+        }),
       );
 
       expect(result.archetype).toBe('MONOLITHIC_DB');
@@ -141,8 +153,8 @@ describe('project-resolver — archetype attributes', () => {
       // Confirm the UpdateCommand's expression carried the new attrs through
       const updateCalls = dynamoMock.commandCalls(UpdateCommand);
       expect(updateCalls).toHaveLength(1);
-      const updateInput = updateCalls[0].args[0].input as any;
-      const values = updateInput.ExpressionAttributeValues as Record<string, any>;
+      const updateInput = updateCalls[0].args[0].input;
+      const values = updateInput.ExpressionAttributeValues as Record<string, unknown>;
       expect(values[':archetype']).toBe('MONOLITHIC_DB');
       expect(values[':archetypeConfidence']).toBeCloseTo(0.85);
       expect(values[':archetypeStatus']).toBe('CLASSIFIED');
@@ -163,10 +175,8 @@ describe('project-resolver — archetype attributes', () => {
         },
       });
 
-      const result = await handler(
-        makeEvent('getProject', { id: 'legacy-1' }) as any,
-        {} as any,
-        {} as any
+      const result = await invokeHandler(
+        makeEvent('getProject', { id: 'legacy-1' }),
       );
 
       expect(result.archetypeStatus).toBe('PENDING');
@@ -194,7 +204,7 @@ describe('project-resolver — archetype attributes', () => {
         identity: { sub: 'user-123', 'custom:organization': 'org-claim' },
       };
 
-      const result = await handler(claimEvent as any, {} as any, {} as any);
+      const result = await invokeHandler(claimEvent as unknown as HandlerEvent);
 
       expect(result.id).toBe('proj-claim');
       expect(cognitoMock.commandCalls(AdminGetUserCommand).length).toBe(0);
@@ -251,7 +261,7 @@ describe('phase-transition gates', () => {
   let specSpy: jest.SpyInstance;
   let assessmentSpy: jest.SpyInstance;
 
-  const makeExistingProject = (overrides: Partial<Record<string, any>> = {}) => ({
+  const makeExistingProject = (overrides: Record<string, unknown> = {}) => ({
     id: 'proj-gate-1',
     name: 'Gate Test',
     description: 'fixture',
@@ -292,13 +302,13 @@ describe('phase-transition gates', () => {
     // Spy on sibling resolver modules (C7/C10/C3 data sources). Each test
     // overrides the return value as needed. Default: empty arrays / null.
     adrSpy = jest
-      .spyOn(require('../adr-resolver'), 'listADRsForProject')
+      .spyOn(adrResolver, 'listADRsForProject')
       .mockResolvedValue([]);
     specSpy = jest
-      .spyOn(require('../execspec-resolver'), 'listExecutionSpecifications')
+      .spyOn(execspecResolver, 'listExecutionSpecifications')
       .mockResolvedValue([]);
     assessmentSpy = jest
-      .spyOn(require('../agent-design-assessment-resolver'), 'getAgentDesignAssessment')
+      .spyOn(assessmentResolver, 'getAgentDesignAssessment')
       .mockResolvedValue(null);
   });
 
@@ -316,10 +326,10 @@ describe('phase-transition gates', () => {
   const bypassEvents = () => {
     const out: Array<Record<string, unknown>> = [];
     for (const call of eventBridgeMock.commandCalls(PutEventsCommand)) {
-      const entries = (call.args[0].input as any).Entries ?? [];
+      const entries = call.args[0].input.Entries ?? [];
       for (const e of entries) {
         if (e.DetailType === 'governance.grandfathered.bypass') {
-          out.push(JSON.parse(e.Detail));
+          out.push(JSON.parse(e.Detail as string));
         }
       }
     }
@@ -334,13 +344,11 @@ describe('phase-transition gates', () => {
     adrSpy.mockResolvedValue([{ status: 'PROPOSED' }, { status: 'REOPENED' }]);
 
     await expect(
-      handler(
+      invokeHandler(
         makeEvent('updateProject', {
           id: existing.id,
           input: { status: 'PLANNING_COMPLETE' },
-        }) as any,
-        {} as any,
-        {} as any,
+        }),
       ),
     ).rejects.toThrow(/PLANNING_COMPLETE requires at least one LOCKED ADR/);
 
@@ -358,13 +366,11 @@ describe('phase-transition gates', () => {
       Attributes: { ...existing, status: 'PLANNING_COMPLETE', version: 1 },
     });
 
-    const result = await handler(
+    const result = await invokeHandler(
       makeEvent('updateProject', {
         id: existing.id,
         input: { status: 'PLANNING_COMPLETE' },
-      }) as any,
-      {} as any,
-      {} as any,
+      }),
     );
 
     expect(result.status).toBe('PLANNING_COMPLETE');
@@ -383,13 +389,11 @@ describe('phase-transition gates', () => {
       Attributes: { ...existing, status: 'PLANNING_COMPLETE', version: 1 },
     });
 
-    const result = await handler(
+    const result = await invokeHandler(
       makeEvent('updateProject', {
         id: existing.id,
         input: { status: 'PLANNING_COMPLETE' },
-      }) as any,
-      {} as any,
-      {} as any,
+      }),
     );
 
     expect(result.status).toBe('PLANNING_COMPLETE');
@@ -411,13 +415,11 @@ describe('phase-transition gates', () => {
     assessmentSpy.mockResolvedValue(null);
 
     await expect(
-      handler(
+      invokeHandler(
         makeEvent('updateProject', {
           id: existing.id,
           input: { status: 'IN_PROGRESS' },
-        }) as any,
-        {} as any,
-        {} as any,
+        }),
       ),
     ).rejects.toThrow(/IN_PROGRESS requires a completed AgentDesignAssessment/);
 
@@ -436,13 +438,11 @@ describe('phase-transition gates', () => {
       Attributes: { ...existing, status: 'IN_PROGRESS', version: 1 },
     });
 
-    const result = await handler(
+    const result = await invokeHandler(
       makeEvent('updateProject', {
         id: existing.id,
         input: { status: 'IN_PROGRESS' },
-      }) as any,
-      {} as any,
-      {} as any,
+      }),
     );
 
     expect(result.status).toBe('IN_PROGRESS');
@@ -461,13 +461,11 @@ describe('phase-transition gates', () => {
     specSpy.mockResolvedValue([{ status: 'DRAFT' }, { status: 'IN_REVIEW' }]);
 
     await expect(
-      handler(
+      invokeHandler(
         makeEvent('updateProject', {
           id: existing.id,
           input: { status: 'IMPLEMENTATION_READY' },
-        }) as any,
-        {} as any,
-        {} as any,
+        }),
       ),
     ).rejects.toThrow(
       /IMPLEMENTATION_READY requires at least one APPROVED ExecutionSpecification/,
@@ -488,13 +486,11 @@ describe('phase-transition gates', () => {
       Attributes: { ...existing, status: 'IMPLEMENTATION_READY', version: 1 },
     });
 
-    const result = await handler(
+    const result = await invokeHandler(
       makeEvent('updateProject', {
         id: existing.id,
         input: { status: 'IMPLEMENTATION_READY' },
-      }) as any,
-      {} as any,
-      {} as any,
+      }),
     );
 
     expect(result.status).toBe('IMPLEMENTATION_READY');
@@ -514,13 +510,11 @@ describe('phase-transition gates', () => {
       Attributes: { ...existing, status: 'DESIGN_COMPLETE', version: 1 },
     });
 
-    const result = await handler(
+    const result = await invokeHandler(
       makeEvent('updateProject', {
         id: existing.id,
         input: { status: 'DESIGN_COMPLETE' },
-      }) as any,
-      {} as any,
-      {} as any,
+      }),
     );
 
     expect(result.status).toBe('DESIGN_COMPLETE');

--- a/backend/src/lambda/governance-ui-resolver.ts
+++ b/backend/src/lambda/governance-ui-resolver.ts
@@ -39,10 +39,7 @@ import {
 } from '@aws-sdk/client-cloudwatch';
 import {
   IAMClient,
-  GetRoleCommand,
   GetRolePolicyCommand,
-  GetRoleCommandOutput,
-  GetRolePolicyCommandOutput,
 } from '@aws-sdk/client-iam';
 import {
   STSClient,

--- a/backend/src/lambda/project-resolver.ts
+++ b/backend/src/lambda/project-resolver.ts
@@ -1,6 +1,6 @@
-import { AppSyncResolverHandler } from 'aws-lambda';
+import { AppSyncResolverEvent, AppSyncResolverHandler } from 'aws-lambda';
 import { DynamoDBClient } from '@aws-sdk/client-dynamodb';
-import { DynamoDBDocumentClient, GetCommand, PutCommand, UpdateCommand, ScanCommand, QueryCommand } from '@aws-sdk/lib-dynamodb';
+import { DynamoDBDocumentClient, GetCommand, PutCommand, UpdateCommand, ScanCommand, QueryCommand, type NativeAttributeValue } from '@aws-sdk/lib-dynamodb';
 import { EventBridgeClient, PutEventsCommand } from '@aws-sdk/client-eventbridge';
 import { v4 as uuidv4 } from 'uuid';
 import { getUserId } from '../utils/appsync';
@@ -43,6 +43,10 @@ interface Project {
   owner: string;
   description?: string;
   requirements?: string;
+  /** Tenant the project belongs to — persisted on create, used for org-scoped access checks. */
+  organization?: string;
+  /** D-02 optimistic-locking counter — absent on rows written before locking landed. */
+  version?: number;
   // governance archetype classification.
   // archetypeStatus defaults to PENDING when absent; normaliseArchetype
   // handles grandfathering for DDB rows written before this story.
@@ -50,6 +54,53 @@ interface Project {
   archetypeConfidence?: number;
   archetypeStatus?: 'PENDING' | 'CLASSIFIED' | 'PENDING_ESCALATION';
 }
+
+/** Filter accepted by listProjects — mirrors the GraphQL ProjectFilter input. */
+interface ProjectFilter {
+  status?: string;
+  createdAfter?: string;
+  createdBefore?: string;
+}
+
+/** Input accepted by createProject — mirrors the GraphQL CreateProjectInput. */
+interface CreateProjectInput {
+  name: string;
+  description?: string;
+  requirements?: string;
+}
+
+/** Input accepted by updateProject — mirrors the GraphQL UpdateProjectInput. */
+interface UpdateProjectInput {
+  name?: string;
+  description?: string;
+  requirements?: string;
+  status?: string;
+  archetype?: 'MONOLITHIC_DB' | 'ENTERPRISE_APP_SPRAWL' | 'HYBRID_IT_OT';
+  archetypeConfidence?: number;
+  archetypeStatus?: 'PENDING' | 'CLASSIFIED' | 'PENDING_ESCALATION';
+}
+
+/** File descriptor accepted by uploadDocument. */
+interface UploadDocumentFile {
+  bucket?: string;
+  key?: string;
+  [key: string]: unknown;
+}
+
+/**
+ * Union of the arguments AppSync passes for the fields this resolver serves.
+ * Compile-time shape only — AppSync populates just the fields relevant to
+ * each GraphQL operation at runtime.
+ */
+interface HandlerArgs {
+  id: string;
+  filter?: ProjectFilter;
+  input: CreateProjectInput & UpdateProjectInput;
+  projectId: string;
+  file: UploadDocumentFile;
+}
+
+type ResolverEvent = AppSyncResolverEvent<HandlerArgs>;
 
 /**
  * Normalises archetype attributes on a Project read from DynamoDB.
@@ -68,7 +119,7 @@ function normaliseArchetype<T extends Partial<Project> | null | undefined>(proje
   return project;
 }
 
-export const handler: AppSyncResolverHandler<any, unknown> = async (event) => {
+export const handler: AppSyncResolverHandler<HandlerArgs, unknown> = async (event) => {
   console.log('Project resolver event:', JSON.stringify(event, null, 2));
 
   const { info, arguments: args, identity } = event;
@@ -96,7 +147,7 @@ export const handler: AppSyncResolverHandler<any, unknown> = async (event) => {
   }
 };
 
-async function getProject(id: string, userId: string, event: any): Promise<Project | null> {
+async function getProject(id: string, userId: string, event: ResolverEvent): Promise<Project | null> {
   const command = new GetCommand({
     TableName: PROJECTS_TABLE,
     Key: { id },
@@ -108,7 +159,7 @@ async function getProject(id: string, userId: string, event: any): Promise<Proje
     return null;
   }
 
-  const project = result.Item as any;
+  const project = result.Item as Project;
 
   // Check if user has access to this project
   // Allow access if: user is owner OR user is in same organization
@@ -125,7 +176,7 @@ async function getProject(id: string, userId: string, event: any): Promise<Proje
   return normaliseArchetype(project) as Project;
 }
 
-async function listProjects(filter: any, userId: string, event: any): Promise<{ items: Project[]; nextToken?: string }> {
+async function listProjects(filter: ProjectFilter | undefined, userId: string, event: ResolverEvent): Promise<{ items: Project[]; nextToken?: string }> {
   // Get user's organization
   const userOrganization = await extractOrgFromEvent(event);
 
@@ -170,17 +221,17 @@ async function listProjects(filter: any, userId: string, event: any): Promise<{ 
       items = items.filter(item => item.status === filter.status);
     }
     if (filter.createdAfter) {
-      items = items.filter(item => item.createdAt >= filter.createdAfter);
+      items = items.filter(item => item.createdAt >= filter.createdAfter!);
     }
     if (filter.createdBefore) {
-      items = items.filter(item => item.createdAt <= filter.createdBefore);
+      items = items.filter(item => item.createdAt <= filter.createdBefore!);
     }
   }
 
   return { items: items.map((p) => normaliseArchetype(p)!) };
 }
 
-async function createProject(input: any, userId: string, event: any): Promise<Project> {
+async function createProject(input: CreateProjectInput, userId: string, event: ResolverEvent): Promise<Project> {
   const now = new Date().toISOString();
   const projectId = uuidv4();
 
@@ -215,7 +266,7 @@ async function createProject(input: any, userId: string, event: any): Promise<Pr
     // new projects start PENDING; archetype/archetypeConfidence
     // stay absent until an archetype classifier populates them.
     archetypeStatus: 'PENDING',
-  } as any;
+  };
 
   const command = new PutCommand({
     TableName: PROJECTS_TABLE,
@@ -293,7 +344,7 @@ async function checkC7Adr(project: Project): Promise<void> {
     return;
   }
   const adrs = await listADRsForProject(project.id);
-  if (!adrs.some((a: any) => a.status === 'LOCKED')) {
+  if (!adrs.some((a) => a.status === 'LOCKED')) {
     throw new Error(
       'ValidationError: PLANNING_COMPLETE requires at least one LOCKED ADR',
     );
@@ -306,7 +357,7 @@ async function checkC10Spec(project: Project): Promise<void> {
     return;
   }
   const specs = await listExecutionSpecifications(project.id);
-  if (!specs.some((s: any) => s.status === 'APPROVED')) {
+  if (!specs.some((s) => s.status === 'APPROVED')) {
     throw new Error(
       'ValidationError: IMPLEMENTATION_READY requires at least one APPROVED ExecutionSpecification',
     );
@@ -334,7 +385,7 @@ async function emitBypass(
   }
 }
 
-async function updateProject(id: string, input: any, userId: string, event: any): Promise<Project> {
+async function updateProject(id: string, input: UpdateProjectInput, userId: string, event: ResolverEvent): Promise<Project> {
   // First check if project exists and user has access
   const existingProject = await getProject(id, userId, event);
   if (!existingProject) {
@@ -344,7 +395,7 @@ async function updateProject(id: string, input: any, userId: string, event: any)
   const now = new Date().toISOString();
   const updateExpression: string[] = [];
   const expressionAttributeNames: Record<string, string> = {};
-  const expressionAttributeValues: Record<string, any> = {};
+  const expressionAttributeValues: Record<string, NativeAttributeValue> = {};
 
   if (input.name) {
     updateExpression.push('#name = :name');
@@ -368,9 +419,9 @@ async function updateProject(id: string, input: any, userId: string, event: any)
     // When status is changing (not same-status write), route through the
     // LifecycleManager hook so C3/C7/C10 governance preconditions are
     // enforced (or bypassed + telemetry-logged for grandfathered projects).
-    if (input.status && input.status !== (existingProject as any).status) {
+    if (input.status && input.status !== existingProject.status) {
       await projectPhaseGuard(
-        (existingProject as any).status,
+        existingProject.status,
         input.status,
         existingProject as Project,
         userId,
@@ -411,7 +462,7 @@ async function updateProject(id: string, input: any, userId: string, event: any)
   expressionAttributeValues[':updatedAt'] = now;
 
   // D-02: Optimistic locking — increment version with conditional write
-  const currentVersion = (existingProject as any).version || 0;
+  const currentVersion = existingProject.version || 0;
   updateExpression.push('#version = :nextVersion');
   expressionAttributeNames['#version'] = 'version';
   expressionAttributeValues[':nextVersion'] = currentVersion + 1;
@@ -450,7 +501,7 @@ async function updateProject(id: string, input: any, userId: string, event: any)
   }
 }
 
-async function uploadDocument(projectId: string, file: any, userId: string, event: any): Promise<unknown> {
+async function uploadDocument(projectId: string, file: UploadDocumentFile, userId: string, event: ResolverEvent): Promise<unknown> {
   // Check if user has access to this project
   const project = await getProject(projectId, userId, event);
   if (!project) {

--- a/backend/src/utils/__tests__/credential-manager.test.ts
+++ b/backend/src/utils/__tests__/credential-manager.test.ts
@@ -62,13 +62,13 @@ describe('Credential Manager - Property-Based Tests', () => {
             ssmMock.reset();
 
             // Build valid credentials based on connector spec
-            const credentials: Record<string, any> = {};
+            const credentials: Record<string, unknown> = {};
             for (const field of spec.authentication.fields) {
               credentials[field] = `test-${field}-${Math.random()}`;
             }
 
             // Build valid config
-            const config: Record<string, any> = {};
+            const config: Record<string, unknown> = {};
             for (const field of spec.configuration.required) {
               config[field] = `test-${field}-${Math.random()}`;
             }
@@ -133,13 +133,13 @@ describe('Credential Manager - Property-Based Tests', () => {
             if (!spec || spec.authentication.fields.length === 0) return true;
 
             // Build incomplete credentials (missing last required field)
-            const credentials: Record<string, any> = {};
+            const credentials: Record<string, unknown> = {};
             for (let i = 0; i < spec.authentication.fields.length - 1; i++) {
               const field = spec.authentication.fields[i];
               credentials[field] = `test-${field}-${Math.random()}`;
             }
 
-            const config: Record<string, any> = {};
+            const config: Record<string, unknown> = {};
 
             // Property: storeCredentials should throw error for missing required fields
             await expect(
@@ -167,12 +167,12 @@ describe('Credential Manager - Property-Based Tests', () => {
             secretsManagerMock.reset();
             ssmMock.reset();
 
-            const credentials: Record<string, any> = {};
+            const credentials: Record<string, unknown> = {};
             for (const field of spec.authentication.fields) {
               credentials[field] = `test-${field}-${Math.random()}`;
             }
 
-            const config: Record<string, any> = {};
+            const config: Record<string, unknown> = {};
             for (const field of spec.configuration.required) {
               config[field] = `test-${field}-${Math.random()}`;
             }
@@ -216,12 +216,12 @@ describe('Credential Manager - Property-Based Tests', () => {
         ssmMock.reset();
 
         const spec = getConnectorSpec(connectorType)!;
-        const credentials: Record<string, any> = {};
+        const credentials: Record<string, unknown> = {};
         for (const field of spec.authentication.fields) {
           credentials[field] = `test-${field}`;
         }
 
-        const config: Record<string, any> = {};
+        const config: Record<string, unknown> = {};
         for (const field of spec.configuration.required) {
           config[field] = `test-${field}`;
         }
@@ -247,12 +247,12 @@ describe('Credential Manager - Property-Based Tests', () => {
         ssmMock.reset();
 
         const spec = getConnectorSpec(connectorType)!;
-        const credentials: Record<string, any> = {};
+        const credentials: Record<string, unknown> = {};
         for (const field of spec.authentication.fields) {
           credentials[field] = `test-${field}`;
         }
 
-        const config: Record<string, any> = {};
+        const config: Record<string, unknown> = {};
         for (const field of spec.configuration.required) {
           config[field] = `test-${field}`;
         }
@@ -278,12 +278,12 @@ describe('Credential Manager - Property-Based Tests', () => {
         ssmMock.reset();
 
         const spec = getConnectorSpec(connectorType)!;
-        const credentials: Record<string, any> = {};
+        const credentials: Record<string, unknown> = {};
         for (const field of spec.authentication.fields) {
           credentials[field] = `test-${field}`;
         }
 
-        const config: Record<string, any> = {};
+        const config: Record<string, unknown> = {};
         for (const field of spec.configuration.required) {
           config[field] = `test-${field}`;
         }
@@ -309,12 +309,12 @@ describe('Credential Manager - Property-Based Tests', () => {
         ssmMock.reset();
 
         const spec = getConnectorSpec(connectorType)!;
-        const credentials: Record<string, any> = {};
+        const credentials: Record<string, unknown> = {};
         for (const field of spec.authentication.fields) {
           credentials[field] = `test-${field}`;
         }
 
-        const config: Record<string, any> = {};
+        const config: Record<string, unknown> = {};
 
         secretsManagerMock.on(CreateSecretCommand).resolves({
           ARN: 'arn:aws:secretsmanager:us-east-1:123456789012:secret:test',
@@ -379,12 +379,12 @@ describe('Credential Manager - Property-Based Tests', () => {
             secretsManagerMock.reset();
             ssmMock.reset();
 
-            const credentials: Record<string, any> = {};
+            const credentials: Record<string, unknown> = {};
             for (const field of spec.authentication.fields) {
               credentials[field] = `test-${field}`;
             }
 
-            const config: Record<string, any> = {};
+            const config: Record<string, unknown> = {};
             for (const field of spec.configuration.required) {
               config[field] = `test-config-${field}`;
             }
@@ -434,12 +434,12 @@ describe('Credential Manager - Property-Based Tests', () => {
             secretsManagerMock.reset();
             ssmMock.reset();
 
-            const credentials: Record<string, any> = {};
+            const credentials: Record<string, unknown> = {};
             for (const field of spec.authentication.fields) {
               credentials[field] = `test-${field}`;
             }
 
-            const config: Record<string, any> = {};
+            const config: Record<string, unknown> = {};
             for (const field of spec.configuration.required) {
               config[field] = `test-${field}`;
             }
@@ -478,12 +478,12 @@ describe('Credential Manager - Property-Based Tests', () => {
             secretsManagerMock.reset();
             ssmMock.reset();
 
-            const credentials: Record<string, any> = {};
+            const credentials: Record<string, unknown> = {};
             for (const field of spec.authentication.fields) {
               credentials[field] = `sensitive-${field}`;
             }
 
-            const config: Record<string, any> = {};
+            const config: Record<string, unknown> = {};
             for (const field of spec.configuration.required) {
               config[field] = `config-${field}`;
             }
@@ -542,7 +542,7 @@ describe('Credential Manager - Property-Based Tests', () => {
             secretsManagerMock.reset();
 
             // Build valid credentials based on connector spec
-            const storedCredentials: Record<string, any> = {};
+            const storedCredentials: Record<string, unknown> = {};
             for (const field of spec.authentication.fields) {
               storedCredentials[field] = `test-${field}-value`;
             }
@@ -595,7 +595,7 @@ describe('Credential Manager - Property-Based Tests', () => {
             secretsManagerMock.reset();
 
             // Build incomplete credentials (missing last required field)
-            const incompleteCredentials: Record<string, any> = {};
+            const incompleteCredentials: Record<string, unknown> = {};
             for (let i = 0; i < spec.authentication.fields.length - 1; i++) {
               const field = spec.authentication.fields[i];
               incompleteCredentials[field] = `test-${field}-value`;
@@ -629,7 +629,7 @@ describe('Credential Manager - Property-Based Tests', () => {
         secretsManagerMock.reset();
         const spec = getConnectorSpec(connectorType)!;
         
-        const credentials: Record<string, any> = {};
+        const credentials: Record<string, unknown> = {};
         for (const field of spec.authentication.fields) {
           credentials[field] = `test-${field}`;
         }
@@ -653,7 +653,7 @@ describe('Credential Manager - Property-Based Tests', () => {
         secretsManagerMock.reset();
         const spec = getConnectorSpec(connectorType)!;
         
-        const credentials: Record<string, any> = {};
+        const credentials: Record<string, unknown> = {};
         for (const field of spec.authentication.fields) {
           credentials[field] = `test-${field}`;
         }
@@ -677,7 +677,7 @@ describe('Credential Manager - Property-Based Tests', () => {
         secretsManagerMock.reset();
         const spec = getConnectorSpec(connectorType)!;
         
-        const credentials: Record<string, any> = {};
+        const credentials: Record<string, unknown> = {};
         for (const field of spec.authentication.fields) {
           credentials[field] = `test-${field}`;
         }
@@ -701,7 +701,7 @@ describe('Credential Manager - Property-Based Tests', () => {
         secretsManagerMock.reset();
         const spec = getConnectorSpec(connectorType)!;
         
-        const credentials: Record<string, any> = {};
+        const credentials: Record<string, unknown> = {};
         for (const field of spec.authentication.fields) {
           credentials[field] = `test-${field}`;
         }
@@ -924,7 +924,7 @@ describe('Credential Manager - Property-Based Tests', () => {
             };
 
             // Build valid config based on connector type
-            const config: Record<string, any> = {};
+            const config: Record<string, unknown> = {};
             if (connectorType === 'AWS_LAMBDA') {
               config.lambdaArn = `arn:aws:lambda:us-east-1:${accountId}:function:TestFunction`;
               config.toolSchema = JSON.stringify({
@@ -994,7 +994,7 @@ describe('Credential Manager - Property-Based Tests', () => {
             ssmMock.reset();
 
             // Build credentials based on auth method
-            const credentials: Record<string, any> = {
+            const credentials: Record<string, unknown> = {
               authMethod
             };
 
@@ -1093,7 +1093,7 @@ describe('Credential Manager - Property-Based Tests', () => {
               executionRoleArn: `arn:aws:iam::123456789012:role/TestRole-${integrationId}`
             };
 
-            const config: Record<string, any> = {};
+            const config: Record<string, unknown> = {};
             if (connectorType === 'AWS_LAMBDA') {
               config.lambdaArn = 'arn:aws:lambda:us-east-1:123456789012:function:TestFunction';
               config.toolSchema = JSON.stringify({ name: 'test', description: 'test', inputSchema: { type: 'object' } });
@@ -1193,7 +1193,7 @@ describe('Credential Manager - Property-Based Tests', () => {
             secretsManagerMock.reset();
 
             // Build stored credentials based on auth method
-            const storedCredentials: Record<string, any> = {
+            const storedCredentials: Record<string, unknown> = {
               authMethod
             };
 
@@ -1290,7 +1290,7 @@ describe('Credential Manager - Property-Based Tests', () => {
             ssmMock.reset();
 
             // Build credentials
-            const credentials: Record<string, any> = {};
+            const credentials: Record<string, unknown> = {};
             if (connectorType === 'AWS_LAMBDA' || connectorType === 'AWS_SMITHY') {
               credentials.executionRoleArn = `arn:aws:iam::123456789012:role/TestRole-${integrationId}`;
             } else {
@@ -1299,7 +1299,7 @@ describe('Credential Manager - Property-Based Tests', () => {
             }
 
             // Build config based on connector type
-            const config: Record<string, any> = {};
+            const config: Record<string, unknown> = {};
             if (connectorType === 'AWS_LAMBDA') {
               config.lambdaArn = `arn:aws:lambda:us-east-1:123456789012:function:Function-${integrationId}`;
               config.toolSchema = JSON.stringify({
@@ -1376,7 +1376,7 @@ describe('Credential Manager - Property-Based Tests', () => {
             ssmMock.reset();
 
             // Build credentials with sensitive data
-            const credentials: Record<string, any> = {};
+            const credentials: Record<string, unknown> = {};
             if (connectorType === 'AWS_LAMBDA' || connectorType === 'AWS_SMITHY') {
               credentials.executionRoleArn = `arn:aws:iam::123456789012:role/SensitiveRole-${integrationId}`;
             } else {
@@ -1385,7 +1385,7 @@ describe('Credential Manager - Property-Based Tests', () => {
             }
 
             // Build config
-            const config: Record<string, any> = {};
+            const config: Record<string, unknown> = {};
             if (connectorType === 'AWS_LAMBDA') {
               config.lambdaArn = `arn:aws:lambda:us-east-1:123456789012:function:Function-${integrationId}`;
               config.toolSchema = JSON.stringify({ name: 'test', description: 'test', inputSchema: { type: 'object' } });
@@ -1440,7 +1440,7 @@ describe('Credential Manager - Property-Based Tests', () => {
             secretsManagerMock.reset();
             ssmMock.reset();
 
-            const credentials: Record<string, any> = {};
+            const credentials: Record<string, unknown> = {};
             if (connectorType === 'AWS_LAMBDA' || connectorType === 'AWS_SMITHY') {
               credentials.executionRoleArn = `arn:aws:iam::123456789012:role/TestRole`;
             } else {
@@ -1448,7 +1448,7 @@ describe('Credential Manager - Property-Based Tests', () => {
               credentials.apiKey = 'test-key';
             }
 
-            const config: Record<string, any> = {};
+            const config: Record<string, unknown> = {};
             if (connectorType === 'AWS_LAMBDA') {
               config.lambdaArn = 'arn:aws:lambda:us-east-1:123456789012:function:TestFunction';
               config.toolSchema = JSON.stringify({ name: 'test', description: 'test', inputSchema: { type: 'object' } });

--- a/backend/src/utils/credential-manager.ts
+++ b/backend/src/utils/credential-manager.ts
@@ -31,8 +31,8 @@ export async function storeCredentials(
   connectorType: string,
   integrationId: string,
   orgId: string,
-  credentials: any,
-  config: any
+  credentials: Record<string, unknown>,
+  config: Record<string, unknown>
 ): Promise<StoreCredentialsResult> {
   // Read connector spec from registry
   const spec = getConnectorSpec(connectorType);
@@ -41,7 +41,7 @@ export async function storeCredentials(
   }
   
   // Build secret value based on connector's authentication config
-  const secretValue: Record<string, any> = {};
+  const secretValue: Record<string, unknown> = {};
   
   // For IAM_ROLE authentication, only executionRoleArn is required
   // For CONFIGURABLE authentication (MCP_SERVER), fields are conditionally required
@@ -185,7 +185,7 @@ export async function getAgentInvocationSecret(secretRef: string): Promise<strin
  * @param spec - Connector specification
  * @returns true if credentials appear to be in old format
  */
-function isOldCredentialFormat(secretData: any, spec: ConnectorSpec): boolean {
+function isOldCredentialFormat(secretData: Record<string, unknown>, spec: ConnectorSpec): boolean {
   // Check if any expected authentication fields are missing
   for (const field of spec.authentication.fields) {
     if (secretData[field] === undefined) {
@@ -220,8 +220,8 @@ function isOldCredentialFormat(secretData: any, spec: ConnectorSpec): boolean {
  * @param spec - Connector specification
  * @returns Migrated credentials in new format
  */
-function migrateOldCredentials(secretData: any, spec: ConnectorSpec): any {
-  const migrated: Record<string, any> = { ...secretData };
+function migrateOldCredentials(secretData: Record<string, unknown>, spec: ConnectorSpec): Record<string, unknown> {
+  const migrated: Record<string, unknown> = { ...secretData };
   
   // Migrate legacy field names to new format
   const fieldMappings: Record<string, string> = {
@@ -280,7 +280,7 @@ function migrateOldCredentials(secretData: any, spec: ConnectorSpec): any {
 export async function retrieveCredentials(
   secretArn: string,
   connectorType: string
-): Promise<any> {
+): Promise<Record<string, unknown>> {
   // Retrieve secret from Secrets Manager
   const response = await secretsManager.send(new GetSecretValueCommand({
     SecretId: secretArn
@@ -308,7 +308,7 @@ export async function retrieveCredentials(
   
   // Return credentials in expected format
   // Validate that all expected fields are present
-  const credentials: Record<string, any> = {};
+  const credentials: Record<string, unknown> = {};
   const isConfigurable = spec.authentication.method === 'CONFIGURABLE';
   
   for (const field of spec.authentication.fields) {
@@ -354,8 +354,8 @@ export async function retrieveCredentials(
 export async function updateCredentials(
   secretArn: string,
   connectorType: string,
-  credentials: any,
-  config: any
+  credentials: Record<string, unknown>,
+  config: Record<string, unknown>
 ): Promise<void> {
   const spec = getConnectorSpec(connectorType);
   if (!spec) {
@@ -363,7 +363,7 @@ export async function updateCredentials(
   }
   
   // Build updated secret value
-  const secretValue: Record<string, any> = {};
+  const secretValue: Record<string, unknown> = {};
   
   for (const field of spec.authentication.fields) {
     if (credentials[field]) {
@@ -420,7 +420,7 @@ export async function deleteCredentials(secretArn: string): Promise<void> {
 export async function storeConfiguration(
   connectorType: string,
   ssmParameterPrefix: string,
-  config: any
+  config: Record<string, unknown>
 ): Promise<void> {
   const spec = getConnectorSpec(connectorType);
   if (!spec) {
@@ -458,13 +458,13 @@ export async function storeConfiguration(
 export async function retrieveConfiguration(
   connectorType: string,
   ssmParameterPrefix: string
-): Promise<any> {
+): Promise<Record<string, unknown>> {
   const spec = getConnectorSpec(connectorType);
   if (!spec) {
     throw new Error(`Unknown connector type: ${connectorType}`);
   }
   
-  const config: Record<string, any> = {};
+  const config: Record<string, unknown> = {};
   
   for (const paramName of spec.configuration.ssmParameters) {
     try {


### PR DESCRIPTION
## Summary

Lint-debt burn-down, part 2: the governance, project-resolver and credential-manager file clusters.

- Eliminates all 248 `no-explicit-any` / `require-imports` warnings across 11 files (131 governance, 66 project-resolver, 51 credential-manager)
- Test files: typed fixtures and `aws-sdk-client-mock` generics — assertions and per-suite counts unchanged (442 tests across 7 suites)
- 3 source files: strictly type-only changes
- Handler-arity sweep: 24 call sites through typed `invokeHandler` aliases and a typed `DynamoDBStreamEvent`, so CodeQL's superfluous-argument rule finds nothing
- Ratchets `--max-warnings` 1724 → 1476; no `eslint-disable` introduced

## Testing

- All touched suites green with unchanged test counts; `npm run build` passes
- Cluster globs report 0 remaining problems