### PR TITLE
Chore/lint burndown 3

### DIFF
--- a/backend/package.json
+++ b/backend/package.json
@@ -11,7 +11,7 @@
     "watch": "tsc -w",
     "test": "jest",
     "test:integration": "jest --config jest.integration.config.js",
-    "lint": "eslint \"src/**/*.ts\" --max-warnings 1476",
+    "lint": "eslint \"src/**/*.ts\" --max-warnings 1151",
     "lint:fix": "eslint \"src/**/*.ts\" --fix",
     "format": "prettier --write \"src/**/*.ts\"",
     "cdk:synth": "cdk synth",

--- a/backend/package.json
+++ b/backend/package.json
@@ -11,7 +11,7 @@
     "watch": "tsc -w",
     "test": "jest",
     "test:integration": "jest --config jest.integration.config.js",
-    "lint": "eslint \"src/**/*.ts\" --max-warnings 1151",
+    "lint": "eslint \"src/**/*.ts\" --max-warnings 851",
     "lint:fix": "eslint \"src/**/*.ts\" --fix",
     "format": "prettier --write \"src/**/*.ts\"",
     "cdk:synth": "cdk synth",

--- a/backend/src/lambda/adapters/__tests__/aurora-adapter.test.ts
+++ b/backend/src/lambda/adapters/__tests__/aurora-adapter.test.ts
@@ -4,7 +4,9 @@ import {
   ConnectionError,
   PermissionError,
   ResourceNotFoundError,
+  DataStoreError,
 } from '../errors';
+import { RDSClient, CreateDBClusterCommand } from '@aws-sdk/client-rds';
 
 const mockSend = jest.fn();
 jest.mock('@aws-sdk/client-rds', () => {
@@ -66,7 +68,6 @@ describe('AuroraAdapter', () => {
     });
 
     it('uses aurora-postgresql engine for postgres adapter', async () => {
-      const { CreateDBClusterCommand } = require('@aws-sdk/client-rds');
       mockSend.mockResolvedValueOnce({ DBCluster: {} });
       await postgresAdapter.provision(config, creds);
       expect(CreateDBClusterCommand).toHaveBeenCalledWith(
@@ -75,7 +76,6 @@ describe('AuroraAdapter', () => {
     });
 
     it('uses aurora-mysql engine for mysql adapter', async () => {
-      const { CreateDBClusterCommand } = require('@aws-sdk/client-rds');
       mockSend.mockResolvedValueOnce({ DBCluster: {} });
       await mysqlAdapter.provision(config, creds);
       expect(CreateDBClusterCommand).toHaveBeenCalledWith(
@@ -89,7 +89,7 @@ describe('AuroraAdapter', () => {
 
     it('handles DBClusterAlreadyExistsFault as idempotent success', async () => {
       const sdkError = new Error('Already exists');
-      (sdkError as any).name = 'DBClusterAlreadyExistsFault';
+      sdkError.name = 'DBClusterAlreadyExistsFault';
       mockSend.mockRejectedValueOnce(sdkError);
       const result = await postgresAdapter.provision(config, creds);
       expect(result.resourceArn).toContain('my-test-cluster');
@@ -97,21 +97,21 @@ describe('AuroraAdapter', () => {
 
     it('wraps AccessDeniedException in PermissionError', async () => {
       const sdkError = new Error('Access Denied');
-      (sdkError as any).name = 'AccessDeniedException';
+      sdkError.name = 'AccessDeniedException';
       mockSend.mockRejectedValueOnce(sdkError);
       await expect(postgresAdapter.provision(config, creds)).rejects.toThrow(PermissionError);
     });
 
     it('wraps unknown SDK errors in ProvisioningError with cause', async () => {
       const sdkError = new Error('Something broke');
-      (sdkError as any).name = 'InternalError';
+      sdkError.name = 'InternalError';
       mockSend.mockRejectedValueOnce(sdkError);
       try {
         await postgresAdapter.provision(config, creds);
         fail('Expected ProvisioningError');
-      } catch (err: any) {
+      } catch (err) {
         expect(err).toBeInstanceOf(ProvisioningError);
-        expect(err.cause).toBe(sdkError);
+        expect((err as DataStoreError).cause).toBe(sdkError);
       }
     });
   });
@@ -133,28 +133,28 @@ describe('AuroraAdapter', () => {
 
     it('throws ResourceNotFoundError when cluster does not exist', async () => {
       const sdkError = new Error('Not found');
-      (sdkError as any).name = 'DBClusterNotFoundFault';
+      sdkError.name = 'DBClusterNotFoundFault';
       mockSend.mockRejectedValueOnce(sdkError);
       await expect(postgresAdapter.connect(config)).rejects.toThrow(ResourceNotFoundError);
     });
 
     it('throws PermissionError on AccessDeniedException', async () => {
       const sdkError = new Error('Forbidden');
-      (sdkError as any).name = 'AccessDeniedException';
+      sdkError.name = 'AccessDeniedException';
       mockSend.mockRejectedValueOnce(sdkError);
       await expect(postgresAdapter.connect(config)).rejects.toThrow(PermissionError);
     });
 
     it('wraps other errors in ConnectionError with cause', async () => {
       const sdkError = new Error('Network issue');
-      (sdkError as any).name = 'NetworkingError';
+      sdkError.name = 'NetworkingError';
       mockSend.mockRejectedValueOnce(sdkError);
       try {
         await postgresAdapter.connect(config);
         fail('Expected ConnectionError');
-      } catch (err: any) {
+      } catch (err) {
         expect(err).toBeInstanceOf(ConnectionError);
-        expect(err.cause).toBe(sdkError);
+        expect((err as DataStoreError).cause).toBe(sdkError);
       }
     });
   });
@@ -201,14 +201,14 @@ describe('AuroraAdapter', () => {
 
     it('wraps AccessDeniedException in PermissionError', async () => {
       const sdkError = new Error('Access Denied');
-      (sdkError as any).name = 'AccessDeniedException';
+      sdkError.name = 'AccessDeniedException';
       mockSend.mockRejectedValueOnce(sdkError);
       await expect(postgresAdapter.getMetrics(config)).rejects.toThrow(PermissionError);
     });
 
     it('wraps other errors in ConnectionError', async () => {
       const sdkError = new Error('Timeout');
-      (sdkError as any).name = 'RequestTimeout';
+      sdkError.name = 'RequestTimeout';
       mockSend.mockRejectedValueOnce(sdkError);
       await expect(postgresAdapter.getMetrics(config)).rejects.toThrow(ConnectionError);
     });
@@ -216,7 +216,6 @@ describe('AuroraAdapter', () => {
 
   describe('scoped credentials', () => {
     it('constructs client with provided credentials', async () => {
-      const { RDSClient } = require('@aws-sdk/client-rds');
       mockSend.mockResolvedValueOnce({
         DBClusters: [{ Status: 'available' }],
       });

--- a/backend/src/lambda/adapters/__tests__/aws-generic-adapter.test.ts
+++ b/backend/src/lambda/adapters/__tests__/aws-generic-adapter.test.ts
@@ -44,9 +44,9 @@ describe('AwsGenericAdapter', () => {
       try {
         await adapter.provision(config);
         fail('Expected NotImplementedError');
-      } catch (err: any) {
-        expect(err.message).toContain('opensearch');
-        expect(err.message).toContain('provision');
+      } catch (err) {
+        expect((err as Error).message).toContain('opensearch');
+        expect((err as Error).message).toContain('provision');
       }
     });
 
@@ -69,9 +69,9 @@ describe('AwsGenericAdapter', () => {
       try {
         await adapter.connect(config);
         fail('Expected NotImplementedError');
-      } catch (err: any) {
-        expect(err.message).toContain('opensearch');
-        expect(err.message).toContain('connect');
+      } catch (err) {
+        expect((err as Error).message).toContain('opensearch');
+        expect((err as Error).message).toContain('connect');
       }
     });
   });
@@ -85,9 +85,9 @@ describe('AwsGenericAdapter', () => {
       try {
         await adapter.disconnect(config);
         fail('Expected NotImplementedError');
-      } catch (err: any) {
-        expect(err.message).toContain('opensearch');
-        expect(err.message).toContain('disconnect');
+      } catch (err) {
+        expect((err as Error).message).toContain('opensearch');
+        expect((err as Error).message).toContain('disconnect');
       }
     });
   });
@@ -101,9 +101,9 @@ describe('AwsGenericAdapter', () => {
       try {
         await adapter.testConnection(config);
         fail('Expected NotImplementedError');
-      } catch (err: any) {
-        expect(err.message).toContain('opensearch');
-        expect(err.message).toContain('testConnection');
+      } catch (err) {
+        expect((err as Error).message).toContain('opensearch');
+        expect((err as Error).message).toContain('testConnection');
       }
     });
   });
@@ -117,9 +117,9 @@ describe('AwsGenericAdapter', () => {
       try {
         await adapter.getMetrics(config);
         fail('Expected NotImplementedError');
-      } catch (err: any) {
-        expect(err.message).toContain('opensearch');
-        expect(err.message).toContain('getMetrics');
+      } catch (err) {
+        expect((err as Error).message).toContain('opensearch');
+        expect((err as Error).message).toContain('getMetrics');
       }
     });
   });
@@ -132,9 +132,9 @@ describe('AwsGenericAdapter', () => {
       try {
         await a.testConnection({});
         fail('Expected NotImplementedError');
-      } catch (err: any) {
+      } catch (err) {
         expect(err).toBeInstanceOf(NotImplementedError);
-        expect(err.message).toContain(svc);
+        expect((err as Error).message).toContain(svc);
       }
     });
   });

--- a/backend/src/lambda/adapters/__tests__/databricks-adapter.test.ts
+++ b/backend/src/lambda/adapters/__tests__/databricks-adapter.test.ts
@@ -99,9 +99,9 @@ describe('DatabricksAdapter', () => {
       try {
         await adapter.testConnection(validConfig);
         fail('Expected PermissionError');
-      } catch (err: any) {
+      } catch (err) {
         expect(err).toBeInstanceOf(PermissionError);
-        expect(err.cause).toBe(sdkError);
+        expect((err as DataStoreError).cause).toBe(sdkError);
       }
     });
 
@@ -113,9 +113,9 @@ describe('DatabricksAdapter', () => {
       try {
         await adapter.testConnection(validConfig);
         fail('Expected ConnectionError');
-      } catch (err: any) {
+      } catch (err) {
         expect(err).toBeInstanceOf(ConnectionError);
-        expect(err.cause).toBe(sdkError);
+        expect((err as DataStoreError).cause).toBe(sdkError);
       }
     });
 
@@ -127,9 +127,9 @@ describe('DatabricksAdapter', () => {
       try {
         await adapter.testConnection(validConfig);
         fail('Expected DataStoreError');
-      } catch (err: any) {
+      } catch (err) {
         expect(err).toBeInstanceOf(DataStoreError);
-        expect(err.cause).toBe(sdkError);
+        expect((err as DataStoreError).cause).toBe(sdkError);
       }
     });
 

--- a/backend/src/lambda/adapters/__tests__/documentdb-adapter.test.ts
+++ b/backend/src/lambda/adapters/__tests__/documentdb-adapter.test.ts
@@ -4,7 +4,9 @@ import {
   ConnectionError,
   PermissionError,
   ResourceNotFoundError,
+  DataStoreError,
 } from '../errors';
+import { DocDBClient, CreateDBClusterCommand } from '@aws-sdk/client-docdb';
 
 const mockSend = jest.fn();
 jest.mock('@aws-sdk/client-docdb', () => {
@@ -60,7 +62,6 @@ describe('DocumentDBAdapter', () => {
     });
 
     it('uses docdb engine', async () => {
-      const { CreateDBClusterCommand } = require('@aws-sdk/client-docdb');
       mockSend.mockResolvedValueOnce({ DBCluster: {} });
       await adapter.provision(config, creds);
       expect(CreateDBClusterCommand).toHaveBeenCalledWith(
@@ -69,7 +70,6 @@ describe('DocumentDBAdapter', () => {
     });
 
     it('generates identifier with citadel-docdb prefix when not provided', async () => {
-      const { CreateDBClusterCommand } = require('@aws-sdk/client-docdb');
       mockSend.mockResolvedValueOnce({ DBCluster: {} });
       await adapter.provision({}, creds);
       expect(CreateDBClusterCommand).toHaveBeenCalledWith(
@@ -85,7 +85,7 @@ describe('DocumentDBAdapter', () => {
 
     it('handles DBClusterAlreadyExistsFault as idempotent success', async () => {
       const sdkError = new Error('Already exists');
-      (sdkError as any).name = 'DBClusterAlreadyExistsFault';
+      sdkError.name = 'DBClusterAlreadyExistsFault';
       mockSend.mockRejectedValueOnce(sdkError);
       const result = await adapter.provision(config, creds);
       expect(result.resourceArn).toContain('my-docdb-cluster');
@@ -93,21 +93,21 @@ describe('DocumentDBAdapter', () => {
 
     it('wraps AccessDeniedException in PermissionError', async () => {
       const sdkError = new Error('Access Denied');
-      (sdkError as any).name = 'AccessDeniedException';
+      sdkError.name = 'AccessDeniedException';
       mockSend.mockRejectedValueOnce(sdkError);
       await expect(adapter.provision(config, creds)).rejects.toThrow(PermissionError);
     });
 
     it('wraps unknown SDK errors in ProvisioningError with cause', async () => {
       const sdkError = new Error('Something broke');
-      (sdkError as any).name = 'InternalError';
+      sdkError.name = 'InternalError';
       mockSend.mockRejectedValueOnce(sdkError);
       try {
         await adapter.provision(config, creds);
         fail('Expected ProvisioningError');
-      } catch (err: any) {
+      } catch (err) {
         expect(err).toBeInstanceOf(ProvisioningError);
-        expect(err.cause).toBe(sdkError);
+        expect((err as DataStoreError).cause).toBe(sdkError);
       }
     });
   });
@@ -129,28 +129,28 @@ describe('DocumentDBAdapter', () => {
 
     it('throws ResourceNotFoundError when cluster does not exist', async () => {
       const sdkError = new Error('Not found');
-      (sdkError as any).name = 'DBClusterNotFoundFault';
+      sdkError.name = 'DBClusterNotFoundFault';
       mockSend.mockRejectedValueOnce(sdkError);
       await expect(adapter.connect(config)).rejects.toThrow(ResourceNotFoundError);
     });
 
     it('throws PermissionError on AccessDeniedException', async () => {
       const sdkError = new Error('Forbidden');
-      (sdkError as any).name = 'AccessDeniedException';
+      sdkError.name = 'AccessDeniedException';
       mockSend.mockRejectedValueOnce(sdkError);
       await expect(adapter.connect(config)).rejects.toThrow(PermissionError);
     });
 
     it('wraps other errors in ConnectionError with cause', async () => {
       const sdkError = new Error('Network issue');
-      (sdkError as any).name = 'NetworkingError';
+      sdkError.name = 'NetworkingError';
       mockSend.mockRejectedValueOnce(sdkError);
       try {
         await adapter.connect(config);
         fail('Expected ConnectionError');
-      } catch (err: any) {
+      } catch (err) {
         expect(err).toBeInstanceOf(ConnectionError);
-        expect(err.cause).toBe(sdkError);
+        expect((err as DataStoreError).cause).toBe(sdkError);
       }
     });
   });
@@ -204,14 +204,14 @@ describe('DocumentDBAdapter', () => {
 
     it('wraps AccessDeniedException in PermissionError', async () => {
       const sdkError = new Error('Access Denied');
-      (sdkError as any).name = 'AccessDeniedException';
+      sdkError.name = 'AccessDeniedException';
       mockSend.mockRejectedValueOnce(sdkError);
       await expect(adapter.getMetrics(config)).rejects.toThrow(PermissionError);
     });
 
     it('wraps other errors in ConnectionError', async () => {
       const sdkError = new Error('Timeout');
-      (sdkError as any).name = 'RequestTimeout';
+      sdkError.name = 'RequestTimeout';
       mockSend.mockRejectedValueOnce(sdkError);
       await expect(adapter.getMetrics(config)).rejects.toThrow(ConnectionError);
     });
@@ -219,7 +219,6 @@ describe('DocumentDBAdapter', () => {
 
   describe('scoped credentials', () => {
     it('constructs client with provided credentials', async () => {
-      const { DocDBClient } = require('@aws-sdk/client-docdb');
       mockSend.mockResolvedValueOnce({
         DBClusters: [{ Status: 'available' }],
       });

--- a/backend/src/lambda/adapters/__tests__/dynamodb-adapter.test.ts
+++ b/backend/src/lambda/adapters/__tests__/dynamodb-adapter.test.ts
@@ -4,7 +4,9 @@ import {
   ConnectionError,
   PermissionError,
   ResourceNotFoundError,
+  DataStoreError,
 } from '../errors';
+import { DynamoDBClient, CreateTableCommand } from '@aws-sdk/client-dynamodb';
 
 // Mock the entire @aws-sdk/client-dynamodb module
 const mockSend = jest.fn();
@@ -73,7 +75,6 @@ describe('DynamoDBAdapter', () => {
     });
 
     it('uses default partition key "pk" and no sort key when sortKey not provided', async () => {
-      const { CreateTableCommand } = require('@aws-sdk/client-dynamodb');
       mockSend.mockResolvedValueOnce({});
       await adapter.provision(config);
       expect(CreateTableCommand).toHaveBeenCalledWith(
@@ -91,7 +92,6 @@ describe('DynamoDBAdapter', () => {
     });
 
     it('uses custom partition and sort keys from config', async () => {
-      const { CreateTableCommand } = require('@aws-sdk/client-dynamodb');
       mockSend.mockResolvedValueOnce({});
       await adapter.provision({
         ...config,
@@ -110,7 +110,7 @@ describe('DynamoDBAdapter', () => {
 
     it('handles ResourceInUseException as idempotent success', async () => {
       const sdkError = new Error('Table already exists');
-      (sdkError as any).name = 'ResourceInUseException';
+      sdkError.name = 'ResourceInUseException';
       mockSend.mockRejectedValueOnce(sdkError);
       const result = await adapter.provision(config);
       expect(result.resourceArn).toContain('my-test-table');
@@ -118,27 +118,27 @@ describe('DynamoDBAdapter', () => {
 
     it('wraps AccessDeniedException in PermissionError', async () => {
       const sdkError = new Error('Access Denied');
-      (sdkError as any).name = 'AccessDeniedException';
+      sdkError.name = 'AccessDeniedException';
       mockSend.mockRejectedValueOnce(sdkError);
       await expect(adapter.provision(config)).rejects.toThrow(PermissionError);
     });
 
     it('wraps unknown SDK errors in ProvisioningError', async () => {
       const sdkError = new Error('Something broke');
-      (sdkError as any).name = 'InternalServerError';
+      sdkError.name = 'InternalServerError';
       mockSend.mockRejectedValueOnce(sdkError);
       await expect(adapter.provision(config)).rejects.toThrow(ProvisioningError);
     });
 
     it('preserves the original SDK error as cause', async () => {
       const sdkError = new Error('Something broke');
-      (sdkError as any).name = 'InternalServerError';
+      sdkError.name = 'InternalServerError';
       mockSend.mockRejectedValueOnce(sdkError);
       try {
         await adapter.provision(config);
         fail('Expected ProvisioningError');
-      } catch (err: any) {
-        expect(err.cause).toBe(sdkError);
+      } catch (err) {
+        expect((err as DataStoreError).cause).toBe(sdkError);
       }
     });
   });
@@ -160,34 +160,34 @@ describe('DynamoDBAdapter', () => {
 
     it('throws ResourceNotFoundError when table does not exist', async () => {
       const sdkError = new Error('Table not found');
-      (sdkError as any).name = 'ResourceNotFoundException';
+      sdkError.name = 'ResourceNotFoundException';
       mockSend.mockRejectedValueOnce(sdkError);
       await expect(adapter.connect(config)).rejects.toThrow(ResourceNotFoundError);
     });
 
     it('throws PermissionError on AccessDeniedException', async () => {
       const sdkError = new Error('Forbidden');
-      (sdkError as any).name = 'AccessDeniedException';
+      sdkError.name = 'AccessDeniedException';
       mockSend.mockRejectedValueOnce(sdkError);
       await expect(adapter.connect(config)).rejects.toThrow(PermissionError);
     });
 
     it('throws ConnectionError on other errors', async () => {
       const sdkError = new Error('Network issue');
-      (sdkError as any).name = 'NetworkingError';
+      sdkError.name = 'NetworkingError';
       mockSend.mockRejectedValueOnce(sdkError);
       await expect(adapter.connect(config)).rejects.toThrow(ConnectionError);
     });
 
     it('preserves SDK error as cause in ConnectionError', async () => {
       const sdkError = new Error('Network issue');
-      (sdkError as any).name = 'NetworkingError';
+      sdkError.name = 'NetworkingError';
       mockSend.mockRejectedValueOnce(sdkError);
       try {
         await adapter.connect(config);
         fail('Expected ConnectionError');
-      } catch (err: any) {
-        expect(err.cause).toBe(sdkError);
+      } catch (err) {
+        expect((err as DataStoreError).cause).toBe(sdkError);
       }
     });
   });
@@ -219,7 +219,7 @@ describe('DynamoDBAdapter', () => {
 
     it('returns failure when DescribeTable fails', async () => {
       const sdkError = new Error('Not Found');
-      (sdkError as any).name = 'ResourceNotFoundException';
+      sdkError.name = 'ResourceNotFoundException';
       mockSend.mockRejectedValueOnce(sdkError);
       const result = await adapter.testConnection(config);
       expect(result.success).toBe(false);
@@ -263,14 +263,14 @@ describe('DynamoDBAdapter', () => {
 
     it('wraps AccessDeniedException in PermissionError', async () => {
       const sdkError = new Error('Access Denied');
-      (sdkError as any).name = 'AccessDeniedException';
+      sdkError.name = 'AccessDeniedException';
       mockSend.mockRejectedValueOnce(sdkError);
       await expect(adapter.getMetrics(config)).rejects.toThrow(PermissionError);
     });
 
     it('wraps other errors in ConnectionError', async () => {
       const sdkError = new Error('Timeout');
-      (sdkError as any).name = 'TimeoutError';
+      sdkError.name = 'TimeoutError';
       mockSend.mockRejectedValueOnce(sdkError);
       await expect(adapter.getMetrics(config)).rejects.toThrow(ConnectionError);
     });
@@ -278,7 +278,6 @@ describe('DynamoDBAdapter', () => {
 
   describe('scoped credentials', () => {
     it('constructs client with provided credentials', async () => {
-      const { DynamoDBClient } = require('@aws-sdk/client-dynamodb');
       mockSend.mockResolvedValueOnce({
         Table: { TableStatus: 'ACTIVE' },
       });
@@ -298,7 +297,6 @@ describe('DynamoDBAdapter', () => {
     });
 
     it('constructs default client when no credentials provided', async () => {
-      const { DynamoDBClient } = require('@aws-sdk/client-dynamodb');
       mockSend.mockResolvedValueOnce({
         Table: { TableStatus: 'ACTIVE' },
       });

--- a/backend/src/lambda/adapters/__tests__/elasticache-adapter.test.ts
+++ b/backend/src/lambda/adapters/__tests__/elasticache-adapter.test.ts
@@ -4,7 +4,9 @@ import {
   ConnectionError,
   PermissionError,
   ResourceNotFoundError,
+  DataStoreError,
 } from '../errors';
+import { ElastiCacheClient, CreateCacheClusterCommand } from '@aws-sdk/client-elasticache';
 
 const mockSend = jest.fn();
 jest.mock('@aws-sdk/client-elasticache', () => {
@@ -54,7 +56,6 @@ describe('ElastiCacheAdapter', () => {
     });
 
     it('sends CreateCacheClusterCommand with redis engine and cache.t3.micro', async () => {
-      const { CreateCacheClusterCommand } = require('@aws-sdk/client-elasticache');
       mockSend.mockResolvedValueOnce({ CacheCluster: {} });
       await adapter.provision(config);
       expect(CreateCacheClusterCommand).toHaveBeenCalledWith(
@@ -69,7 +70,7 @@ describe('ElastiCacheAdapter', () => {
 
     it('handles CacheClusterAlreadyExistsFault as idempotent success', async () => {
       const sdkError = new Error('Already exists');
-      (sdkError as any).name = 'CacheClusterAlreadyExistsFault';
+      sdkError.name = 'CacheClusterAlreadyExistsFault';
       mockSend.mockRejectedValueOnce(sdkError);
       const result = await adapter.provision(config);
       expect(result.resourceArn).toContain('my-test-cluster');
@@ -77,21 +78,21 @@ describe('ElastiCacheAdapter', () => {
 
     it('wraps AccessDeniedException in PermissionError', async () => {
       const sdkError = new Error('Access Denied');
-      (sdkError as any).name = 'AccessDeniedException';
+      sdkError.name = 'AccessDeniedException';
       mockSend.mockRejectedValueOnce(sdkError);
       await expect(adapter.provision(config)).rejects.toThrow(PermissionError);
     });
 
     it('wraps unknown SDK errors in ProvisioningError with cause', async () => {
       const sdkError = new Error('Something broke');
-      (sdkError as any).name = 'InternalError';
+      sdkError.name = 'InternalError';
       mockSend.mockRejectedValueOnce(sdkError);
       try {
         await adapter.provision(config);
         fail('Expected ProvisioningError');
-      } catch (err: any) {
+      } catch (err) {
         expect(err).toBeInstanceOf(ProvisioningError);
-        expect(err.cause).toBe(sdkError);
+        expect((err as DataStoreError).cause).toBe(sdkError);
       }
     });
   });
@@ -113,28 +114,28 @@ describe('ElastiCacheAdapter', () => {
 
     it('throws ResourceNotFoundError when cluster does not exist', async () => {
       const sdkError = new Error('Not found');
-      (sdkError as any).name = 'CacheClusterNotFoundFault';
+      sdkError.name = 'CacheClusterNotFoundFault';
       mockSend.mockRejectedValueOnce(sdkError);
       await expect(adapter.connect(config)).rejects.toThrow(ResourceNotFoundError);
     });
 
     it('throws PermissionError on AccessDeniedException', async () => {
       const sdkError = new Error('Forbidden');
-      (sdkError as any).name = 'AccessDeniedException';
+      sdkError.name = 'AccessDeniedException';
       mockSend.mockRejectedValueOnce(sdkError);
       await expect(adapter.connect(config)).rejects.toThrow(PermissionError);
     });
 
     it('wraps other errors in ConnectionError with cause', async () => {
       const sdkError = new Error('Network issue');
-      (sdkError as any).name = 'NetworkingError';
+      sdkError.name = 'NetworkingError';
       mockSend.mockRejectedValueOnce(sdkError);
       try {
         await adapter.connect(config);
         fail('Expected ConnectionError');
-      } catch (err: any) {
+      } catch (err) {
         expect(err).toBeInstanceOf(ConnectionError);
-        expect(err.cause).toBe(sdkError);
+        expect((err as DataStoreError).cause).toBe(sdkError);
       }
     });
   });
@@ -180,14 +181,14 @@ describe('ElastiCacheAdapter', () => {
 
     it('wraps AccessDeniedException in PermissionError', async () => {
       const sdkError = new Error('Access Denied');
-      (sdkError as any).name = 'AccessDeniedException';
+      sdkError.name = 'AccessDeniedException';
       mockSend.mockRejectedValueOnce(sdkError);
       await expect(adapter.getMetrics(config)).rejects.toThrow(PermissionError);
     });
 
     it('wraps other errors in ConnectionError', async () => {
       const sdkError = new Error('Timeout');
-      (sdkError as any).name = 'RequestTimeout';
+      sdkError.name = 'RequestTimeout';
       mockSend.mockRejectedValueOnce(sdkError);
       await expect(adapter.getMetrics(config)).rejects.toThrow(ConnectionError);
     });
@@ -195,7 +196,6 @@ describe('ElastiCacheAdapter', () => {
 
   describe('scoped credentials', () => {
     it('constructs client with provided credentials', async () => {
-      const { ElastiCacheClient } = require('@aws-sdk/client-elasticache');
       mockSend.mockResolvedValueOnce({
         CacheClusters: [{ CacheClusterStatus: 'available' }],
       });

--- a/backend/src/lambda/adapters/__tests__/error-wrapping.property.test.ts
+++ b/backend/src/lambda/adapters/__tests__/error-wrapping.property.test.ts
@@ -18,6 +18,10 @@ import { KnowledgeBaseAdapter } from '../knowledge-base-adapter';
 import { SnowflakeAdapter } from '../snowflake-adapter';
 import { DatabricksAdapter } from '../databricks-adapter';
 import { DataStoreError } from '../errors';
+import type { ConnectorAdapter } from '../../../adapters/base';
+
+/** Adapter with a concrete provision method (all datastore adapters under test). */
+type ProvisioningAdapter = ConnectorAdapter & Required<Pick<ConnectorAdapter, 'provision'>>;
 
 // Feature: datastore-adapter-pattern, Property 1: Adapter SDK error wrapping
 // Validates: Requirements 2.4
@@ -177,7 +181,7 @@ const sdkErrorMessageArb = fc.string({ minLength: 1, maxLength: 100 });
 
 function makeSdkError(name: string, message: string): Error {
   const err = new Error(message);
-  (err as any).name = name;
+  err.name = name;
   return err;
 }
 
@@ -198,10 +202,10 @@ describe('Property 1: Adapter SDK error wrapping', () => {
   // Helper: test that provision wraps SDK errors for adapters using mockSend pattern
   function testProvisionWrapping(
     name: string,
-    createAdapter: () => any,
+    createAdapter: () => ProvisioningAdapter,
     mockSend: jest.Mock,
-    config: Record<string, any>,
-    credentials?: Record<string, any>
+    config: Record<string, unknown>,
+    credentials?: Record<string, string>
   ) {
     it(`${name}.provision wraps SDK errors in DataStoreError with cause`, async () => {
       const adapter = createAdapter();
@@ -211,9 +215,9 @@ describe('Property 1: Adapter SDK error wrapping', () => {
           mockSend.mockRejectedValueOnce(sdkError);
           try {
             await adapter.provision(config, credentials);
-          } catch (thrown: any) {
+          } catch (thrown) {
             expect(thrown).toBeInstanceOf(DataStoreError);
-            expect(thrown.cause).toBe(sdkError);
+            expect((thrown as DataStoreError).cause).toBe(sdkError);
           }
         }),
         { numRuns: 100 }
@@ -258,9 +262,9 @@ describe('Property 1: Adapter SDK error wrapping', () => {
         mockBedrockAgentSend.mockRejectedValue(sdkError);
         try {
           await adapter.provision(config);
-        } catch (thrown: any) {
+        } catch (thrown) {
           expect(thrown).toBeInstanceOf(DataStoreError);
-          expect(thrown.cause).toBe(sdkError);
+          expect((thrown as DataStoreError).cause).toBe(sdkError);
         }
       }),
       { numRuns: 100 }
@@ -278,9 +282,9 @@ describe('Property 1: Adapter SDK error wrapping', () => {
         mockSnowflakeConnect.mockImplementation((cb: (err: unknown) => void) => cb(sdkError));
         try {
           await adapter.testConnection(config);
-        } catch (thrown: any) {
+        } catch (thrown) {
           expect(thrown).toBeInstanceOf(DataStoreError);
-          expect(thrown.cause).toBe(sdkError);
+          expect((thrown as DataStoreError).cause).toBe(sdkError);
         }
       }),
       { numRuns: 100 }
@@ -299,9 +303,9 @@ describe('Property 1: Adapter SDK error wrapping', () => {
         mockDatabricksClose.mockResolvedValueOnce(undefined);
         try {
           await adapter.testConnection(config);
-        } catch (thrown: any) {
+        } catch (thrown) {
           expect(thrown).toBeInstanceOf(DataStoreError);
-          expect(thrown.cause).toBe(sdkError);
+          expect((thrown as DataStoreError).cause).toBe(sdkError);
         }
       }),
       { numRuns: 100 }

--- a/backend/src/lambda/adapters/__tests__/external-adapter.property.test.ts
+++ b/backend/src/lambda/adapters/__tests__/external-adapter.property.test.ts
@@ -18,7 +18,7 @@ jest.mock('net', () => ({
         handlers[event] = cb;
         mockOn(event, cb);
       },
-      connect: (...args: any[]) => {
+      connect: (...args: unknown[]) => {
         mockConnect(...args);
         // By default trigger 'connect' event on next tick
         if (handlers['connect']) {
@@ -113,8 +113,8 @@ describe('Property 7: External adapter provision throws ProvisioningError', () =
         try {
           await adapter.provision({});
           fail('Expected ProvisioningError');
-        } catch (err: any) {
-          expect(err.message).toContain(kind);
+        } catch (err) {
+          expect((err as Error).message).toContain(kind);
         }
       }),
       { numRuns: 100 }

--- a/backend/src/lambda/adapters/__tests__/generic-idempotent.property.test.ts
+++ b/backend/src/lambda/adapters/__tests__/generic-idempotent.property.test.ts
@@ -16,6 +16,11 @@ import { S3TablesAdapter } from '../s3-tables-adapter';
 import { SageMakerLakehouseAdapter } from '../sagemaker-lakehouse-adapter';
 import { SageMakerFeatureStoreAdapter } from '../sagemaker-feature-store-adapter';
 import { KnowledgeBaseAdapter } from '../knowledge-base-adapter';
+import { NotImplementedError } from '../../../adapters/errors';
+import type { ConnectorAdapter } from '../../../adapters/base';
+
+/** Adapter with a concrete provision method (all datastore adapters under test). */
+type ProvisioningAdapter = ConnectorAdapter & Required<Pick<ConnectorAdapter, 'provision'>>;
 
 // --- Mock all AWS SDK modules ---
 const mockS3Send = jest.fn();
@@ -153,14 +158,9 @@ const allMocks = [
 // every integration failure across the registry. The adapter now throws
 // NotImplementedError so unimplemented connector types fail loudly.
 describe('Property 10: Generic adapter throws NotImplementedError instead of faking success', () => {
-  // NotImplementedError lives in the canonical adapters/errors module; this
-  // import is local to the property so the surrounding describe blocks remain
-  // untouched.
-  // eslint-disable-next-line @typescript-eslint/no-var-requires
-  const { NotImplementedError } = require('../../../adapters/errors');
-
-  const serviceNameArb = fc.constantFrom(
-    'knowledge-base', 'aurora-postgresql', 'aurora-mysql', 'redshift',
+  // NotImplementedError is imported from the canonical adapters/errors module
+  // at the top of this file.
+  const serviceNameArb = fc.constantFrom(    'knowledge-base', 'aurora-postgresql', 'aurora-mysql', 'redshift',
     'lake-formation', 'opensearch', 'neptune', 'timestream',
     'documentdb', 'elasticache-redis', 'keyspaces', 'qldb',
     'sagemaker-feature-store'
@@ -206,9 +206,9 @@ describe('Property 10: Generic adapter throws NotImplementedError instead of fak
         try {
           await adapter.testConnection({});
           fail('Expected NotImplementedError');
-        } catch (err: any) {
+        } catch (err) {
           expect(err).toBeInstanceOf(NotImplementedError);
-          expect(err.message).toContain(serviceName);
+          expect((err as Error).message).toContain(serviceName);
         }
       }),
       { numRuns: 100 }
@@ -226,10 +226,10 @@ describe('Property 16: Adapter idempotent provisioning on already-exists', () =>
   // Each adapter entry: [name, adapter factory, mockSend, config, credentials, alreadyExistsErrorName]
   const adapterCases: Array<{
     name: string;
-    create: () => any;
+    create: () => ProvisioningAdapter;
     mock: jest.Mock;
-    config: Record<string, any>;
-    creds?: Record<string, any>;
+    config: Record<string, unknown>;
+    creds?: Record<string, string>;
     errorName: string;
   }> = [
     {
@@ -360,14 +360,14 @@ describe('Property 16: Adapter idempotent provisioning on already-exists', () =>
             allMocks.forEach((m) => m.mockReset());
             const adapter = create();
             const err = new Error(errorMessage);
-            (err as any).name = errorName;
+            err.name = errorName;
             // Use mockRejectedValue (persistent) so multi-call adapters get the error on every call
             mock.mockRejectedValue(err);
             // For adapters that use multiple SDK clients (e.g. KnowledgeBase uses OSS + Bedrock),
             // also mock the OSS client to reject with the same error
             if (mock !== mockOssSend) {
               const ossErr = new Error(errorMessage);
-              (ossErr as any).name = errorName;
+              ossErr.name = errorName;
               mockOssSend.mockRejectedValue(ossErr);
             }
 

--- a/backend/src/lambda/adapters/__tests__/keyspaces-adapter.test.ts
+++ b/backend/src/lambda/adapters/__tests__/keyspaces-adapter.test.ts
@@ -4,7 +4,9 @@ import {
   ConnectionError,
   PermissionError,
   ResourceNotFoundError,
+  DataStoreError,
 } from '../errors';
+import { KeyspacesClient } from '@aws-sdk/client-keyspaces';
 
 const mockSend = jest.fn();
 jest.mock('@aws-sdk/client-keyspaces', () => {
@@ -66,7 +68,7 @@ describe('KeyspacesAdapter', () => {
 
     it('handles ConflictException as idempotent success', async () => {
       const sdkError = new Error('Already exists');
-      (sdkError as any).name = 'ConflictException';
+      sdkError.name = 'ConflictException';
       mockSend.mockRejectedValueOnce(sdkError);
       const result = await adapter.provision(config);
       expect(result.resourceArn).toContain('my_test_keyspace');
@@ -74,21 +76,21 @@ describe('KeyspacesAdapter', () => {
 
     it('wraps AccessDeniedException in PermissionError', async () => {
       const sdkError = new Error('Access Denied');
-      (sdkError as any).name = 'AccessDeniedException';
+      sdkError.name = 'AccessDeniedException';
       mockSend.mockRejectedValueOnce(sdkError);
       await expect(adapter.provision(config)).rejects.toThrow(PermissionError);
     });
 
     it('wraps unknown SDK errors in ProvisioningError with cause', async () => {
       const sdkError = new Error('Something broke');
-      (sdkError as any).name = 'InternalError';
+      sdkError.name = 'InternalError';
       mockSend.mockRejectedValueOnce(sdkError);
       try {
         await adapter.provision(config);
         fail('Expected ProvisioningError');
-      } catch (err: any) {
+      } catch (err) {
         expect(err).toBeInstanceOf(ProvisioningError);
-        expect(err.cause).toBe(sdkError);
+        expect((err as DataStoreError).cause).toBe(sdkError);
       }
     });
   });
@@ -104,28 +106,28 @@ describe('KeyspacesAdapter', () => {
 
     it('throws ResourceNotFoundError when keyspace does not exist', async () => {
       const sdkError = new Error('Not found');
-      (sdkError as any).name = 'ResourceNotFoundException';
+      sdkError.name = 'ResourceNotFoundException';
       mockSend.mockRejectedValueOnce(sdkError);
       await expect(adapter.connect(config)).rejects.toThrow(ResourceNotFoundError);
     });
 
     it('throws PermissionError on AccessDeniedException', async () => {
       const sdkError = new Error('Forbidden');
-      (sdkError as any).name = 'AccessDeniedException';
+      sdkError.name = 'AccessDeniedException';
       mockSend.mockRejectedValueOnce(sdkError);
       await expect(adapter.connect(config)).rejects.toThrow(PermissionError);
     });
 
     it('wraps other errors in ConnectionError with cause', async () => {
       const sdkError = new Error('Network issue');
-      (sdkError as any).name = 'NetworkingError';
+      sdkError.name = 'NetworkingError';
       mockSend.mockRejectedValueOnce(sdkError);
       try {
         await adapter.connect(config);
         fail('Expected ConnectionError');
-      } catch (err: any) {
+      } catch (err) {
         expect(err).toBeInstanceOf(ConnectionError);
-        expect(err.cause).toBe(sdkError);
+        expect((err as DataStoreError).cause).toBe(sdkError);
       }
     });
 
@@ -173,14 +175,14 @@ describe('KeyspacesAdapter', () => {
 
     it('wraps AccessDeniedException in PermissionError', async () => {
       const sdkError = new Error('Access Denied');
-      (sdkError as any).name = 'AccessDeniedException';
+      sdkError.name = 'AccessDeniedException';
       mockSend.mockRejectedValueOnce(sdkError);
       await expect(adapter.getMetrics(config)).rejects.toThrow(PermissionError);
     });
 
     it('wraps other errors in ConnectionError', async () => {
       const sdkError = new Error('Timeout');
-      (sdkError as any).name = 'RequestTimeout';
+      sdkError.name = 'RequestTimeout';
       mockSend.mockRejectedValueOnce(sdkError);
       await expect(adapter.getMetrics(config)).rejects.toThrow(ConnectionError);
     });
@@ -188,7 +190,6 @@ describe('KeyspacesAdapter', () => {
 
   describe('scoped credentials', () => {
     it('constructs client with provided credentials', async () => {
-      const { KeyspacesClient } = require('@aws-sdk/client-keyspaces');
       mockSend.mockResolvedValueOnce({
         keyspaceName: 'my_test_keyspace',
         resourceArn: 'arn:aws:cassandra:us-east-1:123:/keyspace/my_test_keyspace',

--- a/backend/src/lambda/adapters/__tests__/knowledge-base-adapter-deprovision.test.ts
+++ b/backend/src/lambda/adapters/__tests__/knowledge-base-adapter-deprovision.test.ts
@@ -17,6 +17,7 @@ jest.mock('@aws-sdk/client-bedrock-agent', () => {
 
 import { KnowledgeBaseAdapter } from '../knowledge-base-adapter';
 import { PermissionError } from '../errors';
+import { BedrockAgentClient, DeleteKnowledgeBaseCommand } from '@aws-sdk/client-bedrock-agent';
 
 describe('KnowledgeBaseAdapter.deprovision', () => {
   let adapter: KnowledgeBaseAdapter;
@@ -36,7 +37,6 @@ describe('KnowledgeBaseAdapter.deprovision', () => {
 
     await adapter.deprovision!({ knowledgeBaseId: 'kb-12345' });
 
-    const { DeleteKnowledgeBaseCommand } = require('@aws-sdk/client-bedrock-agent');
     expect(DeleteKnowledgeBaseCommand).toHaveBeenCalledWith({
       knowledgeBaseId: 'kb-12345',
     });
@@ -45,7 +45,7 @@ describe('KnowledgeBaseAdapter.deprovision', () => {
 
   test('succeeds gracefully if knowledge base already deleted', async () => {
     const sdkError = new Error('Not found');
-    (sdkError as any).name = 'ResourceNotFoundException';
+    sdkError.name = 'ResourceNotFoundException';
     mockSend.mockRejectedValueOnce(sdkError);
 
     await expect(
@@ -55,7 +55,7 @@ describe('KnowledgeBaseAdapter.deprovision', () => {
 
   test('throws PermissionError on AccessDeniedException', async () => {
     const sdkError = new Error('Access Denied');
-    (sdkError as any).name = 'AccessDeniedException';
+    sdkError.name = 'AccessDeniedException';
     mockSend.mockRejectedValueOnce(sdkError);
 
     await expect(
@@ -64,7 +64,6 @@ describe('KnowledgeBaseAdapter.deprovision', () => {
   });
 
   test('uses scoped credentials when provided', async () => {
-    const { BedrockAgentClient } = require('@aws-sdk/client-bedrock-agent');
     mockSend.mockResolvedValueOnce({});
 
     await adapter.deprovision!(
@@ -83,7 +82,7 @@ describe('KnowledgeBaseAdapter.deprovision', () => {
 
   test('propagates unexpected errors', async () => {
     const sdkError = new Error('Internal failure');
-    (sdkError as any).name = 'InternalServerError';
+    sdkError.name = 'InternalServerError';
     mockSend.mockRejectedValueOnce(sdkError);
 
     await expect(

--- a/backend/src/lambda/adapters/__tests__/knowledge-base-adapter-provision.test.ts
+++ b/backend/src/lambda/adapters/__tests__/knowledge-base-adapter-provision.test.ts
@@ -48,6 +48,9 @@ jest.mock('@aws-sdk/client-opensearchserverless', () => ({
 }));
 
 import { KnowledgeBaseAdapter } from '../knowledge-base-adapter';
+import { CreateKnowledgeBaseCommand } from '@aws-sdk/client-bedrock-agent';
+import { CreateRoleCommand, DeleteRolePolicyCommand, DeleteRoleCommand } from '@aws-sdk/client-iam';
+import { CreateCollectionCommand, CreateSecurityPolicyCommand } from '@aws-sdk/client-opensearchserverless';
 
 describe('KnowledgeBaseAdapter.provision - service role and defaults', () => {
   let adapter: KnowledgeBaseAdapter;
@@ -67,7 +70,7 @@ describe('KnowledgeBaseAdapter.provision - service role and defaults', () => {
     // Default: IAM role creation succeeds
     mockIamSend.mockResolvedValue({ Role: { Arn: 'arn:aws:iam::123456789012:role/citadel-kb-service-role-test' } });
     // Default: AOSS operations succeed
-    mockOssSend.mockImplementation((cmd: any) => {
+    mockOssSend.mockImplementation((cmd: { _type: string }) => {
       if (cmd._type === 'CreateSecurityPolicy') return Promise.resolve({ securityPolicyDetail: {} });
       if (cmd._type === 'CreateAccessPolicy') return Promise.resolve({ accessPolicyDetail: {} });
       if (cmd._type === 'CreateCollection') return Promise.resolve({
@@ -88,8 +91,10 @@ describe('KnowledgeBaseAdapter.provision - service role and defaults', () => {
       return Promise.resolve({});
     });
 
-    // Stub createVectorIndex to avoid real HTTP calls
-    (adapter as any).createVectorIndex = jest.fn().mockResolvedValue(undefined);
+    // Stub createVectorIndex (private) to avoid real HTTP calls
+    (adapter as unknown as { createVectorIndex: jest.Mock }).createVectorIndex = jest
+      .fn()
+      .mockResolvedValue(undefined);
   });
 
   test('creates a Bedrock service role when roleArn is not provided', async () => {
@@ -103,10 +108,9 @@ describe('KnowledgeBaseAdapter.provision - service role and defaults', () => {
 
     await adapter.provision({ name: 'test-kb' });
 
-    const { CreateRoleCommand } = require('@aws-sdk/client-iam');
     expect(CreateRoleCommand).toHaveBeenCalled();
-    const createRoleInput = CreateRoleCommand.mock.calls[0][0];
-    const trustPolicy = JSON.parse(createRoleInput.AssumeRolePolicyDocument);
+    const createRoleInput = jest.mocked(CreateRoleCommand).mock.calls[0][0];
+    const trustPolicy = JSON.parse(String(createRoleInput.AssumeRolePolicyDocument));
     expect(trustPolicy.Statement[0].Principal.Service).toBe('bedrock.amazonaws.com');
   });
 
@@ -121,9 +125,8 @@ describe('KnowledgeBaseAdapter.provision - service role and defaults', () => {
 
     await adapter.provision({ name: 'test-kb' });
 
-    const { CreateCollectionCommand } = require('@aws-sdk/client-opensearchserverless');
     expect(CreateCollectionCommand).toHaveBeenCalled();
-    const collInput = CreateCollectionCommand.mock.calls[0][0];
+    const collInput = jest.mocked(CreateCollectionCommand).mock.calls[0][0];
     expect(collInput.type).toBe('VECTORSEARCH');
   });
 
@@ -138,10 +141,9 @@ describe('KnowledgeBaseAdapter.provision - service role and defaults', () => {
 
     await adapter.provision({ name: 'test-kb' });
 
-    const { CreateSecurityPolicyCommand } = require('@aws-sdk/client-opensearchserverless');
     // Should have created both encryption and network policies
-    const secPolicyCalls = CreateSecurityPolicyCommand.mock.calls;
-    const types = secPolicyCalls.map((c: any) => c[0].type);
+    const secPolicyCalls = jest.mocked(CreateSecurityPolicyCommand).mock.calls;
+    const types = secPolicyCalls.map((c) => c[0].type);
     expect(types).toContain('encryption');
     expect(types).toContain('network');
   });
@@ -157,18 +159,16 @@ describe('KnowledgeBaseAdapter.provision - service role and defaults', () => {
 
     await adapter.provision({ name: 'test-kb' });
 
-    const { CreateKnowledgeBaseCommand } = require('@aws-sdk/client-bedrock-agent');
     expect(CreateKnowledgeBaseCommand).toHaveBeenCalled();
-    const kbInput = CreateKnowledgeBaseCommand.mock.calls[0][0];
+    const kbInput = jest.mocked(CreateKnowledgeBaseCommand).mock.calls[0][0];
     expect(kbInput.storageConfiguration).toBeDefined();
-    expect(kbInput.storageConfiguration.type).toBe('OPENSEARCH_SERVERLESS');
-    expect(kbInput.storageConfiguration.opensearchServerlessConfiguration.collectionArn).toContain('arn:aws:aoss:');
+    expect(kbInput.storageConfiguration?.type).toBe('OPENSEARCH_SERVERLESS');
+    expect(kbInput.storageConfiguration?.opensearchServerlessConfiguration?.collectionArn).toContain('arn:aws:aoss:');
   });
 
   test('uses provided roleArn without creating a new service role', async () => {
     mockIamSend.mockClear();
-    const { CreateRoleCommand } = require('@aws-sdk/client-iam');
-    CreateRoleCommand.mockClear();
+    jest.mocked(CreateRoleCommand).mockClear();
 
     mockSend.mockResolvedValueOnce({
       knowledgeBase: {
@@ -186,8 +186,8 @@ describe('KnowledgeBaseAdapter.provision - service role and defaults', () => {
 
     expect(CreateRoleCommand).not.toHaveBeenCalled();
 
-    const { CreateKnowledgeBaseCommand } = require('@aws-sdk/client-bedrock-agent');
-    const kbInput = CreateKnowledgeBaseCommand.mock.calls[CreateKnowledgeBaseCommand.mock.calls.length - 1][0];
+    const kbCalls = jest.mocked(CreateKnowledgeBaseCommand).mock.calls;
+    const kbInput = kbCalls[kbCalls.length - 1][0];
     expect(kbInput.roleArn).toBe('arn:aws:iam::123456789012:role/my-custom-role');
   });
 
@@ -202,9 +202,8 @@ describe('KnowledgeBaseAdapter.provision - service role and defaults', () => {
 
     await adapter.provision({ name: 'test-kb' });
 
-    const { CreateKnowledgeBaseCommand } = require('@aws-sdk/client-bedrock-agent');
-    const kbInput = CreateKnowledgeBaseCommand.mock.calls[0][0];
-    expect(kbInput.knowledgeBaseConfiguration.vectorKnowledgeBaseConfiguration.embeddingModelArn).toContain('amazon.titan-embed-text-v2');
+    const kbInput = jest.mocked(CreateKnowledgeBaseCommand).mock.calls[0][0];
+    expect(kbInput.knowledgeBaseConfiguration?.vectorKnowledgeBaseConfiguration?.embeddingModelArn).toContain('amazon.titan-embed-text-v2');
   });
 
   test('returns empty provision policies so Lambda credentials are used', () => {
@@ -217,7 +216,6 @@ describe('KnowledgeBaseAdapter.provision - service role and defaults', () => {
 
     await adapter.deprovision({ knowledgeBaseId: 'KB123', serviceRoleName: 'citadel-ds-kb-svc-KB123' });
 
-    const { DeleteRolePolicyCommand, DeleteRoleCommand } = require('@aws-sdk/client-iam');
     expect(DeleteRolePolicyCommand).toHaveBeenCalled();
     expect(DeleteRoleCommand).toHaveBeenCalled();
   });

--- a/backend/src/lambda/adapters/__tests__/lake-formation-adapter.test.ts
+++ b/backend/src/lambda/adapters/__tests__/lake-formation-adapter.test.ts
@@ -4,7 +4,9 @@ import {
   ConnectionError,
   PermissionError,
   ResourceNotFoundError,
+  DataStoreError,
 } from '../errors';
+import { LakeFormationClient } from '@aws-sdk/client-lakeformation';
 
 const mockSend = jest.fn();
 jest.mock('@aws-sdk/client-lakeformation', () => {
@@ -58,7 +60,7 @@ describe('LakeFormationAdapter', () => {
 
     it('handles AlreadyExistsException as idempotent success', async () => {
       const sdkError = new Error('Already exists');
-      (sdkError as any).name = 'AlreadyExistsException';
+      sdkError.name = 'AlreadyExistsException';
       mockSend.mockRejectedValueOnce(sdkError);
       const result = await adapter.provision(config);
       expect(result.resourceArn).toBe('arn:aws:s3:::my-data-lake-bucket');
@@ -66,21 +68,21 @@ describe('LakeFormationAdapter', () => {
 
     it('wraps AccessDeniedException in PermissionError', async () => {
       const sdkError = new Error('Access Denied');
-      (sdkError as any).name = 'AccessDeniedException';
+      sdkError.name = 'AccessDeniedException';
       mockSend.mockRejectedValueOnce(sdkError);
       await expect(adapter.provision(config)).rejects.toThrow(PermissionError);
     });
 
     it('wraps unknown SDK errors in ProvisioningError with cause', async () => {
       const sdkError = new Error('Something broke');
-      (sdkError as any).name = 'InternalError';
+      sdkError.name = 'InternalError';
       mockSend.mockRejectedValueOnce(sdkError);
       try {
         await adapter.provision(config);
         fail('Expected ProvisioningError');
-      } catch (err: any) {
+      } catch (err) {
         expect(err).toBeInstanceOf(ProvisioningError);
-        expect(err.cause).toBe(sdkError);
+        expect((err as DataStoreError).cause).toBe(sdkError);
       }
     });
   });
@@ -103,28 +105,28 @@ describe('LakeFormationAdapter', () => {
 
     it('throws ResourceNotFoundError on EntityNotFoundException', async () => {
       const sdkError = new Error('Not found');
-      (sdkError as any).name = 'EntityNotFoundException';
+      sdkError.name = 'EntityNotFoundException';
       mockSend.mockRejectedValueOnce(sdkError);
       await expect(adapter.connect(config)).rejects.toThrow(ResourceNotFoundError);
     });
 
     it('throws PermissionError on AccessDeniedException', async () => {
       const sdkError = new Error('Forbidden');
-      (sdkError as any).name = 'AccessDeniedException';
+      sdkError.name = 'AccessDeniedException';
       mockSend.mockRejectedValueOnce(sdkError);
       await expect(adapter.connect(config)).rejects.toThrow(PermissionError);
     });
 
     it('wraps other errors in ConnectionError with cause', async () => {
       const sdkError = new Error('Network issue');
-      (sdkError as any).name = 'NetworkingError';
+      sdkError.name = 'NetworkingError';
       mockSend.mockRejectedValueOnce(sdkError);
       try {
         await adapter.connect(config);
         fail('Expected ConnectionError');
-      } catch (err: any) {
+      } catch (err) {
         expect(err).toBeInstanceOf(ConnectionError);
-        expect(err.cause).toBe(sdkError);
+        expect((err as DataStoreError).cause).toBe(sdkError);
       }
     });
   });
@@ -178,14 +180,14 @@ describe('LakeFormationAdapter', () => {
 
     it('wraps AccessDeniedException in PermissionError', async () => {
       const sdkError = new Error('Access Denied');
-      (sdkError as any).name = 'AccessDeniedException';
+      sdkError.name = 'AccessDeniedException';
       mockSend.mockRejectedValueOnce(sdkError);
       await expect(adapter.getMetrics(config)).rejects.toThrow(PermissionError);
     });
 
     it('wraps other errors in ConnectionError', async () => {
       const sdkError = new Error('Timeout');
-      (sdkError as any).name = 'RequestTimeout';
+      sdkError.name = 'RequestTimeout';
       mockSend.mockRejectedValueOnce(sdkError);
       await expect(adapter.getMetrics(config)).rejects.toThrow(ConnectionError);
     });
@@ -193,7 +195,6 @@ describe('LakeFormationAdapter', () => {
 
   describe('scoped credentials', () => {
     it('constructs client with provided credentials', async () => {
-      const { LakeFormationClient } = require('@aws-sdk/client-lakeformation');
       mockSend.mockResolvedValueOnce({
         DataLakeSettings: {
           DataLakeAdmins: [],

--- a/backend/src/lambda/adapters/__tests__/neptune-adapter.test.ts
+++ b/backend/src/lambda/adapters/__tests__/neptune-adapter.test.ts
@@ -4,7 +4,9 @@ import {
   ConnectionError,
   PermissionError,
   ResourceNotFoundError,
+  DataStoreError,
 } from '../errors';
+import { NeptuneClient, CreateDBClusterCommand } from '@aws-sdk/client-neptune';
 
 const mockSend = jest.fn();
 jest.mock('@aws-sdk/client-neptune', () => {
@@ -67,7 +69,6 @@ describe('NeptuneAdapter', () => {
     });
 
     it('uses neptune engine in CreateDBClusterCommand', async () => {
-      const { CreateDBClusterCommand } = require('@aws-sdk/client-neptune');
       mockSend.mockResolvedValueOnce({ DBCluster: {} });
       await adapter.provision(config);
       expect(CreateDBClusterCommand).toHaveBeenCalledWith(
@@ -77,7 +78,7 @@ describe('NeptuneAdapter', () => {
 
     it('handles DBClusterAlreadyExistsFault as idempotent success', async () => {
       const sdkError = new Error('Already exists');
-      (sdkError as any).name = 'DBClusterAlreadyExistsFault';
+      sdkError.name = 'DBClusterAlreadyExistsFault';
       mockSend.mockRejectedValueOnce(sdkError);
       const result = await adapter.provision(config);
       expect(result.resourceArn).toContain('my-neptune-cluster');
@@ -85,21 +86,21 @@ describe('NeptuneAdapter', () => {
 
     it('wraps AccessDeniedException in PermissionError', async () => {
       const sdkError = new Error('Access Denied');
-      (sdkError as any).name = 'AccessDeniedException';
+      sdkError.name = 'AccessDeniedException';
       mockSend.mockRejectedValueOnce(sdkError);
       await expect(adapter.provision(config)).rejects.toThrow(PermissionError);
     });
 
     it('wraps unknown SDK errors in ProvisioningError with cause', async () => {
       const sdkError = new Error('Something broke');
-      (sdkError as any).name = 'InternalError';
+      sdkError.name = 'InternalError';
       mockSend.mockRejectedValueOnce(sdkError);
       try {
         await adapter.provision(config);
         fail('Expected ProvisioningError');
-      } catch (err: any) {
+      } catch (err) {
         expect(err).toBeInstanceOf(ProvisioningError);
-        expect(err.cause).toBe(sdkError);
+        expect((err as DataStoreError).cause).toBe(sdkError);
       }
     });
   });
@@ -121,28 +122,28 @@ describe('NeptuneAdapter', () => {
 
     it('throws ResourceNotFoundError when cluster does not exist', async () => {
       const sdkError = new Error('Not found');
-      (sdkError as any).name = 'DBClusterNotFoundFault';
+      sdkError.name = 'DBClusterNotFoundFault';
       mockSend.mockRejectedValueOnce(sdkError);
       await expect(adapter.connect(config)).rejects.toThrow(ResourceNotFoundError);
     });
 
     it('throws PermissionError on AccessDeniedException', async () => {
       const sdkError = new Error('Forbidden');
-      (sdkError as any).name = 'AccessDeniedException';
+      sdkError.name = 'AccessDeniedException';
       mockSend.mockRejectedValueOnce(sdkError);
       await expect(adapter.connect(config)).rejects.toThrow(PermissionError);
     });
 
     it('wraps other errors in ConnectionError with cause', async () => {
       const sdkError = new Error('Network issue');
-      (sdkError as any).name = 'NetworkingError';
+      sdkError.name = 'NetworkingError';
       mockSend.mockRejectedValueOnce(sdkError);
       try {
         await adapter.connect(config);
         fail('Expected ConnectionError');
-      } catch (err: any) {
+      } catch (err) {
         expect(err).toBeInstanceOf(ConnectionError);
-        expect(err.cause).toBe(sdkError);
+        expect((err as DataStoreError).cause).toBe(sdkError);
       }
     });
   });
@@ -188,14 +189,14 @@ describe('NeptuneAdapter', () => {
 
     it('wraps AccessDeniedException in PermissionError', async () => {
       const sdkError = new Error('Access Denied');
-      (sdkError as any).name = 'AccessDeniedException';
+      sdkError.name = 'AccessDeniedException';
       mockSend.mockRejectedValueOnce(sdkError);
       await expect(adapter.getMetrics(config)).rejects.toThrow(PermissionError);
     });
 
     it('wraps other errors in ConnectionError', async () => {
       const sdkError = new Error('Timeout');
-      (sdkError as any).name = 'RequestTimeout';
+      sdkError.name = 'RequestTimeout';
       mockSend.mockRejectedValueOnce(sdkError);
       await expect(adapter.getMetrics(config)).rejects.toThrow(ConnectionError);
     });
@@ -203,7 +204,6 @@ describe('NeptuneAdapter', () => {
 
   describe('scoped credentials', () => {
     it('constructs client with provided credentials', async () => {
-      const { NeptuneClient } = require('@aws-sdk/client-neptune');
       mockSend.mockResolvedValueOnce({
         DBClusters: [{ Status: 'available' }],
       });

--- a/backend/src/lambda/adapters/__tests__/opensearch-adapter.test.ts
+++ b/backend/src/lambda/adapters/__tests__/opensearch-adapter.test.ts
@@ -4,7 +4,9 @@ import {
   ConnectionError,
   PermissionError,
   ResourceNotFoundError,
+  DataStoreError,
 } from '../errors';
+import { OpenSearchServerlessClient, CreateCollectionCommand, BatchGetCollectionCommand } from '@aws-sdk/client-opensearchserverless';
 
 const mockSend = jest.fn();
 jest.mock('@aws-sdk/client-opensearchserverless', () => {
@@ -24,7 +26,7 @@ describe('OpenSearchAdapter', () => {
     adapter = new OpenSearchAdapter();
     mockSend.mockReset();
     // Default: security policy calls succeed, other calls need explicit mocking
-    mockSend.mockImplementation((cmd: any) => {
+    mockSend.mockImplementation((cmd: { _type: string }) => {
       if (cmd._type === 'CreateSecurityPolicy') return Promise.resolve({ securityPolicyDetail: {} });
       return Promise.resolve({});
     });
@@ -65,7 +67,7 @@ describe('OpenSearchAdapter', () => {
   describe('provision', () => {
     beforeEach(() => {
       // Default: security policies succeed, collection creation succeeds
-      mockSend.mockImplementation((cmd: any) => {
+      mockSend.mockImplementation((cmd: { _type: string }) => {
         if (cmd._type === 'CreateSecurityPolicy') return Promise.resolve({ securityPolicyDetail: {} });
         if (cmd._type === 'CreateCollection') return Promise.resolve({
           createCollectionDetail: { arn: 'arn:aws:aoss:us-east-1:123:collection/my-test-collection' },
@@ -80,7 +82,6 @@ describe('OpenSearchAdapter', () => {
     });
 
     it('uses SEARCH type by default', async () => {
-      const { CreateCollectionCommand } = require('@aws-sdk/client-opensearchserverless');
       await adapter.provision(config);
       expect(CreateCollectionCommand).toHaveBeenCalledWith(
         expect.objectContaining({ type: 'SEARCH' })
@@ -88,7 +89,6 @@ describe('OpenSearchAdapter', () => {
     });
 
     it('uses VECTORSEARCH type when specified in config', async () => {
-      const { CreateCollectionCommand } = require('@aws-sdk/client-opensearchserverless');
       await adapter.provision({ ...config, collectionType: 'VECTORSEARCH' });
       expect(CreateCollectionCommand).toHaveBeenCalledWith(
         expect.objectContaining({ type: 'VECTORSEARCH' })
@@ -97,8 +97,8 @@ describe('OpenSearchAdapter', () => {
 
     it('handles ConflictException as idempotent success', async () => {
       const sdkError = new Error('Already exists');
-      (sdkError as any).name = 'ConflictException';
-      mockSend.mockImplementation((cmd: any) => {
+      sdkError.name = 'ConflictException';
+      mockSend.mockImplementation((cmd: { _type: string }) => {
         if (cmd._type === 'CreateSecurityPolicy') return Promise.resolve({ securityPolicyDetail: {} });
         if (cmd._type === 'CreateCollection') return Promise.reject(sdkError);
         return Promise.resolve({});
@@ -109,8 +109,8 @@ describe('OpenSearchAdapter', () => {
 
     it('wraps AccessDeniedException in PermissionError', async () => {
       const sdkError = new Error('Access Denied');
-      (sdkError as any).name = 'AccessDeniedException';
-      mockSend.mockImplementation((cmd: any) => {
+      sdkError.name = 'AccessDeniedException';
+      mockSend.mockImplementation((cmd: { _type: string }) => {
         if (cmd._type === 'CreateSecurityPolicy') return Promise.resolve({ securityPolicyDetail: {} });
         if (cmd._type === 'CreateCollection') return Promise.reject(sdkError);
         return Promise.resolve({});
@@ -120,8 +120,8 @@ describe('OpenSearchAdapter', () => {
 
     it('wraps unknown SDK errors in ProvisioningError with cause', async () => {
       const sdkError = new Error('Something broke');
-      (sdkError as any).name = 'InternalError';
-      mockSend.mockImplementation((cmd: any) => {
+      sdkError.name = 'InternalError';
+      mockSend.mockImplementation((cmd: { _type: string }) => {
         if (cmd._type === 'CreateSecurityPolicy') return Promise.resolve({ securityPolicyDetail: {} });
         if (cmd._type === 'CreateCollection') return Promise.reject(sdkError);
         return Promise.resolve({});
@@ -129,14 +129,13 @@ describe('OpenSearchAdapter', () => {
       try {
         await adapter.provision(config);
         fail('Expected ProvisioningError');
-      } catch (err: any) {
+      } catch (err) {
         expect(err).toBeInstanceOf(ProvisioningError);
-        expect(err.cause).toBe(sdkError);
+        expect((err as DataStoreError).cause).toBe(sdkError);
       }
     });
 
     it('generates a name when collectionName is not in config', async () => {
-      const { CreateCollectionCommand } = require('@aws-sdk/client-opensearchserverless');
       await adapter.provision({});
       expect(CreateCollectionCommand).toHaveBeenCalledWith(
         expect.objectContaining({
@@ -168,26 +167,25 @@ describe('OpenSearchAdapter', () => {
 
     it('throws PermissionError on AccessDeniedException', async () => {
       const sdkError = new Error('Forbidden');
-      (sdkError as any).name = 'AccessDeniedException';
+      sdkError.name = 'AccessDeniedException';
       mockSend.mockRejectedValueOnce(sdkError);
       await expect(adapter.connect(config)).rejects.toThrow(PermissionError);
     });
 
     it('wraps other errors in ConnectionError with cause', async () => {
       const sdkError = new Error('Network issue');
-      (sdkError as any).name = 'NetworkingError';
+      sdkError.name = 'NetworkingError';
       mockSend.mockRejectedValueOnce(sdkError);
       try {
         await adapter.connect(config);
         fail('Expected ConnectionError');
-      } catch (err: any) {
+      } catch (err) {
         expect(err).toBeInstanceOf(ConnectionError);
-        expect(err.cause).toBe(sdkError);
+        expect((err as DataStoreError).cause).toBe(sdkError);
       }
     });
 
     it('uses collectionId when collectionName is not provided', async () => {
-      const { BatchGetCollectionCommand } = require('@aws-sdk/client-opensearchserverless');
       mockSend.mockResolvedValueOnce({
         collectionDetails: [{ name: 'test', status: 'ACTIVE' }],
       });
@@ -244,7 +242,6 @@ describe('OpenSearchAdapter', () => {
 
   describe('scoped credentials', () => {
     it('constructs client with provided credentials', async () => {
-      const { OpenSearchServerlessClient } = require('@aws-sdk/client-opensearchserverless');
       mockSend.mockResolvedValueOnce({
         collectionDetails: [{ name: 'test', status: 'ACTIVE' }],
       });

--- a/backend/src/lambda/adapters/__tests__/policy-manager.property.test.ts
+++ b/backend/src/lambda/adapters/__tests__/policy-manager.property.test.ts
@@ -1,4 +1,6 @@
 import * as fc from 'fast-check';
+import type { IAMClient } from '@aws-sdk/client-iam';
+import type { STSClient } from '@aws-sdk/client-sts';
 import { PolicyManager } from '../../../utils/policy-manager';
 import { PolicyStatement } from '../../../adapters/base';
 
@@ -33,15 +35,18 @@ const crossAccountRoleArnArb = accountIdArb.map(
 
 // ---- Mocks ----
 
-function makeMockIamClient(capturedCalls: Record<string, any[]> = {}) {
+/** Captured IAM command inputs, keyed by command constructor name. */
+type CapturedCalls = Record<string, Array<Record<string, string>>>;
+
+function makeMockIamClient(capturedCalls: CapturedCalls = {}) {
   return {
-    send: jest.fn().mockImplementation((cmd: any) => {
+    send: jest.fn().mockImplementation((cmd: { input: Record<string, string> }) => {
       const name = cmd.constructor.name;
       if (!capturedCalls[name]) capturedCalls[name] = [];
       capturedCalls[name].push(cmd.input);
       return Promise.resolve({});
     }),
-  } as any;
+  } as unknown as IAMClient;
 }
 
 function makeMockStsClient(
@@ -50,7 +55,7 @@ function makeMockStsClient(
   region = 'us-east-1'
 ) {
   return {
-    send: jest.fn().mockImplementation((cmd: any) => {
+    send: jest.fn().mockImplementation((cmd: object) => {
       if (cmd.constructor.name === 'GetCallerIdentityCommand') {
         return Promise.resolve({ Account: accountId, Arn: callerArn });
       }
@@ -66,7 +71,7 @@ function makeMockStsClient(
       return Promise.resolve({});
     }),
     config: { region: () => Promise.resolve(region) },
-  } as any;
+  } as unknown as STSClient;
 }
 
 // Feature: datastore-adapter-pattern, Property 2: PolicyManager policy document generation
@@ -79,7 +84,7 @@ describe('Property 2: PolicyManager policy document generation', () => {
         policyStatementsArb,
         accountIdArb,
         async (dataStoreId, policies, accountId) => {
-          const capturedCalls: Record<string, any[]> = {};
+          const capturedCalls: CapturedCalls = {};
           const iamClient = makeMockIamClient(capturedCalls);
           const callerArn = `arn:aws:sts::${accountId}:assumed-role/LambdaRole/session`;
           const stsClient = makeMockStsClient(accountId, callerArn);
@@ -127,7 +132,7 @@ describe('Property 3: PolicyManager cross-account trust policy', () => {
         accountIdArb,
         crossAccountRoleArnArb,
         async (dataStoreId, policies, accountId, crossAccountRoleArn) => {
-          const capturedCalls: Record<string, any[]> = {};
+          const capturedCalls: CapturedCalls = {};
           const iamClient = makeMockIamClient(capturedCalls);
           const callerArn = `arn:aws:sts::${accountId}:assumed-role/LambdaRole/session`;
           const stsClient = makeMockStsClient(accountId, callerArn);
@@ -156,7 +161,7 @@ describe('Property 3: PolicyManager cross-account trust policy', () => {
         policyStatementsArb,
         accountIdArb,
         async (dataStoreId, policies, accountId) => {
-          const capturedCalls: Record<string, any[]> = {};
+          const capturedCalls: CapturedCalls = {};
           const iamClient = makeMockIamClient(capturedCalls);
           const callerArn = `arn:aws:sts::${accountId}:assumed-role/LambdaRole/session`;
           const stsClient = makeMockStsClient(accountId, callerArn);
@@ -198,7 +203,7 @@ describe('Property 4: Retry mechanism correctness', () => {
             return 'success';
           };
 
-          const pm = new PolicyManager({} as any, {} as any);
+          const pm = new PolicyManager({} as unknown as IAMClient, {} as unknown as STSClient);
           const result = await pm.retryWithBackoff(fn, maxRetries, baseDelayMs);
           expect(result).toBe('success');
           expect(attempts).toBe(failCount + 1);
@@ -220,14 +225,14 @@ describe('Property 4: Retry mechanism correctness', () => {
             throw new Error(`Attempt ${attempts} failed`);
           };
 
-          const pm = new PolicyManager({} as any, {} as any);
+          const pm = new PolicyManager({} as unknown as IAMClient, {} as unknown as STSClient);
           try {
             await pm.retryWithBackoff(fn, maxRetries, baseDelayMs);
             fail('Expected error to be thrown');
-          } catch (error: any) {
+          } catch (error) {
             // Should have attempted maxRetries + 1 times (initial + retries)
             expect(attempts).toBe(maxRetries + 1);
-            expect(error.message).toBe(`Attempt ${maxRetries + 1} failed`);
+            expect((error as Error).message).toBe(`Attempt ${maxRetries + 1} failed`);
           }
         }
       ),
@@ -265,7 +270,7 @@ describe('Property 4: Retry mechanism correctness', () => {
               return 'success';
             };
 
-            const pm = new PolicyManager({} as any, {} as any);
+            const pm = new PolicyManager({} as unknown as IAMClient, {} as unknown as STSClient);
             const result = await pm.retryWithBackoff(fn, maxRetries, baseDelayMs);
 
             expect(result).toBe('success');

--- a/backend/src/lambda/adapters/__tests__/rds-adapter.test.ts
+++ b/backend/src/lambda/adapters/__tests__/rds-adapter.test.ts
@@ -4,7 +4,9 @@ import {
   ConnectionError,
   PermissionError,
   ResourceNotFoundError,
+  DataStoreError,
 } from '../errors';
+import { RDSClient, CreateDBInstanceCommand } from '@aws-sdk/client-rds';
 
 const mockSend = jest.fn();
 jest.mock('@aws-sdk/client-rds', () => {
@@ -60,7 +62,6 @@ describe('RdsAdapter', () => {
     });
 
     it('uses postgres engine for postgres adapter', async () => {
-      const { CreateDBInstanceCommand } = require('@aws-sdk/client-rds');
       mockSend.mockResolvedValueOnce({ DBInstance: {} });
       await postgresAdapter.provision(config, creds);
       expect(CreateDBInstanceCommand).toHaveBeenCalledWith(
@@ -69,7 +70,6 @@ describe('RdsAdapter', () => {
     });
 
     it('uses mysql engine for mysql adapter', async () => {
-      const { CreateDBInstanceCommand } = require('@aws-sdk/client-rds');
       mockSend.mockResolvedValueOnce({ DBInstance: {} });
       await mysqlAdapter.provision(config, creds);
       expect(CreateDBInstanceCommand).toHaveBeenCalledWith(
@@ -83,7 +83,7 @@ describe('RdsAdapter', () => {
 
     it('handles DBInstanceAlreadyExistsFault as idempotent success', async () => {
       const sdkError = new Error('Already exists');
-      (sdkError as any).name = 'DBInstanceAlreadyExistsFault';
+      sdkError.name = 'DBInstanceAlreadyExistsFault';
       mockSend.mockRejectedValueOnce(sdkError);
       const result = await postgresAdapter.provision(config, creds);
       expect(result.resourceArn).toContain('my-test-db');
@@ -91,21 +91,21 @@ describe('RdsAdapter', () => {
 
     it('wraps AccessDeniedException in PermissionError', async () => {
       const sdkError = new Error('Access Denied');
-      (sdkError as any).name = 'AccessDeniedException';
+      sdkError.name = 'AccessDeniedException';
       mockSend.mockRejectedValueOnce(sdkError);
       await expect(postgresAdapter.provision(config, creds)).rejects.toThrow(PermissionError);
     });
 
     it('wraps unknown SDK errors in ProvisioningError with cause', async () => {
       const sdkError = new Error('Something broke');
-      (sdkError as any).name = 'InternalError';
+      sdkError.name = 'InternalError';
       mockSend.mockRejectedValueOnce(sdkError);
       try {
         await postgresAdapter.provision(config, creds);
         fail('Expected ProvisioningError');
-      } catch (err: any) {
+      } catch (err) {
         expect(err).toBeInstanceOf(ProvisioningError);
-        expect(err.cause).toBe(sdkError);
+        expect((err as DataStoreError).cause).toBe(sdkError);
       }
     });
   });
@@ -127,28 +127,28 @@ describe('RdsAdapter', () => {
 
     it('throws ResourceNotFoundError when instance does not exist', async () => {
       const sdkError = new Error('Not found');
-      (sdkError as any).name = 'DBInstanceNotFoundFault';
+      sdkError.name = 'DBInstanceNotFoundFault';
       mockSend.mockRejectedValueOnce(sdkError);
       await expect(postgresAdapter.connect(config)).rejects.toThrow(ResourceNotFoundError);
     });
 
     it('throws PermissionError on AccessDeniedException', async () => {
       const sdkError = new Error('Forbidden');
-      (sdkError as any).name = 'AccessDeniedException';
+      sdkError.name = 'AccessDeniedException';
       mockSend.mockRejectedValueOnce(sdkError);
       await expect(postgresAdapter.connect(config)).rejects.toThrow(PermissionError);
     });
 
     it('wraps other errors in ConnectionError with cause', async () => {
       const sdkError = new Error('Network issue');
-      (sdkError as any).name = 'NetworkingError';
+      sdkError.name = 'NetworkingError';
       mockSend.mockRejectedValueOnce(sdkError);
       try {
         await postgresAdapter.connect(config);
         fail('Expected ConnectionError');
-      } catch (err: any) {
+      } catch (err) {
         expect(err).toBeInstanceOf(ConnectionError);
-        expect(err.cause).toBe(sdkError);
+        expect((err as DataStoreError).cause).toBe(sdkError);
       }
     });
   });
@@ -194,7 +194,7 @@ describe('RdsAdapter', () => {
 
     it('wraps AccessDeniedException in PermissionError', async () => {
       const sdkError = new Error('Access Denied');
-      (sdkError as any).name = 'AccessDeniedException';
+      sdkError.name = 'AccessDeniedException';
       mockSend.mockRejectedValueOnce(sdkError);
       await expect(postgresAdapter.getMetrics(config)).rejects.toThrow(PermissionError);
     });
@@ -202,7 +202,6 @@ describe('RdsAdapter', () => {
 
   describe('scoped credentials', () => {
     it('constructs client with provided credentials', async () => {
-      const { RDSClient } = require('@aws-sdk/client-rds');
       mockSend.mockResolvedValueOnce({
         DBInstances: [{ DBInstanceStatus: 'available' }],
       });

--- a/backend/src/lambda/adapters/__tests__/redshift-adapter.test.ts
+++ b/backend/src/lambda/adapters/__tests__/redshift-adapter.test.ts
@@ -4,7 +4,9 @@ import {
   ConnectionError,
   PermissionError,
   ResourceNotFoundError,
+  DataStoreError,
 } from '../errors';
+import { RedshiftClient, CreateClusterCommand } from '@aws-sdk/client-redshift';
 
 const mockSend = jest.fn();
 jest.mock('@aws-sdk/client-redshift', () => {
@@ -57,7 +59,6 @@ describe('RedshiftAdapter', () => {
     });
 
     it('sends CreateClusterCommand with ra3.xlplus node type', async () => {
-      const { CreateClusterCommand } = require('@aws-sdk/client-redshift');
       mockSend.mockResolvedValueOnce({ Cluster: {} });
       await adapter.provision(config, creds);
       expect(CreateClusterCommand).toHaveBeenCalledWith(
@@ -76,7 +77,7 @@ describe('RedshiftAdapter', () => {
 
     it('handles ClusterAlreadyExistsFault as idempotent success', async () => {
       const sdkError = new Error('Already exists');
-      (sdkError as any).name = 'ClusterAlreadyExistsFault';
+      sdkError.name = 'ClusterAlreadyExistsFault';
       mockSend.mockRejectedValueOnce(sdkError);
       const result = await adapter.provision(config, creds);
       expect(result.resourceArn).toContain('my-test-cluster');
@@ -84,21 +85,21 @@ describe('RedshiftAdapter', () => {
 
     it('wraps AccessDeniedException in PermissionError', async () => {
       const sdkError = new Error('Access Denied');
-      (sdkError as any).name = 'AccessDeniedException';
+      sdkError.name = 'AccessDeniedException';
       mockSend.mockRejectedValueOnce(sdkError);
       await expect(adapter.provision(config, creds)).rejects.toThrow(PermissionError);
     });
 
     it('wraps unknown SDK errors in ProvisioningError with cause', async () => {
       const sdkError = new Error('Something broke');
-      (sdkError as any).name = 'InternalError';
+      sdkError.name = 'InternalError';
       mockSend.mockRejectedValueOnce(sdkError);
       try {
         await adapter.provision(config, creds);
         fail('Expected ProvisioningError');
-      } catch (err: any) {
+      } catch (err) {
         expect(err).toBeInstanceOf(ProvisioningError);
-        expect(err.cause).toBe(sdkError);
+        expect((err as DataStoreError).cause).toBe(sdkError);
       }
     });
   });
@@ -120,28 +121,28 @@ describe('RedshiftAdapter', () => {
 
     it('throws ResourceNotFoundError when cluster does not exist', async () => {
       const sdkError = new Error('Not found');
-      (sdkError as any).name = 'ClusterNotFoundFault';
+      sdkError.name = 'ClusterNotFoundFault';
       mockSend.mockRejectedValueOnce(sdkError);
       await expect(adapter.connect(config)).rejects.toThrow(ResourceNotFoundError);
     });
 
     it('throws PermissionError on AccessDeniedException', async () => {
       const sdkError = new Error('Forbidden');
-      (sdkError as any).name = 'AccessDeniedException';
+      sdkError.name = 'AccessDeniedException';
       mockSend.mockRejectedValueOnce(sdkError);
       await expect(adapter.connect(config)).rejects.toThrow(PermissionError);
     });
 
     it('wraps other errors in ConnectionError with cause', async () => {
       const sdkError = new Error('Network issue');
-      (sdkError as any).name = 'NetworkingError';
+      sdkError.name = 'NetworkingError';
       mockSend.mockRejectedValueOnce(sdkError);
       try {
         await adapter.connect(config);
         fail('Expected ConnectionError');
-      } catch (err: any) {
+      } catch (err) {
         expect(err).toBeInstanceOf(ConnectionError);
-        expect(err.cause).toBe(sdkError);
+        expect((err as DataStoreError).cause).toBe(sdkError);
       }
     });
   });
@@ -187,14 +188,14 @@ describe('RedshiftAdapter', () => {
 
     it('wraps AccessDeniedException in PermissionError', async () => {
       const sdkError = new Error('Access Denied');
-      (sdkError as any).name = 'AccessDeniedException';
+      sdkError.name = 'AccessDeniedException';
       mockSend.mockRejectedValueOnce(sdkError);
       await expect(adapter.getMetrics(config)).rejects.toThrow(PermissionError);
     });
 
     it('wraps other errors in ConnectionError', async () => {
       const sdkError = new Error('Timeout');
-      (sdkError as any).name = 'RequestTimeout';
+      sdkError.name = 'RequestTimeout';
       mockSend.mockRejectedValueOnce(sdkError);
       await expect(adapter.getMetrics(config)).rejects.toThrow(ConnectionError);
     });
@@ -202,7 +203,6 @@ describe('RedshiftAdapter', () => {
 
   describe('scoped credentials', () => {
     it('constructs client with provided credentials', async () => {
-      const { RedshiftClient } = require('@aws-sdk/client-redshift');
       mockSend.mockResolvedValueOnce({
         Clusters: [{ ClusterStatus: 'available' }],
       });

--- a/backend/src/lambda/adapters/__tests__/s3-adapter.test.ts
+++ b/backend/src/lambda/adapters/__tests__/s3-adapter.test.ts
@@ -4,7 +4,9 @@ import {
   ConnectionError,
   PermissionError,
   ResourceNotFoundError,
+  DataStoreError,
 } from '../errors';
+import { S3Client } from '@aws-sdk/client-s3';
 
 // Mock the entire @aws-sdk/client-s3 module
 const mockSend = jest.fn();
@@ -70,7 +72,7 @@ describe('S3Adapter', () => {
 
     it('handles BucketAlreadyOwnedByYou as idempotent success', async () => {
       const sdkError = new Error('Bucket already owned by you');
-      (sdkError as any).name = 'BucketAlreadyOwnedByYou';
+      sdkError.name = 'BucketAlreadyOwnedByYou';
       mockSend.mockRejectedValueOnce(sdkError);
       const result = await adapter.provision(config);
       expect(result.resourceArn).toBe('arn:aws:s3:::my-test-bucket');
@@ -78,34 +80,34 @@ describe('S3Adapter', () => {
 
     it('wraps AccessDenied in PermissionError', async () => {
       const sdkError = new Error('Access Denied');
-      (sdkError as any).name = 'AccessDenied';
+      sdkError.name = 'AccessDenied';
       mockSend.mockRejectedValueOnce(sdkError);
       await expect(adapter.provision(config)).rejects.toThrow(PermissionError);
     });
 
     it('wraps unknown SDK errors in ProvisioningError', async () => {
       const sdkError = new Error('Something broke');
-      (sdkError as any).name = 'InternalError';
+      sdkError.name = 'InternalError';
       mockSend.mockRejectedValueOnce(sdkError);
       await expect(adapter.provision(config)).rejects.toThrow(ProvisioningError);
     });
 
     it('preserves the original SDK error as cause', async () => {
       const sdkError = new Error('Something broke');
-      (sdkError as any).name = 'InternalError';
+      sdkError.name = 'InternalError';
       mockSend.mockRejectedValueOnce(sdkError);
       try {
         await adapter.provision(config);
         fail('Expected ProvisioningError');
-      } catch (err: any) {
-        expect(err.cause).toBe(sdkError);
+      } catch (err) {
+        expect((err as DataStoreError).cause).toBe(sdkError);
       }
     });
 
     it('wraps versioning AccessDenied in PermissionError', async () => {
       mockSend.mockResolvedValueOnce({}); // CreateBucket succeeds
       const sdkError = new Error('Access Denied');
-      (sdkError as any).name = 'AccessDenied';
+      sdkError.name = 'AccessDenied';
       mockSend.mockRejectedValueOnce(sdkError);
       await expect(
         adapter.provision({ ...config, versioning: true })
@@ -121,34 +123,34 @@ describe('S3Adapter', () => {
 
     it('throws ResourceNotFoundError when bucket does not exist', async () => {
       const sdkError = new Error('Not Found');
-      (sdkError as any).name = 'NotFound';
+      sdkError.name = 'NotFound';
       mockSend.mockRejectedValueOnce(sdkError);
       await expect(adapter.connect(config)).rejects.toThrow(ResourceNotFoundError);
     });
 
     it('throws PermissionError on AccessDenied', async () => {
       const sdkError = new Error('Forbidden');
-      (sdkError as any).name = 'AccessDenied';
+      sdkError.name = 'AccessDenied';
       mockSend.mockRejectedValueOnce(sdkError);
       await expect(adapter.connect(config)).rejects.toThrow(PermissionError);
     });
 
     it('throws ConnectionError on other errors', async () => {
       const sdkError = new Error('Network issue');
-      (sdkError as any).name = 'NetworkingError';
+      sdkError.name = 'NetworkingError';
       mockSend.mockRejectedValueOnce(sdkError);
       await expect(adapter.connect(config)).rejects.toThrow(ConnectionError);
     });
 
     it('preserves SDK error as cause in ConnectionError', async () => {
       const sdkError = new Error('Network issue');
-      (sdkError as any).name = 'NetworkingError';
+      sdkError.name = 'NetworkingError';
       mockSend.mockRejectedValueOnce(sdkError);
       try {
         await adapter.connect(config);
         fail('Expected ConnectionError');
-      } catch (err: any) {
-        expect(err.cause).toBe(sdkError);
+      } catch (err) {
+        expect((err as DataStoreError).cause).toBe(sdkError);
       }
     });
   });
@@ -169,7 +171,7 @@ describe('S3Adapter', () => {
 
     it('returns failure when HeadBucket fails', async () => {
       const sdkError = new Error('Not Found');
-      (sdkError as any).name = 'NotFound';
+      sdkError.name = 'NotFound';
       mockSend.mockRejectedValueOnce(sdkError);
       const result = await adapter.testConnection(config);
       expect(result.success).toBe(false);
@@ -204,14 +206,14 @@ describe('S3Adapter', () => {
 
     it('wraps AccessDenied in PermissionError', async () => {
       const sdkError = new Error('Access Denied');
-      (sdkError as any).name = 'AccessDenied';
+      sdkError.name = 'AccessDenied';
       mockSend.mockRejectedValueOnce(sdkError);
       await expect(adapter.getMetrics(config)).rejects.toThrow(PermissionError);
     });
 
     it('wraps other errors in ConnectionError', async () => {
       const sdkError = new Error('Timeout');
-      (sdkError as any).name = 'TimeoutError';
+      sdkError.name = 'TimeoutError';
       mockSend.mockRejectedValueOnce(sdkError);
       await expect(adapter.getMetrics(config)).rejects.toThrow(ConnectionError);
     });
@@ -219,7 +221,6 @@ describe('S3Adapter', () => {
 
   describe('scoped credentials', () => {
     it('constructs client with provided credentials', async () => {
-      const { S3Client } = require('@aws-sdk/client-s3');
       mockSend.mockResolvedValueOnce({});
       const creds = {
         accessKeyId: 'AKIA...',
@@ -237,7 +238,6 @@ describe('S3Adapter', () => {
     });
 
     it('constructs default client when no credentials provided', async () => {
-      const { S3Client } = require('@aws-sdk/client-s3');
       mockSend.mockResolvedValueOnce({});
       await adapter.connect(config);
       expect(S3Client).toHaveBeenCalledWith({});

--- a/backend/src/lambda/adapters/__tests__/s3-tables-adapter.test.ts
+++ b/backend/src/lambda/adapters/__tests__/s3-tables-adapter.test.ts
@@ -4,7 +4,9 @@ import {
   ConnectionError,
   PermissionError,
   ResourceNotFoundError,
+  DataStoreError,
 } from '../errors';
+import { S3TablesClient } from '@aws-sdk/client-s3tables';
 
 const mockSend = jest.fn();
 jest.mock('@aws-sdk/client-s3tables', () => {
@@ -67,7 +69,7 @@ describe('S3TablesAdapter', () => {
 
     it('handles ConflictException as idempotent success', async () => {
       const sdkError = new Error('Already exists');
-      (sdkError as any).name = 'ConflictException';
+      sdkError.name = 'ConflictException';
       mockSend.mockRejectedValueOnce(sdkError);
       const result = await adapter.provision(config);
       expect(result.resourceArn).toContain('my-test-bucket');
@@ -75,21 +77,21 @@ describe('S3TablesAdapter', () => {
 
     it('wraps AccessDeniedException in PermissionError', async () => {
       const sdkError = new Error('Access Denied');
-      (sdkError as any).name = 'AccessDeniedException';
+      sdkError.name = 'AccessDeniedException';
       mockSend.mockRejectedValueOnce(sdkError);
       await expect(adapter.provision(config)).rejects.toThrow(PermissionError);
     });
 
     it('wraps unknown SDK errors in ProvisioningError with cause', async () => {
       const sdkError = new Error('Something broke');
-      (sdkError as any).name = 'InternalError';
+      sdkError.name = 'InternalError';
       mockSend.mockRejectedValueOnce(sdkError);
       try {
         await adapter.provision(config);
         fail('Expected ProvisioningError');
-      } catch (err: any) {
+      } catch (err) {
         expect(err).toBeInstanceOf(ProvisioningError);
-        expect(err.cause).toBe(sdkError);
+        expect((err as DataStoreError).cause).toBe(sdkError);
       }
     });
   });
@@ -105,28 +107,28 @@ describe('S3TablesAdapter', () => {
 
     it('throws ResourceNotFoundError when table bucket does not exist', async () => {
       const sdkError = new Error('Not found');
-      (sdkError as any).name = 'NotFoundException';
+      sdkError.name = 'NotFoundException';
       mockSend.mockRejectedValueOnce(sdkError);
       await expect(adapter.connect(config)).rejects.toThrow(ResourceNotFoundError);
     });
 
     it('throws PermissionError on AccessDeniedException', async () => {
       const sdkError = new Error('Forbidden');
-      (sdkError as any).name = 'AccessDeniedException';
+      sdkError.name = 'AccessDeniedException';
       mockSend.mockRejectedValueOnce(sdkError);
       await expect(adapter.connect(config)).rejects.toThrow(PermissionError);
     });
 
     it('wraps other errors in ConnectionError with cause', async () => {
       const sdkError = new Error('Network issue');
-      (sdkError as any).name = 'NetworkingError';
+      sdkError.name = 'NetworkingError';
       mockSend.mockRejectedValueOnce(sdkError);
       try {
         await adapter.connect(config);
         fail('Expected ConnectionError');
-      } catch (err: any) {
+      } catch (err) {
         expect(err).toBeInstanceOf(ConnectionError);
-        expect(err.cause).toBe(sdkError);
+        expect((err as DataStoreError).cause).toBe(sdkError);
       }
     });
 
@@ -182,14 +184,14 @@ describe('S3TablesAdapter', () => {
 
     it('wraps AccessDeniedException in PermissionError', async () => {
       const sdkError = new Error('Access Denied');
-      (sdkError as any).name = 'AccessDeniedException';
+      sdkError.name = 'AccessDeniedException';
       mockSend.mockRejectedValueOnce(sdkError);
       await expect(adapter.getMetrics(config)).rejects.toThrow(PermissionError);
     });
 
     it('wraps other errors in ConnectionError', async () => {
       const sdkError = new Error('Timeout');
-      (sdkError as any).name = 'RequestTimeout';
+      sdkError.name = 'RequestTimeout';
       mockSend.mockRejectedValueOnce(sdkError);
       await expect(adapter.getMetrics(config)).rejects.toThrow(ConnectionError);
     });
@@ -197,7 +199,6 @@ describe('S3TablesAdapter', () => {
 
   describe('scoped credentials', () => {
     it('constructs client with provided credentials', async () => {
-      const { S3TablesClient } = require('@aws-sdk/client-s3tables');
       mockSend.mockResolvedValueOnce({
         arn: 'arn:aws:s3tables:us-east-1:123:bucket/my-test-bucket',
         name: 'my-test-bucket',

--- a/backend/src/lambda/adapters/__tests__/sagemaker-feature-store-adapter.test.ts
+++ b/backend/src/lambda/adapters/__tests__/sagemaker-feature-store-adapter.test.ts
@@ -4,7 +4,9 @@ import {
   ConnectionError,
   PermissionError,
   ResourceNotFoundError,
+  DataStoreError,
 } from '../errors';
+import { SageMakerClient, CreateFeatureGroupCommand } from '@aws-sdk/client-sagemaker';
 
 const mockSend = jest.fn();
 jest.mock('@aws-sdk/client-sagemaker', () => {
@@ -58,7 +60,6 @@ describe('SageMakerFeatureStoreAdapter', () => {
 
   describe('provision', () => {
     it('creates a feature group with online and offline store config and returns the ARN', async () => {
-      const { CreateFeatureGroupCommand } = require('@aws-sdk/client-sagemaker');
       mockSend.mockResolvedValueOnce({
         FeatureGroupArn: 'arn:aws:sagemaker:us-east-1:123:feature-group/my-feature-group',
       });
@@ -71,7 +72,7 @@ describe('SageMakerFeatureStoreAdapter', () => {
 
     it('handles ResourceInUse as idempotent success', async () => {
       const sdkError = new Error('Already exists');
-      (sdkError as any).name = 'ResourceInUse';
+      sdkError.name = 'ResourceInUse';
       mockSend.mockRejectedValueOnce(sdkError);
       const result = await adapter.provision(config);
       expect(result.resourceArn).toContain('my-feature-group');
@@ -79,21 +80,21 @@ describe('SageMakerFeatureStoreAdapter', () => {
 
     it('wraps AccessDeniedException in PermissionError', async () => {
       const sdkError = new Error('Access Denied');
-      (sdkError as any).name = 'AccessDeniedException';
+      sdkError.name = 'AccessDeniedException';
       mockSend.mockRejectedValueOnce(sdkError);
       await expect(adapter.provision(config)).rejects.toThrow(PermissionError);
     });
 
     it('wraps unknown SDK errors in ProvisioningError with cause', async () => {
       const sdkError = new Error('Something broke');
-      (sdkError as any).name = 'InternalError';
+      sdkError.name = 'InternalError';
       mockSend.mockRejectedValueOnce(sdkError);
       try {
         await adapter.provision(config);
         fail('Expected ProvisioningError');
-      } catch (err: any) {
+      } catch (err) {
         expect(err).toBeInstanceOf(ProvisioningError);
-        expect(err.cause).toBe(sdkError);
+        expect((err as DataStoreError).cause).toBe(sdkError);
       }
     });
   });
@@ -117,28 +118,28 @@ describe('SageMakerFeatureStoreAdapter', () => {
 
     it('throws ResourceNotFoundError when feature group does not exist', async () => {
       const sdkError = new Error('Not found');
-      (sdkError as any).name = 'ResourceNotFound';
+      sdkError.name = 'ResourceNotFound';
       mockSend.mockRejectedValueOnce(sdkError);
       await expect(adapter.connect(config)).rejects.toThrow(ResourceNotFoundError);
     });
 
     it('throws PermissionError on AccessDeniedException', async () => {
       const sdkError = new Error('Forbidden');
-      (sdkError as any).name = 'AccessDeniedException';
+      sdkError.name = 'AccessDeniedException';
       mockSend.mockRejectedValueOnce(sdkError);
       await expect(adapter.connect(config)).rejects.toThrow(PermissionError);
     });
 
     it('wraps other errors in ConnectionError with cause', async () => {
       const sdkError = new Error('Network issue');
-      (sdkError as any).name = 'NetworkingError';
+      sdkError.name = 'NetworkingError';
       mockSend.mockRejectedValueOnce(sdkError);
       try {
         await adapter.connect(config);
         fail('Expected ConnectionError');
-      } catch (err: any) {
+      } catch (err) {
         expect(err).toBeInstanceOf(ConnectionError);
-        expect(err.cause).toBe(sdkError);
+        expect((err as DataStoreError).cause).toBe(sdkError);
       }
     });
   });
@@ -184,14 +185,14 @@ describe('SageMakerFeatureStoreAdapter', () => {
 
     it('wraps AccessDeniedException in PermissionError', async () => {
       const sdkError = new Error('Access Denied');
-      (sdkError as any).name = 'AccessDeniedException';
+      sdkError.name = 'AccessDeniedException';
       mockSend.mockRejectedValueOnce(sdkError);
       await expect(adapter.getMetrics(config)).rejects.toThrow(PermissionError);
     });
 
     it('wraps other errors in ConnectionError', async () => {
       const sdkError = new Error('Timeout');
-      (sdkError as any).name = 'RequestTimeout';
+      sdkError.name = 'RequestTimeout';
       mockSend.mockRejectedValueOnce(sdkError);
       await expect(adapter.getMetrics(config)).rejects.toThrow(ConnectionError);
     });
@@ -199,7 +200,6 @@ describe('SageMakerFeatureStoreAdapter', () => {
 
   describe('scoped credentials', () => {
     it('constructs client with provided credentials', async () => {
-      const { SageMakerClient } = require('@aws-sdk/client-sagemaker');
       mockSend.mockResolvedValueOnce({
         FeatureGroupStatus: 'Created',
         FeatureGroupArn: 'arn:aws:sagemaker:us-east-1:123:feature-group/my-feature-group',

--- a/backend/src/lambda/adapters/__tests__/sagemaker-lakehouse-adapter.test.ts
+++ b/backend/src/lambda/adapters/__tests__/sagemaker-lakehouse-adapter.test.ts
@@ -4,7 +4,9 @@ import {
   ConnectionError,
   PermissionError,
   ResourceNotFoundError,
+  DataStoreError,
 } from '../errors';
+import { SageMakerClient } from '@aws-sdk/client-sagemaker';
 
 const mockSend = jest.fn();
 jest.mock('@aws-sdk/client-sagemaker', () => {
@@ -66,7 +68,7 @@ describe('SageMakerLakehouseAdapter', () => {
 
     it('handles ResourceInUse as idempotent success', async () => {
       const sdkError = new Error('Already exists');
-      (sdkError as any).name = 'ResourceInUse';
+      sdkError.name = 'ResourceInUse';
       mockSend.mockRejectedValueOnce(sdkError);
       const result = await adapter.provision(config);
       expect(result.resourceArn).toContain('my-feature-group');
@@ -74,21 +76,21 @@ describe('SageMakerLakehouseAdapter', () => {
 
     it('wraps AccessDeniedException in PermissionError', async () => {
       const sdkError = new Error('Access Denied');
-      (sdkError as any).name = 'AccessDeniedException';
+      sdkError.name = 'AccessDeniedException';
       mockSend.mockRejectedValueOnce(sdkError);
       await expect(adapter.provision(config)).rejects.toThrow(PermissionError);
     });
 
     it('wraps unknown SDK errors in ProvisioningError with cause', async () => {
       const sdkError = new Error('Something broke');
-      (sdkError as any).name = 'InternalError';
+      sdkError.name = 'InternalError';
       mockSend.mockRejectedValueOnce(sdkError);
       try {
         await adapter.provision(config);
         fail('Expected ProvisioningError');
-      } catch (err: any) {
+      } catch (err) {
         expect(err).toBeInstanceOf(ProvisioningError);
-        expect(err.cause).toBe(sdkError);
+        expect((err as DataStoreError).cause).toBe(sdkError);
       }
     });
   });
@@ -112,28 +114,28 @@ describe('SageMakerLakehouseAdapter', () => {
 
     it('throws ResourceNotFoundError when feature group does not exist', async () => {
       const sdkError = new Error('Not found');
-      (sdkError as any).name = 'ResourceNotFound';
+      sdkError.name = 'ResourceNotFound';
       mockSend.mockRejectedValueOnce(sdkError);
       await expect(adapter.connect(config)).rejects.toThrow(ResourceNotFoundError);
     });
 
     it('throws PermissionError on AccessDeniedException', async () => {
       const sdkError = new Error('Forbidden');
-      (sdkError as any).name = 'AccessDeniedException';
+      sdkError.name = 'AccessDeniedException';
       mockSend.mockRejectedValueOnce(sdkError);
       await expect(adapter.connect(config)).rejects.toThrow(PermissionError);
     });
 
     it('wraps other errors in ConnectionError with cause', async () => {
       const sdkError = new Error('Network issue');
-      (sdkError as any).name = 'NetworkingError';
+      sdkError.name = 'NetworkingError';
       mockSend.mockRejectedValueOnce(sdkError);
       try {
         await adapter.connect(config);
         fail('Expected ConnectionError');
-      } catch (err: any) {
+      } catch (err) {
         expect(err).toBeInstanceOf(ConnectionError);
-        expect(err.cause).toBe(sdkError);
+        expect((err as DataStoreError).cause).toBe(sdkError);
       }
     });
   });
@@ -178,14 +180,14 @@ describe('SageMakerLakehouseAdapter', () => {
 
     it('wraps AccessDeniedException in PermissionError', async () => {
       const sdkError = new Error('Access Denied');
-      (sdkError as any).name = 'AccessDeniedException';
+      sdkError.name = 'AccessDeniedException';
       mockSend.mockRejectedValueOnce(sdkError);
       await expect(adapter.getMetrics(config)).rejects.toThrow(PermissionError);
     });
 
     it('wraps other errors in ConnectionError', async () => {
       const sdkError = new Error('Timeout');
-      (sdkError as any).name = 'RequestTimeout';
+      sdkError.name = 'RequestTimeout';
       mockSend.mockRejectedValueOnce(sdkError);
       await expect(adapter.getMetrics(config)).rejects.toThrow(ConnectionError);
     });
@@ -193,7 +195,6 @@ describe('SageMakerLakehouseAdapter', () => {
 
   describe('scoped credentials', () => {
     it('constructs client with provided credentials', async () => {
-      const { SageMakerClient } = require('@aws-sdk/client-sagemaker');
       mockSend.mockResolvedValueOnce({
         FeatureGroupStatus: 'Created',
         FeatureGroupArn: 'arn:aws:sagemaker:us-east-1:123:feature-group/my-feature-group',

--- a/backend/src/lambda/adapters/__tests__/snowflake-adapter.test.ts
+++ b/backend/src/lambda/adapters/__tests__/snowflake-adapter.test.ts
@@ -1,4 +1,5 @@
 import { SnowflakeAdapter } from '../snowflake-adapter';
+import type { SdkError } from '../sdk-types';
 import {
   ProvisioningError,
   ConnectionError,
@@ -12,7 +13,7 @@ const mockDestroy = jest.fn();
 const mockCreateConnection = jest.fn();
 
 jest.mock('snowflake-sdk', () => ({
-  createConnection: (...args: any[]) => {
+  createConnection: (...args: unknown[]) => {
     mockCreateConnection(...args);
     return { connect: mockConnect, destroy: mockDestroy };
   },
@@ -107,16 +108,16 @@ describe('SnowflakeAdapter', () => {
     });
 
     it('wraps authentication errors in PermissionError', async () => {
-      const sdkError = new Error('Incorrect username or password');
-      (sdkError as any).code = '390100';
+      const sdkError: SdkError = new Error('Incorrect username or password');
+      sdkError.code = '390100';
       mockConnect.mockImplementation((cb: (err: unknown) => void) => cb(sdkError));
 
       try {
         await adapter.testConnection(validConfig);
         fail('Expected PermissionError');
-      } catch (err: any) {
+      } catch (err) {
         expect(err).toBeInstanceOf(PermissionError);
-        expect(err.cause).toBe(sdkError);
+        expect((err as DataStoreError).cause).toBe(sdkError);
       }
     });
 
@@ -127,9 +128,9 @@ describe('SnowflakeAdapter', () => {
       try {
         await adapter.testConnection(validConfig);
         fail('Expected ConnectionError');
-      } catch (err: any) {
+      } catch (err) {
         expect(err).toBeInstanceOf(ConnectionError);
-        expect(err.cause).toBe(sdkError);
+        expect((err as DataStoreError).cause).toBe(sdkError);
       }
     });
 
@@ -140,9 +141,9 @@ describe('SnowflakeAdapter', () => {
       try {
         await adapter.testConnection(validConfig);
         fail('Expected DataStoreError');
-      } catch (err: any) {
+      } catch (err) {
         expect(err).toBeInstanceOf(DataStoreError);
-        expect(err.cause).toBe(sdkError);
+        expect((err as DataStoreError).cause).toBe(sdkError);
       }
     });
 

--- a/backend/src/lambda/adapters/__tests__/timestream-adapter.test.ts
+++ b/backend/src/lambda/adapters/__tests__/timestream-adapter.test.ts
@@ -4,7 +4,9 @@ import {
   ConnectionError,
   PermissionError,
   ResourceNotFoundError,
+  DataStoreError,
 } from '../errors';
+import { TimestreamWriteClient, CreateTableCommand } from '@aws-sdk/client-timestream-write';
 
 const mockSend = jest.fn();
 jest.mock('@aws-sdk/client-timestream-write', () => {
@@ -61,7 +63,6 @@ describe('TimestreamAdapter', () => {
     });
 
     it('creates a table when tableName is in config', async () => {
-      const { CreateTableCommand } = require('@aws-sdk/client-timestream-write');
       mockSend
         .mockResolvedValueOnce({ Database: { Arn: 'arn:aws:timestream:us-east-1:123:database/my-test-db' } })
         .mockResolvedValueOnce({ Table: { Arn: 'arn:aws:timestream:us-east-1:123:table/my-test-db/my-table' } });
@@ -78,7 +79,7 @@ describe('TimestreamAdapter', () => {
 
     it('handles ConflictException on database creation as idempotent success', async () => {
       const sdkError = new Error('Already exists');
-      (sdkError as any).name = 'ConflictException';
+      sdkError.name = 'ConflictException';
       mockSend.mockRejectedValueOnce(sdkError);
       const result = await adapter.provision(config);
       expect(result.resourceArn).toContain('my-test-db');
@@ -86,7 +87,7 @@ describe('TimestreamAdapter', () => {
 
     it('handles ConflictException on table creation as idempotent success', async () => {
       const tableError = new Error('Table already exists');
-      (tableError as any).name = 'ConflictException';
+      tableError.name = 'ConflictException';
       mockSend
         .mockResolvedValueOnce({ Database: { Arn: 'arn:aws:timestream:us-east-1:123:database/my-test-db' } })
         .mockRejectedValueOnce(tableError);
@@ -98,27 +99,27 @@ describe('TimestreamAdapter', () => {
 
     it('wraps AccessDeniedException in PermissionError', async () => {
       const sdkError = new Error('Access Denied');
-      (sdkError as any).name = 'AccessDeniedException';
+      sdkError.name = 'AccessDeniedException';
       mockSend.mockRejectedValueOnce(sdkError);
       await expect(adapter.provision(config)).rejects.toThrow(PermissionError);
     });
 
     it('wraps unknown SDK errors in ProvisioningError with cause', async () => {
       const sdkError = new Error('Something broke');
-      (sdkError as any).name = 'InternalError';
+      sdkError.name = 'InternalError';
       mockSend.mockRejectedValueOnce(sdkError);
       try {
         await adapter.provision(config);
         fail('Expected ProvisioningError');
-      } catch (err: any) {
+      } catch (err) {
         expect(err).toBeInstanceOf(ProvisioningError);
-        expect(err.cause).toBe(sdkError);
+        expect((err as DataStoreError).cause).toBe(sdkError);
       }
     });
 
     it('propagates non-ConflictException table errors as ProvisioningError', async () => {
       const tableError = new Error('Validation failed');
-      (tableError as any).name = 'ValidationException';
+      tableError.name = 'ValidationException';
       mockSend
         .mockResolvedValueOnce({ Database: { Arn: 'arn:aws:timestream:us-east-1:123:database/my-test-db' } })
         .mockRejectedValueOnce(tableError);
@@ -138,28 +139,28 @@ describe('TimestreamAdapter', () => {
 
     it('throws ResourceNotFoundError when database does not exist', async () => {
       const sdkError = new Error('Not found');
-      (sdkError as any).name = 'ResourceNotFoundException';
+      sdkError.name = 'ResourceNotFoundException';
       mockSend.mockRejectedValueOnce(sdkError);
       await expect(adapter.connect(config)).rejects.toThrow(ResourceNotFoundError);
     });
 
     it('throws PermissionError on AccessDeniedException', async () => {
       const sdkError = new Error('Forbidden');
-      (sdkError as any).name = 'AccessDeniedException';
+      sdkError.name = 'AccessDeniedException';
       mockSend.mockRejectedValueOnce(sdkError);
       await expect(adapter.connect(config)).rejects.toThrow(PermissionError);
     });
 
     it('wraps other errors in ConnectionError with cause', async () => {
       const sdkError = new Error('Network issue');
-      (sdkError as any).name = 'NetworkingError';
+      sdkError.name = 'NetworkingError';
       mockSend.mockRejectedValueOnce(sdkError);
       try {
         await adapter.connect(config);
         fail('Expected ConnectionError');
-      } catch (err: any) {
+      } catch (err) {
         expect(err).toBeInstanceOf(ConnectionError);
-        expect(err.cause).toBe(sdkError);
+        expect((err as DataStoreError).cause).toBe(sdkError);
       }
     });
 
@@ -208,14 +209,14 @@ describe('TimestreamAdapter', () => {
 
     it('wraps AccessDeniedException in PermissionError', async () => {
       const sdkError = new Error('Access Denied');
-      (sdkError as any).name = 'AccessDeniedException';
+      sdkError.name = 'AccessDeniedException';
       mockSend.mockRejectedValueOnce(sdkError);
       await expect(adapter.getMetrics(config)).rejects.toThrow(PermissionError);
     });
 
     it('wraps other errors in ConnectionError', async () => {
       const sdkError = new Error('Timeout');
-      (sdkError as any).name = 'RequestTimeout';
+      sdkError.name = 'RequestTimeout';
       mockSend.mockRejectedValueOnce(sdkError);
       await expect(adapter.getMetrics(config)).rejects.toThrow(ConnectionError);
     });
@@ -223,7 +224,6 @@ describe('TimestreamAdapter', () => {
 
   describe('scoped credentials', () => {
     it('constructs client with provided credentials', async () => {
-      const { TimestreamWriteClient } = require('@aws-sdk/client-timestream-write');
       mockSend.mockResolvedValueOnce({
         Database: { Arn: 'arn:aws:timestream:us-east-1:123:database/my-test-db', DatabaseName: 'my-test-db' },
       });

--- a/backend/src/lambda/adapters/aurora-adapter.ts
+++ b/backend/src/lambda/adapters/aurora-adapter.ts
@@ -11,6 +11,7 @@ import {
 import {
   ProvisioningError, ConnectionError, PermissionError, ResourceNotFoundError,
 } from './errors';
+import { SdkError, AwsCredentialFields } from './sdk-types';
 
 export class AuroraAdapter implements ConnectorAdapter {
   readonly category: ConnectorCategory = 'datastore';
@@ -20,13 +21,14 @@ export class AuroraAdapter implements ConnectorAdapter {
     this.spec = { type: engine === 'postgres' ? 'AURORA_POSTGRESQL' : 'AURORA_MYSQL', provider: 'Amazon Web Services', category: 'datastore', authentication: { method: AuthenticationMethod.IAM_ROLE, fields: [], secretStructure: {} }, configuration: { required: ['clusterIdentifier'], optional: [], ssmParameters: [] } };
   }
 
-  private makeClient(creds?: Record<string, any>): RDSClient {
-    if (creds?.accessKeyId && creds?.secretAccessKey && creds?.sessionToken) {
+  private makeClient(creds?: Record<string, unknown>): RDSClient {
+    const c = creds as AwsCredentialFields | undefined;
+    if (c?.accessKeyId && c?.secretAccessKey && c?.sessionToken) {
       return new RDSClient({
         credentials: {
-          accessKeyId: creds.accessKeyId,
-          secretAccessKey: creds.secretAccessKey,
-          sessionToken: creds.sessionToken,
+          accessKeyId: c.accessKeyId,
+          secretAccessKey: c.secretAccessKey,
+          sessionToken: c.sessionToken,
         },
       });
     }
@@ -34,7 +36,7 @@ export class AuroraAdapter implements ConnectorAdapter {
   }
 
   requiredPolicies(
-    config: Record<string, any>,
+    config: Record<string, unknown>,
     accountId: string,
     region: string
   ): RequiredPolicies {
@@ -62,17 +64,17 @@ export class AuroraAdapter implements ConnectorAdapter {
   }
 
   async provision(
-    config: Record<string, any>,
-    credentials?: Record<string, any>
+    config: Record<string, unknown>,
+    credentials?: Record<string, unknown>
   ): Promise<ProvisionResult> {
     const client = this.makeClient(credentials);
     const identifier =
-      config.dbClusterIdentifier ??
+      (config.dbClusterIdentifier as string | undefined) ??
       `citadel-aurora-${this.engine}-${Date.now()}`;
     const engineName = this.engine === 'postgres' ? 'aurora-postgresql' : 'aurora-mysql';
 
-    const masterUsername = credentials?.masterUsername ?? config.masterUsername;
-    const masterPassword = credentials?.masterPassword ?? config.masterPassword;
+    const masterUsername = (credentials?.masterUsername ?? config.masterUsername) as string | undefined;
+    const masterPassword = (credentials?.masterPassword ?? config.masterPassword) as string | undefined;
 
     if (!masterUsername || !masterPassword) {
       throw new ProvisioningError(
@@ -103,34 +105,35 @@ export class AuroraAdapter implements ConnectorAdapter {
         `arn:aws:rds:${config.region ?? 'us-east-1'}:${config.accountId ?? '000000000000'}:cluster:${identifier}`;
 
       return { resourceArn: arn };
-    } catch (error: any) {
-      if (error.name === 'DBClusterAlreadyExistsFault') {
+    } catch (error) {
+      const err = error as SdkError;
+      if (err.name === 'DBClusterAlreadyExistsFault') {
         return {
           resourceArn: `arn:aws:rds:${config.region ?? 'us-east-1'}:${config.accountId ?? '000000000000'}:cluster:${identifier}`,
         };
       }
       if (
-        error.name === 'AccessDenied' ||
-        error.name === 'AccessDeniedException'
+        err.name === 'AccessDenied' ||
+        err.name === 'AccessDeniedException'
       ) {
         throw new PermissionError(
           `Permission denied creating Aurora cluster ${identifier}`,
-          error
+          err
         );
       }
       throw new ProvisioningError(
-        `Failed to create Aurora cluster ${identifier}: ${error.message}`,
-        error
+        `Failed to create Aurora cluster ${identifier}: ${err.message}`,
+        err
       );
     }
   }
 
   async connect(
-    config: Record<string, any>,
-    credentials?: Record<string, any>
+    config: Record<string, unknown>,
+    credentials?: Record<string, unknown>
   ): Promise<void> {
     const client = this.makeClient(credentials);
-    const identifier = config.dbClusterIdentifier;
+    const identifier = config.dbClusterIdentifier as string | undefined;
 
     try {
       const response = await client.send(
@@ -145,43 +148,44 @@ export class AuroraAdapter implements ConnectorAdapter {
           true
         );
       }
-    } catch (error: any) {
-      if (error instanceof ConnectionError) {
-        throw error;
+    } catch (error) {
+      const err = error as SdkError;
+      if (err instanceof ConnectionError) {
+        throw err;
       }
-      if (error.name === 'DBClusterNotFoundFault') {
+      if (err.name === 'DBClusterNotFoundFault') {
         throw new ResourceNotFoundError(
           `Aurora cluster ${identifier} does not exist`,
-          error
+          err
         );
       }
       if (
-        error.name === 'AccessDenied' ||
-        error.name === 'AccessDeniedException'
+        err.name === 'AccessDenied' ||
+        err.name === 'AccessDeniedException'
       ) {
         throw new PermissionError(
           `Permission denied accessing Aurora cluster ${identifier}`,
-          error
+          err
         );
       }
       throw new ConnectionError(
-        `Failed to connect to Aurora cluster ${identifier}: ${error.message}`,
+        `Failed to connect to Aurora cluster ${identifier}: ${err.message}`,
         true,
-        error
+        err
       );
     }
   }
 
-  async disconnect(_config: Record<string, any>): Promise<void> {
+  async disconnect(_config: Record<string, unknown>): Promise<void> {
     // No-op: disconnecting from Aurora doesn't require cleanup
   }
 
   async deprovision(
-    config: Record<string, any>,
-    credentials?: Record<string, any>
+    config: Record<string, unknown>,
+    credentials?: Record<string, unknown>
   ): Promise<void> {
     const client = this.makeClient(credentials);
-    const identifier = config.dbClusterIdentifier;
+    const identifier = config.dbClusterIdentifier as string | undefined;
 
     try {
       await client.send(
@@ -190,20 +194,21 @@ export class AuroraAdapter implements ConnectorAdapter {
           SkipFinalSnapshot: true,
         })
       );
-    } catch (error: any) {
-      if (error.name === 'DBClusterNotFoundFault') {
+    } catch (error) {
+      const err = error as SdkError;
+      if (err.name === 'DBClusterNotFoundFault') {
         return; // Already gone
       }
-      throw error;
+      throw err;
     }
   }
 
   async testConnection(
-    config: Record<string, any>,
-    credentials?: Record<string, any>
+    config: Record<string, unknown>,
+    credentials?: Record<string, unknown>
   ): Promise<ConnectionTestResult> {
     const client = this.makeClient(credentials);
-    const identifier = config.dbClusterIdentifier;
+    const identifier = config.dbClusterIdentifier as string | undefined;
 
     try {
       const response = await client.send(
@@ -222,21 +227,22 @@ export class AuroraAdapter implements ConnectorAdapter {
           engine: cluster?.Engine,
         },
       };
-    } catch (error: any) {
+    } catch (error) {
+      const err = error as SdkError;
       return {
         success: false,
-        message: `Failed to connect to Aurora cluster ${identifier}: ${error.message}`,
-        details: { errorName: error.name },
+        message: `Failed to connect to Aurora cluster ${identifier}: ${err.message}`,
+        details: { errorName: err.name },
       };
     }
   }
 
   async getMetrics(
-    config: Record<string, any>,
+    config: Record<string, unknown>,
     _resourceArn?: string
   ): Promise<MetricsResult> {
     const client = this.makeClient();
-    const identifier = config.dbClusterIdentifier;
+    const identifier = config.dbClusterIdentifier as string | undefined;
 
     try {
       const response = await client.send(
@@ -251,20 +257,21 @@ export class AuroraAdapter implements ConnectorAdapter {
         size: `${allocatedGB} GB`,
         records: 0, // Aurora doesn't expose row count via API
       };
-    } catch (error: any) {
+    } catch (error) {
+      const err = error as SdkError;
       if (
-        error.name === 'AccessDenied' ||
-        error.name === 'AccessDeniedException'
+        err.name === 'AccessDenied' ||
+        err.name === 'AccessDeniedException'
       ) {
         throw new PermissionError(
           `Permission denied describing Aurora cluster ${identifier}`,
-          error
+          err
         );
       }
       throw new ConnectionError(
-        `Failed to get metrics for Aurora cluster ${identifier}: ${error.message}`,
+        `Failed to get metrics for Aurora cluster ${identifier}: ${err.message}`,
         true,
-        error
+        err
       );
     }
   }

--- a/backend/src/lambda/adapters/aws-generic-adapter.ts
+++ b/backend/src/lambda/adapters/aws-generic-adapter.ts
@@ -28,34 +28,34 @@ export class AwsGenericAdapter implements ConnectorAdapter {
   }
 
   requiredPolicies(
-    _config: Record<string, any>,
+    _config: Record<string, unknown>,
     _accountId: string,
     _region: string
   ): RequiredPolicies {
     return { provision: [], connect: [] };
   }
 
-  async provision(config: Record<string, any>): Promise<ProvisionResult> {
+  async provision(config: Record<string, unknown>): Promise<ProvisionResult> {
     console.log(`[AwsGenericAdapter:${this.serviceName}] provision called`, config);
     throw new NotImplementedError(`AwsGenericAdapter:${this.serviceName}`, 'provision');
   }
 
-  async connect(config: Record<string, any>): Promise<void> {
+  async connect(config: Record<string, unknown>): Promise<void> {
     console.log(`[AwsGenericAdapter:${this.serviceName}] connect called`, config);
     throw new NotImplementedError(`AwsGenericAdapter:${this.serviceName}`, 'connect');
   }
 
-  async disconnect(config: Record<string, any>): Promise<void> {
+  async disconnect(config: Record<string, unknown>): Promise<void> {
     console.log(`[AwsGenericAdapter:${this.serviceName}] disconnect called`, config);
     throw new NotImplementedError(`AwsGenericAdapter:${this.serviceName}`, 'disconnect');
   }
 
-  async testConnection(config: Record<string, any>): Promise<ConnectionTestResult> {
+  async testConnection(config: Record<string, unknown>): Promise<ConnectionTestResult> {
     console.log(`[AwsGenericAdapter:${this.serviceName}] testConnection called`, config);
     throw new NotImplementedError(`AwsGenericAdapter:${this.serviceName}`, 'testConnection');
   }
 
-  async getMetrics(config: Record<string, any>): Promise<MetricsResult> {
+  async getMetrics(config: Record<string, unknown>): Promise<MetricsResult> {
     console.log(`[AwsGenericAdapter:${this.serviceName}] getMetrics called`, config);
     throw new NotImplementedError(`AwsGenericAdapter:${this.serviceName}`, 'getMetrics');
   }

--- a/backend/src/lambda/adapters/databricks-adapter.ts
+++ b/backend/src/lambda/adapters/databricks-adapter.ts
@@ -3,11 +3,16 @@ import {
   RequiredPolicies, ProvisionResult, ConnectionTestResult, MetricsResult,
 } from '../../adapters/base';
 import { ProvisioningError, ConnectionError, PermissionError, ValidationError } from './errors';
+import { SdkError } from './sdk-types';
 
-function getDatabricksSQL() {
+/** Constructor type of DBSQLClient, resolved from the module's type surface. */
+type DBSQLClientCtor = (typeof import('@databricks/sql'))['DBSQLClient'];
+
+async function getDatabricksSQL(): Promise<DBSQLClientCtor> {
   try {
-    const mod = require('@databricks/sql');
-    return mod.DBSQLClient ?? mod.default?.DBSQLClient;
+    const mod = await import('@databricks/sql');
+    return (mod.DBSQLClient ??
+      (mod as unknown as { default?: { DBSQLClient?: DBSQLClientCtor } }).default?.DBSQLClient) as DBSQLClientCtor;
   } catch {
     throw new ConnectionError('@databricks/sql is not installed. Install it to use the Databricks adapter.');
   }
@@ -19,7 +24,7 @@ export class DatabricksAdapter implements ConnectorAdapter {
   private readonly kind = 'databricks';
 
   requiredPolicies(
-    _config: Record<string, any>,
+    _config: Record<string, unknown>,
     _accountId: string,
     _region: string
   ): RequiredPolicies {
@@ -27,8 +32,8 @@ export class DatabricksAdapter implements ConnectorAdapter {
   }
 
   async provision(
-    _config: Record<string, any>,
-    _credentials?: Record<string, any>
+    _config: Record<string, unknown>,
+    _credentials?: Record<string, unknown>
   ): Promise<ProvisionResult> {
     throw new ProvisioningError(
       `Provisioning is not supported for external ${this.kind} data stores`
@@ -36,8 +41,8 @@ export class DatabricksAdapter implements ConnectorAdapter {
   }
 
   async connect(
-    config: Record<string, any>,
-    credentials?: Record<string, any>
+    config: Record<string, unknown>,
+    credentials?: Record<string, unknown>
   ): Promise<void> {
     const result = await this.testConnection(config, credentials);
     if (!result.success) {
@@ -47,13 +52,13 @@ export class DatabricksAdapter implements ConnectorAdapter {
     }
   }
 
-  async disconnect(_config: Record<string, any>): Promise<void> {
+  async disconnect(_config: Record<string, unknown>): Promise<void> {
     // No-op for external stores
   }
 
   async testConnection(
-    config: Record<string, any>,
-    credentials?: Record<string, any>
+    config: Record<string, unknown>,
+    credentials?: Record<string, unknown>
   ): Promise<ConnectionTestResult> {
     if (!config.host) {
       throw new ValidationError('Missing required Databricks config field: host');
@@ -62,20 +67,20 @@ export class DatabricksAdapter implements ConnectorAdapter {
       throw new ValidationError('Missing required Databricks config field: httpPath');
     }
 
-    const token = credentials?.token ?? config.token;
+    const token = (credentials?.token ?? config.token) as string | undefined;
     if (!token) {
       throw new ValidationError(
         'Missing required Databricks credential: token'
       );
     }
 
-    let client: any;
+    let client: InstanceType<DBSQLClientCtor> | undefined;
     try {
-      const DBSQLClient = getDatabricksSQL();
+      const DBSQLClient = await getDatabricksSQL();
       client = new DBSQLClient();
       await client.connect({
-        host: config.host,
-        path: config.httpPath,
+        host: config.host as string,
+        path: config.httpPath as string,
         token,
       });
 
@@ -89,31 +94,32 @@ export class DatabricksAdapter implements ConnectorAdapter {
           httpPath: config.httpPath,
         },
       };
-    } catch (error: any) {
+    } catch (error) {
+      const err = error as SdkError;
       if (client) {
         try { await client.close(); } catch { /* ignore cleanup errors */ }
       }
 
       if (
-        error.message?.includes('401') ||
-        error.message?.includes('Unauthorized') ||
-        error.message?.includes('authentication')
+        err.message?.includes('401') ||
+        err.message?.includes('Unauthorized') ||
+        err.message?.includes('authentication')
       ) {
         throw new PermissionError(
           `Authentication failed for Databricks workspace at ${config.host}`,
-          error
+          err
         );
       }
       throw new ConnectionError(
-        `Failed to connect to Databricks workspace at ${config.host}: ${error.message}`,
+        `Failed to connect to Databricks workspace at ${config.host}: ${err.message}`,
         true,
-        error
+        err
       );
     }
   }
 
   async getMetrics(
-    _config: Record<string, any>,
+    _config: Record<string, unknown>,
     _resourceArn?: string
   ): Promise<MetricsResult> {
     return { size: '0 MB', records: 0 };

--- a/backend/src/lambda/adapters/documentdb-adapter.ts
+++ b/backend/src/lambda/adapters/documentdb-adapter.ts
@@ -6,17 +6,19 @@ import {
 } from '@aws-sdk/client-docdb';
 import { ConnectorAdapter, ConnectorCategory, ConnectorSpec, AuthenticationMethod, RequiredPolicies, ProvisionResult, ConnectionTestResult, MetricsResult } from '../../adapters/base';
 import { ProvisioningError, ConnectionError, PermissionError, ResourceNotFoundError } from './errors';
+import { SdkError, AwsCredentialFields } from './sdk-types';
 
 export class DocumentDBAdapter implements ConnectorAdapter {
   readonly category: ConnectorCategory = 'datastore';
   readonly spec: ConnectorSpec = { type: 'DOCUMENTDB', provider: 'Amazon Web Services', category: 'datastore', authentication: { method: AuthenticationMethod.IAM_ROLE, fields: [], secretStructure: {} }, configuration: { required: ['clusterIdentifier'], optional: [], ssmParameters: [] } };
-  private makeClient(creds?: Record<string, any>): DocDBClient {
-    if (creds?.accessKeyId && creds?.secretAccessKey && creds?.sessionToken) {
+  private makeClient(creds?: Record<string, unknown>): DocDBClient {
+    const c = creds as AwsCredentialFields | undefined;
+    if (c?.accessKeyId && c?.secretAccessKey && c?.sessionToken) {
       return new DocDBClient({
         credentials: {
-          accessKeyId: creds.accessKeyId,
-          secretAccessKey: creds.secretAccessKey,
-          sessionToken: creds.sessionToken,
+          accessKeyId: c.accessKeyId,
+          secretAccessKey: c.secretAccessKey,
+          sessionToken: c.sessionToken,
         },
       });
     }
@@ -24,7 +26,7 @@ export class DocumentDBAdapter implements ConnectorAdapter {
   }
 
   requiredPolicies(
-    config: Record<string, any>,
+    config: Record<string, unknown>,
     accountId: string,
     region: string
   ): RequiredPolicies {
@@ -52,15 +54,15 @@ export class DocumentDBAdapter implements ConnectorAdapter {
   }
 
   async provision(
-    config: Record<string, any>,
-    credentials?: Record<string, any>
+    config: Record<string, unknown>,
+    credentials?: Record<string, unknown>
   ): Promise<ProvisionResult> {
     const client = this.makeClient(credentials);
     const identifier =
-      config.dbClusterIdentifier ?? `citadel-docdb-${Date.now()}`;
+      (config.dbClusterIdentifier as string | undefined) ?? `citadel-docdb-${Date.now()}`;
 
-    const masterUsername = credentials?.masterUsername ?? config.masterUsername;
-    const masterPassword = credentials?.masterPassword ?? config.masterPassword;
+    const masterUsername = (credentials?.masterUsername ?? config.masterUsername) as string | undefined;
+    const masterPassword = (credentials?.masterPassword ?? config.masterPassword) as string | undefined;
 
     if (!masterUsername || !masterPassword) {
       throw new ProvisioningError(
@@ -83,34 +85,35 @@ export class DocumentDBAdapter implements ConnectorAdapter {
         `arn:aws:rds:${config.region ?? 'us-east-1'}:${config.accountId ?? '000000000000'}:cluster:${identifier}`;
 
       return { resourceArn: arn };
-    } catch (error: any) {
-      if (error.name === 'DBClusterAlreadyExistsFault') {
+    } catch (error) {
+      const err = error as SdkError;
+      if (err.name === 'DBClusterAlreadyExistsFault') {
         return {
           resourceArn: `arn:aws:rds:${config.region ?? 'us-east-1'}:${config.accountId ?? '000000000000'}:cluster:${identifier}`,
         };
       }
       if (
-        error.name === 'AccessDenied' ||
-        error.name === 'AccessDeniedException'
+        err.name === 'AccessDenied' ||
+        err.name === 'AccessDeniedException'
       ) {
         throw new PermissionError(
           `Permission denied creating DocumentDB cluster ${identifier}`,
-          error
+          err
         );
       }
       throw new ProvisioningError(
-        `Failed to create DocumentDB cluster ${identifier}: ${error.message}`,
-        error
+        `Failed to create DocumentDB cluster ${identifier}: ${err.message}`,
+        err
       );
     }
   }
 
   async connect(
-    config: Record<string, any>,
-    credentials?: Record<string, any>
+    config: Record<string, unknown>,
+    credentials?: Record<string, unknown>
   ): Promise<void> {
     const client = this.makeClient(credentials);
-    const identifier = config.dbClusterIdentifier;
+    const identifier = config.dbClusterIdentifier as string | undefined;
 
     try {
       const response = await client.send(
@@ -125,43 +128,44 @@ export class DocumentDBAdapter implements ConnectorAdapter {
           true
         );
       }
-    } catch (error: any) {
-      if (error instanceof ConnectionError) {
-        throw error;
+    } catch (error) {
+      const err = error as SdkError;
+      if (err instanceof ConnectionError) {
+        throw err;
       }
-      if (error.name === 'DBClusterNotFoundFault') {
+      if (err.name === 'DBClusterNotFoundFault') {
         throw new ResourceNotFoundError(
           `DocumentDB cluster ${identifier} does not exist`,
-          error
+          err
         );
       }
       if (
-        error.name === 'AccessDenied' ||
-        error.name === 'AccessDeniedException'
+        err.name === 'AccessDenied' ||
+        err.name === 'AccessDeniedException'
       ) {
         throw new PermissionError(
           `Permission denied accessing DocumentDB cluster ${identifier}`,
-          error
+          err
         );
       }
       throw new ConnectionError(
-        `Failed to connect to DocumentDB cluster ${identifier}: ${error.message}`,
+        `Failed to connect to DocumentDB cluster ${identifier}: ${err.message}`,
         true,
-        error
+        err
       );
     }
   }
 
-  async disconnect(_config: Record<string, any>): Promise<void> {
+  async disconnect(_config: Record<string, unknown>): Promise<void> {
     // No-op: disconnecting from DocumentDB doesn't require cleanup
   }
 
   async deprovision(
-    config: Record<string, any>,
-    credentials?: Record<string, any>
+    config: Record<string, unknown>,
+    credentials?: Record<string, unknown>
   ): Promise<void> {
     const client = this.makeClient(credentials);
-    const identifier = config.dbClusterIdentifier;
+    const identifier = config.dbClusterIdentifier as string | undefined;
 
     try {
       await client.send(
@@ -170,20 +174,21 @@ export class DocumentDBAdapter implements ConnectorAdapter {
           SkipFinalSnapshot: true,
         })
       );
-    } catch (error: any) {
-      if (error.name === 'DBClusterNotFoundFault') {
+    } catch (error) {
+      const err = error as SdkError;
+      if (err.name === 'DBClusterNotFoundFault') {
         return; // Already gone
       }
-      throw error;
+      throw err;
     }
   }
 
   async testConnection(
-    config: Record<string, any>,
-    credentials?: Record<string, any>
+    config: Record<string, unknown>,
+    credentials?: Record<string, unknown>
   ): Promise<ConnectionTestResult> {
     const client = this.makeClient(credentials);
-    const identifier = config.dbClusterIdentifier;
+    const identifier = config.dbClusterIdentifier as string | undefined;
 
     try {
       const response = await client.send(
@@ -201,21 +206,22 @@ export class DocumentDBAdapter implements ConnectorAdapter {
           port: cluster?.Port,
         },
       };
-    } catch (error: any) {
+    } catch (error) {
+      const err = error as SdkError;
       return {
         success: false,
-        message: `Failed to connect to DocumentDB cluster ${identifier}: ${error.message}`,
-        details: { errorName: error.name },
+        message: `Failed to connect to DocumentDB cluster ${identifier}: ${err.message}`,
+        details: { errorName: err.name },
       };
     }
   }
 
   async getMetrics(
-    config: Record<string, any>,
+    config: Record<string, unknown>,
     _resourceArn?: string
   ): Promise<MetricsResult> {
     const client = this.makeClient();
-    const identifier = config.dbClusterIdentifier;
+    const identifier = config.dbClusterIdentifier as string | undefined;
 
     try {
       const response = await client.send(
@@ -223,27 +229,28 @@ export class DocumentDBAdapter implements ConnectorAdapter {
           DBClusterIdentifier: identifier,
         })
       );
-      const cluster = response.DBClusters?.[0] as Record<string, any> | undefined;
+      const cluster = response.DBClusters?.[0] as Record<string, unknown> | undefined;
       const allocatedGB = cluster?.AllocatedStorage ?? 0;
 
       return {
         size: `${allocatedGB} GB`,
         records: 0, // DocumentDB doesn't expose document count via API
       };
-    } catch (error: any) {
+    } catch (error) {
+      const err = error as SdkError;
       if (
-        error.name === 'AccessDenied' ||
-        error.name === 'AccessDeniedException'
+        err.name === 'AccessDenied' ||
+        err.name === 'AccessDeniedException'
       ) {
         throw new PermissionError(
           `Permission denied describing DocumentDB cluster ${identifier}`,
-          error
+          err
         );
       }
       throw new ConnectionError(
-        `Failed to get metrics for DocumentDB cluster ${identifier}: ${error.message}`,
+        `Failed to get metrics for DocumentDB cluster ${identifier}: ${err.message}`,
         true,
-        error
+        err
       );
     }
   }

--- a/backend/src/lambda/adapters/dynamodb-adapter.ts
+++ b/backend/src/lambda/adapters/dynamodb-adapter.ts
@@ -23,17 +23,19 @@ import {
   PermissionError,
   ResourceNotFoundError,
 } from './errors';
+import { SdkError, AwsCredentialFields } from './sdk-types';
 
 export class DynamoDBAdapter implements ConnectorAdapter {
   readonly category: ConnectorCategory = 'datastore';
   readonly spec: ConnectorSpec = { type: 'DYNAMODB', provider: 'Amazon Web Services', category: 'datastore', authentication: { method: AuthenticationMethod.IAM_ROLE, fields: [], secretStructure: {} }, configuration: { required: ['tableName'], optional: ['partitionKey', 'sortKey'], ssmParameters: [] } };
-  private makeClient(creds?: Record<string, any>): DynamoDBClient {
-    if (creds?.accessKeyId && creds?.secretAccessKey && creds?.sessionToken) {
+  private makeClient(creds?: Record<string, unknown>): DynamoDBClient {
+    const c = creds as AwsCredentialFields | undefined;
+    if (c?.accessKeyId && c?.secretAccessKey && c?.sessionToken) {
       return new DynamoDBClient({
         credentials: {
-          accessKeyId: creds.accessKeyId,
-          secretAccessKey: creds.secretAccessKey,
-          sessionToken: creds.sessionToken,
+          accessKeyId: c.accessKeyId,
+          secretAccessKey: c.secretAccessKey,
+          sessionToken: c.sessionToken,
         },
       });
     }
@@ -41,11 +43,11 @@ export class DynamoDBAdapter implements ConnectorAdapter {
   }
 
   requiredPolicies(
-    config: Record<string, any>,
+    config: Record<string, unknown>,
     accountId: string,
     region: string
   ): RequiredPolicies {
-    const tableName = config.tableName;
+    const tableName = config.tableName as string | undefined;
     const tableArn = `arn:aws:dynamodb:${region}:${accountId}:table/${tableName}`;
 
     return {
@@ -71,13 +73,13 @@ export class DynamoDBAdapter implements ConnectorAdapter {
   }
 
   async provision(
-    config: Record<string, any>,
-    credentials?: Record<string, any>
+    config: Record<string, unknown>,
+    credentials?: Record<string, unknown>
   ): Promise<ProvisionResult> {
     const client = this.makeClient(credentials);
-    const tableName = config.tableName;
-    const partitionKey = config.partitionKey || 'pk';
-    const sortKey = config.sortKey || undefined;
+    const tableName = config.tableName as string | undefined;
+    const partitionKey = (config.partitionKey as string | undefined) || 'pk';
+    const sortKey = (config.sortKey as string | undefined) || undefined;
 
     try {
       const keySchema = [
@@ -97,21 +99,22 @@ export class DynamoDBAdapter implements ConnectorAdapter {
           BillingMode: BillingMode.PAY_PER_REQUEST,
         })
       );
-    } catch (error: any) {
-      if (error.name === 'ResourceInUseException') {
+    } catch (error) {
+      const err = error as SdkError;
+      if (err.name === 'ResourceInUseException') {
         // Idempotent success — table already exists
       } else if (
-        error.name === 'AccessDenied' ||
-        error.name === 'AccessDeniedException'
+        err.name === 'AccessDenied' ||
+        err.name === 'AccessDeniedException'
       ) {
         throw new PermissionError(
           `Permission denied creating table ${tableName}`,
-          error
+          err
         );
       } else {
         throw new ProvisioningError(
-          `Failed to create table ${tableName}: ${error.message}`,
-          error
+          `Failed to create table ${tableName}: ${err.message}`,
+          err
         );
       }
     }
@@ -122,11 +125,11 @@ export class DynamoDBAdapter implements ConnectorAdapter {
   }
 
   async connect(
-    config: Record<string, any>,
-    credentials?: Record<string, any>
+    config: Record<string, unknown>,
+    credentials?: Record<string, unknown>
   ): Promise<void> {
     const client = this.makeClient(credentials);
-    const tableName = config.tableName;
+    const tableName = config.tableName as string | undefined;
 
     try {
       const response = await client.send(
@@ -139,62 +142,64 @@ export class DynamoDBAdapter implements ConnectorAdapter {
           true
         );
       }
-    } catch (error: any) {
-      if (error instanceof ConnectionError) {
-        throw error;
+    } catch (error) {
+      const err = error as SdkError;
+      if (err instanceof ConnectionError) {
+        throw err;
       }
       if (
-        error.name === 'ResourceNotFoundException'
+        err.name === 'ResourceNotFoundException'
       ) {
         throw new ResourceNotFoundError(
           `Table ${tableName} does not exist`,
-          error
+          err
         );
       }
       if (
-        error.name === 'AccessDenied' ||
-        error.name === 'AccessDeniedException'
+        err.name === 'AccessDenied' ||
+        err.name === 'AccessDeniedException'
       ) {
         throw new PermissionError(
           `Permission denied accessing table ${tableName}`,
-          error
+          err
         );
       }
       throw new ConnectionError(
-        `Failed to connect to table ${tableName}: ${error.message}`,
+        `Failed to connect to table ${tableName}: ${err.message}`,
         true,
-        error
+        err
       );
     }
   }
 
-  async disconnect(_config: Record<string, any>): Promise<void> {
+  async disconnect(_config: Record<string, unknown>): Promise<void> {
     // No-op: disconnecting from DynamoDB doesn't require cleanup
   }
 
   async deprovision(
-    config: Record<string, any>,
-    credentials?: Record<string, any>
+    config: Record<string, unknown>,
+    credentials?: Record<string, unknown>
   ): Promise<void> {
     const client = this.makeClient(credentials);
-    const tableName = config.tableName;
+    const tableName = config.tableName as string | undefined;
 
     try {
       await client.send(new DeleteTableCommand({ TableName: tableName }));
-    } catch (error: any) {
-      if (error.name === 'ResourceNotFoundException') {
+    } catch (error) {
+      const err = error as SdkError;
+      if (err.name === 'ResourceNotFoundException') {
         return; // Already gone
       }
-      throw error;
+      throw err;
     }
   }
 
   async testConnection(
-    config: Record<string, any>,
-    credentials?: Record<string, any>
+    config: Record<string, unknown>,
+    credentials?: Record<string, unknown>
   ): Promise<ConnectionTestResult> {
     const client = this.makeClient(credentials);
-    const tableName = config.tableName;
+    const tableName = config.tableName as string | undefined;
 
     try {
       const response = await client.send(
@@ -210,21 +215,22 @@ export class DynamoDBAdapter implements ConnectorAdapter {
           tableSizeBytes: table?.TableSizeBytes ?? 0,
         },
       };
-    } catch (error: any) {
+    } catch (error) {
+      const err = error as SdkError;
       return {
         success: false,
-        message: `Failed to connect to table ${tableName}: ${error.message}`,
-        details: { errorName: error.name },
+        message: `Failed to connect to table ${tableName}: ${err.message}`,
+        details: { errorName: err.name },
       };
     }
   }
 
   async getMetrics(
-    config: Record<string, any>,
+    config: Record<string, unknown>,
     _resourceArn?: string
   ): Promise<MetricsResult> {
     const client = this.makeClient();
-    const tableName = config.tableName;
+    const tableName = config.tableName as string | undefined;
 
     try {
       const response = await client.send(
@@ -238,20 +244,21 @@ export class DynamoDBAdapter implements ConnectorAdapter {
         size: `${sizeMB} MB`,
         records: table?.ItemCount ?? 0,
       };
-    } catch (error: any) {
+    } catch (error) {
+      const err = error as SdkError;
       if (
-        error.name === 'AccessDenied' ||
-        error.name === 'AccessDeniedException'
+        err.name === 'AccessDenied' ||
+        err.name === 'AccessDeniedException'
       ) {
         throw new PermissionError(
           `Permission denied describing table ${tableName}`,
-          error
+          err
         );
       }
       throw new ConnectionError(
-        `Failed to get metrics for table ${tableName}: ${error.message}`,
+        `Failed to get metrics for table ${tableName}: ${err.message}`,
         true,
-        error
+        err
       );
     }
   }

--- a/backend/src/lambda/adapters/elasticache-adapter.ts
+++ b/backend/src/lambda/adapters/elasticache-adapter.ts
@@ -6,17 +6,19 @@ import {
 } from '@aws-sdk/client-elasticache';
 import { ConnectorAdapter, ConnectorCategory, ConnectorSpec, AuthenticationMethod, RequiredPolicies, ProvisionResult, ConnectionTestResult, MetricsResult } from '../../adapters/base';
 import { ProvisioningError, ConnectionError, PermissionError, ResourceNotFoundError } from './errors';
+import { SdkError, AwsCredentialFields } from './sdk-types';
 
 export class ElastiCacheAdapter implements ConnectorAdapter {
   readonly category: ConnectorCategory = 'datastore';
   readonly spec: ConnectorSpec = { type: 'ELASTICACHE_REDIS', provider: 'Amazon Web Services', category: 'datastore', authentication: { method: AuthenticationMethod.IAM_ROLE, fields: [], secretStructure: {} }, configuration: { required: ['replicationGroupId'], optional: [], ssmParameters: [] } };
-  private makeClient(creds?: Record<string, any>): ElastiCacheClient {
-    if (creds?.accessKeyId && creds?.secretAccessKey && creds?.sessionToken) {
+  private makeClient(creds?: Record<string, unknown>): ElastiCacheClient {
+    const c = creds as AwsCredentialFields | undefined;
+    if (c?.accessKeyId && c?.secretAccessKey && c?.sessionToken) {
       return new ElastiCacheClient({
         credentials: {
-          accessKeyId: creds.accessKeyId,
-          secretAccessKey: creds.secretAccessKey,
-          sessionToken: creds.sessionToken,
+          accessKeyId: c.accessKeyId,
+          secretAccessKey: c.secretAccessKey,
+          sessionToken: c.sessionToken,
         },
       });
     }
@@ -24,7 +26,7 @@ export class ElastiCacheAdapter implements ConnectorAdapter {
   }
 
   requiredPolicies(
-    config: Record<string, any>,
+    config: Record<string, unknown>,
     accountId: string,
     region: string
   ): RequiredPolicies {
@@ -56,12 +58,12 @@ export class ElastiCacheAdapter implements ConnectorAdapter {
   }
 
   async provision(
-    config: Record<string, any>,
-    credentials?: Record<string, any>
+    config: Record<string, unknown>,
+    credentials?: Record<string, unknown>
   ): Promise<ProvisionResult> {
     const client = this.makeClient(credentials);
     const identifier =
-      config.cacheClusterId ?? `citadel-redis-${Date.now()}`;
+      (config.cacheClusterId as string | undefined) ?? `citadel-redis-${Date.now()}`;
 
     // Retry up to 3 times for transient IAM propagation errors
     const maxRetries = 3;
@@ -72,7 +74,7 @@ export class ElastiCacheAdapter implements ConnectorAdapter {
             CacheClusterId: identifier,
             Engine: 'redis',
             CacheNodeType: 'cache.t3.micro',
-            NumCacheNodes: config.numCacheNodes ?? 1,
+            NumCacheNodes: (config.numCacheNodes as number | undefined) ?? 1,
           })
         );
 
@@ -81,32 +83,33 @@ export class ElastiCacheAdapter implements ConnectorAdapter {
           `arn:aws:elasticache:${config.region ?? 'us-east-1'}:${config.accountId ?? '000000000000'}:cluster:${identifier}`;
 
         return { resourceArn: arn };
-      } catch (error: any) {
-        if (error.name === 'CacheClusterAlreadyExistsFault') {
+      } catch (error) {
+        const err = error as SdkError;
+        if (err.name === 'CacheClusterAlreadyExistsFault') {
           return {
             resourceArn: `arn:aws:elasticache:${config.region ?? 'us-east-1'}:${config.accountId ?? '000000000000'}:cluster:${identifier}`,
           };
         }
         // Retry on transient IAM/credentials propagation errors
         if (
-          (error.name === 'InvalidCredentialsException' || error.name === 'ServiceLinkedRoleNotFoundFault') &&
+          (err.name === 'InvalidCredentialsException' || err.name === 'ServiceLinkedRoleNotFoundFault') &&
           attempt < maxRetries
         ) {
           await new Promise((resolve) => setTimeout(resolve, 5000 * (attempt + 1)));
           continue;
         }
         if (
-          error.name === 'AccessDenied' ||
-          error.name === 'AccessDeniedException'
+          err.name === 'AccessDenied' ||
+          err.name === 'AccessDeniedException'
         ) {
           throw new PermissionError(
             `Permission denied creating ElastiCache cluster ${identifier}`,
-            error
+            err
           );
         }
         throw new ProvisioningError(
-          `Failed to create ElastiCache cluster ${identifier}: ${error.message}`,
-          error
+          `Failed to create ElastiCache cluster ${identifier}: ${err.message}`,
+          err
         );
       }
     }
@@ -114,11 +117,11 @@ export class ElastiCacheAdapter implements ConnectorAdapter {
   }
 
   async connect(
-    config: Record<string, any>,
-    credentials?: Record<string, any>
+    config: Record<string, unknown>,
+    credentials?: Record<string, unknown>
   ): Promise<void> {
     const client = this.makeClient(credentials);
-    const identifier = config.cacheClusterId;
+    const identifier = config.cacheClusterId as string | undefined;
 
     try {
       const response = await client.send(
@@ -133,62 +136,64 @@ export class ElastiCacheAdapter implements ConnectorAdapter {
           true
         );
       }
-    } catch (error: any) {
-      if (error instanceof ConnectionError) {
-        throw error;
+    } catch (error) {
+      const err = error as SdkError;
+      if (err instanceof ConnectionError) {
+        throw err;
       }
-      if (error.name === 'CacheClusterNotFoundFault') {
+      if (err.name === 'CacheClusterNotFoundFault') {
         throw new ResourceNotFoundError(
           `ElastiCache cluster ${identifier} does not exist`,
-          error
+          err
         );
       }
       if (
-        error.name === 'AccessDenied' ||
-        error.name === 'AccessDeniedException'
+        err.name === 'AccessDenied' ||
+        err.name === 'AccessDeniedException'
       ) {
         throw new PermissionError(
           `Permission denied accessing ElastiCache cluster ${identifier}`,
-          error
+          err
         );
       }
       throw new ConnectionError(
-        `Failed to connect to ElastiCache cluster ${identifier}: ${error.message}`,
+        `Failed to connect to ElastiCache cluster ${identifier}: ${err.message}`,
         true,
-        error
+        err
       );
     }
   }
 
-  async disconnect(_config: Record<string, any>): Promise<void> {
+  async disconnect(_config: Record<string, unknown>): Promise<void> {
     // No-op: disconnecting from ElastiCache doesn't require cleanup
   }
 
   async deprovision(
-    config: Record<string, any>,
-    credentials?: Record<string, any>
+    config: Record<string, unknown>,
+    credentials?: Record<string, unknown>
   ): Promise<void> {
     const client = this.makeClient(credentials);
-    const identifier = config.cacheClusterId;
+    const identifier = config.cacheClusterId as string | undefined;
 
     try {
       await client.send(
         new DeleteCacheClusterCommand({ CacheClusterId: identifier })
       );
-    } catch (error: any) {
-      if (error.name === 'CacheClusterNotFoundFault') {
+    } catch (error) {
+      const err = error as SdkError;
+      if (err.name === 'CacheClusterNotFoundFault') {
         return; // Already gone
       }
-      throw error;
+      throw err;
     }
   }
 
   async testConnection(
-    config: Record<string, any>,
-    credentials?: Record<string, any>
+    config: Record<string, unknown>,
+    credentials?: Record<string, unknown>
   ): Promise<ConnectionTestResult> {
     const client = this.makeClient(credentials);
-    const identifier = config.cacheClusterId;
+    const identifier = config.cacheClusterId as string | undefined;
 
     try {
       const response = await client.send(
@@ -207,21 +212,22 @@ export class ElastiCacheAdapter implements ConnectorAdapter {
           engineVersion: cluster?.EngineVersion,
         },
       };
-    } catch (error: any) {
+    } catch (error) {
+      const err = error as SdkError;
       return {
         success: false,
-        message: `Failed to connect to ElastiCache cluster ${identifier}: ${error.message}`,
-        details: { errorName: error.name },
+        message: `Failed to connect to ElastiCache cluster ${identifier}: ${err.message}`,
+        details: { errorName: err.name },
       };
     }
   }
 
   async getMetrics(
-    config: Record<string, any>,
+    config: Record<string, unknown>,
     _resourceArn?: string
   ): Promise<MetricsResult> {
     const client = this.makeClient();
-    const identifier = config.cacheClusterId;
+    const identifier = config.cacheClusterId as string | undefined;
 
     try {
       const response = await client.send(
@@ -236,20 +242,21 @@ export class ElastiCacheAdapter implements ConnectorAdapter {
         size: `${numCacheNodes} node(s)`,
         records: numCacheNodes,
       };
-    } catch (error: any) {
+    } catch (error) {
+      const err = error as SdkError;
       if (
-        error.name === 'AccessDenied' ||
-        error.name === 'AccessDeniedException'
+        err.name === 'AccessDenied' ||
+        err.name === 'AccessDeniedException'
       ) {
         throw new PermissionError(
           `Permission denied describing ElastiCache cluster ${identifier}`,
-          error
+          err
         );
       }
       throw new ConnectionError(
-        `Failed to get metrics for ElastiCache cluster ${identifier}: ${error.message}`,
+        `Failed to get metrics for ElastiCache cluster ${identifier}: ${err.message}`,
         true,
-        error
+        err
       );
     }
   }

--- a/backend/src/lambda/adapters/external-adapter.ts
+++ b/backend/src/lambda/adapters/external-adapter.ts
@@ -4,6 +4,7 @@ import {
   RequiredPolicies, ProvisionResult, ConnectionTestResult, MetricsResult,
 } from '../../adapters/base';
 import { ProvisioningError, ConnectionError } from './errors';
+import { SdkError } from './sdk-types';
 
 export class ExternalDatabaseAdapter implements ConnectorAdapter {
   readonly category: ConnectorCategory = 'datastore';
@@ -14,7 +15,7 @@ export class ExternalDatabaseAdapter implements ConnectorAdapter {
   }
 
   requiredPolicies(
-    _config: Record<string, any>,
+    _config: Record<string, unknown>,
     _accountId: string,
     _region: string
   ): RequiredPolicies {
@@ -22,8 +23,8 @@ export class ExternalDatabaseAdapter implements ConnectorAdapter {
   }
 
   async provision(
-    _config: Record<string, any>,
-    _credentials?: Record<string, any>
+    _config: Record<string, unknown>,
+    _credentials?: Record<string, unknown>
   ): Promise<ProvisionResult> {
     throw new ProvisioningError(
       `Provisioning is not supported for external ${this.kind} data stores`
@@ -31,8 +32,8 @@ export class ExternalDatabaseAdapter implements ConnectorAdapter {
   }
 
   async connect(
-    config: Record<string, any>,
-    credentials?: Record<string, any>
+    config: Record<string, unknown>,
+    credentials?: Record<string, unknown>
   ): Promise<void> {
     const result = await this.testConnection(config, credentials);
     if (!result.success) {
@@ -42,13 +43,13 @@ export class ExternalDatabaseAdapter implements ConnectorAdapter {
     }
   }
 
-  async disconnect(_config: Record<string, any>): Promise<void> {
+  async disconnect(_config: Record<string, unknown>): Promise<void> {
     // No-op for external stores
   }
 
   async testConnection(
-    config: Record<string, any>,
-    _credentials?: Record<string, any>
+    config: Record<string, unknown>,
+    _credentials?: Record<string, unknown>
   ): Promise<ConnectionTestResult> {
     switch (this.kind) {
       case 'mongodb':
@@ -66,17 +67,17 @@ export class ExternalDatabaseAdapter implements ConnectorAdapter {
   }
 
   async getMetrics(
-    _config: Record<string, any>,
+    _config: Record<string, unknown>,
     _resourceArn?: string
   ): Promise<MetricsResult> {
     return { size: '0 MB', records: 0 };
   }
 
   private async testMongoConnection(
-    config: Record<string, any>
+    config: Record<string, unknown>
   ): Promise<ConnectionTestResult> {
     try {
-      const url = new URL(config.connectionString);
+      const url = new URL(config.connectionString as string);
       const host = url.hostname;
       const port = url.port ? parseInt(url.port, 10) : 27017;
       const reachable = await this.tcpCheck(host, port, 5000);
@@ -91,19 +92,20 @@ export class ExternalDatabaseAdapter implements ConnectorAdapter {
         success: false,
         message: `Failed to reach MongoDB at ${host}:${port}`,
       };
-    } catch (error: any) {
+    } catch (error) {
+      const err = error as SdkError;
       return {
         success: false,
-        message: `Invalid MongoDB connection string: ${error.message}`,
+        message: `Invalid MongoDB connection string: ${err.message}`,
       };
     }
   }
 
   private async testApiConnection(
-    config: Record<string, any>
+    config: Record<string, unknown>
   ): Promise<ConnectionTestResult> {
     try {
-      new URL(config.baseUrl);
+      new URL(config.baseUrl as string);
       return {
         success: true,
         message: `API URL is well-formed: ${config.baseUrl}`,
@@ -118,10 +120,10 @@ export class ExternalDatabaseAdapter implements ConnectorAdapter {
   }
 
   private async testTcpConnection(
-    config: Record<string, any>
+    config: Record<string, unknown>
   ): Promise<ConnectionTestResult> {
-    const host = config.host;
-    const port = config.port;
+    const host = config.host as string | undefined;
+    const port = config.port as number | undefined;
     if (!host || !port) {
       return {
         success: false,

--- a/backend/src/lambda/adapters/keyspaces-adapter.ts
+++ b/backend/src/lambda/adapters/keyspaces-adapter.ts
@@ -6,17 +6,19 @@ import {
 } from '@aws-sdk/client-keyspaces';
 import { ConnectorAdapter, ConnectorCategory, ConnectorSpec, AuthenticationMethod, RequiredPolicies, ProvisionResult, ConnectionTestResult, MetricsResult } from '../../adapters/base';
 import { ProvisioningError, ConnectionError, PermissionError, ResourceNotFoundError } from './errors';
+import { SdkError, AwsCredentialFields } from './sdk-types';
 
 export class KeyspacesAdapter implements ConnectorAdapter {
   readonly category: ConnectorCategory = 'datastore';
   readonly spec: ConnectorSpec = { type: 'KEYSPACES', provider: 'Amazon Web Services', category: 'datastore', authentication: { method: AuthenticationMethod.IAM_ROLE, fields: [], secretStructure: {} }, configuration: { required: ['keyspaceName'], optional: [], ssmParameters: [] } };
-  private makeClient(creds?: Record<string, any>): KeyspacesClient {
-    if (creds?.accessKeyId && creds?.secretAccessKey && creds?.sessionToken) {
+  private makeClient(creds?: Record<string, unknown>): KeyspacesClient {
+    const c = creds as AwsCredentialFields | undefined;
+    if (c?.accessKeyId && c?.secretAccessKey && c?.sessionToken) {
       return new KeyspacesClient({
         credentials: {
-          accessKeyId: creds.accessKeyId,
-          secretAccessKey: creds.secretAccessKey,
-          sessionToken: creds.sessionToken,
+          accessKeyId: c.accessKeyId,
+          secretAccessKey: c.secretAccessKey,
+          sessionToken: c.sessionToken,
         },
       });
     }
@@ -24,7 +26,7 @@ export class KeyspacesAdapter implements ConnectorAdapter {
   }
 
   requiredPolicies(
-    config: Record<string, any>,
+    config: Record<string, unknown>,
     accountId: string,
     region: string
   ): RequiredPolicies {
@@ -48,11 +50,12 @@ export class KeyspacesAdapter implements ConnectorAdapter {
   }
 
   async provision(
-    config: Record<string, any>,
-    credentials?: Record<string, any>
+    config: Record<string, unknown>,
+    credentials?: Record<string, unknown>
   ): Promise<ProvisionResult> {
     const client = this.makeClient(credentials);
-    const keyspaceName = config.keyspaceName ?? `citadel-keyspaces-${Date.now()}`;
+    const keyspaceName =
+      (config.keyspaceName as string | undefined) ?? `citadel-keyspaces-${Date.now()}`;
 
     try {
       const result = await client.send(
@@ -64,34 +67,35 @@ export class KeyspacesAdapter implements ConnectorAdapter {
         `arn:aws:cassandra:${config.region ?? 'us-east-1'}:${config.accountId ?? '000000000000'}:/keyspace/${keyspaceName}`;
 
       return { resourceArn };
-    } catch (error: any) {
-      if (error.name === 'ConflictException') {
+    } catch (error) {
+      const err = error as SdkError;
+      if (err.name === 'ConflictException') {
         return {
           resourceArn: `arn:aws:cassandra:${config.region ?? 'us-east-1'}:${config.accountId ?? '000000000000'}:/keyspace/${keyspaceName}`,
         };
       }
       if (
-        error.name === 'AccessDenied' ||
-        error.name === 'AccessDeniedException'
+        err.name === 'AccessDenied' ||
+        err.name === 'AccessDeniedException'
       ) {
         throw new PermissionError(
           `Permission denied creating Keyspaces keyspace ${keyspaceName}`,
-          error
+          err
         );
       }
       throw new ProvisioningError(
-        `Failed to create Keyspaces keyspace ${keyspaceName}: ${error.message}`,
-        error
+        `Failed to create Keyspaces keyspace ${keyspaceName}: ${err.message}`,
+        err
       );
     }
   }
 
   async connect(
-    config: Record<string, any>,
-    credentials?: Record<string, any>
+    config: Record<string, unknown>,
+    credentials?: Record<string, unknown>
   ): Promise<void> {
     const client = this.makeClient(credentials);
-    const keyspaceName = config.keyspaceName;
+    const keyspaceName = config.keyspaceName as string | undefined;
 
     try {
       const response = await client.send(
@@ -102,62 +106,64 @@ export class KeyspacesAdapter implements ConnectorAdapter {
           `Keyspaces keyspace ${keyspaceName} does not exist`
         );
       }
-    } catch (error: any) {
-      if (error instanceof ResourceNotFoundError) {
-        throw error;
+    } catch (error) {
+      const err = error as SdkError;
+      if (err instanceof ResourceNotFoundError) {
+        throw err;
       }
-      if (error.name === 'ResourceNotFoundException') {
+      if (err.name === 'ResourceNotFoundException') {
         throw new ResourceNotFoundError(
           `Keyspaces keyspace ${keyspaceName} does not exist`,
-          error
+          err
         );
       }
       if (
-        error.name === 'AccessDenied' ||
-        error.name === 'AccessDeniedException'
+        err.name === 'AccessDenied' ||
+        err.name === 'AccessDeniedException'
       ) {
         throw new PermissionError(
           `Permission denied accessing Keyspaces keyspace ${keyspaceName}`,
-          error
+          err
         );
       }
       throw new ConnectionError(
-        `Failed to connect to Keyspaces keyspace ${keyspaceName}: ${error.message}`,
+        `Failed to connect to Keyspaces keyspace ${keyspaceName}: ${err.message}`,
         true,
-        error
+        err
       );
     }
   }
 
-  async disconnect(_config: Record<string, any>): Promise<void> {
+  async disconnect(_config: Record<string, unknown>): Promise<void> {
     // No-op: disconnecting from Keyspaces doesn't require cleanup
   }
 
   async deprovision(
-    config: Record<string, any>,
-    credentials?: Record<string, any>
+    config: Record<string, unknown>,
+    credentials?: Record<string, unknown>
   ): Promise<void> {
     const client = this.makeClient(credentials);
-    const keyspaceName = config.keyspaceName;
+    const keyspaceName = config.keyspaceName as string | undefined;
 
     try {
       await client.send(
         new DeleteKeyspaceCommand({ keyspaceName })
       );
-    } catch (error: any) {
-      if (error.name === 'ResourceNotFoundException') {
+    } catch (error) {
+      const err = error as SdkError;
+      if (err.name === 'ResourceNotFoundException') {
         return; // Already gone
       }
-      throw error;
+      throw err;
     }
   }
 
   async testConnection(
-    config: Record<string, any>,
-    credentials?: Record<string, any>
+    config: Record<string, unknown>,
+    credentials?: Record<string, unknown>
   ): Promise<ConnectionTestResult> {
     const client = this.makeClient(credentials);
-    const keyspaceName = config.keyspaceName;
+    const keyspaceName = config.keyspaceName as string | undefined;
 
     try {
       const response = await client.send(
@@ -171,21 +177,22 @@ export class KeyspacesAdapter implements ConnectorAdapter {
           status: 'ACTIVE',
         },
       };
-    } catch (error: any) {
+    } catch (error) {
+      const err = error as SdkError;
       return {
         success: false,
-        message: `Failed to connect to Keyspaces keyspace ${keyspaceName}: ${error.message}`,
-        details: { errorName: error.name },
+        message: `Failed to connect to Keyspaces keyspace ${keyspaceName}: ${err.message}`,
+        details: { errorName: err.name },
       };
     }
   }
 
   async getMetrics(
-    config: Record<string, any>,
+    config: Record<string, unknown>,
     _resourceArn?: string
   ): Promise<MetricsResult> {
     const client = this.makeClient();
-    const keyspaceName = config.keyspaceName;
+    const keyspaceName = config.keyspaceName as string | undefined;
 
     try {
       await client.send(
@@ -196,20 +203,21 @@ export class KeyspacesAdapter implements ConnectorAdapter {
         size: '0 MB',
         records: 0,
       };
-    } catch (error: any) {
+    } catch (error) {
+      const err = error as SdkError;
       if (
-        error.name === 'AccessDenied' ||
-        error.name === 'AccessDeniedException'
+        err.name === 'AccessDenied' ||
+        err.name === 'AccessDeniedException'
       ) {
         throw new PermissionError(
           `Permission denied describing Keyspaces keyspace ${keyspaceName}`,
-          error
+          err
         );
       }
       throw new ConnectionError(
-        `Failed to get metrics for Keyspaces keyspace ${keyspaceName}: ${error.message}`,
+        `Failed to get metrics for Keyspaces keyspace ${keyspaceName}: ${err.message}`,
         true,
-        error
+        err
       );
     }
   }

--- a/backend/src/lambda/adapters/knowledge-base-adapter.ts
+++ b/backend/src/lambda/adapters/knowledge-base-adapter.ts
@@ -3,6 +3,8 @@ import {
   CreateKnowledgeBaseCommand,
   GetKnowledgeBaseCommand,
   DeleteKnowledgeBaseCommand,
+  type KnowledgeBaseConfiguration,
+  type StorageConfiguration,
 } from '@aws-sdk/client-bedrock-agent';
 import {
   OpenSearchServerlessClient,
@@ -25,6 +27,7 @@ import {
 } from '@aws-sdk/client-sts';
 import { ConnectorAdapter, ConnectorCategory, ConnectorSpec, AuthenticationMethod, RequiredPolicies, ProvisionResult, ConnectionTestResult, MetricsResult } from '../../adapters/base';
 import { ProvisioningError, ConnectionError, PermissionError, ResourceNotFoundError } from './errors';
+import { SdkError, AwsCredentialFields } from './sdk-types';
 
 const DEFAULT_EMBEDDING_MODEL = 'amazon.titan-embed-text-v2:0';
 const SERVICE_ROLE_POLICY_NAME = 'BedrockKnowledgeBaseAccess';
@@ -44,13 +47,14 @@ export class KnowledgeBaseAdapter implements ConnectorAdapter {
   /** Maximum time (ms) to wait for AOSS collection to become ACTIVE. */
   collectionMaxWaitMs = 300000;
 
-  private makeClient(creds?: Record<string, any>): BedrockAgentClient {
-    if (creds?.accessKeyId && creds?.secretAccessKey && creds?.sessionToken) {
+  private makeClient(creds?: Record<string, unknown>): BedrockAgentClient {
+    const c = creds as AwsCredentialFields | undefined;
+    if (c?.accessKeyId && c?.secretAccessKey && c?.sessionToken) {
       return new BedrockAgentClient({
         credentials: {
-          accessKeyId: creds.accessKeyId,
-          secretAccessKey: creds.secretAccessKey,
-          sessionToken: creds.sessionToken,
+          accessKeyId: c.accessKeyId,
+          secretAccessKey: c.secretAccessKey,
+          sessionToken: c.sessionToken,
         },
       });
     }
@@ -62,7 +66,7 @@ export class KnowledgeBaseAdapter implements ConnectorAdapter {
   }
 
   requiredPolicies(
-    _config: Record<string, any>,
+    _config: Record<string, unknown>,
     _accountId: string,
     _region: string
   ): RequiredPolicies {
@@ -116,9 +120,10 @@ export class KnowledgeBaseAdapter implements ConnectorAdapter {
           { Key: 'Purpose', Value: 'bedrock-knowledge-base-service-role' },
         ],
       }));
-    } catch (error: any) {
-      if (error.name !== 'EntityAlreadyExistsException') {
-        throw new ProvisioningError(`Failed to create Bedrock service role: ${error.message}`, error);
+    } catch (error) {
+      const err = error as SdkError;
+      if (err.name !== 'EntityAlreadyExistsException') {
+        throw new ProvisioningError(`Failed to create Bedrock service role: ${err.message}`, err);
       }
     }
 
@@ -145,8 +150,9 @@ export class KnowledgeBaseAdapter implements ConnectorAdapter {
         PolicyName: SERVICE_ROLE_POLICY_NAME,
         PolicyDocument: JSON.stringify(policyDocument),
       }));
-    } catch (error: any) {
-      throw new ProvisioningError(`Failed to attach policy to Bedrock service role: ${error.message}`, error);
+    } catch (error) {
+      const err = error as SdkError;
+      throw new ProvisioningError(`Failed to attach policy to Bedrock service role: ${err.message}`, err);
     }
 
     return `arn:aws:iam::${accountId}:role/${roleName}`;
@@ -162,16 +168,18 @@ export class KnowledgeBaseAdapter implements ConnectorAdapter {
         RoleName: roleName,
         PolicyName: SERVICE_ROLE_POLICY_NAME,
       }));
-    } catch (error: any) {
-      if (error.name !== 'NoSuchEntityException') {
-        console.warn(`Failed to delete service role policy: ${error.message}`);
+    } catch (error) {
+      const err = error as SdkError;
+      if (err.name !== 'NoSuchEntityException') {
+        console.warn(`Failed to delete service role policy: ${err.message}`);
       }
     }
     try {
       await iamClient.send(new DeleteRoleCommand({ RoleName: roleName }));
-    } catch (error: any) {
-      if (error.name !== 'NoSuchEntityException') {
-        console.warn(`Failed to delete service role: ${error.message}`);
+    } catch (error) {
+      const err = error as SdkError;
+      if (err.name !== 'NoSuchEntityException') {
+        console.warn(`Failed to delete service role: ${err.message}`);
       }
     }
   }
@@ -200,9 +208,10 @@ export class KnowledgeBaseAdapter implements ConnectorAdapter {
           AWSOwnedKey: true,
         }),
       }));
-    } catch (error: any) {
-      if (error.name !== 'ConflictException') {
-        throw new ProvisioningError(`Failed to create encryption policy: ${error.message}`, error);
+    } catch (error) {
+      const err = error as SdkError;
+      if (err.name !== 'ConflictException') {
+        throw new ProvisioningError(`Failed to create encryption policy: ${err.message}`, err);
       }
     }
 
@@ -221,9 +230,10 @@ export class KnowledgeBaseAdapter implements ConnectorAdapter {
           AllowFromPublic: true,
         }]),
       }));
-    } catch (error: any) {
-      if (error.name !== 'ConflictException') {
-        throw new ProvisioningError(`Failed to create network policy: ${error.message}`, error);
+    } catch (error) {
+      const err = error as SdkError;
+      if (err.name !== 'ConflictException') {
+        throw new ProvisioningError(`Failed to create network policy: ${err.message}`, err);
       }
     }
 
@@ -252,9 +262,10 @@ export class KnowledgeBaseAdapter implements ConnectorAdapter {
           Principal: [serviceRoleArn, `arn:aws:iam::${accountId}:root`],
         }]),
       }));
-    } catch (error: any) {
-      if (error.name !== 'ConflictException') {
-        throw new ProvisioningError(`Failed to create data access policy: ${error.message}`, error);
+    } catch (error) {
+      const err = error as SdkError;
+      if (err.name !== 'ConflictException') {
+        throw new ProvisioningError(`Failed to create data access policy: ${err.message}`, err);
       }
     }
 
@@ -269,15 +280,16 @@ export class KnowledgeBaseAdapter implements ConnectorAdapter {
       }));
       collectionId = result.createCollectionDetail?.id;
       collectionArn = result.createCollectionDetail?.arn;
-    } catch (error: any) {
-      if (error.name === 'ConflictException') {
+    } catch (error) {
+      const err = error as SdkError;
+      if (err.name === 'ConflictException') {
         // Collection already exists — look it up
         const existing = await ossClient.send(new BatchGetCollectionCommand({ names: [collectionName] }));
         const detail = existing.collectionDetails?.[0];
         collectionId = detail?.id;
         collectionArn = detail?.arn;
       } else {
-        throw new ProvisioningError(`Failed to create AOSS collection: ${error.message}`, error);
+        throw new ProvisioningError(`Failed to create AOSS collection: ${err.message}`, err);
       }
     }
 
@@ -378,7 +390,7 @@ export class KnowledgeBaseAdapter implements ConnectorAdapter {
         },
         (res) => {
           let data = '';
-          res.on('data', (chunk: any) => { data += chunk; });
+          res.on('data', (chunk: Buffer) => { data += chunk; });
           res.on('end', () => {
             if (res.statusCode === 200 || res.statusCode === 201) {
               resolve();
@@ -392,44 +404,50 @@ export class KnowledgeBaseAdapter implements ConnectorAdapter {
           });
         },
       );
-      req.on('error', (err: any) => reject(new ProvisioningError(`Failed to create vector index: ${err.message}`, err)));
+      req.on('error', (err: Error) => reject(new ProvisioningError(`Failed to create vector index: ${err.message}`, err)));
       req.write(body);
       req.end();
     });
   }
 
   async provision(
-    config: Record<string, any>,
-    credentials?: Record<string, any>
+    config: Record<string, unknown>,
+    credentials?: Record<string, unknown>
   ): Promise<ProvisionResult> {
     const client = this.makeClient(credentials);
-    const name = config.name ?? config.resourceName ?? `citadel-kb-${Date.now()}`;
+    const name =
+      (config.name as string | undefined) ??
+      (config.resourceName as string | undefined) ??
+      `citadel-kb-${Date.now()}`;
     const { region, accountId } = await this.getAccountContext();
 
     // Determine embedding model ARN
-    const embeddingModelArn = config.embeddingModelArn ??
+    const embeddingModelArn =
+      (config.embeddingModelArn as string | undefined) ??
       `arn:aws:bedrock:${region}::foundation-model/${DEFAULT_EMBEDDING_MODEL}`;
 
     // Resolve or provision the vector store
     let collectionArn: string;
-    let storageConfiguration: any;
+    let storageConfiguration: StorageConfiguration;
 
     if (config.storageConfiguration) {
       // Caller provided explicit storage config — use as-is
-      storageConfiguration = config.storageConfiguration;
-      collectionArn = config.storageConfiguration?.opensearchServerlessConfiguration?.collectionArn ?? '*';
+      storageConfiguration = config.storageConfiguration as StorageConfiguration;
+      collectionArn =
+        (config.storageConfiguration as StorageConfiguration | undefined)
+          ?.opensearchServerlessConfiguration?.collectionArn ?? '*';
     } else if (config.collectionArn) {
       // Caller provided a real collection ARN
-      collectionArn = config.collectionArn;
+      collectionArn = config.collectionArn as string;
       storageConfiguration = {
         type: 'OPENSEARCH_SERVERLESS',
         opensearchServerlessConfiguration: {
           collectionArn,
-          vectorIndexName: config.vectorIndexName ?? VECTOR_INDEX_NAME,
+          vectorIndexName: (config.vectorIndexName as string | undefined) ?? VECTOR_INDEX_NAME,
           fieldMapping: {
-            vectorField: config.vectorField ?? VECTOR_FIELD,
-            textField: config.textField ?? TEXT_FIELD,
-            metadataField: config.metadataField ?? METADATA_FIELD,
+            vectorField: (config.vectorField as string | undefined) ?? VECTOR_FIELD,
+            textField: (config.textField as string | undefined) ?? TEXT_FIELD,
+            metadataField: (config.metadataField as string | undefined) ?? METADATA_FIELD,
           },
         },
       };
@@ -440,7 +458,7 @@ export class KnowledgeBaseAdapter implements ConnectorAdapter {
       // creating the role first with a wildcard, then updating after.
       const tempCollectionArn = `arn:aws:aoss:${region}:${accountId}:collection/*`;
 
-      let roleArn = config.roleArn;
+      let roleArn = config.roleArn as string | undefined;
       if (!roleArn) {
         roleArn = await this.createServiceRole(name, tempCollectionArn);
         await new Promise((resolve) => setTimeout(resolve, this.roleCreationDelayMs));
@@ -468,7 +486,7 @@ export class KnowledgeBaseAdapter implements ConnectorAdapter {
           new CreateKnowledgeBaseCommand({
             name,
             roleArn,
-            knowledgeBaseConfiguration: config.knowledgeBaseConfiguration ?? {
+            knowledgeBaseConfiguration: (config.knowledgeBaseConfiguration as KnowledgeBaseConfiguration | undefined) ?? {
               type: 'VECTOR',
               vectorKnowledgeBaseConfiguration: { embeddingModelArn },
             },
@@ -480,19 +498,20 @@ export class KnowledgeBaseAdapter implements ConnectorAdapter {
           resourceArn: result.knowledgeBase?.knowledgeBaseArn ??
             `arn:aws:bedrock:${region}:${accountId}:knowledge-base/${result.knowledgeBase?.knowledgeBaseId ?? name}`,
         };
-      } catch (error: any) {
-        if (error.name === 'ConflictException') {
+      } catch (error) {
+        const err = error as SdkError;
+        if (err.name === 'ConflictException') {
           return { resourceArn: `arn:aws:bedrock:${region}:${accountId}:knowledge-base/${name}` };
         }
-        if (error.name === 'AccessDenied' || error.name === 'AccessDeniedException') {
-          throw new PermissionError(`Permission denied creating Bedrock knowledge base ${name}`, error);
+        if (err.name === 'AccessDenied' || err.name === 'AccessDeniedException') {
+          throw new PermissionError(`Permission denied creating Bedrock knowledge base ${name}`, err);
         }
-        throw new ProvisioningError(`Failed to create Bedrock knowledge base ${name}: ${error.message}`, error);
+        throw new ProvisioningError(`Failed to create Bedrock knowledge base ${name}: ${err.message}`, err);
       }
     }
 
     // Path for caller-provided storage config or collectionArn
-    let roleArn = config.roleArn;
+    let roleArn = config.roleArn as string | undefined;
     if (!roleArn) {
       roleArn = await this.createServiceRole(name, collectionArn);
       await new Promise((resolve) => setTimeout(resolve, this.roleCreationDelayMs));
@@ -503,7 +522,7 @@ export class KnowledgeBaseAdapter implements ConnectorAdapter {
         new CreateKnowledgeBaseCommand({
           name,
           roleArn,
-          knowledgeBaseConfiguration: config.knowledgeBaseConfiguration ?? {
+          knowledgeBaseConfiguration: (config.knowledgeBaseConfiguration as KnowledgeBaseConfiguration | undefined) ?? {
             type: 'VECTOR',
             vectorKnowledgeBaseConfiguration: { embeddingModelArn },
           },
@@ -515,23 +534,24 @@ export class KnowledgeBaseAdapter implements ConnectorAdapter {
         resourceArn: result.knowledgeBase?.knowledgeBaseArn ??
           `arn:aws:bedrock:${region}:${accountId}:knowledge-base/${result.knowledgeBase?.knowledgeBaseId ?? name}`,
       };
-    } catch (error: any) {
-      if (error.name === 'ConflictException') {
+    } catch (error) {
+      const err = error as SdkError;
+      if (err.name === 'ConflictException') {
         return { resourceArn: `arn:aws:bedrock:${region}:${accountId}:knowledge-base/${name}` };
       }
-      if (error.name === 'AccessDenied' || error.name === 'AccessDeniedException') {
-        throw new PermissionError(`Permission denied creating Bedrock knowledge base ${name}`, error);
+      if (err.name === 'AccessDenied' || err.name === 'AccessDeniedException') {
+        throw new PermissionError(`Permission denied creating Bedrock knowledge base ${name}`, err);
       }
-      throw new ProvisioningError(`Failed to create Bedrock knowledge base ${name}: ${error.message}`, error);
+      throw new ProvisioningError(`Failed to create Bedrock knowledge base ${name}: ${err.message}`, err);
     }
   }
 
   async connect(
-    config: Record<string, any>,
-    credentials?: Record<string, any>
+    config: Record<string, unknown>,
+    credentials?: Record<string, unknown>
   ): Promise<void> {
     const client = this.makeClient(credentials);
-    const knowledgeBaseId = config.knowledgeBaseId;
+    const knowledgeBaseId = config.knowledgeBaseId as string | undefined;
 
     try {
       const response = await client.send(
@@ -543,44 +563,46 @@ export class KnowledgeBaseAdapter implements ConnectorAdapter {
           true
         );
       }
-    } catch (error: any) {
-      if (error instanceof ConnectionError) throw error;
-      if (error.name === 'ResourceNotFoundException') {
+    } catch (error) {
+      const err = error as SdkError;
+      if (err instanceof ConnectionError) throw err;
+      if (err.name === 'ResourceNotFoundException') {
         throw new ResourceNotFoundError(
-          `Bedrock knowledge base ${knowledgeBaseId} does not exist`, error
+          `Bedrock knowledge base ${knowledgeBaseId} does not exist`, err
         );
       }
-      if (error.name === 'AccessDenied' || error.name === 'AccessDeniedException') {
+      if (err.name === 'AccessDenied' || err.name === 'AccessDeniedException') {
         throw new PermissionError(
-          `Permission denied accessing Bedrock knowledge base ${knowledgeBaseId}`, error
+          `Permission denied accessing Bedrock knowledge base ${knowledgeBaseId}`, err
         );
       }
       throw new ConnectionError(
-        `Failed to connect to Bedrock knowledge base ${knowledgeBaseId}: ${error.message}`, true, error
+        `Failed to connect to Bedrock knowledge base ${knowledgeBaseId}: ${err.message}`, true, err
       );
     }
   }
 
-  async disconnect(_config: Record<string, any>): Promise<void> {}
+  async disconnect(_config: Record<string, unknown>): Promise<void> {}
 
   async deprovision(
-    config: Record<string, any>,
-    credentials?: Record<string, any>
+    config: Record<string, unknown>,
+    credentials?: Record<string, unknown>
   ): Promise<void> {
     const client = this.makeClient(credentials);
-    const knowledgeBaseId = config.knowledgeBaseId;
+    const knowledgeBaseId = config.knowledgeBaseId as string | undefined;
 
     try {
       await client.send(new DeleteKnowledgeBaseCommand({ knowledgeBaseId }));
-    } catch (error: any) {
-      if (error.name === 'ResourceNotFoundException') {
+    } catch (error) {
+      const err = error as SdkError;
+      if (err.name === 'ResourceNotFoundException') {
         // Already gone — continue to clean up
-      } else if (error.name === 'AccessDenied' || error.name === 'AccessDeniedException') {
+      } else if (err.name === 'AccessDenied' || err.name === 'AccessDeniedException') {
         throw new PermissionError(
-          `Permission denied deleting Bedrock knowledge base ${knowledgeBaseId}`, error
+          `Permission denied deleting Bedrock knowledge base ${knowledgeBaseId}`, err
         );
       } else {
-        throw error;
+        throw err;
       }
     }
 
@@ -588,26 +610,27 @@ export class KnowledgeBaseAdapter implements ConnectorAdapter {
     if (config.collectionId) {
       try {
         const ossClient = this.makeOssClient();
-        await ossClient.send(new DeleteCollectionCommand({ id: config.collectionId }));
-      } catch (error: any) {
-        if (error.name !== 'ResourceNotFoundException') {
-          console.warn(`Failed to delete AOSS collection: ${error.message}`);
+        await ossClient.send(new DeleteCollectionCommand({ id: config.collectionId as string }));
+      } catch (error) {
+        const err = error as SdkError;
+        if (err.name !== 'ResourceNotFoundException') {
+          console.warn(`Failed to delete AOSS collection: ${err.message}`);
         }
       }
     }
 
     // Clean up the service role if one was created during provisioning
     if (config.serviceRoleName) {
-      await this.deleteServiceRole(config.serviceRoleName);
+      await this.deleteServiceRole(config.serviceRoleName as string);
     }
   }
 
   async testConnection(
-    config: Record<string, any>,
-    credentials?: Record<string, any>
+    config: Record<string, unknown>,
+    credentials?: Record<string, unknown>
   ): Promise<ConnectionTestResult> {
     const client = this.makeClient(credentials);
-    const knowledgeBaseId = config.knowledgeBaseId;
+    const knowledgeBaseId = config.knowledgeBaseId as string | undefined;
     try {
       const response = await client.send(new GetKnowledgeBaseCommand({ knowledgeBaseId }));
       return {
@@ -619,32 +642,34 @@ export class KnowledgeBaseAdapter implements ConnectorAdapter {
           description: response.knowledgeBase?.description,
         },
       };
-    } catch (error: any) {
+    } catch (error) {
+      const err = error as SdkError;
       return {
         success: false,
-        message: `Failed to connect to Bedrock knowledge base ${knowledgeBaseId}: ${error.message}`,
-        details: { errorName: error.name },
+        message: `Failed to connect to Bedrock knowledge base ${knowledgeBaseId}: ${err.message}`,
+        details: { errorName: err.name },
       };
     }
   }
 
   async getMetrics(
-    config: Record<string, any>,
+    config: Record<string, unknown>,
     _resourceArn?: string
   ): Promise<MetricsResult> {
     const client = this.makeClient();
-    const knowledgeBaseId = config.knowledgeBaseId;
+    const knowledgeBaseId = config.knowledgeBaseId as string | undefined;
     try {
       await client.send(new GetKnowledgeBaseCommand({ knowledgeBaseId }));
       return { size: '0 MB', records: 0 };
-    } catch (error: any) {
-      if (error.name === 'AccessDenied' || error.name === 'AccessDeniedException') {
+    } catch (error) {
+      const err = error as SdkError;
+      if (err.name === 'AccessDenied' || err.name === 'AccessDeniedException') {
         throw new PermissionError(
-          `Permission denied describing Bedrock knowledge base ${knowledgeBaseId}`, error
+          `Permission denied describing Bedrock knowledge base ${knowledgeBaseId}`, err
         );
       }
       throw new ConnectionError(
-        `Failed to get metrics for Bedrock knowledge base ${knowledgeBaseId}: ${error.message}`, true, error
+        `Failed to get metrics for Bedrock knowledge base ${knowledgeBaseId}: ${err.message}`, true, err
       );
     }
   }

--- a/backend/src/lambda/adapters/lake-formation-adapter.ts
+++ b/backend/src/lambda/adapters/lake-formation-adapter.ts
@@ -6,17 +6,19 @@ import {
 } from '@aws-sdk/client-lakeformation';
 import { ConnectorAdapter, ConnectorCategory, ConnectorSpec, AuthenticationMethod, RequiredPolicies, ProvisionResult, ConnectionTestResult, MetricsResult } from '../../adapters/base';
 import { ProvisioningError, ConnectionError, PermissionError, ResourceNotFoundError } from './errors';
+import { SdkError, AwsCredentialFields } from './sdk-types';
 
 export class LakeFormationAdapter implements ConnectorAdapter {
   readonly category: ConnectorCategory = 'datastore';
   readonly spec: ConnectorSpec = { type: 'LAKE_FORMATION', provider: 'Amazon Web Services', category: 'datastore', authentication: { method: AuthenticationMethod.IAM_ROLE, fields: [], secretStructure: {} }, configuration: { required: ['databaseName'], optional: [], ssmParameters: [] } };
-  private makeClient(creds?: Record<string, any>): LakeFormationClient {
-    if (creds?.accessKeyId && creds?.secretAccessKey && creds?.sessionToken) {
+  private makeClient(creds?: Record<string, unknown>): LakeFormationClient {
+    const c = creds as AwsCredentialFields | undefined;
+    if (c?.accessKeyId && c?.secretAccessKey && c?.sessionToken) {
       return new LakeFormationClient({
         credentials: {
-          accessKeyId: creds.accessKeyId,
-          secretAccessKey: creds.secretAccessKey,
-          sessionToken: creds.sessionToken,
+          accessKeyId: c.accessKeyId,
+          secretAccessKey: c.secretAccessKey,
+          sessionToken: c.sessionToken,
         },
       });
     }
@@ -24,7 +26,7 @@ export class LakeFormationAdapter implements ConnectorAdapter {
   }
 
   requiredPolicies(
-    config: Record<string, any>,
+    config: Record<string, unknown>,
     accountId: string,
     region: string
   ): RequiredPolicies {
@@ -54,11 +56,11 @@ export class LakeFormationAdapter implements ConnectorAdapter {
   }
 
   async provision(
-    config: Record<string, any>,
-    credentials?: Record<string, any>
+    config: Record<string, unknown>,
+    credentials?: Record<string, unknown>
   ): Promise<ProvisionResult> {
     const client = this.makeClient(credentials);
-    const resourceArn = config.resourceArn;
+    const resourceArn = config.resourceArn as string;
 
     try {
       await client.send(
@@ -69,29 +71,30 @@ export class LakeFormationAdapter implements ConnectorAdapter {
       );
 
       return { resourceArn };
-    } catch (error: any) {
-      if (error.name === 'AlreadyExistsException') {
+    } catch (error) {
+      const err = error as SdkError;
+      if (err.name === 'AlreadyExistsException') {
         return { resourceArn };
       }
       if (
-        error.name === 'AccessDenied' ||
-        error.name === 'AccessDeniedException'
+        err.name === 'AccessDenied' ||
+        err.name === 'AccessDeniedException'
       ) {
         throw new PermissionError(
           `Permission denied registering Lake Formation resource ${resourceArn}`,
-          error
+          err
         );
       }
       throw new ProvisioningError(
-        `Failed to register Lake Formation resource ${resourceArn}: ${error.message}`,
-        error
+        `Failed to register Lake Formation resource ${resourceArn}: ${err.message}`,
+        err
       );
     }
   }
 
   async connect(
-    config: Record<string, any>,
-    credentials?: Record<string, any>
+    config: Record<string, unknown>,
+    credentials?: Record<string, unknown>
   ): Promise<void> {
     const client = this.makeClient(credentials);
 
@@ -104,59 +107,61 @@ export class LakeFormationAdapter implements ConnectorAdapter {
           'Lake Formation data lake settings do not exist'
         );
       }
-    } catch (error: any) {
-      if (error instanceof ResourceNotFoundError) {
-        throw error;
+    } catch (error) {
+      const err = error as SdkError;
+      if (err instanceof ResourceNotFoundError) {
+        throw err;
       }
-      if (error.name === 'EntityNotFoundException') {
+      if (err.name === 'EntityNotFoundException') {
         throw new ResourceNotFoundError(
           'Lake Formation data lake settings not found',
-          error
+          err
         );
       }
       if (
-        error.name === 'AccessDenied' ||
-        error.name === 'AccessDeniedException'
+        err.name === 'AccessDenied' ||
+        err.name === 'AccessDeniedException'
       ) {
         throw new PermissionError(
           'Permission denied accessing Lake Formation settings',
-          error
+          err
         );
       }
       throw new ConnectionError(
-        `Failed to connect to Lake Formation: ${error.message}`,
+        `Failed to connect to Lake Formation: ${err.message}`,
         true,
-        error
+        err
       );
     }
   }
 
-  async disconnect(_config: Record<string, any>): Promise<void> {
+  async disconnect(_config: Record<string, unknown>): Promise<void> {
     // No-op: disconnecting from Lake Formation doesn't require cleanup
   }
 
   async deprovision(
-    config: Record<string, any>,
-    credentials?: Record<string, any>
+    config: Record<string, unknown>,
+    credentials?: Record<string, unknown>
   ): Promise<void> {
     const client = this.makeClient(credentials);
-    const resourceArn = config.resourceArn;
+    const resourceArn = config.resourceArn as string;
 
     try {
       await client.send(
         new DeregisterResourceCommand({ ResourceArn: resourceArn })
       );
-    } catch (error: any) {
-      if (error.name === 'EntityNotFoundException') {
+    } catch (error) {
+      const err = error as SdkError;
+      if (err.name === 'EntityNotFoundException') {
         return; // Already gone
       }
-      throw error;
+      throw err;
     }
   }
 
   async testConnection(
-    config: Record<string, any>,
-    credentials?: Record<string, any>
+    config: Record<string, unknown>,
+    credentials?: Record<string, unknown>
   ): Promise<ConnectionTestResult> {
     const client = this.makeClient(credentials);
 
@@ -173,17 +178,18 @@ export class LakeFormationAdapter implements ConnectorAdapter {
           trustedResourceOwners: settings?.TrustedResourceOwners ?? [],
         },
       };
-    } catch (error: any) {
+    } catch (error) {
+      const err = error as SdkError;
       return {
         success: false,
-        message: `Failed to connect to Lake Formation: ${error.message}`,
-        details: { errorName: error.name },
+        message: `Failed to connect to Lake Formation: ${err.message}`,
+        details: { errorName: err.name },
       };
     }
   }
 
   async getMetrics(
-    _config: Record<string, any>,
+    _config: Record<string, unknown>,
     _resourceArn?: string
   ): Promise<MetricsResult> {
     const client = this.makeClient();
@@ -195,20 +201,21 @@ export class LakeFormationAdapter implements ConnectorAdapter {
         size: '0 MB',
         records: 0,
       };
-    } catch (error: any) {
+    } catch (error) {
+      const err = error as SdkError;
       if (
-        error.name === 'AccessDenied' ||
-        error.name === 'AccessDeniedException'
+        err.name === 'AccessDenied' ||
+        err.name === 'AccessDeniedException'
       ) {
         throw new PermissionError(
           'Permission denied accessing Lake Formation metrics',
-          error
+          err
         );
       }
       throw new ConnectionError(
-        `Failed to get Lake Formation metrics: ${error.message}`,
+        `Failed to get Lake Formation metrics: ${err.message}`,
         true,
-        error
+        err
       );
     }
   }

--- a/backend/src/lambda/adapters/neptune-adapter.ts
+++ b/backend/src/lambda/adapters/neptune-adapter.ts
@@ -6,17 +6,19 @@ import {
 } from '@aws-sdk/client-neptune';
 import { ConnectorAdapter, ConnectorCategory, ConnectorSpec, AuthenticationMethod, RequiredPolicies, ProvisionResult, ConnectionTestResult, MetricsResult } from '../../adapters/base';
 import { ProvisioningError, ConnectionError, PermissionError, ResourceNotFoundError } from './errors';
+import { SdkError, AwsCredentialFields } from './sdk-types';
 
 export class NeptuneAdapter implements ConnectorAdapter {
   readonly category: ConnectorCategory = 'datastore';
   readonly spec: ConnectorSpec = { type: 'NEPTUNE', provider: 'Amazon Web Services', category: 'datastore', authentication: { method: AuthenticationMethod.IAM_ROLE, fields: [], secretStructure: {} }, configuration: { required: ['clusterIdentifier'], optional: [], ssmParameters: [] } };
-  private makeClient(creds?: Record<string, any>): NeptuneClient {
-    if (creds?.accessKeyId && creds?.secretAccessKey && creds?.sessionToken) {
+  private makeClient(creds?: Record<string, unknown>): NeptuneClient {
+    const c = creds as AwsCredentialFields | undefined;
+    if (c?.accessKeyId && c?.secretAccessKey && c?.sessionToken) {
       return new NeptuneClient({
         credentials: {
-          accessKeyId: creds.accessKeyId,
-          secretAccessKey: creds.secretAccessKey,
-          sessionToken: creds.sessionToken,
+          accessKeyId: c.accessKeyId,
+          secretAccessKey: c.secretAccessKey,
+          sessionToken: c.sessionToken,
         },
       });
     }
@@ -24,7 +26,7 @@ export class NeptuneAdapter implements ConnectorAdapter {
   }
 
   requiredPolicies(
-    config: Record<string, any>,
+    config: Record<string, unknown>,
     accountId: string,
     region: string
   ): RequiredPolicies {
@@ -57,12 +59,12 @@ export class NeptuneAdapter implements ConnectorAdapter {
   }
 
   async provision(
-    config: Record<string, any>,
-    credentials?: Record<string, any>
+    config: Record<string, unknown>,
+    credentials?: Record<string, unknown>
   ): Promise<ProvisionResult> {
     const client = this.makeClient(credentials);
     const identifier =
-      config.dbClusterIdentifier ?? `citadel-neptune-${Date.now()}`;
+      (config.dbClusterIdentifier as string | undefined) ?? `citadel-neptune-${Date.now()}`;
 
     try {
       const result = await client.send(
@@ -77,34 +79,35 @@ export class NeptuneAdapter implements ConnectorAdapter {
         `arn:aws:rds:${config.region ?? 'us-east-1'}:${config.accountId ?? '000000000000'}:cluster:${identifier}`;
 
       return { resourceArn: arn };
-    } catch (error: any) {
-      if (error.name === 'DBClusterAlreadyExistsFault') {
+    } catch (error) {
+      const err = error as SdkError;
+      if (err.name === 'DBClusterAlreadyExistsFault') {
         return {
           resourceArn: `arn:aws:rds:${config.region ?? 'us-east-1'}:${config.accountId ?? '000000000000'}:cluster:${identifier}`,
         };
       }
       if (
-        error.name === 'AccessDenied' ||
-        error.name === 'AccessDeniedException'
+        err.name === 'AccessDenied' ||
+        err.name === 'AccessDeniedException'
       ) {
         throw new PermissionError(
           `Permission denied creating Neptune cluster ${identifier}`,
-          error
+          err
         );
       }
       throw new ProvisioningError(
-        `Failed to create Neptune cluster ${identifier}: ${error.message}`,
-        error
+        `Failed to create Neptune cluster ${identifier}: ${err.message}`,
+        err
       );
     }
   }
 
   async connect(
-    config: Record<string, any>,
-    credentials?: Record<string, any>
+    config: Record<string, unknown>,
+    credentials?: Record<string, unknown>
   ): Promise<void> {
     const client = this.makeClient(credentials);
-    const identifier = config.dbClusterIdentifier;
+    const identifier = config.dbClusterIdentifier as string | undefined;
 
     try {
       const response = await client.send(
@@ -119,43 +122,44 @@ export class NeptuneAdapter implements ConnectorAdapter {
           true
         );
       }
-    } catch (error: any) {
-      if (error instanceof ConnectionError) {
-        throw error;
+    } catch (error) {
+      const err = error as SdkError;
+      if (err instanceof ConnectionError) {
+        throw err;
       }
-      if (error.name === 'DBClusterNotFoundFault') {
+      if (err.name === 'DBClusterNotFoundFault') {
         throw new ResourceNotFoundError(
           `Neptune cluster ${identifier} does not exist`,
-          error
+          err
         );
       }
       if (
-        error.name === 'AccessDenied' ||
-        error.name === 'AccessDeniedException'
+        err.name === 'AccessDenied' ||
+        err.name === 'AccessDeniedException'
       ) {
         throw new PermissionError(
           `Permission denied accessing Neptune cluster ${identifier}`,
-          error
+          err
         );
       }
       throw new ConnectionError(
-        `Failed to connect to Neptune cluster ${identifier}: ${error.message}`,
+        `Failed to connect to Neptune cluster ${identifier}: ${err.message}`,
         true,
-        error
+        err
       );
     }
   }
 
-  async disconnect(_config: Record<string, any>): Promise<void> {
+  async disconnect(_config: Record<string, unknown>): Promise<void> {
     // No-op: disconnecting from Neptune doesn't require cleanup
   }
 
   async deprovision(
-    config: Record<string, any>,
-    credentials?: Record<string, any>
+    config: Record<string, unknown>,
+    credentials?: Record<string, unknown>
   ): Promise<void> {
     const client = this.makeClient(credentials);
-    const identifier = config.dbClusterIdentifier;
+    const identifier = config.dbClusterIdentifier as string | undefined;
 
     try {
       await client.send(
@@ -164,20 +168,21 @@ export class NeptuneAdapter implements ConnectorAdapter {
           SkipFinalSnapshot: true,
         })
       );
-    } catch (error: any) {
-      if (error.name === 'DBClusterNotFoundFault') {
+    } catch (error) {
+      const err = error as SdkError;
+      if (err.name === 'DBClusterNotFoundFault') {
         return; // Already gone
       }
-      throw error;
+      throw err;
     }
   }
 
   async testConnection(
-    config: Record<string, any>,
-    credentials?: Record<string, any>
+    config: Record<string, unknown>,
+    credentials?: Record<string, unknown>
   ): Promise<ConnectionTestResult> {
     const client = this.makeClient(credentials);
-    const identifier = config.dbClusterIdentifier;
+    const identifier = config.dbClusterIdentifier as string | undefined;
 
     try {
       const response = await client.send(
@@ -195,21 +200,22 @@ export class NeptuneAdapter implements ConnectorAdapter {
           port: cluster?.Port,
         },
       };
-    } catch (error: any) {
+    } catch (error) {
+      const err = error as SdkError;
       return {
         success: false,
-        message: `Failed to connect to Neptune cluster ${identifier}: ${error.message}`,
-        details: { errorName: error.name },
+        message: `Failed to connect to Neptune cluster ${identifier}: ${err.message}`,
+        details: { errorName: err.name },
       };
     }
   }
 
   async getMetrics(
-    config: Record<string, any>,
+    config: Record<string, unknown>,
     _resourceArn?: string
   ): Promise<MetricsResult> {
     const client = this.makeClient();
-    const identifier = config.dbClusterIdentifier;
+    const identifier = config.dbClusterIdentifier as string | undefined;
 
     try {
       const response = await client.send(
@@ -224,20 +230,21 @@ export class NeptuneAdapter implements ConnectorAdapter {
         size: `${allocatedGB} GB`,
         records: 0, // Neptune doesn't expose record count via API
       };
-    } catch (error: any) {
+    } catch (error) {
+      const err = error as SdkError;
       if (
-        error.name === 'AccessDenied' ||
-        error.name === 'AccessDeniedException'
+        err.name === 'AccessDenied' ||
+        err.name === 'AccessDeniedException'
       ) {
         throw new PermissionError(
           `Permission denied describing Neptune cluster ${identifier}`,
-          error
+          err
         );
       }
       throw new ConnectionError(
-        `Failed to get metrics for Neptune cluster ${identifier}: ${error.message}`,
+        `Failed to get metrics for Neptune cluster ${identifier}: ${err.message}`,
         true,
-        error
+        err
       );
     }
   }

--- a/backend/src/lambda/adapters/opensearch-adapter.ts
+++ b/backend/src/lambda/adapters/opensearch-adapter.ts
@@ -7,17 +7,19 @@ import {
 } from '@aws-sdk/client-opensearchserverless';
 import { ConnectorAdapter, ConnectorCategory, ConnectorSpec, AuthenticationMethod, RequiredPolicies, ProvisionResult, ConnectionTestResult, MetricsResult } from '../../adapters/base';
 import { ProvisioningError, ConnectionError, PermissionError, ResourceNotFoundError } from './errors';
+import { SdkError, AwsCredentialFields } from './sdk-types';
 
 export class OpenSearchAdapter implements ConnectorAdapter {
   readonly category: ConnectorCategory = 'datastore';
   readonly spec: ConnectorSpec = { type: 'OPENSEARCH', provider: 'Amazon Web Services', category: 'datastore', authentication: { method: AuthenticationMethod.IAM_ROLE, fields: [], secretStructure: {} }, configuration: { required: ['collectionName'], optional: [], ssmParameters: [] } };
-  private makeClient(creds?: Record<string, any>): OpenSearchServerlessClient {
-    if (creds?.accessKeyId && creds?.secretAccessKey && creds?.sessionToken) {
+  private makeClient(creds?: Record<string, unknown>): OpenSearchServerlessClient {
+    const c = creds as AwsCredentialFields | undefined;
+    if (c?.accessKeyId && c?.secretAccessKey && c?.sessionToken) {
       return new OpenSearchServerlessClient({
         credentials: {
-          accessKeyId: creds.accessKeyId,
-          secretAccessKey: creds.secretAccessKey,
-          sessionToken: creds.sessionToken,
+          accessKeyId: c.accessKeyId,
+          secretAccessKey: c.secretAccessKey,
+          sessionToken: c.sessionToken,
         },
       });
     }
@@ -25,7 +27,7 @@ export class OpenSearchAdapter implements ConnectorAdapter {
   }
 
   requiredPolicies(
-    _config: Record<string, any>,
+    _config: Record<string, unknown>,
     accountId: string,
     region: string
   ): RequiredPolicies {
@@ -61,11 +63,11 @@ export class OpenSearchAdapter implements ConnectorAdapter {
   }
 
   async provision(
-    config: Record<string, any>,
-    credentials?: Record<string, any>
+    config: Record<string, unknown>,
+    credentials?: Record<string, unknown>
   ): Promise<ProvisionResult> {
     const client = this.makeClient(credentials);
-    const name = config.collectionName ?? `citadel-os-${Date.now()}`;
+    const name = (config.collectionName as string | undefined) ?? `citadel-os-${Date.now()}`;
     const type = config.collectionType === 'VECTORSEARCH' ? 'VECTORSEARCH' : 'SEARCH';
     const policyName = `aifos-${name.substring(0, 30)}`;
 
@@ -80,9 +82,10 @@ export class OpenSearchAdapter implements ConnectorAdapter {
           AWSOwnedKey: true,
         }),
       }));
-    } catch (error: any) {
-      if (error.name !== 'ConflictException') {
-        throw new ProvisioningError(`Failed to create encryption policy for ${name}: ${error.message}`, error);
+    } catch (error) {
+      const err = error as SdkError;
+      if (err.name !== 'ConflictException') {
+        throw new ProvisioningError(`Failed to create encryption policy for ${name}: ${err.message}`, err);
       }
     }
 
@@ -101,9 +104,10 @@ export class OpenSearchAdapter implements ConnectorAdapter {
           AllowFromPublic: true,
         }]),
       }));
-    } catch (error: any) {
-      if (error.name !== 'ConflictException') {
-        throw new ProvisioningError(`Failed to create network policy for ${name}: ${error.message}`, error);
+    } catch (error) {
+      const err = error as SdkError;
+      if (err.name !== 'ConflictException') {
+        throw new ProvisioningError(`Failed to create network policy for ${name}: ${err.message}`, err);
       }
     }
 
@@ -117,35 +121,36 @@ export class OpenSearchAdapter implements ConnectorAdapter {
         `arn:aws:aoss:${config.region ?? 'us-east-1'}:${config.accountId ?? '000000000000'}:collection/${name}`;
 
       return { resourceArn: arn };
-    } catch (error: any) {
-      if (error.name === 'ConflictException') {
+    } catch (error) {
+      const err = error as SdkError;
+      if (err.name === 'ConflictException') {
         return {
           resourceArn: `arn:aws:aoss:${config.region ?? 'us-east-1'}:${config.accountId ?? '000000000000'}:collection/${name}`,
         };
       }
       if (
-        error.name === 'AccessDenied' ||
-        error.name === 'AccessDeniedException'
+        err.name === 'AccessDenied' ||
+        err.name === 'AccessDeniedException'
       ) {
         throw new PermissionError(
           `Permission denied creating OpenSearch collection ${name}`,
-          error
+          err
         );
       }
       throw new ProvisioningError(
-        `Failed to create OpenSearch collection ${name}: ${error.message}`,
-        error
+        `Failed to create OpenSearch collection ${name}: ${err.message}`,
+        err
       );
     }
   }
 
   async connect(
-    config: Record<string, any>,
-    credentials?: Record<string, any>
+    config: Record<string, unknown>,
+    credentials?: Record<string, unknown>
   ): Promise<void> {
     const client = this.makeClient(credentials);
-    const names = config.collectionName ? [config.collectionName] : undefined;
-    const ids = config.collectionId ? [config.collectionId] : undefined;
+    const names = config.collectionName ? [config.collectionName as string] : undefined;
+    const ids = config.collectionId ? [config.collectionId as string] : undefined;
 
     try {
       const response = await client.send(
@@ -163,57 +168,59 @@ export class OpenSearchAdapter implements ConnectorAdapter {
           true
         );
       }
-    } catch (error: any) {
-      if (error instanceof ConnectionError || error instanceof ResourceNotFoundError) {
-        throw error;
+    } catch (error) {
+      const err = error as SdkError;
+      if (err instanceof ConnectionError || err instanceof ResourceNotFoundError) {
+        throw err;
       }
       if (
-        error.name === 'AccessDenied' ||
-        error.name === 'AccessDeniedException'
+        err.name === 'AccessDenied' ||
+        err.name === 'AccessDeniedException'
       ) {
         throw new PermissionError(
           `Permission denied accessing OpenSearch collection`,
-          error
+          err
         );
       }
       throw new ConnectionError(
-        `Failed to connect to OpenSearch collection: ${error.message}`,
+        `Failed to connect to OpenSearch collection: ${err.message}`,
         true,
-        error
+        err
       );
     }
   }
 
-  async disconnect(_config: Record<string, any>): Promise<void> {
+  async disconnect(_config: Record<string, unknown>): Promise<void> {
     // No-op: disconnecting from OpenSearch doesn't require cleanup
   }
 
   async deprovision(
-    config: Record<string, any>,
-    credentials?: Record<string, any>
+    config: Record<string, unknown>,
+    credentials?: Record<string, unknown>
   ): Promise<void> {
     const client = this.makeClient(credentials);
-    const collectionId = config.collectionId;
+    const collectionId = config.collectionId as string | undefined;
 
     try {
       await client.send(
         new DeleteCollectionCommand({ id: collectionId })
       );
-    } catch (error: any) {
-      if (error.name === 'ResourceNotFoundException') {
+    } catch (error) {
+      const err = error as SdkError;
+      if (err.name === 'ResourceNotFoundException') {
         return; // Already gone
       }
-      throw error;
+      throw err;
     }
   }
 
   async testConnection(
-    config: Record<string, any>,
-    credentials?: Record<string, any>
+    config: Record<string, unknown>,
+    credentials?: Record<string, unknown>
   ): Promise<ConnectionTestResult> {
     const client = this.makeClient(credentials);
-    const names = config.collectionName ? [config.collectionName] : undefined;
-    const ids = config.collectionId ? [config.collectionId] : undefined;
+    const names = config.collectionName ? [config.collectionName as string] : undefined;
+    const ids = config.collectionId ? [config.collectionId as string] : undefined;
 
     try {
       const response = await client.send(
@@ -235,17 +242,18 @@ export class OpenSearchAdapter implements ConnectorAdapter {
           endpoint: collection.collectionEndpoint,
         },
       };
-    } catch (error: any) {
+    } catch (error) {
+      const err = error as SdkError;
       return {
         success: false,
-        message: `Failed to connect to OpenSearch collection: ${error.message}`,
-        details: { errorName: error.name },
+        message: `Failed to connect to OpenSearch collection: ${err.message}`,
+        details: { errorName: err.name },
       };
     }
   }
 
   async getMetrics(
-    _config: Record<string, any>,
+    _config: Record<string, unknown>,
     _resourceArn?: string
   ): Promise<MetricsResult> {
     // OpenSearch Serverless doesn't expose size via API

--- a/backend/src/lambda/adapters/rds-adapter.ts
+++ b/backend/src/lambda/adapters/rds-adapter.ts
@@ -11,6 +11,7 @@ import {
 import {
   ProvisioningError, ConnectionError, PermissionError, ResourceNotFoundError,
 } from './errors';
+import { SdkError, AwsCredentialFields } from './sdk-types';
 
 export class RdsAdapter implements ConnectorAdapter {
   readonly category: ConnectorCategory = 'datastore';
@@ -20,13 +21,14 @@ export class RdsAdapter implements ConnectorAdapter {
     this.spec = { type: engine === 'postgres' ? 'RDS_POSTGRESQL' : 'RDS_MYSQL', provider: 'Amazon Web Services', category: 'datastore', authentication: { method: AuthenticationMethod.IAM_ROLE, fields: [], secretStructure: {} }, configuration: { required: ['instanceIdentifier'], optional: [], ssmParameters: [] } };
   }
 
-  private makeClient(creds?: Record<string, any>): RDSClient {
-    if (creds?.accessKeyId && creds?.secretAccessKey && creds?.sessionToken) {
+  private makeClient(creds?: Record<string, unknown>): RDSClient {
+    const c = creds as AwsCredentialFields | undefined;
+    if (c?.accessKeyId && c?.secretAccessKey && c?.sessionToken) {
       return new RDSClient({
         credentials: {
-          accessKeyId: creds.accessKeyId,
-          secretAccessKey: creds.secretAccessKey,
-          sessionToken: creds.sessionToken,
+          accessKeyId: c.accessKeyId,
+          secretAccessKey: c.secretAccessKey,
+          sessionToken: c.sessionToken,
         },
       });
     }
@@ -34,7 +36,7 @@ export class RdsAdapter implements ConnectorAdapter {
   }
 
   requiredPolicies(
-    config: Record<string, any>,
+    config: Record<string, unknown>,
     accountId: string,
     region: string
   ): RequiredPolicies {
@@ -62,17 +64,17 @@ export class RdsAdapter implements ConnectorAdapter {
   }
 
   async provision(
-    config: Record<string, any>,
-    credentials?: Record<string, any>
+    config: Record<string, unknown>,
+    credentials?: Record<string, unknown>
   ): Promise<ProvisionResult> {
     const client = this.makeClient(credentials);
     const identifier =
-      config.dbInstanceIdentifier ??
+      (config.dbInstanceIdentifier as string | undefined) ??
       `citadel-${this.engine}-${Date.now()}`;
     const engineName = this.engine === 'postgres' ? 'postgres' : 'mysql';
 
-    const masterUsername = credentials?.masterUsername ?? config.masterUsername;
-    const masterPassword = credentials?.masterPassword ?? config.masterPassword;
+    const masterUsername = (credentials?.masterUsername ?? config.masterUsername) as string | undefined;
+    const masterPassword = (credentials?.masterPassword ?? config.masterPassword) as string | undefined;
 
     if (!masterUsername || !masterPassword) {
       throw new ProvisioningError(
@@ -93,8 +95,8 @@ export class RdsAdapter implements ConnectorAdapter {
         new CreateDBInstanceCommand({
           DBInstanceIdentifier: identifier,
           Engine: engineName,
-          DBInstanceClass: config.dbInstanceClass ?? 'db.t3.micro',
-          AllocatedStorage: config.allocatedStorage ?? 20,
+          DBInstanceClass: (config.dbInstanceClass as string | undefined) ?? 'db.t3.micro',
+          AllocatedStorage: (config.allocatedStorage as number | undefined) ?? 20,
           MasterUsername: masterUsername,
           MasterUserPassword: masterPassword,
         })
@@ -105,34 +107,35 @@ export class RdsAdapter implements ConnectorAdapter {
         `arn:aws:rds:${config.region ?? 'us-east-1'}:${config.accountId ?? '000000000000'}:db:${identifier}`;
 
       return { resourceArn: arn };
-    } catch (error: any) {
-      if (error.name === 'DBInstanceAlreadyExistsFault') {
+    } catch (error) {
+      const err = error as SdkError;
+      if (err.name === 'DBInstanceAlreadyExistsFault') {
         return {
           resourceArn: `arn:aws:rds:${config.region ?? 'us-east-1'}:${config.accountId ?? '000000000000'}:db:${identifier}`,
         };
       }
       if (
-        error.name === 'AccessDenied' ||
-        error.name === 'AccessDeniedException'
+        err.name === 'AccessDenied' ||
+        err.name === 'AccessDeniedException'
       ) {
         throw new PermissionError(
           `Permission denied creating RDS instance ${identifier}`,
-          error
+          err
         );
       }
       throw new ProvisioningError(
-        `Failed to create RDS instance ${identifier}: ${error.message}`,
-        error
+        `Failed to create RDS instance ${identifier}: ${err.message}`,
+        err
       );
     }
   }
 
   async connect(
-    config: Record<string, any>,
-    credentials?: Record<string, any>
+    config: Record<string, unknown>,
+    credentials?: Record<string, unknown>
   ): Promise<void> {
     const client = this.makeClient(credentials);
-    const identifier = config.dbInstanceIdentifier;
+    const identifier = config.dbInstanceIdentifier as string | undefined;
 
     try {
       const response = await client.send(
@@ -147,43 +150,44 @@ export class RdsAdapter implements ConnectorAdapter {
           true
         );
       }
-    } catch (error: any) {
-      if (error instanceof ConnectionError) {
-        throw error;
+    } catch (error) {
+      const err = error as SdkError;
+      if (err instanceof ConnectionError) {
+        throw err;
       }
-      if (error.name === 'DBInstanceNotFoundFault') {
+      if (err.name === 'DBInstanceNotFoundFault') {
         throw new ResourceNotFoundError(
           `RDS instance ${identifier} does not exist`,
-          error
+          err
         );
       }
       if (
-        error.name === 'AccessDenied' ||
-        error.name === 'AccessDeniedException'
+        err.name === 'AccessDenied' ||
+        err.name === 'AccessDeniedException'
       ) {
         throw new PermissionError(
           `Permission denied accessing RDS instance ${identifier}`,
-          error
+          err
         );
       }
       throw new ConnectionError(
-        `Failed to connect to RDS instance ${identifier}: ${error.message}`,
+        `Failed to connect to RDS instance ${identifier}: ${err.message}`,
         true,
-        error
+        err
       );
     }
   }
 
-  async disconnect(_config: Record<string, any>): Promise<void> {
+  async disconnect(_config: Record<string, unknown>): Promise<void> {
     // No-op: disconnecting from RDS doesn't require cleanup
   }
 
   async deprovision(
-    config: Record<string, any>,
-    credentials?: Record<string, any>
+    config: Record<string, unknown>,
+    credentials?: Record<string, unknown>
   ): Promise<void> {
     const client = this.makeClient(credentials);
-    const identifier = config.dbInstanceIdentifier;
+    const identifier = config.dbInstanceIdentifier as string | undefined;
 
     try {
       await client.send(
@@ -192,20 +196,21 @@ export class RdsAdapter implements ConnectorAdapter {
           SkipFinalSnapshot: true,
         })
       );
-    } catch (error: any) {
-      if (error.name === 'DBInstanceNotFoundFault') {
+    } catch (error) {
+      const err = error as SdkError;
+      if (err.name === 'DBInstanceNotFoundFault') {
         return; // Already gone
       }
-      throw error;
+      throw err;
     }
   }
 
   async testConnection(
-    config: Record<string, any>,
-    credentials?: Record<string, any>
+    config: Record<string, unknown>,
+    credentials?: Record<string, unknown>
   ): Promise<ConnectionTestResult> {
     const client = this.makeClient(credentials);
-    const identifier = config.dbInstanceIdentifier;
+    const identifier = config.dbInstanceIdentifier as string | undefined;
 
     try {
       const response = await client.send(
@@ -225,21 +230,22 @@ export class RdsAdapter implements ConnectorAdapter {
           allocatedStorage: instance?.AllocatedStorage,
         },
       };
-    } catch (error: any) {
+    } catch (error) {
+      const err = error as SdkError;
       return {
         success: false,
-        message: `Failed to connect to RDS instance ${identifier}: ${error.message}`,
-        details: { errorName: error.name },
+        message: `Failed to connect to RDS instance ${identifier}: ${err.message}`,
+        details: { errorName: err.name },
       };
     }
   }
 
   async getMetrics(
-    config: Record<string, any>,
+    config: Record<string, unknown>,
     _resourceArn?: string
   ): Promise<MetricsResult> {
     const client = this.makeClient();
-    const identifier = config.dbInstanceIdentifier;
+    const identifier = config.dbInstanceIdentifier as string | undefined;
 
     try {
       const response = await client.send(
@@ -254,20 +260,21 @@ export class RdsAdapter implements ConnectorAdapter {
         size: `${allocatedGB} GB`,
         records: 0, // RDS doesn't expose row count via API
       };
-    } catch (error: any) {
+    } catch (error) {
+      const err = error as SdkError;
       if (
-        error.name === 'AccessDenied' ||
-        error.name === 'AccessDeniedException'
+        err.name === 'AccessDenied' ||
+        err.name === 'AccessDeniedException'
       ) {
         throw new PermissionError(
           `Permission denied describing RDS instance ${identifier}`,
-          error
+          err
         );
       }
       throw new ConnectionError(
-        `Failed to get metrics for RDS instance ${identifier}: ${error.message}`,
+        `Failed to get metrics for RDS instance ${identifier}: ${err.message}`,
         true,
-        error
+        err
       );
     }
   }

--- a/backend/src/lambda/adapters/redshift-adapter.ts
+++ b/backend/src/lambda/adapters/redshift-adapter.ts
@@ -6,17 +6,19 @@ import {
 } from '@aws-sdk/client-redshift';
 import { ConnectorAdapter, ConnectorCategory, ConnectorSpec, AuthenticationMethod, RequiredPolicies, ProvisionResult, ConnectionTestResult, MetricsResult } from '../../adapters/base';
 import { ProvisioningError, ConnectionError, PermissionError, ResourceNotFoundError } from './errors';
+import { SdkError, AwsCredentialFields } from './sdk-types';
 
 export class RedshiftAdapter implements ConnectorAdapter {
   readonly category: ConnectorCategory = 'datastore';
   readonly spec: ConnectorSpec = { type: 'REDSHIFT', provider: 'Amazon Web Services', category: 'datastore', authentication: { method: AuthenticationMethod.IAM_ROLE, fields: [], secretStructure: {} }, configuration: { required: ['clusterIdentifier'], optional: [], ssmParameters: [] } };
-  private makeClient(creds?: Record<string, any>): RedshiftClient {
-    if (creds?.accessKeyId && creds?.secretAccessKey && creds?.sessionToken) {
+  private makeClient(creds?: Record<string, unknown>): RedshiftClient {
+    const c = creds as AwsCredentialFields | undefined;
+    if (c?.accessKeyId && c?.secretAccessKey && c?.sessionToken) {
       return new RedshiftClient({
         credentials: {
-          accessKeyId: creds.accessKeyId,
-          secretAccessKey: creds.secretAccessKey,
-          sessionToken: creds.sessionToken,
+          accessKeyId: c.accessKeyId,
+          secretAccessKey: c.secretAccessKey,
+          sessionToken: c.sessionToken,
         },
       });
     }
@@ -24,7 +26,7 @@ export class RedshiftAdapter implements ConnectorAdapter {
   }
 
   requiredPolicies(
-    config: Record<string, any>,
+    config: Record<string, unknown>,
     accountId: string,
     region: string
   ): RequiredPolicies {
@@ -60,15 +62,15 @@ export class RedshiftAdapter implements ConnectorAdapter {
   }
 
   async provision(
-    config: Record<string, any>,
-    credentials?: Record<string, any>
+    config: Record<string, unknown>,
+    credentials?: Record<string, unknown>
   ): Promise<ProvisionResult> {
     const client = this.makeClient(credentials);
     const identifier =
-      config.clusterIdentifier ?? `citadel-redshift-${Date.now()}`;
+      (config.clusterIdentifier as string | undefined) ?? `citadel-redshift-${Date.now()}`;
 
-    const masterUsername = credentials?.masterUsername ?? config.masterUsername;
-    const masterPassword = credentials?.masterPassword ?? config.masterPassword;
+    const masterUsername = (credentials?.masterUsername ?? config.masterUsername) as string | undefined;
+    const masterPassword = (credentials?.masterPassword ?? config.masterPassword) as string | undefined;
 
     if (!masterUsername || !masterPassword) {
       throw new ProvisioningError(
@@ -87,11 +89,13 @@ export class RedshiftAdapter implements ConnectorAdapter {
       throw new ProvisioningError('masterPassword must contain at least one digit.');
     }
 
-    const nodeType = config.nodeType ?? 'ra3.xlplus';
+    const nodeType = (config.nodeType as string | undefined) ?? 'ra3.xlplus';
     // ra3.xlplus, ra3.4xlarge, ra3.16xlarge require multi-node (min 2 nodes)
     const MULTI_NODE_TYPES = ['ra3.xlplus', 'ra3.4xlarge', 'ra3.16xlarge'];
     const isMultiNode = MULTI_NODE_TYPES.includes(nodeType);
-    const numberOfNodes = isMultiNode ? Math.max(config.numberOfNodes ?? 2, 2) : (config.numberOfNodes ?? 1);
+    const numberOfNodes = isMultiNode
+      ? Math.max((config.numberOfNodes as number | undefined) ?? 2, 2)
+      : ((config.numberOfNodes as number | undefined) ?? 1);
     const clusterType = numberOfNodes > 1 ? 'multi-node' : 'single-node';
 
     try {
@@ -111,34 +115,35 @@ export class RedshiftAdapter implements ConnectorAdapter {
         `arn:aws:redshift:${config.region ?? 'us-east-1'}:${config.accountId ?? '000000000000'}:cluster:${identifier}`;
 
       return { resourceArn: arn };
-    } catch (error: any) {
-      if (error.name === 'ClusterAlreadyExistsFault') {
+    } catch (error) {
+      const err = error as SdkError;
+      if (err.name === 'ClusterAlreadyExistsFault') {
         return {
           resourceArn: `arn:aws:redshift:${config.region ?? 'us-east-1'}:${config.accountId ?? '000000000000'}:cluster:${identifier}`,
         };
       }
       if (
-        error.name === 'AccessDenied' ||
-        error.name === 'AccessDeniedException'
+        err.name === 'AccessDenied' ||
+        err.name === 'AccessDeniedException'
       ) {
         throw new PermissionError(
           `Permission denied creating Redshift cluster ${identifier}`,
-          error
+          err
         );
       }
       throw new ProvisioningError(
-        `Failed to create Redshift cluster ${identifier}: ${error.message}`,
-        error
+        `Failed to create Redshift cluster ${identifier}: ${err.message}`,
+        err
       );
     }
   }
 
   async connect(
-    config: Record<string, any>,
-    credentials?: Record<string, any>
+    config: Record<string, unknown>,
+    credentials?: Record<string, unknown>
   ): Promise<void> {
     const client = this.makeClient(credentials);
-    const identifier = config.clusterIdentifier;
+    const identifier = config.clusterIdentifier as string | undefined;
 
     try {
       const response = await client.send(
@@ -153,43 +158,44 @@ export class RedshiftAdapter implements ConnectorAdapter {
           true
         );
       }
-    } catch (error: any) {
-      if (error instanceof ConnectionError) {
-        throw error;
+    } catch (error) {
+      const err = error as SdkError;
+      if (err instanceof ConnectionError) {
+        throw err;
       }
-      if (error.name === 'ClusterNotFoundFault') {
+      if (err.name === 'ClusterNotFoundFault') {
         throw new ResourceNotFoundError(
           `Redshift cluster ${identifier} does not exist`,
-          error
+          err
         );
       }
       if (
-        error.name === 'AccessDenied' ||
-        error.name === 'AccessDeniedException'
+        err.name === 'AccessDenied' ||
+        err.name === 'AccessDeniedException'
       ) {
         throw new PermissionError(
           `Permission denied accessing Redshift cluster ${identifier}`,
-          error
+          err
         );
       }
       throw new ConnectionError(
-        `Failed to connect to Redshift cluster ${identifier}: ${error.message}`,
+        `Failed to connect to Redshift cluster ${identifier}: ${err.message}`,
         true,
-        error
+        err
       );
     }
   }
 
-  async disconnect(_config: Record<string, any>): Promise<void> {
+  async disconnect(_config: Record<string, unknown>): Promise<void> {
     // No-op: disconnecting from Redshift doesn't require cleanup
   }
 
   async deprovision(
-    config: Record<string, any>,
-    credentials?: Record<string, any>
+    config: Record<string, unknown>,
+    credentials?: Record<string, unknown>
   ): Promise<void> {
     const client = this.makeClient(credentials);
-    const identifier = config.clusterIdentifier;
+    const identifier = config.clusterIdentifier as string | undefined;
 
     try {
       await client.send(
@@ -198,20 +204,21 @@ export class RedshiftAdapter implements ConnectorAdapter {
           SkipFinalClusterSnapshot: true,
         })
       );
-    } catch (error: any) {
-      if (error.name === 'ClusterNotFoundFault') {
+    } catch (error) {
+      const err = error as SdkError;
+      if (err.name === 'ClusterNotFoundFault') {
         return; // Already gone
       }
-      throw error;
+      throw err;
     }
   }
 
   async testConnection(
-    config: Record<string, any>,
-    credentials?: Record<string, any>
+    config: Record<string, unknown>,
+    credentials?: Record<string, unknown>
   ): Promise<ConnectionTestResult> {
     const client = this.makeClient(credentials);
-    const identifier = config.clusterIdentifier;
+    const identifier = config.clusterIdentifier as string | undefined;
 
     try {
       const response = await client.send(
@@ -230,21 +237,22 @@ export class RedshiftAdapter implements ConnectorAdapter {
           numberOfNodes: cluster?.NumberOfNodes,
         },
       };
-    } catch (error: any) {
+    } catch (error) {
+      const err = error as SdkError;
       return {
         success: false,
-        message: `Failed to connect to Redshift cluster ${identifier}: ${error.message}`,
-        details: { errorName: error.name },
+        message: `Failed to connect to Redshift cluster ${identifier}: ${err.message}`,
+        details: { errorName: err.name },
       };
     }
   }
 
   async getMetrics(
-    config: Record<string, any>,
+    config: Record<string, unknown>,
     _resourceArn?: string
   ): Promise<MetricsResult> {
     const client = this.makeClient();
-    const identifier = config.clusterIdentifier;
+    const identifier = config.clusterIdentifier as string | undefined;
 
     try {
       const response = await client.send(
@@ -261,20 +269,21 @@ export class RedshiftAdapter implements ConnectorAdapter {
         size: `${estimatedStorageGB} GB`,
         records: numberOfNodes,
       };
-    } catch (error: any) {
+    } catch (error) {
+      const err = error as SdkError;
       if (
-        error.name === 'AccessDenied' ||
-        error.name === 'AccessDeniedException'
+        err.name === 'AccessDenied' ||
+        err.name === 'AccessDeniedException'
       ) {
         throw new PermissionError(
           `Permission denied describing Redshift cluster ${identifier}`,
-          error
+          err
         );
       }
       throw new ConnectionError(
-        `Failed to get metrics for Redshift cluster ${identifier}: ${error.message}`,
+        `Failed to get metrics for Redshift cluster ${identifier}: ${err.message}`,
         true,
-        error
+        err
       );
     }
   }

--- a/backend/src/lambda/adapters/s3-adapter.ts
+++ b/backend/src/lambda/adapters/s3-adapter.ts
@@ -23,17 +23,19 @@ import {
   PermissionError,
   ResourceNotFoundError,
 } from './errors';
+import { SdkError, AwsCredentialFields } from './sdk-types';
 
 export class S3Adapter implements ConnectorAdapter {
   readonly category: ConnectorCategory = 'datastore';
   readonly spec: ConnectorSpec = { type: 'S3', provider: 'Amazon Web Services', category: 'datastore', authentication: { method: AuthenticationMethod.IAM_ROLE, fields: [], secretStructure: {} }, configuration: { required: ['bucketName'], optional: ['versioning'], ssmParameters: [] } };
-  private makeClient(creds?: Record<string, any>): S3Client {
-    if (creds?.accessKeyId && creds?.secretAccessKey && creds?.sessionToken) {
+  private makeClient(creds?: Record<string, unknown>): S3Client {
+    const c = creds as AwsCredentialFields | undefined;
+    if (c?.accessKeyId && c?.secretAccessKey && c?.sessionToken) {
       return new S3Client({
         credentials: {
-          accessKeyId: creds.accessKeyId,
-          secretAccessKey: creds.secretAccessKey,
-          sessionToken: creds.sessionToken,
+          accessKeyId: c.accessKeyId,
+          secretAccessKey: c.secretAccessKey,
+          sessionToken: c.sessionToken,
         },
       });
     }
@@ -41,11 +43,11 @@ export class S3Adapter implements ConnectorAdapter {
   }
 
   requiredPolicies(
-    config: Record<string, any>,
+    config: Record<string, unknown>,
     _accountId: string,
     _region: string
   ): RequiredPolicies {
-    const bucketName = config.bucketName;
+    const bucketName = config.bucketName as string | undefined;
     const bucketArn = `arn:aws:s3:::${bucketName}`;
 
     return {
@@ -78,11 +80,11 @@ export class S3Adapter implements ConnectorAdapter {
   }
 
   async provision(
-    config: Record<string, any>,
-    credentials?: Record<string, any>
+    config: Record<string, unknown>,
+    credentials?: Record<string, unknown>
   ): Promise<ProvisionResult> {
     const client = this.makeClient(credentials);
-    const rawBucketName = config.bucketName;
+    const rawBucketName = config.bucketName as string | undefined;
 
     if (!rawBucketName) {
       throw new ProvisioningError(
@@ -100,21 +102,22 @@ export class S3Adapter implements ConnectorAdapter {
 
     try {
       await client.send(new CreateBucketCommand({ Bucket: bucketName }));
-    } catch (error: any) {
-      if (error.name === 'BucketAlreadyOwnedByYou') {
+    } catch (error) {
+      const err = error as SdkError;
+      if (err.name === 'BucketAlreadyOwnedByYou') {
         // Idempotent success — bucket already exists and is owned by us
       } else if (
-        error.name === 'AccessDenied' ||
-        error.name === 'AccessDeniedException'
+        err.name === 'AccessDenied' ||
+        err.name === 'AccessDeniedException'
       ) {
         throw new PermissionError(
           `Permission denied creating bucket ${bucketName}`,
-          error
+          err
         );
       } else {
         throw new ProvisioningError(
-          `Failed to create bucket ${bucketName}: ${error.message}`,
-          error
+          `Failed to create bucket ${bucketName}: ${err.message}`,
+          err
         );
       }
     }
@@ -127,19 +130,20 @@ export class S3Adapter implements ConnectorAdapter {
             VersioningConfiguration: { Status: 'Enabled' },
           })
         );
-      } catch (error: any) {
+      } catch (error) {
+        const err = error as SdkError;
         if (
-          error.name === 'AccessDenied' ||
-          error.name === 'AccessDeniedException'
+          err.name === 'AccessDenied' ||
+          err.name === 'AccessDeniedException'
         ) {
           throw new PermissionError(
             `Permission denied enabling versioning on bucket ${bucketName}`,
-            error
+            err
           );
         }
         throw new ProvisioningError(
-          `Failed to enable versioning on bucket ${bucketName}: ${error.message}`,
-          error
+          `Failed to enable versioning on bucket ${bucketName}: ${err.message}`,
+          err
         );
       }
     }
@@ -150,49 +154,50 @@ export class S3Adapter implements ConnectorAdapter {
   }
 
   async connect(
-    config: Record<string, any>,
-    credentials?: Record<string, any>
+    config: Record<string, unknown>,
+    credentials?: Record<string, unknown>
   ): Promise<void> {
     const client = this.makeClient(credentials);
-    const bucketName = config.bucketName;
+    const bucketName = config.bucketName as string | undefined;
 
     try {
       await client.send(new HeadBucketCommand({ Bucket: bucketName }));
-    } catch (error: any) {
-      if (error.name === 'NotFound' || error.$metadata?.httpStatusCode === 404) {
+    } catch (error) {
+      const err = error as SdkError;
+      if (err.name === 'NotFound' || err.$metadata?.httpStatusCode === 404) {
         throw new ResourceNotFoundError(
           `Bucket ${bucketName} does not exist`,
-          error
+          err
         );
       }
       if (
-        error.name === 'AccessDenied' ||
-        error.name === 'AccessDeniedException' ||
-        error.$metadata?.httpStatusCode === 403
+        err.name === 'AccessDenied' ||
+        err.name === 'AccessDeniedException' ||
+        err.$metadata?.httpStatusCode === 403
       ) {
         throw new PermissionError(
           `Permission denied accessing bucket ${bucketName}`,
-          error
+          err
         );
       }
       throw new ConnectionError(
-        `Failed to connect to bucket ${bucketName}: ${error.message}`,
+        `Failed to connect to bucket ${bucketName}: ${err.message}`,
         true,
-        error
+        err
       );
     }
   }
 
-  async disconnect(_config: Record<string, any>): Promise<void> {
+  async disconnect(_config: Record<string, unknown>): Promise<void> {
     // No-op: disconnecting from S3 doesn't require cleanup
   }
 
   async deprovision(
-    config: Record<string, any>,
-    credentials?: Record<string, any>
+    config: Record<string, unknown>,
+    credentials?: Record<string, unknown>
   ): Promise<void> {
     const client = this.makeClient(credentials);
-    const bucketName = config.bucketName;
+    const bucketName = config.bucketName as string | undefined;
 
     // Empty the bucket first (DeleteBucket requires an empty bucket)
     try {
@@ -222,11 +227,12 @@ export class S3Adapter implements ConnectorAdapter {
           ? listResponse.NextContinuationToken
           : undefined;
       } while (continuationToken);
-    } catch (error: any) {
-      if (error.name === 'NoSuchBucket') {
+    } catch (error) {
+      const err = error as SdkError;
+      if (err.name === 'NoSuchBucket') {
         return; // Already gone
       }
-      throw error;
+      throw err;
     }
 
     // Delete the bucket
@@ -234,11 +240,11 @@ export class S3Adapter implements ConnectorAdapter {
   }
 
   async testConnection(
-    config: Record<string, any>,
-    credentials?: Record<string, any>
+    config: Record<string, unknown>,
+    credentials?: Record<string, unknown>
   ): Promise<ConnectionTestResult> {
     const client = this.makeClient(credentials);
-    const bucketName = config.bucketName;
+    const bucketName = config.bucketName as string | undefined;
 
     try {
       await client.send(new HeadBucketCommand({ Bucket: bucketName }));
@@ -246,21 +252,22 @@ export class S3Adapter implements ConnectorAdapter {
         success: true,
         message: `Successfully connected to bucket ${bucketName}`,
       };
-    } catch (error: any) {
+    } catch (error) {
+      const err = error as SdkError;
       return {
         success: false,
-        message: `Failed to connect to bucket ${bucketName}: ${error.message}`,
-        details: { errorName: error.name },
+        message: `Failed to connect to bucket ${bucketName}: ${err.message}`,
+        details: { errorName: err.name },
       };
     }
   }
 
   async getMetrics(
-    config: Record<string, any>,
+    config: Record<string, unknown>,
     _resourceArn?: string
   ): Promise<MetricsResult> {
     const client = this.makeClient();
-    const bucketName = config.bucketName;
+    const bucketName = config.bucketName as string | undefined;
 
     try {
       let objectCount = 0;
@@ -283,20 +290,21 @@ export class S3Adapter implements ConnectorAdapter {
         size: `${objectCount} objects`,
         records: objectCount,
       };
-    } catch (error: any) {
+    } catch (error) {
+      const err = error as SdkError;
       if (
-        error.name === 'AccessDenied' ||
-        error.name === 'AccessDeniedException'
+        err.name === 'AccessDenied' ||
+        err.name === 'AccessDeniedException'
       ) {
         throw new PermissionError(
           `Permission denied listing objects in bucket ${bucketName}`,
-          error
+          err
         );
       }
       throw new ConnectionError(
-        `Failed to get metrics for bucket ${bucketName}: ${error.message}`,
+        `Failed to get metrics for bucket ${bucketName}: ${err.message}`,
         true,
-        error
+        err
       );
     }
   }

--- a/backend/src/lambda/adapters/s3-tables-adapter.ts
+++ b/backend/src/lambda/adapters/s3-tables-adapter.ts
@@ -6,17 +6,19 @@ import {
 } from '@aws-sdk/client-s3tables';
 import { ConnectorAdapter, ConnectorCategory, ConnectorSpec, AuthenticationMethod, RequiredPolicies, ProvisionResult, ConnectionTestResult, MetricsResult } from '../../adapters/base';
 import { ProvisioningError, ConnectionError, PermissionError, ResourceNotFoundError } from './errors';
+import { SdkError, AwsCredentialFields } from './sdk-types';
 
 export class S3TablesAdapter implements ConnectorAdapter {
   readonly category: ConnectorCategory = 'datastore';
   readonly spec: ConnectorSpec = { type: 'S3_TABLES', provider: 'Amazon Web Services', category: 'datastore', authentication: { method: AuthenticationMethod.IAM_ROLE, fields: [], secretStructure: {} }, configuration: { required: ['tableBucketArn'], optional: [], ssmParameters: [] } };
-  private makeClient(creds?: Record<string, any>): S3TablesClient {
-    if (creds?.accessKeyId && creds?.secretAccessKey && creds?.sessionToken) {
+  private makeClient(creds?: Record<string, unknown>): S3TablesClient {
+    const c = creds as AwsCredentialFields | undefined;
+    if (c?.accessKeyId && c?.secretAccessKey && c?.sessionToken) {
       return new S3TablesClient({
         credentials: {
-          accessKeyId: creds.accessKeyId,
-          secretAccessKey: creds.secretAccessKey,
-          sessionToken: creds.sessionToken,
+          accessKeyId: c.accessKeyId,
+          secretAccessKey: c.secretAccessKey,
+          sessionToken: c.sessionToken,
         },
       });
     }
@@ -24,7 +26,7 @@ export class S3TablesAdapter implements ConnectorAdapter {
   }
 
   requiredPolicies(
-    config: Record<string, any>,
+    config: Record<string, unknown>,
     accountId: string,
     region: string
   ): RequiredPolicies {
@@ -55,11 +57,12 @@ export class S3TablesAdapter implements ConnectorAdapter {
   }
 
   async provision(
-    config: Record<string, any>,
-    credentials?: Record<string, any>
+    config: Record<string, unknown>,
+    credentials?: Record<string, unknown>
   ): Promise<ProvisionResult> {
     const client = this.makeClient(credentials);
-    const bucketName = config.tableBucketName ?? `citadel-s3tables-${Date.now()}`;
+    const bucketName =
+      (config.tableBucketName as string | undefined) ?? `citadel-s3tables-${Date.now()}`;
 
     try {
       const result = await client.send(
@@ -71,34 +74,35 @@ export class S3TablesAdapter implements ConnectorAdapter {
         `arn:aws:s3tables:${config.region ?? 'us-east-1'}:${config.accountId ?? '000000000000'}:bucket/${bucketName}`;
 
       return { resourceArn };
-    } catch (error: any) {
-      if (error.name === 'ConflictException') {
+    } catch (error) {
+      const err = error as SdkError;
+      if (err.name === 'ConflictException') {
         return {
           resourceArn: `arn:aws:s3tables:${config.region ?? 'us-east-1'}:${config.accountId ?? '000000000000'}:bucket/${bucketName}`,
         };
       }
       if (
-        error.name === 'AccessDenied' ||
-        error.name === 'AccessDeniedException'
+        err.name === 'AccessDenied' ||
+        err.name === 'AccessDeniedException'
       ) {
         throw new PermissionError(
           `Permission denied creating S3 Tables bucket ${bucketName}`,
-          error
+          err
         );
       }
       throw new ProvisioningError(
-        `Failed to create S3 Tables bucket ${bucketName}: ${error.message}`,
-        error
+        `Failed to create S3 Tables bucket ${bucketName}: ${err.message}`,
+        err
       );
     }
   }
 
   async connect(
-    config: Record<string, any>,
-    credentials?: Record<string, any>
+    config: Record<string, unknown>,
+    credentials?: Record<string, unknown>
   ): Promise<void> {
     const client = this.makeClient(credentials);
-    const tableBucketARN = config.tableBucketARN;
+    const tableBucketARN = config.tableBucketARN as string | undefined;
 
     try {
       const response = await client.send(
@@ -109,43 +113,44 @@ export class S3TablesAdapter implements ConnectorAdapter {
           `S3 Tables bucket ${tableBucketARN} does not exist`
         );
       }
-    } catch (error: any) {
-      if (error instanceof ResourceNotFoundError) {
-        throw error;
+    } catch (error) {
+      const err = error as SdkError;
+      if (err instanceof ResourceNotFoundError) {
+        throw err;
       }
-      if (error.name === 'NotFoundException') {
+      if (err.name === 'NotFoundException') {
         throw new ResourceNotFoundError(
           `S3 Tables bucket ${tableBucketARN} does not exist`,
-          error
+          err
         );
       }
       if (
-        error.name === 'AccessDenied' ||
-        error.name === 'AccessDeniedException'
+        err.name === 'AccessDenied' ||
+        err.name === 'AccessDeniedException'
       ) {
         throw new PermissionError(
           `Permission denied accessing S3 Tables bucket ${tableBucketARN}`,
-          error
+          err
         );
       }
       throw new ConnectionError(
-        `Failed to connect to S3 Tables bucket ${tableBucketARN}: ${error.message}`,
+        `Failed to connect to S3 Tables bucket ${tableBucketARN}: ${err.message}`,
         true,
-        error
+        err
       );
     }
   }
 
-  async disconnect(_config: Record<string, any>): Promise<void> {
+  async disconnect(_config: Record<string, unknown>): Promise<void> {
     // No-op: disconnecting from S3 Tables doesn't require cleanup
   }
 
   async testConnection(
-    config: Record<string, any>,
-    credentials?: Record<string, any>
+    config: Record<string, unknown>,
+    credentials?: Record<string, unknown>
   ): Promise<ConnectionTestResult> {
     const client = this.makeClient(credentials);
-    const tableBucketARN = config.tableBucketARN;
+    const tableBucketARN = config.tableBucketARN as string | undefined;
 
     try {
       const response = await client.send(
@@ -159,21 +164,22 @@ export class S3TablesAdapter implements ConnectorAdapter {
           name: response.name,
         },
       };
-    } catch (error: any) {
+    } catch (error) {
+      const err = error as SdkError;
       return {
         success: false,
-        message: `Failed to connect to S3 Tables bucket ${tableBucketARN}: ${error.message}`,
-        details: { errorName: error.name },
+        message: `Failed to connect to S3 Tables bucket ${tableBucketARN}: ${err.message}`,
+        details: { errorName: err.name },
       };
     }
   }
 
   async getMetrics(
-    config: Record<string, any>,
+    config: Record<string, unknown>,
     _resourceArn?: string
   ): Promise<MetricsResult> {
     const client = this.makeClient();
-    const tableBucketARN = config.tableBucketARN;
+    const tableBucketARN = config.tableBucketARN as string | undefined;
 
     try {
       const response = await client.send(
@@ -186,20 +192,21 @@ export class S3TablesAdapter implements ConnectorAdapter {
         size: '0 MB',
         records: tableCount,
       };
-    } catch (error: any) {
+    } catch (error) {
+      const err = error as SdkError;
       if (
-        error.name === 'AccessDenied' ||
-        error.name === 'AccessDeniedException'
+        err.name === 'AccessDenied' ||
+        err.name === 'AccessDeniedException'
       ) {
         throw new PermissionError(
           `Permission denied listing S3 Tables in bucket ${tableBucketARN}`,
-          error
+          err
         );
       }
       throw new ConnectionError(
-        `Failed to get metrics for S3 Tables bucket ${tableBucketARN}: ${error.message}`,
+        `Failed to get metrics for S3 Tables bucket ${tableBucketARN}: ${err.message}`,
         true,
-        error
+        err
       );
     }
   }

--- a/backend/src/lambda/adapters/sagemaker-feature-store-adapter.ts
+++ b/backend/src/lambda/adapters/sagemaker-feature-store-adapter.ts
@@ -2,20 +2,25 @@ import {
   SageMakerClient,
   CreateFeatureGroupCommand,
   DescribeFeatureGroupCommand,
+  type FeatureDefinition,
+  type OnlineStoreConfig,
+  type OfflineStoreConfig,
 } from '@aws-sdk/client-sagemaker';
 import { ConnectorAdapter, ConnectorCategory, ConnectorSpec, AuthenticationMethod, RequiredPolicies, ProvisionResult, ConnectionTestResult, MetricsResult } from '../../adapters/base';
 import { ProvisioningError, ConnectionError, PermissionError, ResourceNotFoundError } from './errors';
+import { SdkError, AwsCredentialFields } from './sdk-types';
 
 export class SageMakerFeatureStoreAdapter implements ConnectorAdapter {
   readonly category: ConnectorCategory = 'datastore';
   readonly spec: ConnectorSpec = { type: 'SAGEMAKER_FEATURE_STORE', provider: 'Amazon Web Services', category: 'datastore', authentication: { method: AuthenticationMethod.IAM_ROLE, fields: [], secretStructure: {} }, configuration: { required: ['featureGroupName'], optional: [], ssmParameters: [] } };
-  private makeClient(creds?: Record<string, any>): SageMakerClient {
-    if (creds?.accessKeyId && creds?.secretAccessKey && creds?.sessionToken) {
+  private makeClient(creds?: Record<string, unknown>): SageMakerClient {
+    const c = creds as AwsCredentialFields | undefined;
+    if (c?.accessKeyId && c?.secretAccessKey && c?.sessionToken) {
       return new SageMakerClient({
         credentials: {
-          accessKeyId: creds.accessKeyId,
-          secretAccessKey: creds.secretAccessKey,
-          sessionToken: creds.sessionToken,
+          accessKeyId: c.accessKeyId,
+          secretAccessKey: c.secretAccessKey,
+          sessionToken: c.sessionToken,
         },
       });
     }
@@ -23,7 +28,7 @@ export class SageMakerFeatureStoreAdapter implements ConnectorAdapter {
   }
 
   requiredPolicies(
-    config: Record<string, any>,
+    config: Record<string, unknown>,
     accountId: string,
     region: string
   ): RequiredPolicies {
@@ -51,26 +56,27 @@ export class SageMakerFeatureStoreAdapter implements ConnectorAdapter {
   }
 
   async provision(
-    config: Record<string, any>,
-    credentials?: Record<string, any>
+    config: Record<string, unknown>,
+    credentials?: Record<string, unknown>
   ): Promise<ProvisionResult> {
     const client = this.makeClient(credentials);
-    const featureGroupName = config.featureGroupName ?? `citadel-feature-store-${Date.now()}`;
+    const featureGroupName =
+      (config.featureGroupName as string | undefined) ?? `citadel-feature-store-${Date.now()}`;
 
     try {
       const result = await client.send(
         new CreateFeatureGroupCommand({
           FeatureGroupName: featureGroupName,
-          RecordIdentifierFeatureName: config.recordIdentifierFeatureName ?? 'record_id',
-          EventTimeFeatureName: config.eventTimeFeatureName ?? 'event_time',
-          FeatureDefinitions: config.featureDefinitions ?? [
+          RecordIdentifierFeatureName: (config.recordIdentifierFeatureName as string | undefined) ?? 'record_id',
+          EventTimeFeatureName: (config.eventTimeFeatureName as string | undefined) ?? 'event_time',
+          FeatureDefinitions: (config.featureDefinitions as FeatureDefinition[] | undefined) ?? [
             { FeatureName: 'record_id', FeatureType: 'String' },
             { FeatureName: 'event_time', FeatureType: 'String' },
           ],
-          OnlineStoreConfig: config.onlineStoreConfig ?? { EnableOnlineStore: true },
-          OfflineStoreConfig: config.offlineStoreConfig ?? {
+          OnlineStoreConfig: (config.onlineStoreConfig as OnlineStoreConfig | undefined) ?? { EnableOnlineStore: true },
+          OfflineStoreConfig: (config.offlineStoreConfig as OfflineStoreConfig | undefined) ?? {
             S3StorageConfig: {
-              S3Uri: config.s3Uri ?? `s3://citadel-feature-store-${featureGroupName}`,
+              S3Uri: (config.s3Uri as string | undefined) ?? `s3://citadel-feature-store-${featureGroupName}`,
             },
           },
         })
@@ -81,34 +87,35 @@ export class SageMakerFeatureStoreAdapter implements ConnectorAdapter {
         `arn:aws:sagemaker:${config.region ?? 'us-east-1'}:${config.accountId ?? '000000000000'}:feature-group/${featureGroupName}`;
 
       return { resourceArn };
-    } catch (error: any) {
-      if (error.name === 'ResourceInUse') {
+    } catch (error) {
+      const err = error as SdkError;
+      if (err.name === 'ResourceInUse') {
         return {
           resourceArn: `arn:aws:sagemaker:${config.region ?? 'us-east-1'}:${config.accountId ?? '000000000000'}:feature-group/${featureGroupName}`,
         };
       }
       if (
-        error.name === 'AccessDenied' ||
-        error.name === 'AccessDeniedException'
+        err.name === 'AccessDenied' ||
+        err.name === 'AccessDeniedException'
       ) {
         throw new PermissionError(
           `Permission denied creating SageMaker feature group ${featureGroupName}`,
-          error
+          err
         );
       }
       throw new ProvisioningError(
-        `Failed to create SageMaker feature group ${featureGroupName}: ${error.message}`,
-        error
+        `Failed to create SageMaker feature group ${featureGroupName}: ${err.message}`,
+        err
       );
     }
   }
 
   async connect(
-    config: Record<string, any>,
-    credentials?: Record<string, any>
+    config: Record<string, unknown>,
+    credentials?: Record<string, unknown>
   ): Promise<void> {
     const client = this.makeClient(credentials);
-    const featureGroupName = config.featureGroupName;
+    const featureGroupName = config.featureGroupName as string | undefined;
 
     try {
       const response = await client.send(
@@ -120,43 +127,44 @@ export class SageMakerFeatureStoreAdapter implements ConnectorAdapter {
           true
         );
       }
-    } catch (error: any) {
-      if (error instanceof ConnectionError) {
-        throw error;
+    } catch (error) {
+      const err = error as SdkError;
+      if (err instanceof ConnectionError) {
+        throw err;
       }
-      if (error.name === 'ResourceNotFound') {
+      if (err.name === 'ResourceNotFound') {
         throw new ResourceNotFoundError(
           `SageMaker feature group ${featureGroupName} does not exist`,
-          error
+          err
         );
       }
       if (
-        error.name === 'AccessDenied' ||
-        error.name === 'AccessDeniedException'
+        err.name === 'AccessDenied' ||
+        err.name === 'AccessDeniedException'
       ) {
         throw new PermissionError(
           `Permission denied accessing SageMaker feature group ${featureGroupName}`,
-          error
+          err
         );
       }
       throw new ConnectionError(
-        `Failed to connect to SageMaker feature group ${featureGroupName}: ${error.message}`,
+        `Failed to connect to SageMaker feature group ${featureGroupName}: ${err.message}`,
         true,
-        error
+        err
       );
     }
   }
 
-  async disconnect(_config: Record<string, any>): Promise<void> {
+  async disconnect(_config: Record<string, unknown>): Promise<void> {
     // No-op: disconnecting from SageMaker Feature Store doesn't require cleanup
   }
 
   async testConnection(
-    config: Record<string, any>,
-    credentials?: Record<string, any>
+    config: Record<string, unknown>,
+    credentials?: Record<string, unknown>
   ): Promise<ConnectionTestResult> {
     const client = this.makeClient(credentials);
-    const featureGroupName = config.featureGroupName;
+    const featureGroupName = config.featureGroupName as string | undefined;
 
     try {
       const response = await client.send(
@@ -171,21 +179,22 @@ export class SageMakerFeatureStoreAdapter implements ConnectorAdapter {
           creationTime: response.CreationTime?.toISOString(),
         },
       };
-    } catch (error: any) {
+    } catch (error) {
+      const err = error as SdkError;
       return {
         success: false,
-        message: `Failed to connect to SageMaker feature group ${featureGroupName}: ${error.message}`,
-        details: { errorName: error.name },
+        message: `Failed to connect to SageMaker feature group ${featureGroupName}: ${err.message}`,
+        details: { errorName: err.name },
       };
     }
   }
 
   async getMetrics(
-    config: Record<string, any>,
+    config: Record<string, unknown>,
     _resourceArn?: string
   ): Promise<MetricsResult> {
     const client = this.makeClient();
-    const featureGroupName = config.featureGroupName;
+    const featureGroupName = config.featureGroupName as string | undefined;
 
     try {
       await client.send(
@@ -196,20 +205,21 @@ export class SageMakerFeatureStoreAdapter implements ConnectorAdapter {
         size: '0 MB',
         records: 0,
       };
-    } catch (error: any) {
+    } catch (error) {
+      const err = error as SdkError;
       if (
-        error.name === 'AccessDenied' ||
-        error.name === 'AccessDeniedException'
+        err.name === 'AccessDenied' ||
+        err.name === 'AccessDeniedException'
       ) {
         throw new PermissionError(
           `Permission denied describing SageMaker feature group ${featureGroupName}`,
-          error
+          err
         );
       }
       throw new ConnectionError(
-        `Failed to get metrics for SageMaker feature group ${featureGroupName}: ${error.message}`,
+        `Failed to get metrics for SageMaker feature group ${featureGroupName}: ${err.message}`,
         true,
-        error
+        err
       );
     }
   }

--- a/backend/src/lambda/adapters/sagemaker-lakehouse-adapter.ts
+++ b/backend/src/lambda/adapters/sagemaker-lakehouse-adapter.ts
@@ -2,20 +2,23 @@ import {
   SageMakerClient,
   CreateFeatureGroupCommand,
   DescribeFeatureGroupCommand,
+  type FeatureDefinition,
 } from '@aws-sdk/client-sagemaker';
 import { ConnectorAdapter, ConnectorCategory, ConnectorSpec, AuthenticationMethod, RequiredPolicies, ProvisionResult, ConnectionTestResult, MetricsResult } from '../../adapters/base';
 import { ProvisioningError, ConnectionError, PermissionError, ResourceNotFoundError } from './errors';
+import { SdkError, AwsCredentialFields } from './sdk-types';
 
 export class SageMakerLakehouseAdapter implements ConnectorAdapter {
   readonly category: ConnectorCategory = 'datastore';
   readonly spec: ConnectorSpec = { type: 'SAGEMAKER_LAKEHOUSE', provider: 'Amazon Web Services', category: 'datastore', authentication: { method: AuthenticationMethod.IAM_ROLE, fields: [], secretStructure: {} }, configuration: { required: [], optional: [], ssmParameters: [] } };
-  private makeClient(creds?: Record<string, any>): SageMakerClient {
-    if (creds?.accessKeyId && creds?.secretAccessKey && creds?.sessionToken) {
+  private makeClient(creds?: Record<string, unknown>): SageMakerClient {
+    const c = creds as AwsCredentialFields | undefined;
+    if (c?.accessKeyId && c?.secretAccessKey && c?.sessionToken) {
       return new SageMakerClient({
         credentials: {
-          accessKeyId: creds.accessKeyId,
-          secretAccessKey: creds.secretAccessKey,
-          sessionToken: creds.sessionToken,
+          accessKeyId: c.accessKeyId,
+          secretAccessKey: c.secretAccessKey,
+          sessionToken: c.sessionToken,
         },
       });
     }
@@ -23,7 +26,7 @@ export class SageMakerLakehouseAdapter implements ConnectorAdapter {
   }
 
   requiredPolicies(
-    config: Record<string, any>,
+    config: Record<string, unknown>,
     accountId: string,
     region: string
   ): RequiredPolicies {
@@ -46,25 +49,26 @@ export class SageMakerLakehouseAdapter implements ConnectorAdapter {
   }
 
   async provision(
-    config: Record<string, any>,
-    credentials?: Record<string, any>
+    config: Record<string, unknown>,
+    credentials?: Record<string, unknown>
   ): Promise<ProvisionResult> {
     const client = this.makeClient(credentials);
-    const featureGroupName = config.featureGroupName ?? `citadel-lakehouse-${Date.now()}`;
+    const featureGroupName =
+      (config.featureGroupName as string | undefined) ?? `citadel-lakehouse-${Date.now()}`;
 
     try {
       const result = await client.send(
         new CreateFeatureGroupCommand({
           FeatureGroupName: featureGroupName,
-          RecordIdentifierFeatureName: config.recordIdentifierFeatureName ?? 'record_id',
-          EventTimeFeatureName: config.eventTimeFeatureName ?? 'event_time',
-          FeatureDefinitions: config.featureDefinitions ?? [
+          RecordIdentifierFeatureName: (config.recordIdentifierFeatureName as string | undefined) ?? 'record_id',
+          EventTimeFeatureName: (config.eventTimeFeatureName as string | undefined) ?? 'event_time',
+          FeatureDefinitions: (config.featureDefinitions as FeatureDefinition[] | undefined) ?? [
             { FeatureName: 'record_id', FeatureType: 'String' },
             { FeatureName: 'event_time', FeatureType: 'String' },
           ],
           OfflineStoreConfig: {
             S3StorageConfig: {
-              S3Uri: config.s3Uri ?? `s3://citadel-lakehouse-${featureGroupName}`,
+              S3Uri: (config.s3Uri as string | undefined) ?? `s3://citadel-lakehouse-${featureGroupName}`,
             },
           },
         })
@@ -75,34 +79,35 @@ export class SageMakerLakehouseAdapter implements ConnectorAdapter {
         `arn:aws:sagemaker:${config.region ?? 'us-east-1'}:${config.accountId ?? '000000000000'}:feature-group/${featureGroupName}`;
 
       return { resourceArn };
-    } catch (error: any) {
-      if (error.name === 'ResourceInUse') {
+    } catch (error) {
+      const err = error as SdkError;
+      if (err.name === 'ResourceInUse') {
         return {
           resourceArn: `arn:aws:sagemaker:${config.region ?? 'us-east-1'}:${config.accountId ?? '000000000000'}:feature-group/${featureGroupName}`,
         };
       }
       if (
-        error.name === 'AccessDenied' ||
-        error.name === 'AccessDeniedException'
+        err.name === 'AccessDenied' ||
+        err.name === 'AccessDeniedException'
       ) {
         throw new PermissionError(
           `Permission denied creating SageMaker feature group ${featureGroupName}`,
-          error
+          err
         );
       }
       throw new ProvisioningError(
-        `Failed to create SageMaker feature group ${featureGroupName}: ${error.message}`,
-        error
+        `Failed to create SageMaker feature group ${featureGroupName}: ${err.message}`,
+        err
       );
     }
   }
 
   async connect(
-    config: Record<string, any>,
-    credentials?: Record<string, any>
+    config: Record<string, unknown>,
+    credentials?: Record<string, unknown>
   ): Promise<void> {
     const client = this.makeClient(credentials);
-    const featureGroupName = config.featureGroupName;
+    const featureGroupName = config.featureGroupName as string | undefined;
 
     try {
       const response = await client.send(
@@ -114,43 +119,44 @@ export class SageMakerLakehouseAdapter implements ConnectorAdapter {
           true
         );
       }
-    } catch (error: any) {
-      if (error instanceof ConnectionError) {
-        throw error;
+    } catch (error) {
+      const err = error as SdkError;
+      if (err instanceof ConnectionError) {
+        throw err;
       }
-      if (error.name === 'ResourceNotFound') {
+      if (err.name === 'ResourceNotFound') {
         throw new ResourceNotFoundError(
           `SageMaker feature group ${featureGroupName} does not exist`,
-          error
+          err
         );
       }
       if (
-        error.name === 'AccessDenied' ||
-        error.name === 'AccessDeniedException'
+        err.name === 'AccessDenied' ||
+        err.name === 'AccessDeniedException'
       ) {
         throw new PermissionError(
           `Permission denied accessing SageMaker feature group ${featureGroupName}`,
-          error
+          err
         );
       }
       throw new ConnectionError(
-        `Failed to connect to SageMaker feature group ${featureGroupName}: ${error.message}`,
+        `Failed to connect to SageMaker feature group ${featureGroupName}: ${err.message}`,
         true,
-        error
+        err
       );
     }
   }
 
-  async disconnect(_config: Record<string, any>): Promise<void> {
+  async disconnect(_config: Record<string, unknown>): Promise<void> {
     // No-op: disconnecting from SageMaker Lakehouse doesn't require cleanup
   }
 
   async testConnection(
-    config: Record<string, any>,
-    credentials?: Record<string, any>
+    config: Record<string, unknown>,
+    credentials?: Record<string, unknown>
   ): Promise<ConnectionTestResult> {
     const client = this.makeClient(credentials);
-    const featureGroupName = config.featureGroupName;
+    const featureGroupName = config.featureGroupName as string | undefined;
 
     try {
       const response = await client.send(
@@ -165,21 +171,22 @@ export class SageMakerLakehouseAdapter implements ConnectorAdapter {
           recordIdentifierFeatureName: response.RecordIdentifierFeatureName,
         },
       };
-    } catch (error: any) {
+    } catch (error) {
+      const err = error as SdkError;
       return {
         success: false,
-        message: `Failed to connect to SageMaker feature group ${featureGroupName}: ${error.message}`,
-        details: { errorName: error.name },
+        message: `Failed to connect to SageMaker feature group ${featureGroupName}: ${err.message}`,
+        details: { errorName: err.name },
       };
     }
   }
 
   async getMetrics(
-    config: Record<string, any>,
+    config: Record<string, unknown>,
     _resourceArn?: string
   ): Promise<MetricsResult> {
     const client = this.makeClient();
-    const featureGroupName = config.featureGroupName;
+    const featureGroupName = config.featureGroupName as string | undefined;
 
     try {
       await client.send(
@@ -190,20 +197,21 @@ export class SageMakerLakehouseAdapter implements ConnectorAdapter {
         size: '0 MB',
         records: 0,
       };
-    } catch (error: any) {
+    } catch (error) {
+      const err = error as SdkError;
       if (
-        error.name === 'AccessDenied' ||
-        error.name === 'AccessDeniedException'
+        err.name === 'AccessDenied' ||
+        err.name === 'AccessDeniedException'
       ) {
         throw new PermissionError(
           `Permission denied describing SageMaker feature group ${featureGroupName}`,
-          error
+          err
         );
       }
       throw new ConnectionError(
-        `Failed to get metrics for SageMaker feature group ${featureGroupName}: ${error.message}`,
+        `Failed to get metrics for SageMaker feature group ${featureGroupName}: ${err.message}`,
         true,
-        error
+        err
       );
     }
   }

--- a/backend/src/lambda/adapters/sdk-types.ts
+++ b/backend/src/lambda/adapters/sdk-types.ts
@@ -1,0 +1,21 @@
+/**
+ * Shared structural types for adapter implementations.
+ *
+ * Type-only module: these interfaces narrow `unknown` values (caught SDK
+ * errors, credential records) for type-safe access. No runtime behavior.
+ */
+
+/** Structural shape of errors thrown by AWS SDK v3 clients and driver SDKs. */
+export interface SdkError extends Error {
+  /** Driver-specific error code (e.g. Snowflake auth failure codes). */
+  code?: string;
+  /** AWS SDK v3 response metadata. */
+  $metadata?: { httpStatusCode?: number };
+}
+
+/** Optional STS credential fields carried in adapter `credentials` records. */
+export interface AwsCredentialFields {
+  accessKeyId?: string;
+  secretAccessKey?: string;
+  sessionToken?: string;
+}

--- a/backend/src/lambda/adapters/snowflake-adapter.ts
+++ b/backend/src/lambda/adapters/snowflake-adapter.ts
@@ -3,10 +3,11 @@ import {
   RequiredPolicies, ProvisionResult, ConnectionTestResult, MetricsResult,
 } from '../../adapters/base';
 import { ProvisioningError, ConnectionError, PermissionError, ValidationError } from './errors';
+import { SdkError } from './sdk-types';
 
-function getSnowflakeSDK() {
+async function getSnowflakeSDK(): Promise<typeof import('snowflake-sdk')> {
   try {
-    return require('snowflake-sdk');
+    return await import('snowflake-sdk');
   } catch {
     throw new ConnectionError('snowflake-sdk is not installed. Install it to use the Snowflake adapter.');
   }
@@ -18,7 +19,7 @@ export class SnowflakeAdapter implements ConnectorAdapter {
   private readonly kind = 'snowflake';
 
   requiredPolicies(
-    _config: Record<string, any>,
+    _config: Record<string, unknown>,
     _accountId: string,
     _region: string
   ): RequiredPolicies {
@@ -26,8 +27,8 @@ export class SnowflakeAdapter implements ConnectorAdapter {
   }
 
   async provision(
-    _config: Record<string, any>,
-    _credentials?: Record<string, any>
+    _config: Record<string, unknown>,
+    _credentials?: Record<string, unknown>
   ): Promise<ProvisionResult> {
     throw new ProvisioningError(
       `Provisioning is not supported for external ${this.kind} data stores`
@@ -35,8 +36,8 @@ export class SnowflakeAdapter implements ConnectorAdapter {
   }
 
   async connect(
-    config: Record<string, any>,
-    credentials?: Record<string, any>
+    config: Record<string, unknown>,
+    credentials?: Record<string, unknown>
   ): Promise<void> {
     const result = await this.testConnection(config, credentials);
     if (!result.success) {
@@ -46,13 +47,13 @@ export class SnowflakeAdapter implements ConnectorAdapter {
     }
   }
 
-  async disconnect(_config: Record<string, any>): Promise<void> {
+  async disconnect(_config: Record<string, unknown>): Promise<void> {
     // No-op for external stores
   }
 
   async testConnection(
-    config: Record<string, any>,
-    credentials?: Record<string, any>
+    config: Record<string, unknown>,
+    credentials?: Record<string, unknown>
   ): Promise<ConnectionTestResult> {
     const missing: string[] = [];
     if (!config.accountIdentifier) missing.push('accountIdentifier');
@@ -65,8 +66,8 @@ export class SnowflakeAdapter implements ConnectorAdapter {
       );
     }
 
-    const username = credentials?.username ?? config.username;
-    const password = credentials?.password ?? config.password;
+    const username = (credentials?.username ?? config.username) as string | undefined;
+    const password = (credentials?.password ?? config.password) as string | undefined;
 
     if (!username || !password) {
       throw new ValidationError(
@@ -75,24 +76,24 @@ export class SnowflakeAdapter implements ConnectorAdapter {
     }
 
     try {
-      const snowflake = getSnowflakeSDK();
+      const snowflake = await getSnowflakeSDK();
       const connection = snowflake.createConnection({
-        account: config.accountIdentifier,
+        account: config.accountIdentifier as string,
         username,
         password,
-        warehouse: config.warehouse,
-        database: config.database,
-        schema: config.schema,
+        warehouse: config.warehouse as string,
+        database: config.database as string,
+        schema: config.schema as string | undefined,
       });
 
       await new Promise<void>((resolve, reject) => {
-        connection.connect((err: any) => {
+        connection.connect((err) => {
           if (err) reject(err);
           else resolve();
         });
       });
 
-      connection.destroy((err: any) => {
+      connection.destroy((err) => {
         if (err) console.error('Error destroying Snowflake connection:', err);
       });
 
@@ -105,26 +106,27 @@ export class SnowflakeAdapter implements ConnectorAdapter {
           database: config.database,
         },
       };
-    } catch (error: any) {
+    } catch (error) {
+      const err = error as SdkError;
       if (
-        error.code === '390100' ||
-        error.message?.includes('Incorrect username or password')
+        err.code === '390100' ||
+        err.message?.includes('Incorrect username or password')
       ) {
         throw new PermissionError(
           `Authentication failed for Snowflake account ${config.accountIdentifier}`,
-          error
+          err
         );
       }
       throw new ConnectionError(
-        `Failed to connect to Snowflake account ${config.accountIdentifier}: ${error.message}`,
+        `Failed to connect to Snowflake account ${config.accountIdentifier}: ${err.message}`,
         true,
-        error
+        err
       );
     }
   }
 
   async getMetrics(
-    _config: Record<string, any>,
+    _config: Record<string, unknown>,
     _resourceArn?: string
   ): Promise<MetricsResult> {
     return { size: '0 MB', records: 0 };

--- a/backend/src/lambda/adapters/timestream-adapter.ts
+++ b/backend/src/lambda/adapters/timestream-adapter.ts
@@ -4,20 +4,23 @@ import {
   CreateTableCommand,
   DeleteDatabaseCommand,
   DescribeDatabaseCommand,
+  type RetentionProperties,
 } from '@aws-sdk/client-timestream-write';
 import { ConnectorAdapter, ConnectorCategory, ConnectorSpec, AuthenticationMethod, RequiredPolicies, ProvisionResult, ConnectionTestResult, MetricsResult } from '../../adapters/base';
 import { ProvisioningError, ConnectionError, PermissionError, ResourceNotFoundError } from './errors';
+import { SdkError, AwsCredentialFields } from './sdk-types';
 
 export class TimestreamAdapter implements ConnectorAdapter {
   readonly category: ConnectorCategory = 'datastore';
   readonly spec: ConnectorSpec = { type: 'TIMESTREAM', provider: 'Amazon Web Services', category: 'datastore', authentication: { method: AuthenticationMethod.IAM_ROLE, fields: [], secretStructure: {} }, configuration: { required: ['databaseName'], optional: [], ssmParameters: [] } };
-  private makeClient(creds?: Record<string, any>): TimestreamWriteClient {
-    if (creds?.accessKeyId && creds?.secretAccessKey && creds?.sessionToken) {
+  private makeClient(creds?: Record<string, unknown>): TimestreamWriteClient {
+    const c = creds as AwsCredentialFields | undefined;
+    if (c?.accessKeyId && c?.secretAccessKey && c?.sessionToken) {
       return new TimestreamWriteClient({
         credentials: {
-          accessKeyId: creds.accessKeyId,
-          secretAccessKey: creds.secretAccessKey,
-          sessionToken: creds.sessionToken,
+          accessKeyId: c.accessKeyId,
+          secretAccessKey: c.secretAccessKey,
+          sessionToken: c.sessionToken,
         },
       });
     }
@@ -25,7 +28,7 @@ export class TimestreamAdapter implements ConnectorAdapter {
   }
 
   requiredPolicies(
-    config: Record<string, any>,
+    config: Record<string, unknown>,
     accountId: string,
     region: string
   ): RequiredPolicies {
@@ -59,11 +62,12 @@ export class TimestreamAdapter implements ConnectorAdapter {
   }
 
   async provision(
-    config: Record<string, any>,
-    credentials?: Record<string, any>
+    config: Record<string, unknown>,
+    credentials?: Record<string, unknown>
   ): Promise<ProvisionResult> {
     const client = this.makeClient(credentials);
-    const databaseName = config.databaseName ?? `citadel-timestream-${Date.now()}`;
+    const databaseName =
+      (config.databaseName as string | undefined) ?? `citadel-timestream-${Date.now()}`;
 
     try {
       const dbResult = await client.send(
@@ -79,52 +83,54 @@ export class TimestreamAdapter implements ConnectorAdapter {
           await client.send(
             new CreateTableCommand({
               DatabaseName: databaseName,
-              TableName: config.tableName,
-              RetentionProperties: config.retentionProperties,
+              TableName: config.tableName as string,
+              RetentionProperties: config.retentionProperties as RetentionProperties | undefined,
             })
           );
-        } catch (tableError: any) {
-          if (tableError.name !== 'ConflictException') {
-            throw tableError;
+        } catch (tableError) {
+          const err = tableError as SdkError;
+          if (err.name !== 'ConflictException') {
+            throw err;
           }
         }
       }
 
       return { resourceArn };
-    } catch (error: any) {
-      if (error.name === 'ConflictException') {
+    } catch (error) {
+      const err = error as SdkError;
+      if (err.name === 'ConflictException') {
         return {
           resourceArn: `arn:aws:timestream:${config.region ?? 'us-east-1'}:${config.accountId ?? '000000000000'}:database/${databaseName}`,
         };
       }
-      if (error.message?.includes('discover endpoint')) {
+      if (err.message?.includes('discover endpoint')) {
         throw new ProvisioningError(
           `Timestream is not available in this account/region. The endpoint discovery failed. Please check that Timestream for LiveAnalytics is enabled for your account.`,
-          error
+          err
         );
       }
       if (
-        error.name === 'AccessDenied' ||
-        error.name === 'AccessDeniedException'
+        err.name === 'AccessDenied' ||
+        err.name === 'AccessDeniedException'
       ) {
         throw new PermissionError(
           `Permission denied creating Timestream database ${databaseName}`,
-          error
+          err
         );
       }
       throw new ProvisioningError(
-        `Failed to create Timestream database ${databaseName}: ${error.message}`,
-        error
+        `Failed to create Timestream database ${databaseName}: ${err.message}`,
+        err
       );
     }
   }
 
   async connect(
-    config: Record<string, any>,
-    credentials?: Record<string, any>
+    config: Record<string, unknown>,
+    credentials?: Record<string, unknown>
   ): Promise<void> {
     const client = this.makeClient(credentials);
-    const databaseName = config.databaseName;
+    const databaseName = config.databaseName as string | undefined;
 
     try {
       const response = await client.send(
@@ -135,62 +141,64 @@ export class TimestreamAdapter implements ConnectorAdapter {
           `Timestream database ${databaseName} does not exist`
         );
       }
-    } catch (error: any) {
-      if (error instanceof ResourceNotFoundError) {
-        throw error;
+    } catch (error) {
+      const err = error as SdkError;
+      if (err instanceof ResourceNotFoundError) {
+        throw err;
       }
-      if (error.name === 'ResourceNotFoundException') {
+      if (err.name === 'ResourceNotFoundException') {
         throw new ResourceNotFoundError(
           `Timestream database ${databaseName} does not exist`,
-          error
+          err
         );
       }
       if (
-        error.name === 'AccessDenied' ||
-        error.name === 'AccessDeniedException'
+        err.name === 'AccessDenied' ||
+        err.name === 'AccessDeniedException'
       ) {
         throw new PermissionError(
           `Permission denied accessing Timestream database ${databaseName}`,
-          error
+          err
         );
       }
       throw new ConnectionError(
-        `Failed to connect to Timestream database ${databaseName}: ${error.message}`,
+        `Failed to connect to Timestream database ${databaseName}: ${err.message}`,
         true,
-        error
+        err
       );
     }
   }
 
-  async disconnect(_config: Record<string, any>): Promise<void> {
+  async disconnect(_config: Record<string, unknown>): Promise<void> {
     // No-op: disconnecting from Timestream doesn't require cleanup
   }
 
   async deprovision(
-    config: Record<string, any>,
-    credentials?: Record<string, any>
+    config: Record<string, unknown>,
+    credentials?: Record<string, unknown>
   ): Promise<void> {
     const client = this.makeClient(credentials);
-    const databaseName = config.databaseName;
+    const databaseName = config.databaseName as string | undefined;
 
     try {
       await client.send(
         new DeleteDatabaseCommand({ DatabaseName: databaseName })
       );
-    } catch (error: any) {
-      if (error.name === 'ResourceNotFoundException') {
+    } catch (error) {
+      const err = error as SdkError;
+      if (err.name === 'ResourceNotFoundException') {
         return; // Already gone
       }
-      throw error;
+      throw err;
     }
   }
 
   async testConnection(
-    config: Record<string, any>,
-    credentials?: Record<string, any>
+    config: Record<string, unknown>,
+    credentials?: Record<string, unknown>
   ): Promise<ConnectionTestResult> {
     const client = this.makeClient(credentials);
-    const databaseName = config.databaseName;
+    const databaseName = config.databaseName as string | undefined;
 
     try {
       const response = await client.send(
@@ -205,21 +213,22 @@ export class TimestreamAdapter implements ConnectorAdapter {
           tableCount: database?.TableCount,
         },
       };
-    } catch (error: any) {
+    } catch (error) {
+      const err = error as SdkError;
       return {
         success: false,
-        message: `Failed to connect to Timestream database ${databaseName}: ${error.message}`,
-        details: { errorName: error.name },
+        message: `Failed to connect to Timestream database ${databaseName}: ${err.message}`,
+        details: { errorName: err.name },
       };
     }
   }
 
   async getMetrics(
-    config: Record<string, any>,
+    config: Record<string, unknown>,
     _resourceArn?: string
   ): Promise<MetricsResult> {
     const client = this.makeClient();
-    const databaseName = config.databaseName;
+    const databaseName = config.databaseName as string | undefined;
 
     try {
       const response = await client.send(
@@ -231,20 +240,21 @@ export class TimestreamAdapter implements ConnectorAdapter {
         size: '0 MB',
         records: tableCount,
       };
-    } catch (error: any) {
+    } catch (error) {
+      const err = error as SdkError;
       if (
-        error.name === 'AccessDenied' ||
-        error.name === 'AccessDeniedException'
+        err.name === 'AccessDenied' ||
+        err.name === 'AccessDeniedException'
       ) {
         throw new PermissionError(
           `Permission denied describing Timestream database ${databaseName}`,
-          error
+          err
         );
       }
       throw new ConnectionError(
-        `Failed to get metrics for Timestream database ${databaseName}: ${error.message}`,
+        `Failed to get metrics for Timestream database ${databaseName}: ${err.message}`,
         true,
-        error
+        err
       );
     }
   }


### PR DESCRIPTION
## Summary

Lint-debt burn-down, part 3: the complete datastore adapter family (sources + tests), the largest at 42% of the lint debt.

- Eliminates all 625 `no-explicit-any` / `require-imports` warnings across 45 adapter files
- Sources (21 adapters, commit 1): shared SDK type narrowing via a new type-only `sdk-types.ts`, `Record<string, unknown>` payloads, typed catch narrowing
— strictly type-only, except `require()` → dynamic import in the databricks and snowflake adapters (required by `no-require-imports`), behavior-locked by unchanged suites
- Tests (24 files, commit 2): typed fixtures and `aws-sdk-client-mock` generics reusing the shared helpers; one legacy suppression removed; assertions proven semantically identical
- Ratchets `--max-warnings` 1476 → 851; no `eslint-disable` introduced

## Testing

- Adapter family: 53 suites / 620 tests green with unchanged counts after each commit
- `npx eslint 'src/lambda/adapters/**/*.ts'` reports 0 problems; full lint and build pass at the new cap.