### PR TITLE
fix(lint): type resolver sources and shared types, cap to 183

### DIFF
--- a/backend/package.json
+++ b/backend/package.json
@@ -11,7 +11,7 @@
     "watch": "tsc -w",
     "test": "jest",
     "test:integration": "jest --config jest.integration.config.js",
-    "lint": "eslint \"src/**/*.ts\" --max-warnings 421",
+    "lint": "eslint \"src/**/*.ts\" --max-warnings 183",
     "lint:fix": "eslint \"src/**/*.ts\" --fix",
     "format": "prettier --write \"src/**/*.ts\"",
     "cdk:synth": "cdk synth",

--- a/backend/src/lambda/adr-resolver.ts
+++ b/backend/src/lambda/adr-resolver.ts
@@ -28,7 +28,13 @@ import { v4 as uuidv4 } from 'uuid';
 import { LifecycleManager, ADR_TRANSITIONS } from '../adapters/lifecycle';
 import { emitGovernanceEvent } from '../utils/notifier-base';
 import { hasPermission } from '../utils/auth';
-import type { AuthContext, ADRReopenAttempt, AuthResultLiteral } from '../types';
+import type {
+  AuthContext,
+  ADRReopenAttempt,
+  AuthResultLiteral,
+  GovernanceEventIdentity,
+  GovernanceResolverEvent,
+} from '../types';
 
 const dynamoClient = new DynamoDBClient({});
 const docClient = DynamoDBDocumentClient.from(dynamoClient);
@@ -63,8 +69,22 @@ export interface ADR extends ADRInput {
   supersededBy?: string;
 }
 
-function authContextFromEvent(event: any): AuthContext {
-  const identity = event?.identity || {};
+/** Merged view of every argument this resolver's fields receive. */
+interface ADRResolverArguments {
+  input: ADRInput;
+  adrId: string;
+  oldAdrId: string;
+  newAdrId: string;
+  proposedChange: string;
+  revisitConditionMatched: boolean;
+  reason: string;
+  projectId: string;
+}
+
+type ADRResolverEvent = GovernanceResolverEvent<ADRResolverArguments>;
+
+function authContextFromEvent(event: ADRResolverEvent): AuthContext {
+  const identity: GovernanceEventIdentity = event?.identity || {};
   const claimRole = identity['custom:role'] ?? identity.claims?.['custom:role'];
   return {
     userId: identity.sub || identity.username || 'anonymous',
@@ -409,7 +429,7 @@ export async function lockADR(adrId: string, authContext: AuthContext): Promise<
   return locked;
 }
 
-export const handler = async (event: any): Promise<unknown> => {
+export const handler = async (event: ADRResolverEvent): Promise<unknown> => {
   const fieldName = event?.info?.fieldName;
   const authContext = authContextFromEvent(event);
   try {

--- a/backend/src/lambda/agent-code-resolver.ts
+++ b/backend/src/lambda/agent-code-resolver.ts
@@ -21,7 +21,9 @@ interface UpdateAgentCodeArgs {
   };
 }
 
-export const handler = async (event: AppSyncResolverEvent<any>) => {
+export const handler = async (
+  event: AppSyncResolverEvent<Partial<GetAgentCodeArgs & UpdateAgentCodeArgs>>,
+) => {
   console.log('Agent Code Resolver Event:', JSON.stringify(event, null, 2));
 
   const fieldName = event.info.fieldName;

--- a/backend/src/lambda/agent-config-resolver.ts
+++ b/backend/src/lambda/agent-config-resolver.ts
@@ -92,14 +92,40 @@ export function _resetRegistryService(): void {
 interface AgentConfig {
   agentId: string;
   orgId: string;
-  config: any;
+  config: string | Record<string, unknown>;
   state: 'active' | 'inactive' | 'maintenance' | 'pending' | string;
   categories?: string[] | string;
   createdAt?: string;
   updatedAt?: string;
 }
 
-export const handler = async (event: any) => {
+/** Merged create/update mutation input (config required only on create). */
+interface AgentConfigMutationInput {
+  agentId: string;
+  config?: string | Record<string, unknown>;
+  state?: string;
+  categories?: string[] | string;
+  icon?: string;
+  appId?: string;
+}
+
+/** Minimal slice of the AppSync event needed for org/admin extraction. */
+type OrgScopedEvent = { identity?: Record<string, unknown> };
+
+/** AppSync event shape as dispatched to this resolver's handler. */
+interface AgentConfigResolverEvent extends OrgScopedEvent {
+  info: { fieldName: string };
+  arguments: Record<string, unknown>;
+}
+
+/** Loose manifest shape as parsed from AWSJSON; validated at runtime. */
+export interface RawAgentManifest {
+  name?: unknown;
+  description?: unknown;
+  version?: unknown;
+}
+
+export const handler = async (event: AgentConfigResolverEvent) => {
   console.log('Event:', JSON.stringify(event, null, 2));
 
   const fieldName = event.info.fieldName;
@@ -115,34 +141,34 @@ export const handler = async (event: any) => {
 
       case 'getAgentConfig':
         return registryEnabled
-          ? await getAgentConfigRegistry(event.arguments.agentId, event)
-          : await getAgentConfig(event.arguments.agentId);
+          ? await getAgentConfigRegistry(event.arguments.agentId as string, event)
+          : await getAgentConfig(event.arguments.agentId as string);
 
       case 'createAgentConfig':
         return registryEnabled
-          ? await createAgentConfigRegistry(event.arguments.input, event)
-          : await createAgentConfig(event.arguments.input);
+          ? await createAgentConfigRegistry(event.arguments.input as AgentConfigMutationInput, event)
+          : await createAgentConfig(event.arguments.input as AgentConfigMutationInput);
 
       case 'updateAgentConfig':
         return registryEnabled
-          ? await updateAgentConfigRegistry(event.arguments.input, event)
-          : await updateAgentConfig(event.arguments.input);
+          ? await updateAgentConfigRegistry(event.arguments.input as AgentConfigMutationInput, event)
+          : await updateAgentConfig(event.arguments.input as AgentConfigMutationInput);
 
       case 'deleteAgentConfig':
         return registryEnabled
-          ? await deleteAgentConfigRegistry(event.arguments.agentId)
-          : await deleteAgentConfig(event.arguments.agentId);
+          ? await deleteAgentConfigRegistry(event.arguments.agentId as string)
+          : await deleteAgentConfig(event.arguments.agentId as string);
 
       case 'publishAgentManifest':
         return registryEnabled
-          ? await publishAgentManifestRegistry(event.arguments.agentId, event.arguments.manifest)
-          : await publishAgentManifest(event.arguments.agentId, event.arguments.manifest);
+          ? await publishAgentManifestRegistry(event.arguments.agentId as string, event.arguments.manifest as string)
+          : await publishAgentManifest(event.arguments.agentId as string, event.arguments.manifest as string);
 
       case 'searchAgentConfigs':
-        return await searchAgentConfigsRegistry(event.arguments.query);
+        return await searchAgentConfigsRegistry(event.arguments.query as string);
 
       case 'activateProjectAgents':
-        return await activateProjectAgents(event.arguments.projectId);
+        return await activateProjectAgents(event.arguments.projectId as string);
 
       default:
         throw new Error(`Unknown field: ${fieldName}`);
@@ -163,7 +189,7 @@ export const handler = async (event: any) => {
  * - Registry throws (unavailable / transient error) → log warning, fall
  *   back to DynamoDB so get queries can degrade gracefully
  */
-export async function getAgentConfigRegistry(agentId: string, event?: any): Promise<AgentConfig | null> {
+export async function getAgentConfigRegistry(agentId: string, event?: OrgScopedEvent): Promise<AgentConfig | null> {
   const registryService = getRegistryService();
   const callerOrgId = event !== undefined ? await extractOrgFromEvent(event) : null;
   const admin = event !== undefined ? isAdminFromEvent(event) : false;
@@ -205,7 +231,7 @@ export async function getAgentConfigRegistry(agentId: string, event?: any): Prom
  * receives an empty list with a warning, so anonymous / api-key callers
  * never see cross-tenant data.
  */
-export async function listAgentConfigsRegistry(event?: any): Promise<AgentConfig[]> {
+export async function listAgentConfigsRegistry(event?: OrgScopedEvent): Promise<AgentConfig[]> {
   const callerOrgId = event !== undefined ? await extractOrgFromEvent(event) : null;
   const admin = event !== undefined ? isAdminFromEvent(event) : false;
 
@@ -271,7 +297,7 @@ export async function listAgentConfigsRegistry(event?: any): Promise<AgentConfig
  * payloads never carry orgId — per D1(a) the backend is the sole source
  * of truth for tenant assignment.
  */
-export async function createAgentConfigRegistry(input: any, event?: any): Promise<AgentConfig> {
+export async function createAgentConfigRegistry(input: AgentConfigMutationInput, event?: OrgScopedEvent): Promise<AgentConfig> {
   const registryService = getRegistryService();
 
   const orgId = await extractOrgFromEvent(event);
@@ -288,7 +314,7 @@ export async function createAgentConfigRegistry(input: any, event?: any): Promis
     state: input.state || 'active',
     appId: input.appId || undefined,
     orgId,
-  });
+  } as AgentCustomMetadata);
 
   const record = await registryService.createResource('agent', input.agentId, {
     name: parsedConfig.name || input.agentId,
@@ -393,7 +419,7 @@ async function enforceImportActivationGate(
  * present, and fall back to the caller's JWT org for legacy records that
  * predate Phase-2a. Input payloads never carry orgId.
  */
-export async function updateAgentConfigRegistry(input: any, event?: any): Promise<AgentConfig> {
+export async function updateAgentConfigRegistry(input: AgentConfigMutationInput, event?: OrgScopedEvent): Promise<AgentConfig> {
   const registryService = getRegistryService();
 
   // Fetch existing record to merge with
@@ -407,7 +433,7 @@ export async function updateAgentConfigRegistry(input: any, event?: any): Promis
     icon: string;
     state: string;
     appId?: string;
-    manifest?: Record<string, any>;
+    manifest?: Record<string, unknown>;
     orgId?: string;
   }>(existing.customDescriptorContent ?? null, {
     categories: [],
@@ -429,7 +455,7 @@ export async function updateAgentConfigRegistry(input: any, event?: any): Promis
   // existing record's name. Never throw here: a state-only toggle (e.g. the
   // Activate / Deactivate button) has no input.config and must not blow up
   // on a malformed legacy description.
-  let parsedNewConfig: any = {};
+  let parsedNewConfig: Record<string, unknown> = {};
   if (newConfig && typeof newConfig === 'string') {
     try {
       parsedNewConfig = JSON.parse(newConfig);
@@ -615,7 +641,7 @@ export async function updateAgentConfigRegistry(input: any, event?: any): Promis
   }
 
   const record = await registryService.updateResource('agent', input.agentId, {
-    name: parsedNewConfig.name || existing.name,
+    name: (parsedNewConfig.name as string | undefined) || existing.name,
     description: newConfig,
     customMetadata: updatedMeta,
   });
@@ -679,7 +705,7 @@ export async function deleteAgentConfigRegistry(agentId: string): Promise<{ succ
  */
 export async function publishAgentManifestRegistry(agentId: string, manifestStr: string): Promise<AgentConfig> {
   // Parse the AWSJSON manifest string
-  let manifest: any;
+  let manifest: RawAgentManifest;
   try {
     manifest = JSON.parse(manifestStr);
   } catch {
@@ -706,7 +732,7 @@ export async function publishAgentManifestRegistry(agentId: string, manifestStr:
     icon: string;
     state: string;
     appId?: string;
-    manifest?: Record<string, any>;
+    manifest?: Record<string, unknown>;
     orgId?: string;
   }>(existing.customDescriptorContent ?? null, {
     categories: [],
@@ -720,7 +746,7 @@ export async function publishAgentManifestRegistry(agentId: string, manifestStr:
   const updatedMeta = registryService.serializeCustomMetadata({
     ...existingMeta,
     manifest,
-  } as any);
+  } as AgentCustomMetadata);
 
   const record = await registryService.updateResource('agent', agentId, {
     name: existing.name,
@@ -865,7 +891,7 @@ async function getAgentConfig(agentId: string): Promise<AgentConfig | null> {
   };
 }
 
-async function createAgentConfig(input: any): Promise<AgentConfig> {
+async function createAgentConfig(input: AgentConfigMutationInput): Promise<AgentConfig> {
   const now = new Date().toISOString();
   const config = typeof input.config === 'string' ? JSON.parse(input.config) : input.config;
 
@@ -892,7 +918,7 @@ async function createAgentConfig(input: any): Promise<AgentConfig> {
   };
 }
 
-async function updateAgentConfig(input: any): Promise<AgentConfig> {
+async function updateAgentConfig(input: AgentConfigMutationInput): Promise<AgentConfig> {
   const existing = await getAgentConfig(input.agentId);
   if (!existing) {
     throw new Error(`Agent config not found: ${input.agentId}`);
@@ -909,7 +935,7 @@ async function updateAgentConfig(input: any): Promise<AgentConfig> {
     : existingConfig;
 
   // D-02: Optimistic locking — increment version and use conditional write
-  const currentVersion = (existing as any).version || 0;
+  const currentVersion = (existing as AgentConfig & { version?: number }).version || 0;
   const nextVersion = currentVersion + 1;
 
   const updatedConfig: AgentConfig = {
@@ -973,7 +999,7 @@ async function deleteAgentConfig(agentId: string): Promise<{ success: boolean; m
 
 // ─── Manifest Validation ─────────────────────────────────────
 
-export function validateManifest(manifest: any): { valid: boolean; errors: string[] } {
+export function validateManifest(manifest: RawAgentManifest): { valid: boolean; errors: string[] } {
   const errors: string[] = [];
 
   if (typeof manifest.name !== 'string' || manifest.name.trim() === '') {
@@ -1062,7 +1088,7 @@ export function validateImportDescriptor(
 
 async function publishAgentManifest(agentId: string, manifestStr: string): Promise<unknown> {
   // Parse the AWSJSON manifest string
-  let manifest: any;
+  let manifest: RawAgentManifest;
   try {
     manifest = JSON.parse(manifestStr);
   } catch {

--- a/backend/src/lambda/agent-design-assessment-resolver.ts
+++ b/backend/src/lambda/agent-design-assessment-resolver.ts
@@ -50,6 +50,8 @@ import type {
   SubmitAgentDesignAssessmentInput,
   DimensionComplexityInput,
   FourDimensionLiteral,
+  GovernanceEventIdentity,
+  GovernanceResolverEvent,
 } from '../types';
 import { ProjectArchetypeStatus } from '../types';
 
@@ -69,8 +71,23 @@ const FOUR_DIMENSIONS: readonly FourDimensionLiteral[] = [
 ];
 const EXPECTED_RANKS = [1, 2, 3, 4];
 
-function authContextFromEvent(event: any): AuthContext {
-  const identity = event?.identity || {};
+/**
+ * Merged view of every argument this resolver's fields receive.
+ * submitAgentDesignAssessment spreads its input at the top level of
+ * `arguments`, hence the Partial<SubmitAgentDesignAssessmentInput> base.
+ */
+interface AgentDesignAssessmentResolverArguments
+  extends Partial<SubmitAgentDesignAssessmentInput> {
+  projectId: string;
+}
+
+type AgentDesignAssessmentResolverEvent =
+  GovernanceResolverEvent<AgentDesignAssessmentResolverArguments>;
+
+function authContextFromEvent(
+  event: AgentDesignAssessmentResolverEvent,
+): AuthContext {
+  const identity: GovernanceEventIdentity = event?.identity || {};
   const claimRole = identity['custom:role'] ?? identity.claims?.['custom:role'];
   return {
     userId: identity.sub || identity.username || 'anonymous',
@@ -322,7 +339,7 @@ export async function submitAgentDesignAssessment(
   return after;
 }
 
-export const handler = async (event: any): Promise<unknown> => {
+export const handler = async (event: AgentDesignAssessmentResolverEvent): Promise<unknown> => {
   const fieldName = event?.info?.fieldName;
   const authContext = authContextFromEvent(event);
   try {

--- a/backend/src/lambda/agent-message-handler.ts
+++ b/backend/src/lambda/agent-message-handler.ts
@@ -54,7 +54,8 @@ let _agentConfigCache: Record<string, { config: AgentCoreConfig; cachedAt: numbe
 const SSM_CACHE_TTL = 5 * 60 * 1000; // 5 minutes
 
 // ── SigV4 Credential Cache (per invocation) ─────────────────────────
-let _cachedCredentials: any = null;
+type SigV4Credentials = Awaited<ReturnType<ReturnType<typeof defaultProvider>>>;
+let _cachedCredentials: SigV4Credentials | null = null;
 
 // ── Agent-source adapter registry (import dispatch) ─────────────────
 // Lazily built so the legacy path pays nothing when import is disabled.
@@ -164,7 +165,7 @@ export function _resetCaches(): void {
   _agentSourceRegistry = null;
 }
 
-export async function getCredentials(): Promise<any> {
+export async function getCredentials(): Promise<SigV4Credentials> {
   if (!_cachedCredentials) {
     _cachedCredentials = await defaultProvider()();
   }
@@ -178,7 +179,7 @@ interface MessageSentToAgentEvent {
   messageId: string;
   userId: string;
   timestamp: string;
-  metadata?: Record<string, any>;
+  metadata?: Record<string, unknown>;
 }
 
 interface AgentCoreConfig {
@@ -239,7 +240,7 @@ async function sendMessageToAgentCore(
   config: AgentCoreConfig,
   message: string,
   sessionId: string,
-  sessionAttributes?: Record<string, any>
+  sessionAttributes?: Record<string, unknown>
 ): Promise<string> {
   try {
     const region = config.region || process.env.AWS_REGION || "ap-southeast-2";
@@ -288,7 +289,7 @@ async function sendMessageToAgentCore(
 
         // Read the stream
         const chunks: string[] = [];
-        const stream = response.response as any;
+        const stream = response.response as unknown as AsyncIterable<Uint8Array>;
 
         // Convert stream to string
         for await (const chunk of stream) {
@@ -391,6 +392,18 @@ async function sendProgressUpdate(
   console.log("Progress update sent to frontend");
 }
 
+/** Conversation row persisted for an agent response. */
+interface StoredAgentMessage {
+  projectId: string;
+  timestamp: string;
+  id: string;
+  agentId: string;
+  message: string;
+  messageType: string;
+  correlationId: string;
+  metadata?: string;
+}
+
 /**
  * Store agent response in DynamoDB
  */
@@ -399,8 +412,8 @@ async function storeAgentResponse(
   agentId: string,
   message: string,
   correlationId: string,
-  metadata?: Record<string, any>
-): Promise<any> {
+  metadata?: Record<string, unknown>
+): Promise<StoredAgentMessage> {
   const messageId = uuidv4();
   const timestamp = new Date().toISOString();
 
@@ -429,7 +442,7 @@ async function storeAgentResponse(
 /**
  * Trigger AppSync mutation to fire subscriptions
  */
-async function triggerAppSyncMutation(messageRecord: any): Promise<void> {
+async function triggerAppSyncMutation(messageRecord: StoredAgentMessage): Promise<void> {
   const mutation = `
     mutation PublishMessage($input: PublishMessageInput!) {
       publishConversationMessage(input: $input) {
@@ -488,7 +501,7 @@ async function triggerAppSyncMutation(messageRecord: any): Promise<void> {
 
   const response = await fetch(APPSYNC_ENDPOINT, {
     method: signedRequest.method,
-    headers: signedRequest.headers as any,
+    headers: signedRequest.headers,
     body: signedRequest.body,
   });
 
@@ -763,7 +776,7 @@ export const handler = async (
     const sessionId = projectId;
 
     // Prepare session attributes
-    const sessionAttributes: Record<string, any> = {
+    const sessionAttributes: Record<string, unknown> = {
       projectId: projectId,
       userId: userId,
       messageId: messageId,

--- a/backend/src/lambda/agent-resolver.ts
+++ b/backend/src/lambda/agent-resolver.ts
@@ -1,4 +1,4 @@
-import { AppSyncResolverHandler } from 'aws-lambda';
+import { AppSyncResolverHandler, AppSyncResolverEvent } from 'aws-lambda';
 import { DynamoDBClient } from '@aws-sdk/client-dynamodb';
 import { DynamoDBDocumentClient, GetCommand, PutCommand } from '@aws-sdk/lib-dynamodb';
 import { EventBridgeClient, PutEventsCommand } from '@aws-sdk/client-eventbridge';
@@ -20,11 +20,29 @@ interface AgentStatus {
   currentTask?: string;
   progress?: number;
   lastUpdate: string;
-  metadata?: any;
+  metadata?: Record<string, unknown>;
   errorMessage?: string;
 }
 
-export const handler: AppSyncResolverHandler<any, any> = async (event) => {
+/** updateAgentStatus mutation input shape. */
+interface AgentStatusInputShape {
+  status: string;
+  currentTask?: string;
+  progress?: number;
+  metadata?: Record<string, unknown>;
+  errorMessage?: string;
+}
+
+/** Merged view of every argument this resolver's fields receive. */
+interface AgentResolverArguments {
+  projectId: string;
+  agentId: string;
+  status: AgentStatusInputShape;
+}
+
+type AgentResolverEvent = AppSyncResolverEvent<AgentResolverArguments>;
+
+export const handler: AppSyncResolverHandler<AgentResolverArguments, unknown> = async (event) => {
   console.log('Agent resolver event:', JSON.stringify(event, null, 2));
 
   const { info, arguments: args, identity } = event;
@@ -50,7 +68,7 @@ async function getAgentStatus(
   projectId: string,
   agentId: string,
   _userId: string,
-  event: any,
+  event: AgentResolverEvent,
 ): Promise<AgentStatus | null> {
   // Project-membership check (tenant isolation).
   //
@@ -107,9 +125,9 @@ async function getAgentStatus(
 async function updateAgentStatus(
   projectId: string,
   agentId: string,
-  statusInput: any,
+  statusInput: AgentStatusInputShape,
   _userId: string,
-  event: any,
+  event: AgentResolverEvent,
 ): Promise<AgentStatus | null> {
   // Project-membership check (tenant isolation) — write path.
   //
@@ -165,7 +183,7 @@ async function updateAgentStatus(
   return agentStatus;
 }
 
-async function emitEvent(eventType: string, detail: any): Promise<void> {
+async function emitEvent(eventType: string, detail: Record<string, unknown>): Promise<void> {
   const command = new PutEventsCommand({
     Entries: [
       {

--- a/backend/src/lambda/app-access-control.ts
+++ b/backend/src/lambda/app-access-control.ts
@@ -93,10 +93,19 @@ export function isAdmin(caller: CallerContext): boolean {
 /**
  * Queries all ACCESS# items for an app via GroupIndex.
  */
+/** ACCESS# component row slice this module reads. */
+interface AccessEntryRecord {
+  userId: string;
+  role: string;
+  grantedBy: string;
+  grantedAt: string;
+  [key: string]: unknown;
+}
+
 async function queryAccessEntries(
   appId: string,
   deps: AccessControlDeps,
-): Promise<Array<Record<string, any>>> {
+): Promise<AccessEntryRecord[]> {
   const result = await deps.docClient.send(new QueryCommand({
     TableName: deps.appsTable,
     IndexName: 'GroupIndex',
@@ -106,7 +115,7 @@ async function queryAccessEntries(
       ':sk': 'ACCESS#',
     },
   }));
-  return result.Items || [];
+  return (result.Items || []) as AccessEntryRecord[];
 }
 
 /**

--- a/backend/src/lambda/app-api-authorizer.ts
+++ b/backend/src/lambda/app-api-authorizer.ts
@@ -88,7 +88,7 @@ export function evaluateKeyAuthorization(
  */
 export const handler = async (
   event: AuthorizerEvent,
-  _context?: any,
+  _context?: unknown,
   deps: { docClient?: DynamoDBDocumentClient; appsTable?: string } = {},
 ): Promise<SimpleAuthorizerResult> => {
   const docClient = deps.docClient || getDocClient();
@@ -127,10 +127,12 @@ export const handler = async (
     const items = result.Items || [];
 
     // Find matching key by hash
-    const matchedKey = items.find((item: any) => item.hashedKey === hashedKey) as any;
+    const matchedKey = items.find((item) => item.hashedKey === hashedKey) as
+      | { status: string; expiresAt?: string; keyId?: string; appId?: string }
+      | undefined;
 
     // Evaluate authorization using pure decision logic
-    const decision = evaluateKeyAuthorization(matchedKey as any);
+    const decision = evaluateKeyAuthorization(matchedKey);
 
     logAudit({
       appId,
@@ -147,7 +149,7 @@ export const handler = async (
     // Best-effort async update of lastUsedAt
     docClient.send(new UpdateCommand({
       TableName: appsTable,
-      Key: { appId: matchedKey.appId },
+      Key: { appId: matchedKey!.appId },
       UpdateExpression: 'SET lastUsedAt = :now',
       ExpressionAttributeValues: {
         ':now': new Date().toISOString(),
@@ -160,7 +162,7 @@ export const handler = async (
       isAuthorized: true,
       context: {
         appId,
-        apiKeyId: matchedKey.keyId,
+        apiKeyId: matchedKey!.keyId as string,
       },
     };
   } catch (error) {

--- a/backend/src/lambda/app-api-key-management.ts
+++ b/backend/src/lambda/app-api-key-management.ts
@@ -69,10 +69,23 @@ function generateKey(): { plaintext: string; hashed: string; prefix: string; key
 /**
  * Queries all APIKEY# items for an app via GroupIndex.
  */
+/** APIKEY# component row slice this module reads. */
+interface ApiKeyRecord {
+  keyId: string;
+  name: string;
+  status: string;
+  createdAt: string;
+  prefix: string;
+  hashedKey?: string;
+  expiresAt?: string;
+  lastUsedAt?: string;
+  [key: string]: unknown;
+}
+
 async function queryApiKeys(
   appId: string,
   deps: ApiKeyDeps,
-): Promise<Array<Record<string, any>>> {
+): Promise<ApiKeyRecord[]> {
   const result = await deps.docClient.send(new QueryCommand({
     TableName: deps.appsTable,
     IndexName: 'GroupIndex',
@@ -82,7 +95,7 @@ async function queryApiKeys(
       ':sk': 'APIKEY#',
     },
   }));
-  return result.Items || [];
+  return (result.Items || []) as ApiKeyRecord[];
 }
 
 /**
@@ -90,7 +103,7 @@ async function queryApiKeys(
  */
 async function emitApiKeyEvent(
   detailType: string,
-  detail: Record<string, any>,
+  detail: Record<string, unknown>,
   deps: ApiKeyDeps,
 ): Promise<void> {
   await deps.eventBridgeClient.send(new PutEventsCommand({
@@ -135,7 +148,18 @@ export async function createAppApiKey(
   const key = generateKey();
   const now = new Date().toISOString();
 
-  const item: Record<string, any> = {
+  const item: {
+    appId: string;
+    groupId: string;
+    sortId: string;
+    keyId: string;
+    name: string;
+    hashedKey: string;
+    prefix: string;
+    status: string;
+    createdAt: string;
+    expiresAt?: string;
+  } = {
     appId: `${appId}#APIKEY#${key.keyId}`,
     groupId: `APP#${appId}`,
     sortId: `APIKEY#${key.keyId}`,
@@ -260,7 +284,7 @@ export async function rotateAppApiKey(
   const newKey = generateKey();
   const now = new Date().toISOString();
 
-  const newKeyItem: Record<string, any> = {
+  const newKeyItem: Record<string, string> = {
     appId: `${appId}#APIKEY#${newKey.keyId}`,
     groupId: `APP#${appId}`,
     sortId: `APIKEY#${newKey.keyId}`,

--- a/backend/src/lambda/app-auth-config.ts
+++ b/backend/src/lambda/app-auth-config.ts
@@ -75,7 +75,15 @@ export async function setAppAuthConfig(
     throw new Error(`Auth config validation failed: ${errors.join('; ')}`);
   }
 
-  const item: Record<string, any> = {
+  const item: {
+    appId: string;
+    groupId: string;
+    sortId: string;
+    mode: string;
+    updatedAt: string;
+    issuerUrl?: string;
+    audience?: string;
+  } = {
     appId: `${appId}#CONFIG#auth`,
     groupId: `APP#${appId}`,
     sortId: 'CONFIG#auth',

--- a/backend/src/lambda/app-metrics-handler.ts
+++ b/backend/src/lambda/app-metrics-handler.ts
@@ -435,7 +435,12 @@ export async function getDashboardMetrics(
 
 const docClient = DynamoDBDocumentClient.from(new DynamoDBClient({}));
 
-export const handler = async (event: any): Promise<void> => {
+/** CloudWatch Logs subscription event shape. */
+interface LogsSubscriptionEvent {
+  awslogs: { data: string };
+}
+
+export const handler = async (event: LogsSubscriptionEvent): Promise<void> => {
   const appsTable = process.env.APPS_TABLE!;
   const deps: MetricsDeps = { docClient, appsTable };
 
@@ -444,7 +449,7 @@ export const handler = async (event: any): Promise<void> => {
   const decompressed = gunzipSync(payload);
   const logData = JSON.parse(decompressed.toString());
 
-  const messages: string[] = logData.logEvents.map((e: any) => e.message);
+  const messages: string[] = logData.logEvents.map((e: { message: string }) => e.message);
   const entries = parseAccessLogEntries(messages);
 
   await processMetricsEvent(entries, deps);

--- a/backend/src/lambda/app-publish-handler.ts
+++ b/backend/src/lambda/app-publish-handler.ts
@@ -40,18 +40,18 @@ export interface AppMetadata {
   endpointUrl?: string;
   apiId?: string;
   version?: number;
-  [key: string]: any;
+  [key: string]: unknown;
 }
 
 export interface ComponentItem {
   sortId: string;
   agentId?: string;
   status?: string;
-  schema?: Record<string, any>;
-  values?: Record<string, any>;
+  schema?: Record<string, unknown>;
+  values?: Record<string, unknown>;
   actions?: string[];
   resources?: string[];
-  [key: string]: any;
+  [key: string]: unknown;
 }
 
 export interface PublishResult {
@@ -107,8 +107,8 @@ export function generateApiKey(): ApiKeyGenResult {
 export function buildStatusTransitionEvent(
   fromStatus: string,
   toStatus: string,
-  detail: Record<string, any>,
-): { detailType: string; source: string; detail: Record<string, any> } {
+  detail: Record<string, unknown>,
+): { detailType: string; source: string; detail: Record<string, unknown> } {
   const detailType = `app.status.${fromStatus.toLowerCase()}_to_${toStatus.toLowerCase()}`;
   return {
     detailType,
@@ -165,7 +165,15 @@ export function validatePublishPreconditions(
       const validate = ajv.compile(configSchema.schema);
       const valid = validate(configValues.values);
       if (!valid) {
-        const validationErrors = (validate.errors || []).map((e: any) => {
+        // ErrorObject's compiled type defs lag the runtime shape here
+        // (instancePath); view the errors structurally without changing
+        // the runtime mapping.
+        const ajvErrors = (validate.errors || []) as Array<{
+          instancePath?: string;
+          message?: string;
+          params?: { missingProperty?: string };
+        }>;
+        const validationErrors = ajvErrors.map((e) => {
           const path = e.instancePath || (e.params?.missingProperty ? e.params.missingProperty : '');
           return `${path ? path + ': ' : ''}${e.message}`;
         }).join('; ');
@@ -257,7 +265,7 @@ async function ensureAccessLogGroup(
     logGroupNamePrefix: logGroupName,
     limit: 1,
   }));
-  const logGroup = describeResult.logGroups?.find((lg: any) => lg.logGroupName === logGroupName);
+  const logGroup = describeResult.logGroups?.find((lg) => lg.logGroupName === logGroupName);
   if (logGroup?.arn) {
     return logGroup.arn;
   }
@@ -680,7 +688,14 @@ export async function unpublishApp(
 
 // ── Lambda Handler ──────────────────────────────────────────
 
-export const handler = async (event: any): Promise<any> => {
+/** AppSync event slice this handler reads. */
+interface AppPublishResolverEvent {
+  info?: { fieldName?: string };
+  arguments: { appId: string };
+  identity?: { sub?: string; claims?: { sub?: string } };
+}
+
+export const handler = async (event: AppPublishResolverEvent): Promise<unknown> => {
   console.log('Publish handler event:', JSON.stringify(event, null, 2));
 
   const { info, arguments: args, identity } = event;

--- a/backend/src/lambda/assessment-completion-resolver.ts
+++ b/backend/src/lambda/assessment-completion-resolver.ts
@@ -1,4 +1,4 @@
-export const handler = async (event: any) => {
+export const handler = async (event: { arguments: { projectId: string } }) => {
   const { projectId } = event.arguments;
   
   return {

--- a/backend/src/lambda/assessment-progress-resolver.ts
+++ b/backend/src/lambda/assessment-progress-resolver.ts
@@ -6,7 +6,7 @@ const docClient = DynamoDBDocumentClient.from(client);
 
 const SESSION_MEMORY_TABLE = process.env.SESSION_MEMORY_TABLE!;
 
-export const handler = async (event: any) => {
+export const handler = async (event: { arguments: { sessionId: string } }) => {
   const sessionId = event.arguments.sessionId;
   const dimensions = ['technical', 'business', 'commercial', 'governance'];
   

--- a/backend/src/lambda/chatter-publisher.ts
+++ b/backend/src/lambda/chatter-publisher.ts
@@ -24,10 +24,10 @@ interface ChatterInput {
   timestamp: string;
   source: string;
   detailType: string;
-  detail: any;
+  detail: unknown;
 }
 
-async function executeGraphQL(query: string, variables: any) {
+async function executeGraphQL(query: string, variables: Record<string, unknown>) {
   const endpoint = new URL(APPSYNC_ENDPOINT);
   const signer = new SignatureV4({
     credentials: defaultProvider(),
@@ -64,7 +64,7 @@ async function executeGraphQL(query: string, variables: any) {
   return result.data;
 }
 
-export const handler = async (event: EventBridgeEvent<string, any>) => {
+export const handler = async (event: EventBridgeEvent<string, unknown>) => {
   console.log('Received EventBridge event:', JSON.stringify(event, null, 2));
 
   try {

--- a/backend/src/lambda/chatter-resolver.ts
+++ b/backend/src/lambda/chatter-resolver.ts
@@ -5,7 +5,7 @@ interface AgentChatterInput {
   timestamp: string;
   source: string;
   detailType: string;
-  detail: any;
+  detail: unknown;
 }
 
 interface AgentChatterMessage {
@@ -13,7 +13,7 @@ interface AgentChatterMessage {
   timestamp: string;
   source: string;
   detailType: string;
-  detail: any;
+  detail: unknown;
 }
 
 export const handler = async (

--- a/backend/src/lambda/conversation-resolver.ts
+++ b/backend/src/lambda/conversation-resolver.ts
@@ -143,7 +143,11 @@ async function sendMessage(event: AppSyncEvent) {
  * Get conversation history query handler
  */
 async function getConversationHistory(event: AppSyncEvent) {
-  const { projectId, limit, nextToken } = event.arguments as any;
+  const { projectId, limit, nextToken } = event.arguments as unknown as {
+    projectId: string;
+    limit?: number;
+    nextToken?: string;
+  };
 
   console.log("Getting conversation history for project:", projectId);
 
@@ -177,7 +181,9 @@ async function getConversationHistory(event: AppSyncEvent) {
  * Called by agent-message-handler Lambda to trigger subscriptions
  */
 async function publishConversationMessage(event: AppSyncEvent) {
-  const { input } = event.arguments as any;
+  const { input } = event.arguments as unknown as {
+    input: ConversationMessageInput & { id?: string };
+  };
 
   console.log("Publishing conversation message:", input.id);
 
@@ -190,7 +196,11 @@ async function publishConversationMessage(event: AppSyncEvent) {
  * Send message to agent (simplified interface for direct calls)
  */
 async function sendMessageToAgent(event: AppSyncEvent) {
-  const { projectId, agentId, message } = event.arguments as any;
+  const { projectId, agentId, message } = event.arguments as unknown as {
+    projectId: string;
+    agentId: string;
+    message: string;
+  };
   
   // Convert to sendMessage format
   const convertedEvent = {

--- a/backend/src/lambda/datastore-resolver.ts
+++ b/backend/src/lambda/datastore-resolver.ts
@@ -16,7 +16,7 @@ import {
 } from '@aws-sdk/client-secrets-manager';
 import { v4 as uuidv4 } from 'uuid';
 import { getAdapter } from './adapters/registry';
-import { PolicyManager } from '../utils/policy-manager';
+import { PolicyManager, type ScopedCredentials } from '../utils/policy-manager';
 import { getDataStoreOperations } from '../utils/operations-registry';
 import {
   ConflictError,
@@ -56,7 +56,53 @@ interface AppSyncEventIdentity {
   sub?: string;
 }
 
-interface AppSyncEvent extends Omit<AppSyncResolverEvent<any>, 'identity'> {
+/** Create-mutation input (validated at runtime; config/credentials AWSJSON). */
+interface CreateDataStoreInput {
+  orgId: string;
+  name: string;
+  type: string;
+  category: string;
+  provisionMode: string;
+  description?: string;
+  config: string | Record<string, unknown>;
+  credentials?: string | Record<string, unknown>;
+  usage?: string;
+  clientRequestToken?: string;
+}
+
+/** Update-mutation input; only provided fields are written. */
+interface UpdateDataStoreInput {
+  dataStoreId: string;
+  version: number;
+  name?: string;
+  description?: string;
+  config?: string | Record<string, unknown>;
+  usage?: string;
+}
+
+/** Merged view of every argument this resolver's fields receive. */
+interface DataStoreResolverArguments {
+  orgId: string;
+  category?: string;
+  dataStoreId: string;
+  usage?: string;
+  input: CreateDataStoreInput & UpdateDataStoreInput;
+}
+
+/** DynamoDB data-store row slice this resolver reads. */
+interface DataStoreRecord {
+  dataStoreId: string;
+  type: string;
+  config: string | Record<string, unknown>;
+  version: number;
+  provisionMode?: string;
+  secretArn?: string;
+  status?: string;
+  usage?: string;
+  [key: string]: unknown;
+}
+
+interface AppSyncEvent extends Omit<AppSyncResolverEvent<DataStoreResolverArguments>, 'identity'> {
   identity?: AppSyncEventIdentity;
 }
 
@@ -154,9 +200,9 @@ async function retryOptimisticLock<T>(
   for (let attempt = 0; attempt <= maxRetries; attempt++) {
     try {
       return await fn();
-    } catch (error: any) {
+    } catch (error: unknown) {
       if (
-        error.name === 'ConditionalCheckFailedException' ||
+        (error instanceof Error && error.name === 'ConditionalCheckFailedException') ||
         error instanceof ConflictError
       ) {
         lastError = error;
@@ -178,11 +224,18 @@ async function retryOptimisticLock<T>(
 // --- Queries ---
 
 async function listDataStores(orgId: string, category?: string) {
-  const params: any = {
+  const params: {
+    TableName: string;
+    IndexName: string;
+    KeyConditionExpression: string;
+    ExpressionAttributeValues: Record<string, string>;
+    ScanIndexForward: boolean;
+    FilterExpression?: string;
+  } = {
     TableName: DATASTORES_TABLE,
     IndexName: 'OrgIndex',
     KeyConditionExpression: 'orgId = :orgId',
-    ExpressionAttributeValues: { ':orgId': orgId } as Record<string, any>,
+    ExpressionAttributeValues: { ':orgId': orgId },
     ScanIndexForward: false,
   };
 
@@ -200,7 +253,7 @@ async function listDataStores(orgId: string, category?: string) {
   return items;
 }
 
-async function getDataStore(dataStoreId: string) {
+async function getDataStore(dataStoreId: string): Promise<DataStoreRecord> {
   const result = await dynamodb.send(
     new GetCommand({
       TableName: DATASTORES_TABLE,
@@ -218,7 +271,7 @@ async function getDataStore(dataStoreId: string) {
   const item = result.Item;
   item.usage = (item.usage || 'both').toUpperCase();
 
-  return item;
+  return item as DataStoreRecord;
 }
 
 async function getDataStoreStats(orgId: string) {
@@ -308,7 +361,7 @@ async function listAvailableDataSources(orgId: string, usage?: string) {
 
 // --- Mutations ---
 
-async function createDataStore(input: any, createdBy: string) {
+async function createDataStore(input: CreateDataStoreInput, createdBy: string) {
   const dataStoreId = uuidv4();
   const timestamp = new Date().toISOString();
 
@@ -365,7 +418,7 @@ async function createDataStore(input: any, createdBy: string) {
   }
 
   // Conditional PutItem to prevent duplicate dataStoreId
-  const item: Record<string, any> = {
+  const item: Record<string, unknown> = {
     dataStoreId,
     name: input.name,
     description: input.description || null,
@@ -423,7 +476,7 @@ async function createDataStore(input: any, createdBy: string) {
         ? adapter.requiredPolicies(config, accountId, region).provision
         : adapter.requiredPolicies(config, accountId, region).connect;
 
-    let scopedCredentials: Record<string, any> | undefined;
+    let scopedCredentials: ScopedCredentials | undefined;
     if (policies.length > 0) {
       await policyManager.ensureRole(
         dataStoreId,
@@ -514,7 +567,7 @@ async function createDataStore(input: any, createdBy: string) {
   }
 }
 
-async function updateDataStore(input: any) {
+async function updateDataStore(input: UpdateDataStoreInput) {
   const dataStoreId = input.dataStoreId;
   const existing = await getDataStore(dataStoreId);
 
@@ -525,7 +578,7 @@ async function updateDataStore(input: any) {
     );
   }
 
-  const updates: Record<string, any> = {
+  const updates: Record<string, unknown> = {
     updatedAt: new Date().toISOString(),
     version: existing.version + 1,
   };
@@ -552,7 +605,7 @@ async function updateDataStore(input: any) {
 
   const setExpressions: string[] = [];
   const exprNames: Record<string, string> = {};
-  const exprValues: Record<string, any> = {};
+  const exprValues: Record<string, unknown> = {};
 
   for (const [key, value] of Object.entries(updates)) {
     const nameKey = `#${key}`;
@@ -590,7 +643,7 @@ async function updateDataStore(input: any) {
 }
 
 async function deleteDataStore(dataStoreId: string) {
-  let existing: Record<string, any> | undefined;
+  let existing: DataStoreRecord | undefined;
 
   try {
     existing = await getDataStore(dataStoreId);
@@ -608,7 +661,7 @@ async function deleteDataStore(dataStoreId: string) {
       : existing.config;
 
   // Get scoped credentials for infrastructure cleanup
-  let scopedCredentials: Record<string, any> | undefined;
+  let scopedCredentials: ScopedCredentials | undefined;
   try {
     const { accountId } = await policyManager.getAccountContext();
     scopedCredentials = await policyManager.assumeScopedRole(
@@ -680,7 +733,7 @@ async function connectDataStore(dataStoreId: string) {
         : existing.config;
 
     // Retrieve credentials from Secrets Manager if available
-    let credentials: Record<string, any> | undefined;
+    let credentials: Record<string, unknown> | undefined;
     if (existing.secretArn) {
       try {
         const secretResult = await secretsManager.send(
@@ -695,7 +748,7 @@ async function connectDataStore(dataStoreId: string) {
     // Set up scoped credentials if needed
     const { accountId, region } = await policyManager.getAccountContext();
     const policies = adapter.requiredPolicies(config, accountId, region).connect;
-    let scopedCredentials: Record<string, any> | undefined;
+    let scopedCredentials: ScopedCredentials | undefined;
 
     if (policies.length > 0) {
       await policyManager.ensureRole(
@@ -817,7 +870,7 @@ async function testDataStoreConnection(dataStoreId: string) {
       : existing.config;
 
   // Retrieve credentials if available
-  let credentials: Record<string, any> | undefined;
+  let credentials: Record<string, unknown> | undefined;
   if (existing.secretArn) {
     try {
       const secretResult = await secretsManager.send(
@@ -830,7 +883,7 @@ async function testDataStoreConnection(dataStoreId: string) {
   }
 
   // Set up scoped credentials if needed
-  let scopedCredentials: Record<string, any> | undefined;
+  let scopedCredentials: ScopedCredentials | undefined;
   const { accountId, region } = await policyManager.getAccountContext();
   const policies = adapter.requiredPolicies(config, accountId, region).connect;
 

--- a/backend/src/lambda/design-progress-resolver.ts
+++ b/backend/src/lambda/design-progress-resolver.ts
@@ -1,3 +1,3 @@
-export const handler = async (event: any) => {
+export const handler = async (event: { arguments: { input: unknown } }) => {
   return event.arguments.input;
 };

--- a/backend/src/lambda/document-ingestion-poller.ts
+++ b/backend/src/lambda/document-ingestion-poller.ts
@@ -53,7 +53,7 @@ interface JobRow {
 async function loadNonTerminalJobs(tableName: string): Promise<JobRow[]> {
   const byKey = new Map<string, JobRow>();
   for (const status of POLLABLE_STATUSES) {
-    let nextToken: Record<string, any> | undefined;
+    let nextToken: Record<string, unknown> | undefined;
     do {
       const resp = await ddb.send(new QueryCommand({
         TableName: tableName,

--- a/backend/src/lambda/document-ingestion-shared.ts
+++ b/backend/src/lambda/document-ingestion-shared.ts
@@ -117,6 +117,17 @@ export interface StartIngestionResult {
  * Returns the synchronously-reported status (often STARTING/IN_PROGRESS, but
  * can be FAILED immediately for malformed input).
  */
+/**
+ * Structural view of a Bedrock ingestion document detail. The runtime
+ * response nests status fields differently across SDK versions, so both
+ * layouts are modelled; the reader guards each access.
+ */
+interface IngestionDetailView {
+  status?: { status?: string; statusReason?: string; failureReasons?: string[] };
+  statusReason?: string;
+  failureReasons?: string[];
+}
+
 export async function startIngestion(projectId: string, documentKey: string): Promise<StartIngestionResult> {
   const { kbId, dsId } = await getKbIds();
   const bucket = process.env.DOCUMENT_BUCKET!;
@@ -146,7 +157,10 @@ export async function startIngestion(projectId: string, documentKey: string): Pr
     }],
   });
 
-  const response = (await bedrockAgentClient.send(command)) as any;
+  const response = (await bedrockAgentClient.send(command)) as {
+    documentDetails?: IngestionDetailView[];
+    ingestedDocuments?: IngestionDetailView[];
+  };
   console.log('startIngestion Bedrock response:', JSON.stringify(response));
   const detail = response.documentDetails?.[0] ?? response.ingestedDocuments?.[0];
   const status = (typeof detail?.status === 'string' ? detail?.status : detail?.status?.status) ?? 'UNKNOWN';

--- a/backend/src/lambda/document-resolver.ts
+++ b/backend/src/lambda/document-resolver.ts
@@ -75,7 +75,14 @@ async function generateDocumentPdf(projectId: string, documentKey: string): Prom
   return { url, expiresIn: 900 };
 }
 
-export const handler: AppSyncResolverHandler<any, any> = async (event) => {
+/** Merged view of every argument this resolver's fields receive. */
+interface DocumentResolverArguments {
+  projectId: string;
+  documentKey: string;
+  versionId?: string;
+}
+
+export const handler: AppSyncResolverHandler<DocumentResolverArguments, unknown> = async (event) => {
   const { info, arguments: args } = event;
   const { projectId, documentKey, versionId } = args;
 

--- a/backend/src/lambda/document-upload-resolver.ts
+++ b/backend/src/lambda/document-upload-resolver.ts
@@ -132,7 +132,7 @@ async function readJobsForProject(projectId: string): Promise<Map<string, { stat
     // caller falls back to the KB query path.
     throw new Error("INGESTION_TABLE not configured");
   }
-  let nextToken: Record<string, any> | undefined;
+  let nextToken: Record<string, unknown> | undefined;
   do {
     const resp = await ddb.send(new QueryCommand({
       TableName: tableName,
@@ -140,7 +140,7 @@ async function readJobsForProject(projectId: string): Promise<Map<string, { stat
       ExpressionAttributeValues: { ":pid": projectId },
       ExclusiveStartKey: nextToken,
     }));
-    for (const item of (resp.Items ?? []) as any[]) {
+    for (const item of (resp.Items ?? []) as Array<{ documentKey?: string; status?: string; statusReason?: string }>) {
       if (item.documentKey) map.set(item.documentKey, { status: item.status ?? "UNKNOWN", statusReason: item.statusReason });
     }
     nextToken = resp.LastEvaluatedKey;
@@ -238,7 +238,14 @@ async function deleteDocument(projectId: string, documentKey: string): Promise<{
 /**
  * Lambda handler
  */
-export const handler: AppSyncResolverHandler<any, any> = async (event) => {
+/** Merged view of every argument this resolver's fields receive. */
+interface DocumentUploadResolverArguments {
+  input: GenerateUploadUrlInput;
+  projectId: string;
+  documentKey: string;
+}
+
+export const handler: AppSyncResolverHandler<DocumentUploadResolverArguments, unknown> = async (event) => {
   console.log(
     "Document upload resolver event:",
     JSON.stringify(event, null, 2)

--- a/backend/src/lambda/execspec-resolver.ts
+++ b/backend/src/lambda/execspec-resolver.ts
@@ -51,6 +51,8 @@ import type {
   ExecutionSpecificationInput,
   ReviseExecutionSpecificationInput,
   SpecStatusLiteral,
+  GovernanceEventIdentity,
+  GovernanceResolverEvent,
 } from '../types';
 
 const dynamoClient = new DynamoDBClient({});
@@ -81,8 +83,18 @@ export function isNarrativeUriAllowed(uri: unknown): boolean {
   return typeof uri === 'string' && NARRATIVE_URI_ALLOWLIST.test(uri);
 }
 
-function authContextFromEvent(event: any): AuthContext {
-  const identity = event?.identity || {};
+/** Merged view of every argument this resolver's fields receive. */
+interface ExecSpecResolverArguments {
+  input: ExecutionSpecificationInput & ReviseExecutionSpecificationInput;
+  specId: string;
+  reason: string;
+  projectId: string;
+}
+
+type ExecSpecResolverEvent = GovernanceResolverEvent<ExecSpecResolverArguments>;
+
+function authContextFromEvent(event: ExecSpecResolverEvent): AuthContext {
+  const identity: GovernanceEventIdentity = event?.identity || {};
   const claimRole = identity['custom:role'] ?? identity.claims?.['custom:role'];
   return {
     userId: identity.sub || identity.username || 'anonymous',
@@ -376,7 +388,7 @@ export async function reviseExecutionSpecification(
   });
 }
 
-export const handler = async (event: any): Promise<unknown> => {
+export const handler = async (event: ExecSpecResolverEvent): Promise<unknown> => {
   const fieldName = event?.info?.fieldName;
   const authContext = authContextFromEvent(event);
   try {

--- a/backend/src/lambda/fabrication-event-handler.ts
+++ b/backend/src/lambda/fabrication-event-handler.ts
@@ -26,7 +26,7 @@ const publishFabricationEventMutation = `
   }
 `;
 
-async function executeGraphQL(query: string, variables: any) {
+async function executeGraphQL(query: string, variables: Record<string, unknown>) {
   const endpoint = new URL(APPSYNC_ENDPOINT);
   const signer = new SignatureV4({
     credentials: defaultProvider(),

--- a/backend/src/lambda/fabricator-queue-resolver.ts
+++ b/backend/src/lambda/fabricator-queue-resolver.ts
@@ -27,7 +27,21 @@ interface FabricationQueueItem {
   status: FabricationStatus;
   submittedAt: string;
   errorMessage?: string;
-  metadata?: Record<string, any>;
+  metadata?: Record<string, unknown>;
+}
+
+/** Fabrication-jobs DynamoDB row slice this resolver reads. */
+interface FabricationJobRow {
+  agentUseId: string;
+  agentName?: string;
+  agentId?: string;
+  taskDescription?: string;
+  status?: string;
+  submittedAt?: string;
+  updatedAt?: string;
+  errorMessage?: string;
+  orchestrationId?: string;
+  [key: string]: unknown;
 }
 
 /**
@@ -35,7 +49,7 @@ interface FabricationQueueItem {
  * frontend drawer already renders. agentUseId is the per-request key the UI
  * uses as requestId; orchestrationId + agentId travel in metadata.
  */
-function mapRow(item: Record<string, any>): FabricationQueueItem {
+function mapRow(item: FabricationJobRow): FabricationQueueItem {
   return {
     requestId: item.agentUseId,
     agentName: item.agentName || item.agentId || item.agentUseId || 'Unknown Agent',
@@ -72,7 +86,7 @@ export const handler = async (
   const projectId = event.arguments?.projectId;
 
   try {
-    let items: Record<string, any>[] = [];
+    let items: FabricationJobRow[] = [];
     if (projectId) {
       const response = await docClient.send(
         new QueryCommand({
@@ -81,7 +95,7 @@ export const handler = async (
           ExpressionAttributeValues: { ':pk': projectId },
         }),
       );
-      items = response.Items || [];
+      items = (response.Items || []) as FabricationJobRow[];
     } else {
       const response = await docClient.send(
         new ScanCommand({
@@ -89,7 +103,7 @@ export const handler = async (
           Limit: SCAN_LIMIT,
         }),
       );
-      items = response.Items || [];
+      items = (response.Items || []) as FabricationJobRow[];
     }
 
     const queueItems = items.map(mapRow);

--- a/backend/src/lambda/fabricator-request-resolver.ts
+++ b/backend/src/lambda/fabricator-request-resolver.ts
@@ -103,7 +103,7 @@ async function writePendingFabricationStatus(
  * dependency; the `projectIdFromRegistryRecord` surface is used by this
  * resolver only.
  */
-function projectIdFromRegistryRecord(
+function _projectIdFromRegistryRecord(
   record: RegistryRecord,
 ): string | undefined {
   if (!record.customDescriptorContent) {
@@ -156,15 +156,22 @@ interface CreateToolRequest {
  * Python fabricator via `requested_by` on the SQS body, where it becomes
  * `createdBy` on the Registry record.
  */
-function extractRequestedBy(event: any): string {
+function extractRequestedBy(event: FabricatorRequestResolverEvent): string {
   return (
-    (event.identity && ('sub' in event.identity ? event.identity.sub : undefined)) ||
-    (event.identity && ('username' in event.identity ? event.identity.username : undefined)) ||
-    'unknown'
+    ((event.identity && ('sub' in event.identity ? event.identity.sub : undefined)) ||
+      (event.identity && ('username' in event.identity ? event.identity.username : undefined)) ||
+      'unknown') as string
   );
 }
 
-export const handler = async (event: any) => {
+/** AppSync event slice this resolver reads. */
+interface FabricatorRequestResolverEvent {
+  info: { fieldName: string };
+  identity?: Record<string, unknown>;
+  arguments: Record<string, unknown>;
+}
+
+export const handler = async (event: FabricatorRequestResolverEvent) => {
   console.log('Event:', JSON.stringify(event, null, 2));
 
   const fieldName = event.info.fieldName;
@@ -176,11 +183,11 @@ export const handler = async (event: any) => {
 
   try {
     if (fieldName === 'requestAgentCreation') {
-      return await requestAgentCreation(event.arguments.input, requestedBy, orgId);
+      return await requestAgentCreation(event.arguments.input as CreateAgentRequest, requestedBy, orgId);
     }
 
     if (fieldName === 'requestToolCreation') {
-      return await requestToolCreation(event.arguments.input, requestedBy, orgId);
+      return await requestToolCreation(event.arguments.input as CreateToolRequest, requestedBy, orgId);
     }
 
     throw new Error(`Unknown field: ${fieldName}`);
@@ -198,7 +205,7 @@ async function sendToFabricatorQueue(
   orgId: string | null,
   sourceProjectId?: string,
 ) {
-  const agent_input: Record<string, any> = { taskDetails };
+  const agent_input: Record<string, unknown> = { taskDetails };
   if (sourceProjectId) {
     // Picked up by arbiter/fabricator/index.py:928 where the
     // design_assessment_gate enforces preconditions.

--- a/backend/src/lambda/gateway-registration-handler.ts
+++ b/backend/src/lambda/gateway-registration-handler.ts
@@ -34,6 +34,7 @@ import {
 import {
   BedrockAgentCoreControlClient,
   CreateGatewayTargetCommand,
+  type CreateGatewayTargetCommandInput,
   DeleteGatewayTargetCommand,
 } from '@aws-sdk/client-bedrock-agentcore-control';
 import {
@@ -206,7 +207,7 @@ async function registerConfluence(detail: IntegrationEvent): Promise<void> {
               },
             },
           },
-        } as any,
+        } as CreateGatewayTargetCommandInput['targetConfiguration'],
         credentialProviderConfigurations: [
           {
             credentialProviderType: 'API_KEY',
@@ -219,7 +220,7 @@ async function registerConfluence(detail: IntegrationEvent): Promise<void> {
               },
             },
           },
-        ] as any,
+        ] as CreateGatewayTargetCommandInput['credentialProviderConfigurations'],
       }),
     );
 
@@ -323,7 +324,9 @@ async function registerMcpServer(detail: IntegrationEvent): Promise<void> {
     // credentials (Secrets Manager). The credential provider ARN is the
     // pre-provisioned one; the gateway target receives scopes / grantType.
     const credentials = await retrieveOauthCredentialsFromSecret(integration.secretArn);
-    const grantType = credentials.grantType ?? 'CLIENT_CREDENTIALS';
+    const grantType = (credentials.grantType ?? 'CLIENT_CREDENTIALS') as NonNullable<
+      Parameters<typeof buildMCPServerTargetPayload>[0]['oauthSettings']
+    >['grantType'];
     const oauthSettings: NonNullable<
       Parameters<typeof buildMCPServerTargetPayload>[0]['oauthSettings']
     > = {
@@ -371,10 +374,14 @@ async function registerMcpServer(detail: IntegrationEvent): Promise<void> {
  */
 async function sendCreateGatewayTargetAndPersist(
   detail: IntegrationEvent,
-  cmdInput: any,
+  cmdInput: CreateGatewayTargetCommandInput,
 ): Promise<void> {
   try {
-    const response: any = await bedrockAgentCore.send(
+    const response: {
+      targetId?: string;
+      status?: string;
+      authorizationData?: { oauth2?: { authorizationUrl?: string } };
+    } = await bedrockAgentCore.send(
       new CreateGatewayTargetCommand({
         ...cmdInput,
         gatewayIdentifier: cmdInput.gatewayIdentifier ?? (await getGatewayId()),
@@ -598,7 +605,7 @@ async function handleDisconnect(detail: IntegrationEvent): Promise<void> {
 // Helpers
 // ────────────────────────────────────────────────────────────────────────
 
-async function retrieveOauthCredentialsFromSecret(secretArn: string): Promise<any> {
+async function retrieveOauthCredentialsFromSecret(secretArn: string): Promise<Record<string, unknown>> {
   const resp = await secretsManager.send(new GetSecretValueCommand({ SecretId: secretArn }));
   if (!resp.SecretString) return {};
   try {
@@ -655,7 +662,7 @@ async function updateIntegrationAfterCreate(
     '#agentCoreRegistered': 'agentCoreRegistered',
     '#updatedAt': 'updatedAt',
   };
-  const exprValues: Record<string, any> = {
+  const exprValues: Record<string, unknown> = {
     ':status': input.status,
     ':agentCoreRegistered': input.agentCoreRegistered,
     ':updatedAt': now,
@@ -727,7 +734,7 @@ async function updateIntegrationStatus(
     '#agentCoreRegistered': 'agentCoreRegistered',
     '#updatedAt': 'updatedAt',
   };
-  const exprValues: Record<string, any> = {
+  const exprValues: Record<string, unknown> = {
     ':status': status,
     ':agentCoreRegistered': agentCoreRegistered,
     ':updatedAt': now,

--- a/backend/src/lambda/generate-report-url.ts
+++ b/backend/src/lambda/generate-report-url.ts
@@ -10,7 +10,7 @@ const dynamoClient = new DynamoDBClient({ region: process.env.AWS_REGION || 'ap-
 const docClient = DynamoDBDocumentClient.from(dynamoClient);
 const PROJECTS_TABLE = process.env.PROJECTS_TABLE || 'citadel-projects-dev';
 
-export const handler = async (event: any) => {
+export const handler = async (event: { arguments: { projectId: string } }) => {
   const { projectId } = event.arguments;
 
   try {

--- a/backend/src/lambda/health-monitor.ts
+++ b/backend/src/lambda/health-monitor.ts
@@ -43,13 +43,13 @@ interface DataStoreItem {
   config: string;
   errorMessage?: string | null;
   secretArn?: string;
-  [key: string]: any;
+  [key: string]: unknown;
 }
 
 interface AdapterLike {
   testConnection(
-    config: Record<string, any>,
-    credentials?: Record<string, any>
+    config: Record<string, unknown>,
+    credentials?: Record<string, unknown>
   ): Promise<{ success: boolean; message: string }>;
 }
 
@@ -78,17 +78,20 @@ const PERMISSION_ERROR_NAMES = new Set([
  * the store's status should be preserved (not flipped to ERROR).
  */
 function isPermissionError(
-  testResult?: { details?: Record<string, any>; message?: string },
-  thrownError?: any,
+  testResult?: { details?: Record<string, unknown>; message?: string },
+  thrownError?: unknown,
 ): boolean {
+  // Structural view of the thrown value — health checks re-throw AWS SDK
+  // errors, so name/message are the fields of interest.
+  const err = thrownError as { name?: string; message?: string } | undefined;
   if (testResult?.details?.isPermissionError) return true;
-  if (testResult?.details?.errorName && PERMISSION_ERROR_NAMES.has(testResult.details.errorName)) return true;
-  if (thrownError?.name && PERMISSION_ERROR_NAMES.has(thrownError.name)) return true;
+  if (testResult?.details?.errorName && PERMISSION_ERROR_NAMES.has(testResult.details.errorName as string)) return true;
+  if (err?.name && PERMISSION_ERROR_NAMES.has(err.name)) return true;
   // Heuristic: check message for common permission phrases
-  const msg = (testResult?.message || thrownError?.message || '').toLowerCase();
+  const msg = (testResult?.message || err?.message || '').toLowerCase();
   if (msg.includes('access denied') || msg.includes('not authorized') || msg.includes('forbidden')) return true;
   // AWS SDK returns UnknownError when the caller has no permissions for the service at all
-  const errorName = (testResult?.details?.errorName || thrownError?.name || '').toLowerCase();
+  const errorName = ((testResult?.details?.errorName as string | undefined) || err?.name || '').toLowerCase();
   if (errorName === 'unknownerror') return true;
   return false;
 }
@@ -130,7 +133,7 @@ export async function processHealthChecks(
           const adapter = getAdapterFn(store);
 
           // Try to assume scoped role for this datastore
-          let scopedCreds: Record<string, any> | undefined;
+          let scopedCreds: Record<string, unknown> | undefined;
           try {
             const callerIdentity = await stsClient.send(new GetCallerIdentityCommand({}));
             const accountId = callerIdentity.Account!;

--- a/backend/src/lambda/integration-resolver.ts
+++ b/backend/src/lambda/integration-resolver.ts
@@ -60,9 +60,21 @@ function isAgentCoreType(integrationType: string): boolean {
  * For AWS_LAMBDA / AWS_SMITHY this returns `undefined` (they use
  * GATEWAY_IAM_ROLE and need no provider provisioning).
  */
+/**
+ * Loose credential payload as supplied by GraphQL input (AWSJSON-parsed).
+ * Field presence is validated at runtime per connector spec.
+ */
+interface IntegrationCredentialsInput {
+  authMethod?: string;
+  email?: string;
+  apiToken?: string;
+  apiKey?: string;
+  [field: string]: unknown;
+}
+
 function getCredentialProviderType(
   integrationType: string,
-  credentials: any,
+  credentials: IntegrationCredentialsInput | undefined,
 ): 'API_KEY' | 'OAUTH2' | undefined {
   if (integrationType === 'CONFLUENCE') return 'API_KEY';
   if (integrationType !== 'MCP_SERVER') return undefined;
@@ -78,7 +90,7 @@ function getCredentialProviderType(
  * format), falling back to ARN-pattern inference for defensive recovery.
  */
 function inferCredentialProviderType(
-  integration: any,
+  integration: { credentialProviderArn?: unknown; credentialProviderType?: unknown } | undefined,
 ): 'API_KEY' | 'OAUTH2' | undefined {
   if (!integration?.credentialProviderArn) return undefined;
   if (
@@ -101,7 +113,7 @@ function inferCredentialProviderType(
  */
 function buildCredentialProviderApiKey(
   integrationType: string,
-  credentials: any,
+  credentials: IntegrationCredentialsInput | undefined,
 ): string {
   if (integrationType === 'CONFLUENCE') {
     const email = credentials?.email;
@@ -141,7 +153,7 @@ interface ProvisionResult {
 async function provisionProviderForIntegration(
   integrationId: string,
   integrationType: string,
-  credentials: any,
+  credentials: IntegrationCredentialsInput | undefined,
 ): Promise<ProvisionResult> {
   const providerType = getCredentialProviderType(integrationType, credentials);
   if (!providerType) return {};
@@ -198,7 +210,34 @@ interface AppSyncEventIdentity {
   sub?: string;
 }
 
-interface AppSyncEvent extends Omit<AppSyncResolverEvent<any>, 'identity'> {
+/** Create-mutation input; credentials/config parsed from AWSJSON. */
+interface CreateIntegrationInput {
+  integrationType: string;
+  name: string;
+  orgId: string;
+  credentials: IntegrationCredentialsInput;
+  config: Record<string, unknown>;
+}
+
+/** Update-mutation input; only provided fields are written. */
+interface UpdateIntegrationInput {
+  integrationId: string;
+  name?: string;
+  status?: string;
+  credentials?: IntegrationCredentialsInput;
+  config?: Record<string, unknown>;
+}
+
+/** Merged view of every argument this resolver's fields receive. */
+interface IntegrationResolverArguments {
+  integrationId: string;
+  orgId: string;
+  integrationType?: string;
+  status?: string;
+  input: CreateIntegrationInput & UpdateIntegrationInput;
+}
+
+interface AppSyncEvent extends Omit<AppSyncResolverEvent<IntegrationResolverArguments>, 'identity'> {
   identity?: AppSyncEventIdentity;
 }
 
@@ -218,7 +257,7 @@ function sanitizeEventForLogging(event: AppSyncEvent): unknown {
     'rolearn',
   ];
 
-  const sanitizeObject = (obj: any): any => {
+  const sanitizeObject = (obj: unknown): unknown => {
     if (!obj || typeof obj !== 'object') {
       return obj;
     }
@@ -227,7 +266,7 @@ function sanitizeEventForLogging(event: AppSyncEvent): unknown {
       return obj.map(item => sanitizeObject(item));
     }
 
-    const sanitized: any = {};
+    const sanitized: Record<string, unknown> = {};
     for (const [key, value] of Object.entries(obj)) {
       const lowerKey = key.toLowerCase();
       const isSensitive = sensitiveFields.some(field => lowerKey.includes(field));
@@ -250,7 +289,7 @@ function sanitizeEventForLogging(event: AppSyncEvent): unknown {
  * Sanitize Integration object for API response
  * Removes all sensitive credential fields from config
  */
-function sanitizeIntegrationForResponse(integration: any): unknown {
+function sanitizeIntegrationForResponse(integration: Record<string, unknown>): unknown {
   const sensitiveConfigFields = [
     'apiToken',
     'password',
@@ -265,7 +304,7 @@ function sanitizeIntegrationForResponse(integration: any): unknown {
   const sanitized = { ...integration };
 
   if (sanitized.config && typeof sanitized.config === 'object') {
-    const sanitizedConfig: any = {};
+    const sanitizedConfig: Record<string, unknown> = {};
 
     for (const [key, value] of Object.entries(sanitized.config)) {
       const isSensitive = sensitiveConfigFields.some(field =>
@@ -339,7 +378,7 @@ export async function handler(event: AppSyncEvent) {
  *
  * Other connector types (JIRA, SERVICENOW…) skip steps 3 and 5.
  */
-async function createIntegration(input: any, createdBy: string) {
+async function createIntegration(input: CreateIntegrationInput, createdBy: string) {
   const integrationId = uuidv4();
   const timestamp = new Date().toISOString();
 
@@ -419,7 +458,7 @@ async function createIntegration(input: any, createdBy: string) {
 
     // 3. Persist DDB record with all P3.A fields. `targetStatus: PENDING`
     //    signals the handler has not yet created the gateway target.
-    const integration: any = {
+    const integration: Record<string, unknown> = {
       PK: `ORG#${input.orgId}`,
       SK: `INTEGRATION#${input.integrationType}#${integrationId}`,
       integrationId,
@@ -505,7 +544,7 @@ async function createIntegration(input: any, createdBy: string) {
   }
 }
 
-async function updateIntegration(input: any) {
+async function updateIntegration(input: UpdateIntegrationInput) {
   const integration = await getIntegration(input.integrationId);
 
   const spec = getConnectorSpec(integration.integrationType);
@@ -514,7 +553,7 @@ async function updateIntegration(input: any) {
   }
 
   if (input.credentials) {
-    const secretValue: Record<string, any> = {};
+    const secretValue: Record<string, unknown> = {};
 
     for (const field of spec.authentication.fields) {
       if (input.credentials[field]) {
@@ -826,7 +865,13 @@ async function disconnectIntegration(integrationId: string) {
 }
 
 async function listIntegrations(orgId: string, integrationType?: string, status?: string) {
-  const params: any = {
+  const params: {
+    TableName: string;
+    KeyConditionExpression: string;
+    ExpressionAttributeValues: Record<string, string>;
+    FilterExpression?: string;
+    ExpressionAttributeNames?: Record<string, string>;
+  } = {
     TableName: INTEGRATIONS_TABLE,
     KeyConditionExpression: 'PK = :pk',
     ExpressionAttributeValues: {

--- a/backend/src/lambda/interrogation-round-resolver.ts
+++ b/backend/src/lambda/interrogation-round-resolver.ts
@@ -46,7 +46,11 @@ import { LifecycleManager, ROUND_TRANSITIONS } from '../adapters/lifecycle';
 import { emitGovernanceEvent } from '../utils/notifier-base';
 import { hasPermission } from '../utils/auth';
 import { redactPII } from '../utils/redact-pii';
-import type { AuthContext } from '../types';
+import type {
+  AuthContext,
+  GovernanceEventIdentity,
+  GovernanceResolverEvent,
+} from '../types';
 
 const dynamoClient = new DynamoDBClient({});
 const docClient = DynamoDBDocumentClient.from(dynamoClient);
@@ -81,8 +85,22 @@ export interface InterrogationRound {
   transcriptSizeBytes?: number;
 }
 
-function authContextFromEvent(event: any): AuthContext {
-  const identity = event?.identity || {};
+/** Merged view of every argument this resolver's fields receive. */
+interface InterrogationRoundResolverArguments {
+  projectId: string;
+  roundN: number;
+  constraints: string[];
+  transcript: TranscriptMessage[];
+  stabilisedSummary: string;
+}
+
+type InterrogationRoundResolverEvent =
+  GovernanceResolverEvent<InterrogationRoundResolverArguments>;
+
+function authContextFromEvent(
+  event: InterrogationRoundResolverEvent,
+): AuthContext {
+  const identity: GovernanceEventIdentity = event?.identity || {};
   const claimRole = identity['custom:role'] ?? identity.claims?.['custom:role'];
   return {
     userId: identity.sub || identity.username || 'anonymous',
@@ -329,7 +347,7 @@ export async function stabiliseRound(
   return res.Attributes as InterrogationRound;
 }
 
-export const handler = async (event: any): Promise<unknown> => {
+export const handler = async (event: InterrogationRoundResolverEvent): Promise<unknown> => {
   const fieldName = event?.info?.fieldName;
   const authContext = authContextFromEvent(event);
   try {

--- a/backend/src/lambda/model-catalog-sync.ts
+++ b/backend/src/lambda/model-catalog-sync.ts
@@ -96,8 +96,12 @@ export async function syncModelCatalog(): Promise<{
   const modelSummaries = fmResp.modelSummaries || [];
 
   // 2. Inference profiles — paginated by nextToken.
-  // Untyped Bedrock summary shapes; kept `any[]` to avoid coupling to SDK internals.
-  const inferenceProfileSummaries: any[] = [];
+  // Structural view of the Bedrock summary shapes — only the fields this
+  // mapper reads, so we stay decoupled from SDK internals.
+  const inferenceProfileSummaries: Array<{
+    inferenceProfileId?: string;
+    models?: Array<{ modelArn?: string }>;
+  }> = [];
   let nextToken: string | undefined;
   do {
     const ipResp = await bedrock.send(
@@ -125,9 +129,13 @@ export async function syncModelCatalog(): Promise<{
   }
 
   // 4. Existing catalog rows, keyed by modelKey (scan is paginated).
-  // DynamoDB rows are schemaless here; `any` is intentional for the overlay merge.
-  const existingByKey: Record<string, any> = {};
-  let scanStartKey: Record<string, any> | undefined;
+  // DynamoDB rows are schemaless here; model them as unknown-valued records
+  // plus the two operator-owned fields the overlay merge preserves.
+  const existingByKey: Record<
+    string,
+    { status?: string; discoveredAt?: string; [key: string]: unknown }
+  > = {};
+  let scanStartKey: Record<string, unknown> | undefined;
   do {
     const scanResp = await docClient.send(
       new ScanCommand({

--- a/backend/src/lambda/model-config-resolver.ts
+++ b/backend/src/lambda/model-config-resolver.ts
@@ -40,7 +40,27 @@ interface ModelConfig {
   updatedBy?: string;
 }
 
-export const handler = async (event: any) => {
+/** updateModelConfig mutation input (partial merge onto existing row). */
+interface UpdateModelConfigInput {
+  scope?: string;
+  globalDefaultKey?: string | null;
+  slotDefaults?: string | Record<string, unknown> | null;
+  localityMode?: string | null;
+}
+
+/** AppSync event slice this resolver reads. */
+interface ModelConfigResolverEvent {
+  info: { fieldName: string };
+  identity?: { username?: string; claims?: { sub?: string }; [claim: string]: unknown };
+  arguments: {
+    scope?: string;
+    modelKey: string;
+    status: string;
+    input: UpdateModelConfigInput;
+  };
+}
+
+export const handler = async (event: ModelConfigResolverEvent) => {
   console.log('Event:', JSON.stringify(event, null, 2));
 
   const fieldName = event.info.fieldName;
@@ -134,7 +154,7 @@ async function loadCatalog(): Promise<Record<string, ModelCatalogEntry>> {
  * config row, stamps updatedAt/updatedBy, persists it, and emits
  * MODEL_CONFIG_CHANGED.
  */
-async function updateModelConfig(input: any, event: any): Promise<ModelConfig> {
+async function updateModelConfig(input: UpdateModelConfigInput, event: ModelConfigResolverEvent): Promise<ModelConfig> {
   if (!isAdminFromEvent(event)) {
     throw new Error('Only administrators can update model configuration');
   }
@@ -236,7 +256,7 @@ async function updateModelConfig(input: any, event: any): Promise<ModelConfig> {
 async function setModelCatalogEntryStatus(
   modelKey: string,
   status: string,
-  event: any,
+  event: ModelConfigResolverEvent,
 ): Promise<ModelCatalogEntry> {
   if (!isAdminFromEvent(event)) {
     throw new Error('Only administrators can update model configuration');
@@ -288,7 +308,7 @@ async function setModelCatalogEntryStatus(
  * Lambda — this resolver never invokes that Lambda directly (no
  * lambda:InvokeFunction). Returns a lightweight acknowledgement.
  */
-async function syncModelCatalog(event: any) {
+async function syncModelCatalog(event: ModelConfigResolverEvent) {
   if (!isAdminFromEvent(event)) {
     throw new Error('Only administrators can trigger a model catalog sync');
   }

--- a/backend/src/lambda/organization-resolver.ts
+++ b/backend/src/lambda/organization-resolver.ts
@@ -35,7 +35,13 @@ interface UserManagementResponse {
   message?: string;
 }
 
-export const handler = async (event: any): Promise<any> => {
+/** AppSync event slice this resolver reads. */
+interface OrganizationResolverEvent {
+  info: { fieldName: string };
+  arguments: { input: CreateOrganizationInput; orgId: string };
+}
+
+export const handler = async (event: OrganizationResolverEvent): Promise<unknown> => {
   console.log('Organization resolver event:', JSON.stringify(event, null, 2));
 
   // AppSync delivers the operation name under event.info.fieldName (not

--- a/backend/src/lambda/program-review-resolver.ts
+++ b/backend/src/lambda/program-review-resolver.ts
@@ -49,7 +49,11 @@ import { listExecutionSpecifications } from './execspec-resolver';
 import { listInterrogationRounds } from './interrogation-round-resolver';
 import { getAgentDesignAssessment } from './agent-design-assessment-resolver';
 import { hasPermission } from '../utils/auth';
-import type { AuthContext } from '../types';
+import type {
+  AuthContext,
+  GovernanceEventIdentity,
+  GovernanceResolverEvent,
+} from '../types';
 
 const dynamoClient = new DynamoDBClient({});
 const docClient = DynamoDBDocumentClient.from(dynamoClient);
@@ -118,13 +122,52 @@ try {
 }
 
 // ── Evidence + Evaluator types ──────────────────────────────────────
+// The evidence rows come from the sibling governance resolvers' DynamoDB
+// tables and may carry fields beyond the canonical shared types (e.g.
+// participantRoles, coverage, nonFunctionalConstraints). The structural
+// views below model exactly what the evaluators read, so canonical rows
+// remain assignable while the extra fields stay optional.
+
+interface AdrEvidence {
+  adrId: string;
+  status?: string;
+}
+
+interface SpecEvidence {
+  specId: string;
+  status?: string;
+  approvedBy?: string;
+  sourceAdrIds?: string[];
+  sourceDesignArtifactType?: string;
+  executorKind?: string;
+  narrativeReviewStatus?: string;
+}
+
+interface RoundEvidence {
+  roundN: number;
+  status?: string;
+  participantRoles?: string[];
+  injectedConstraintIds?: string[];
+}
+
+interface AssessmentDimensionEvidence {
+  dimension?: string;
+  coverage?: string;
+}
+
+interface AssessmentEvidence {
+  completedAt?: string | null;
+  archetypeStatus?: string;
+  dimensionRanking?: AssessmentDimensionEvidence[];
+  nonFunctionalConstraints?: string[];
+}
 
 interface Evidence {
   projectId: string;
-  adrs: any[];
-  specs: any[];
-  rounds: any[];
-  assessment: any | null;
+  adrs: AdrEvidence[];
+  specs: SpecEvidence[];
+  rounds: RoundEvidence[];
+  assessment: AssessmentEvidence | null;
 }
 
 interface EvaluatorOutput {
@@ -187,7 +230,7 @@ const EVALUATORS: Record<string, Evaluator> = {
   // status in {'STABILISED','COMPLETE'}.
   Q002: (ev) => {
     const hits = ev.rounds.filter(
-      (r: any) =>
+      (r) =>
         Array.isArray(r.participantRoles) &&
         r.participantRoles.includes('OPERATIONS') &&
         (r.status === 'STABILISED' || r.status === 'COMPLETE'),
@@ -196,7 +239,7 @@ const EVALUATORS: Record<string, Evaluator> = {
       ? {
           answer: 'PASS',
           evidenceRefs: hits
-            .map((r: any) => `InterrogationRound:${ev.projectId}:${r.roundN}`)
+            .map((r) => `InterrogationRound:${ev.projectId}:${r.roundN}`)
             .sort(),
           notes: null,
         }
@@ -220,7 +263,7 @@ const EVALUATORS: Record<string, Evaluator> = {
       };
     }
     const hit = a.dimensionRanking.find(
-      (d: any) =>
+      (d) =>
         d.dimension === 'INTEGRATION_ARCHAEOLOGY' && d.coverage === 'COMPLETE',
     );
     return hit
@@ -266,12 +309,12 @@ const EVALUATORS: Record<string, Evaluator> = {
 
   // Q005: Advisory multi-round loop (≥ 3 stabilised rounds).
   Q005: (ev) => {
-    const stabilised = ev.rounds.filter((r: any) => r.status === 'STABILISED');
+    const stabilised = ev.rounds.filter((r) => r.status === 'STABILISED');
     return stabilised.length >= 3
       ? {
           answer: 'PASS',
           evidenceRefs: stabilised
-            .map((r: any) => `InterrogationRound:${ev.projectId}:${r.roundN}`)
+            .map((r) => `InterrogationRound:${ev.projectId}:${r.roundN}`)
             .sort(),
           notes: null,
         }
@@ -284,11 +327,11 @@ const EVALUATORS: Record<string, Evaluator> = {
 
   // Q006: Decisions captured as locked ADRs.
   Q006: (ev) => {
-    const locked = ev.adrs.filter((a: any) => a.status === 'LOCKED');
+    const locked = ev.adrs.filter((a) => a.status === 'LOCKED');
     return locked.length >= 1
       ? {
           answer: 'PASS',
-          evidenceRefs: locked.map((a: any) => `ADR:${a.adrId}`).sort(),
+          evidenceRefs: locked.map((a) => `ADR:${a.adrId}`).sort(),
           notes: null,
         }
       : {
@@ -302,7 +345,7 @@ const EVALUATORS: Record<string, Evaluator> = {
   // PASS when ≥1 stabilised round has a non-empty injectedConstraintIds.
   Q007: (ev) => {
     const hits = ev.rounds.filter(
-      (r: any) =>
+      (r) =>
         r.status === 'STABILISED' &&
         Array.isArray(r.injectedConstraintIds) &&
         r.injectedConstraintIds.length > 0,
@@ -311,7 +354,7 @@ const EVALUATORS: Record<string, Evaluator> = {
       ? {
           answer: 'PASS',
           evidenceRefs: hits
-            .map((r: any) => `InterrogationRound:${ev.projectId}:${r.roundN}`)
+            .map((r) => `InterrogationRound:${ev.projectId}:${r.roundN}`)
             .sort(),
           notes: null,
         }
@@ -334,7 +377,7 @@ const EVALUATORS: Record<string, Evaluator> = {
       };
     }
     const stabilised = ev.rounds.filter(
-      (r: any) => r.status === 'STABILISED',
+      (r) => r.status === 'STABILISED',
     ).length;
     const ratio = stabilised / total;
     return ratio >= 0.75
@@ -355,7 +398,7 @@ const EVALUATORS: Record<string, Evaluator> = {
   // and executorKind ≠ 'DESIGN_AGENT'.
   Q009: (ev) => {
     const hits = ev.specs.filter(
-      (s: any) =>
+      (s) =>
         (s.sourceDesignArtifactType === 'ADR' ||
           s.sourceDesignArtifactType === 'AgentDesignAssessment') &&
         s.executorKind !== 'DESIGN_AGENT',
@@ -363,7 +406,7 @@ const EVALUATORS: Record<string, Evaluator> = {
     return hits.length > 0
       ? {
           answer: 'PASS',
-          evidenceRefs: hits.map((s: any) => `ExecutionSpecification:${s.specId}`).sort(),
+          evidenceRefs: hits.map((s) => `ExecutionSpecification:${s.specId}`).sort(),
           notes: null,
         }
       : {
@@ -377,7 +420,7 @@ const EVALUATORS: Record<string, Evaluator> = {
   // PASS when ≥1 spec with status='APPROVED' and approvedBy set.
   Q010: (ev) => {
     const hits = ev.specs.filter(
-      (s: any) =>
+      (s) =>
         s.status === 'APPROVED' &&
         typeof s.approvedBy === 'string' &&
         s.approvedBy.length > 0,
@@ -385,7 +428,7 @@ const EVALUATORS: Record<string, Evaluator> = {
     return hits.length > 0
       ? {
           answer: 'PASS',
-          evidenceRefs: hits.map((s: any) => `ExecutionSpecification:${s.specId}`).sort(),
+          evidenceRefs: hits.map((s) => `ExecutionSpecification:${s.specId}`).sort(),
           notes: null,
         }
       : {
@@ -400,17 +443,17 @@ const EVALUATORS: Record<string, Evaluator> = {
   // those IDs maps to an ADR whose status='LOCKED'.
   Q011: (ev) => {
     const lockedIds = new Set(
-      ev.adrs.filter((a: any) => a.status === 'LOCKED').map((a: any) => a.adrId),
+      ev.adrs.filter((a) => a.status === 'LOCKED').map((a) => a.adrId),
     );
     const hits = ev.specs.filter(
-      (s: any) =>
+      (s) =>
         Array.isArray(s.sourceAdrIds) &&
         s.sourceAdrIds.some((id: string) => lockedIds.has(id)),
     );
     return hits.length > 0
       ? {
           answer: 'PASS',
-          evidenceRefs: hits.map((s: any) => `ExecutionSpecification:${s.specId}`).sort(),
+          evidenceRefs: hits.map((s) => `ExecutionSpecification:${s.specId}`).sort(),
           notes: null,
         }
       : {
@@ -424,13 +467,13 @@ const EVALUATORS: Record<string, Evaluator> = {
   // PASS when ≥1 spec with narrativeReviewStatus='REVIEWED' and status='APPROVED'.
   Q012: (ev) => {
     const hits = ev.specs.filter(
-      (s: any) =>
+      (s) =>
         s.narrativeReviewStatus === 'REVIEWED' && s.status === 'APPROVED',
     );
     return hits.length > 0
       ? {
           answer: 'PASS',
-          evidenceRefs: hits.map((s: any) => `ExecutionSpecification:${s.specId}`).sort(),
+          evidenceRefs: hits.map((s) => `ExecutionSpecification:${s.specId}`).sort(),
           notes: null,
         }
       : {
@@ -464,8 +507,16 @@ function evaluate(
 
 // ── AppSync event → AuthContext ─────────────────────────────────────
 
-function authContextFromEvent(event: any): AuthContext {
-  const identity = event?.identity || {};
+/** Merged view of every argument this resolver's fields receive. */
+interface ProgramReviewArguments {
+  projectId: string;
+  reviewId: string;
+}
+
+type ProgramReviewResolverEvent = GovernanceResolverEvent<ProgramReviewArguments>;
+
+function authContextFromEvent(event: ProgramReviewResolverEvent): AuthContext {
+  const identity: GovernanceEventIdentity = event?.identity || {};
   const claimRole =
     identity['custom:role'] ?? identity.claims?.['custom:role'];
   return {
@@ -597,7 +648,7 @@ export async function listProgramReviewsForProject(
   return (res.Items as ProgramReview[] | undefined) ?? [];
 }
 
-export const handler = async (event: any): Promise<unknown> => {
+export const handler = async (event: ProgramReviewResolverEvent): Promise<unknown> => {
   const fieldName = event?.info?.fieldName;
   const authContext = authContextFromEvent(event);
   try {

--- a/backend/src/lambda/project-progress-updater.ts
+++ b/backend/src/lambda/project-progress-updater.ts
@@ -7,7 +7,13 @@ const idempotencyGuard = new IdempotencyGuard(process.env.IDEMPOTENCY_TABLE!);
 
 const VALID_FIELDS = new Set(['assessment', 'design', 'planning', 'implementation']);
 
-export const handler = async (event: any) => {
+/** EventBridge fabrication-progress event slice this handler reads. */
+interface ProgressUpdateEvent {
+  id: string;
+  detail: { sessionId: string; phase: string; completionPercentage: number };
+}
+
+export const handler = async (event: ProgressUpdateEvent) => {
   console.log('Progress event:', JSON.stringify(event));
 
   const { executed } = await idempotencyGuard.withIdempotency(event.id, async () => {

--- a/backend/src/lambda/seed-model-catalog/index.ts
+++ b/backend/src/lambda/seed-model-catalog/index.ts
@@ -111,7 +111,7 @@ async function sendCfnResponse(
   event: CloudFormationCustomResourceEvent,
   context: Context,
   status: 'SUCCESS' | 'FAILED',
-  data: Record<string, any>,
+  data: Record<string, unknown>,
 ): Promise<void> {
   const responseBody = JSON.stringify({
     Status: status,

--- a/backend/src/lambda/task-runner-resolver.ts
+++ b/backend/src/lambda/task-runner-resolver.ts
@@ -12,7 +12,7 @@ interface TaskCallback {
   queueUrl?: string;
   endpoint?: string;
   serverId?: string;
-  metadata?: any;
+  metadata?: unknown;
 }
 
 interface SubmitTaskInput {
@@ -20,7 +20,7 @@ interface SubmitTaskInput {
   callback?: TaskCallback;
 }
 
-export const handler = async (event: any) => {
+export const handler = async (event: { info: { fieldName: string }; arguments: { input: SubmitTaskInput } }) => {
   console.log('Event:', JSON.stringify(event, null, 2));
 
   const fieldName = event.info.fieldName;
@@ -50,7 +50,12 @@ async function submitTask(input: SubmitTaskInput) {
     // Send event to EventBridge for the Supervisor agent
     // The supervisor expects the detail to contain the task information
     // which it will pass to orchestrate() as initial_message
-    const detail: any = {
+    const detail: {
+      task: string;
+      orchestrationId: string;
+      timestamp: string;
+      callback?: TaskCallback;
+    } = {
       task: input.taskDetails,
       orchestrationId: orchestrationId,
       timestamp: new Date().toISOString(),

--- a/backend/src/lambda/tool-config-resolver.ts
+++ b/backend/src/lambda/tool-config-resolver.ts
@@ -1,7 +1,7 @@
 import { DynamoDBClient } from '@aws-sdk/client-dynamodb';
 import { DynamoDBDocumentClient, GetCommand, PutCommand, ScanCommand, DeleteCommand } from '@aws-sdk/lib-dynamodb';
 import { getOperations } from '../utils/operations-registry';
-import { RegistryService } from '../services/registry-service';
+import { RegistryService, type ToolCustomMetadata } from '../services/registry-service';
 import { extractOrgFromEvent, isAdminFromEvent } from '../utils/auth-event';
 
 const client = new DynamoDBClient({});
@@ -76,14 +76,55 @@ export interface DataStoreBinding {
   direction?: BindingDirection;
 }
 
+/**
+ * Raw binding shapes as accepted from GraphQL input or read back from
+ * legacy DynamoDB rows. Required fields and direction casing are enforced
+ * at runtime by the validators/sanitizers below, so everything is optional
+ * and `direction` is a plain string here.
+ */
+interface RawIntegrationBinding {
+  integrationId?: string;
+  integrationType?: string;
+  operations?: string[];
+  direction?: string;
+}
+
+interface RawDataStoreBinding {
+  dataStoreId?: string;
+  dataStoreType?: string;
+  operations?: string[];
+  direction?: string;
+}
+
+/** Merged create/update mutation input (config required only on create). */
+interface ToolConfigMutationInput {
+  toolId: string;
+  config?: string | Record<string, unknown>;
+  state?: string;
+  categories?: string[];
+  icon?: string;
+  appId?: string;
+  integrationBindings?: RawIntegrationBinding[];
+  dataStoreBindings?: RawDataStoreBinding[];
+}
+
+/** Minimal slice of the AppSync event needed for org/admin extraction. */
+type OrgScopedEvent = { identity?: Record<string, unknown> };
+
+/** AppSync event shape as dispatched to this resolver's handler. */
+interface ToolConfigResolverEvent extends OrgScopedEvent {
+  info: { fieldName: string };
+  arguments: Record<string, unknown>;
+}
+
 interface ToolConfig {
   toolId: string;
   orgId: string;
-  config: any;
+  config: string | Record<string, unknown>;
   state: 'active' | 'inactive' | 'maintenance' | 'pending' | string;
   categories?: string[];
-  integrationBindings?: IntegrationBinding[] | null;
-  dataStoreBindings?: DataStoreBinding[] | null;
+  integrationBindings?: RawIntegrationBinding[] | null;
+  dataStoreBindings?: RawDataStoreBinding[] | null;
   createdAt?: string;
   updatedAt?: string;
 }
@@ -92,7 +133,7 @@ interface ToolConfig {
 // Binding validation
 // ---------------------------------------------------------------------------
 
-export function validateIntegrationBindings(bindings: any[]): void {
+export function validateIntegrationBindings(bindings: RawIntegrationBinding[]): void {
   for (const binding of bindings) {
     if (!binding.integrationId || typeof binding.integrationId !== 'string') {
       throw new Error('Validation error: integrationBinding missing required field "integrationId"');
@@ -103,7 +144,7 @@ export function validateIntegrationBindings(bindings: any[]): void {
   }
 }
 
-export function validateDataStoreBindings(bindings: any[]): void {
+export function validateDataStoreBindings(bindings: RawDataStoreBinding[]): void {
   for (const binding of bindings) {
     if (!binding.dataStoreId || typeof binding.dataStoreId !== 'string') {
       throw new Error('Validation error: dataStoreBinding missing required field "dataStoreId"');
@@ -131,30 +172,30 @@ export function validateDataStoreBindings(bindings: any[]): void {
  *
  * Returns `null` if the input is falsy or no bindings survive the filter.
  */
-export function sanitizeIntegrationBindings(bindings: any): IntegrationBinding[] | null {
+export function sanitizeIntegrationBindings(bindings: unknown): IntegrationBinding[] | null {
   if (!Array.isArray(bindings) || bindings.length === 0) return null;
   const cleaned = bindings
-    .filter((b: any) =>
+    .filter((b) =>
       b &&
       typeof b.integrationId === 'string' && b.integrationId.length > 0 &&
       typeof b.integrationType === 'string' && b.integrationType.length > 0,
     )
-    .map((b: any) => ({
+    .map((b) => ({
       ...b,
       direction: b.direction ? String(b.direction).toUpperCase() : 'BIDIRECTIONAL',
     }));
   return cleaned.length > 0 ? cleaned : null;
 }
 
-export function sanitizeDataStoreBindings(bindings: any): DataStoreBinding[] | null {
+export function sanitizeDataStoreBindings(bindings: unknown): DataStoreBinding[] | null {
   if (!Array.isArray(bindings) || bindings.length === 0) return null;
   const cleaned = bindings
-    .filter((b: any) =>
+    .filter((b) =>
       b &&
       typeof b.dataStoreId === 'string' && b.dataStoreId.length > 0 &&
       typeof b.dataStoreType === 'string' && b.dataStoreType.length > 0,
     )
-    .map((b: any) => ({
+    .map((b) => ({
       ...b,
       direction: b.direction ? String(b.direction).toUpperCase() : 'BIDIRECTIONAL',
     }));
@@ -166,7 +207,7 @@ export function sanitizeDataStoreBindings(bindings: any): DataStoreBinding[] | n
 // Handler (task 7.5)
 // ---------------------------------------------------------------------------
 
-export const handler = async (event: any) => {
+export const handler = async (event: ToolConfigResolverEvent) => {
   console.log('Event:', JSON.stringify(event, null, 2));
 
   const fieldName = event.info.fieldName;
@@ -176,9 +217,9 @@ export const handler = async (event: any) => {
   // `username`, API key leaves it undefined). Mirror the fabricator pattern
   // (fabricator-request-resolver.ts) so we stay consistent across resolvers.
   const requestedBy =
-    (event.identity && ('sub' in event.identity ? event.identity.sub : undefined)) ||
-    (event.identity && ('username' in event.identity ? event.identity.username : undefined)) ||
-    'unknown';
+    ((event.identity && ('sub' in event.identity ? event.identity.sub : undefined)) ||
+      (event.identity && ('username' in event.identity ? event.identity.username : undefined)) ||
+      'unknown') as string;
 
   try {
     const registryEnabled = isRegistryEnabled();
@@ -191,29 +232,29 @@ export const handler = async (event: any) => {
 
       case 'getToolConfig':
         return registryEnabled
-          ? await getToolConfigRegistry(event.arguments.toolId, event)
-          : await getToolConfig(event.arguments.toolId);
+          ? await getToolConfigRegistry(event.arguments.toolId as string, event)
+          : await getToolConfig(event.arguments.toolId as string);
 
       case 'createToolConfig':
         return registryEnabled
-          ? await createToolConfigRegistry(event.arguments.input, requestedBy, event)
-          : await createToolConfig(event.arguments.input);
+          ? await createToolConfigRegistry(event.arguments.input as ToolConfigMutationInput, requestedBy, event)
+          : await createToolConfig(event.arguments.input as ToolConfigMutationInput);
 
       case 'updateToolConfig':
         return registryEnabled
-          ? await updateToolConfigRegistry(event.arguments.input, requestedBy, event)
-          : await updateToolConfig(event.arguments.input);
+          ? await updateToolConfigRegistry(event.arguments.input as ToolConfigMutationInput, requestedBy, event)
+          : await updateToolConfig(event.arguments.input as ToolConfigMutationInput);
 
       case 'deleteToolConfig':
         return registryEnabled
-          ? await deleteToolConfigRegistry(event.arguments.toolId)
-          : await deleteToolConfig(event.arguments.toolId);
+          ? await deleteToolConfigRegistry(event.arguments.toolId as string)
+          : await deleteToolConfig(event.arguments.toolId as string);
 
       case 'listIntegrationOperations':
-        return getOperations(event.arguments.integrationType);
+        return getOperations(event.arguments.integrationType as string);
 
       case 'searchToolConfigs':
-        return await searchToolConfigs(event.arguments.query);
+        return await searchToolConfigs(event.arguments.query as string);
 
       default:
         throw new Error(`Unknown field: ${fieldName}`);
@@ -237,7 +278,7 @@ export const handler = async (event: any) => {
  * returned. A non-admin caller without an orgId receives an empty list
  * with a warning.
  */
-export async function listToolConfigsRegistry(event?: any): Promise<ToolConfig[]> {
+export async function listToolConfigsRegistry(event?: OrgScopedEvent): Promise<ToolConfig[]> {
   const callerOrgId = event !== undefined ? await extractOrgFromEvent(event) : null;
   const admin = event !== undefined ? isAdminFromEvent(event) : false;
 
@@ -295,7 +336,7 @@ export async function listToolConfigsRegistry(event?: any): Promise<ToolConfig[]
  * Cross-org access is reported as not-found (404-style, not 403) so we
  * don't leak existence across tenants. Admins bypass the org check.
  */
-export async function getToolConfigRegistry(toolId: string, event?: any): Promise<ToolConfig | null> {
+export async function getToolConfigRegistry(toolId: string, event?: OrgScopedEvent): Promise<ToolConfig | null> {
   const registryService = getRegistryService();
   const callerOrgId = event !== undefined ? await extractOrgFromEvent(event) : null;
   const admin = event !== undefined ? isAdminFromEvent(event) : false;
@@ -326,7 +367,7 @@ export async function getToolConfigRegistry(toolId: string, event?: any): Promis
  * record. Defaults to `'unknown'` so other callers (e.g. internal scripts)
  * still work unchanged.
  */
-export async function createToolConfigRegistry(input: any, userId: string = 'unknown', event?: any): Promise<ToolConfig> {
+export async function createToolConfigRegistry(input: ToolConfigMutationInput, userId: string = 'unknown', event?: OrgScopedEvent): Promise<ToolConfig> {
   // Validate bindings before Registry write
   if (input.integrationBindings && Array.isArray(input.integrationBindings)) {
     validateIntegrationBindings(input.integrationBindings);
@@ -355,7 +396,7 @@ export async function createToolConfigRegistry(input: any, userId: string = 'unk
     config,
     createdBy: userId,
     orgId,
-  });
+  } as ToolCustomMetadata);
 
   const record = await registryService.createResource('tool', input.toolId, {
     name: parsedConfig.name || input.toolId,
@@ -386,7 +427,7 @@ export async function createToolConfigRegistry(input: any, userId: string = 'unk
  * prior `createdBy` get the current caller's id on first edit; existing
  * values are preserved so we never clobber a known creator.
  */
-export async function updateToolConfigRegistry(input: any, userId: string = 'unknown', event?: any): Promise<ToolConfig> {
+export async function updateToolConfigRegistry(input: ToolConfigMutationInput, userId: string = 'unknown', event?: OrgScopedEvent): Promise<ToolConfig> {
   // Validate bindings before Registry write
   if (input.integrationBindings && Array.isArray(input.integrationBindings)) {
     validateIntegrationBindings(input.integrationBindings);
@@ -440,7 +481,7 @@ export async function updateToolConfigRegistry(input: any, userId: string = 'unk
 
   // Defensive parse: legacy records may carry free-text in description
   // rather than JSON. State-only toggles must not crash on malformed data.
-  let parsedNewConfig: any = {};
+  let parsedNewConfig: Record<string, unknown> = {};
   if (newConfig && typeof newConfig === 'string') {
     try {
       parsedNewConfig = JSON.parse(newConfig);
@@ -470,11 +511,11 @@ export async function updateToolConfigRegistry(input: any, userId: string = 'unk
     config: newConfig,
     createdBy: existingMeta.createdBy ?? userId,
     orgId: preservedOrgId,
-  });
+  } as ToolCustomMetadata);
 
   const record = await registryService.updateResource('tool', input.toolId, {
-    name: parsedNewConfig.name || existing.name,
-    description: parsedNewConfig.description ?? '',
+    name: (parsedNewConfig.name as string | undefined) || existing.name,
+    description: (parsedNewConfig.description as string | undefined) ?? '',
     customMetadata: updatedMeta,
   });
 
@@ -587,7 +628,7 @@ async function getToolConfig(toolId: string): Promise<ToolConfig | null> {
   };
 }
 
-async function createToolConfig(input: any): Promise<ToolConfig> {
+async function createToolConfig(input: ToolConfigMutationInput): Promise<ToolConfig> {
   const now = new Date().toISOString();
   const config = typeof input.config === 'string' ? JSON.parse(input.config) : input.config;
 
@@ -599,7 +640,7 @@ async function createToolConfig(input: any): Promise<ToolConfig> {
     validateDataStoreBindings(input.dataStoreBindings);
   }
 
-  const toolConfig: any = {
+  const toolConfig: ToolConfig = {
     toolId: input.toolId,
     orgId: '',
     config,
@@ -610,13 +651,13 @@ async function createToolConfig(input: any): Promise<ToolConfig> {
   };
 
   if (input.integrationBindings && Array.isArray(input.integrationBindings) && input.integrationBindings.length > 0) {
-    toolConfig.integrationBindings = input.integrationBindings.map((b: any) => ({
+    toolConfig.integrationBindings = input.integrationBindings.map((b) => ({
       ...b,
       direction: b.direction ? b.direction.toUpperCase() : 'BIDIRECTIONAL',
     }));
   }
   if (input.dataStoreBindings && Array.isArray(input.dataStoreBindings) && input.dataStoreBindings.length > 0) {
-    toolConfig.dataStoreBindings = input.dataStoreBindings.map((b: any) => ({
+    toolConfig.dataStoreBindings = input.dataStoreBindings.map((b) => ({
       ...b,
       direction: b.direction ? b.direction.toUpperCase() : 'BIDIRECTIONAL',
     }));
@@ -637,7 +678,7 @@ async function createToolConfig(input: any): Promise<ToolConfig> {
   };
 }
 
-async function updateToolConfig(input: any): Promise<ToolConfig> {
+async function updateToolConfig(input: ToolConfigMutationInput): Promise<ToolConfig> {
   const existing = await getToolConfig(input.toolId);
   if (!existing) {
     throw new Error(`Tool config not found: ${input.toolId}`);
@@ -669,7 +710,7 @@ async function updateToolConfig(input: any): Promise<ToolConfig> {
     ? input.dataStoreBindings
     : existing.dataStoreBindings;
 
-  const updatedItem: any = {
+  const updatedItem: ToolConfig = {
     toolId: input.toolId,
     orgId: existing.orgId || '',
     config: newConfig,

--- a/backend/src/lambda/tool-sandbox.ts
+++ b/backend/src/lambda/tool-sandbox.ts
@@ -12,6 +12,7 @@
 import { DynamoDBClient } from '@aws-sdk/client-dynamodb';
 import { DynamoDBDocumentClient, GetCommand } from '@aws-sdk/lib-dynamodb';
 import { S3Client, GetObjectCommand } from '@aws-sdk/client-s3';
+import * as vm from 'vm';
 
 // --- Clients ---
 
@@ -25,31 +26,53 @@ const TOOLS_BUCKET = process.env.TOOLS_BUCKET!;
 
 export interface ToolTestResult {
   success: boolean;
-  output?: any;
+  output?: unknown;
   error?: string;
   executionTimeMs: number;
 }
 
 export interface ToolTestHistoryEntry {
   success: boolean;
-  output?: any;
+  output?: unknown;
   error?: string;
   executionTimeMs: number;
   timestamp: string;
 }
 
+/** Binding slice the sandbox reads when resolving scoped credentials. */
+export interface SandboxBinding {
+  integrationId?: string;
+  dataStoreId?: string;
+}
+
+/** Tool-config slice the sandbox reads. Rows may carry more fields. */
+export interface SandboxToolConfig {
+  integrationBindings?: SandboxBinding[];
+  dataStoreBindings?: SandboxBinding[];
+}
+
+/**
+ * Shape of the module.exports a sandboxed tool may provide: either a
+ * callable handler, or an object exposing a `.handler` function.
+ */
+type SandboxToolFn = (
+  inputs: unknown,
+  credentials: Record<string, unknown>
+) => unknown;
+type SandboxToolExports = SandboxToolFn | { handler?: SandboxToolFn };
+
 export interface ExecuteToolDeps {
-  loadToolConfig: (toolId: string) => Promise<any>;
+  loadToolConfig: (toolId: string) => Promise<SandboxToolConfig | null>;
   loadToolCode: (toolId: string) => Promise<string>;
   resolveCredentials: (bindings: {
-    integrationBindings?: any[];
-    dataStoreBindings?: any[];
-  }) => Promise<Record<string, any>>;
+    integrationBindings?: SandboxBinding[];
+    dataStoreBindings?: SandboxBinding[];
+  }) => Promise<Record<string, unknown>>;
   executeCode: (
     code: string,
-    inputs: any,
-    credentials: any
-  ) => Promise<{ output: any }>;
+    inputs: unknown,
+    credentials: Record<string, unknown>
+  ) => Promise<{ output: unknown }>;
 }
 
 // --- Pure helper: history management (Req 7.9) ---
@@ -88,7 +111,7 @@ export function addToHistory<T>(
  */
 export async function executeTool(
   toolId: string,
-  inputs: any,
+  inputs: unknown,
   orgId: string,
   deps: ExecuteToolDeps,
   timeoutMs: number = 30000
@@ -119,7 +142,7 @@ export async function executeTool(
     }
 
     // 3. Resolve scoped credentials for the tool's bindings (Req 7.5)
-    let credentials: Record<string, any>;
+    let credentials: Record<string, unknown>;
     try {
       credentials = await deps.resolveCredentials({
         integrationBindings: toolConfig.integrationBindings || [],
@@ -197,24 +220,23 @@ function defaultDeps(): ExecuteToolDeps {
     resolveCredentials: async (bindings) => {
       // In production, this calls the Credential Vender to resolve
       // scoped credentials for each binding. Simplified here.
-      const creds: Record<string, any> = {};
+      const creds: Record<string, unknown> = {};
       const allBindings = [
         ...(bindings.integrationBindings || []),
         ...(bindings.dataStoreBindings || []),
       ];
       for (const binding of allBindings) {
-        const id = binding.integrationId || binding.dataStoreId;
+        const id = (binding.integrationId || binding.dataStoreId) as string;
         creds[id] = { scopedAccess: true, bindingId: id };
       }
       return creds;
     },
 
-    executeCode: async (code: string, inputs: any, credentials: any) => {
+    executeCode: async (code: string, inputs: unknown, credentials: Record<string, unknown>) => {
       // Execute tool code in an isolated VM context
-      const vm = require('vm');
       const sandbox = {
-        module: { exports: {} as any },
-        exports: {} as any,
+        module: { exports: {} as SandboxToolExports },
+        exports: {} as SandboxToolExports,
         require: () => {
           throw new Error('require is not allowed in sandbox');
         },
@@ -272,7 +294,7 @@ export async function handler(event: {
   const { toolId, inputs: inputsJson, orgId } = event.arguments;
 
   // Validate inputs
-  let inputs: any;
+  let inputs: unknown;
   try {
     inputs = JSON.parse(inputsJson);
   } catch {

--- a/backend/src/lambda/user-management-resolver.ts
+++ b/backend/src/lambda/user-management-resolver.ts
@@ -81,7 +81,18 @@ async function isUserAdmin(username: string): Promise<boolean> {
   return groups.includes('admin');
 }
 
-export const handler = async (event: any) => {
+/** AppSync event slice this resolver reads: Cognito identity + arguments. */
+interface UserManagementResolverEvent {
+  info: { fieldName: string };
+  identity?: { username?: string; claims?: { username?: string } };
+  arguments: {
+    userId: string;
+    role: string;
+    input: AssignUserRoleInput & ChangePasswordInput & AdminCreateUserInput;
+  };
+}
+
+export const handler = async (event: UserManagementResolverEvent) => {
   console.log('Event:', JSON.stringify(event, null, 2));
 
   const fieldName = event.info.fieldName;
@@ -224,7 +235,7 @@ async function getUser(userId: string): Promise<User> {
   };
 }
 
-async function getCurrentUserProfile(event: any): Promise<User> {
+async function getCurrentUserProfile(event: UserManagementResolverEvent): Promise<User> {
   // Extract username from the Cognito identity
   const username = event.identity?.username || event.identity?.claims?.username;
   
@@ -235,7 +246,7 @@ async function getCurrentUserProfile(event: any): Promise<User> {
   return await getUser(username);
 }
 
-async function assignUserRole(input: AssignUserRoleInput, event: any) {
+async function assignUserRole(input: AssignUserRoleInput, event: UserManagementResolverEvent) {
   const { userId, role, organization } = input;
 
   // Verify the caller is an admin
@@ -306,7 +317,7 @@ async function assignUserRole(input: AssignUserRoleInput, event: any) {
   };
 }
 
-async function removeUserRole(userId: string, role: string, event: any) {
+async function removeUserRole(userId: string, role: string, event: UserManagementResolverEvent) {
   // Verify the caller is an admin
   const callerUsername = event.identity?.username || event.identity?.claims?.username;
   
@@ -390,7 +401,7 @@ async function listOrganizations() {
   });
 }
 
-async function changePassword(event: any, input: ChangePasswordInput) {
+async function changePassword(event: UserManagementResolverEvent, input: ChangePasswordInput) {
   const { newPassword } = input;
   
   // Get username from the Cognito identity
@@ -425,7 +436,7 @@ async function changePassword(event: any, input: ChangePasswordInput) {
   }
 }
 
-async function adminResetUserPassword(event: any, userId: string) {
+async function adminResetUserPassword(event: UserManagementResolverEvent, userId: string) {
   // Verify the caller is an admin
   const callerUsername = event.identity?.username || event.identity?.claims?.username;
   
@@ -466,7 +477,7 @@ async function adminResetUserPassword(event: any, userId: string) {
   }
 }
 
-async function adminCreateUser(event: any, input: AdminCreateUserInput) {
+async function adminCreateUser(event: UserManagementResolverEvent, input: AdminCreateUserInput) {
   // Verify the caller is an admin
   const callerUsername = event.identity?.username || event.identity?.claims?.username;
   
@@ -524,7 +535,7 @@ async function adminCreateUser(event: any, input: AdminCreateUserInput) {
   }
 }
 
-async function adminResendInvitation(event: any, userId: string) {
+async function adminResendInvitation(event: UserManagementResolverEvent, userId: string) {
   // Verify the caller is an admin
   const callerUsername = event.identity?.username || event.identity?.claims?.username;
   

--- a/backend/src/lambda/utils/invoke-event-builder.ts
+++ b/backend/src/lambda/utils/invoke-event-builder.ts
@@ -16,7 +16,7 @@ export interface AppContext {
 }
 
 export interface InvokeEventDetail {
-  body: Record<string, any>;
+  body: Record<string, unknown>;
   headers: {
     'x-citadel-group-id': string;
     'x-citadel-app-name': string;
@@ -35,7 +35,7 @@ export interface InvokeEventDetail {
  * @returns The constructed event detail with body, injected headers, and requestId
  */
 export function buildInvokeEventDetail(
-  requestBody: Record<string, any>,
+  requestBody: Record<string, unknown>,
   appContext: AppContext,
   apiKeyId: string,
 ): InvokeEventDetail {

--- a/backend/src/types/index.ts
+++ b/backend/src/types/index.ts
@@ -43,7 +43,7 @@ export interface AgentStatus {
   currentTask?: string;
   progress?: number;
   lastUpdate: string;
-  metadata?: any;
+  metadata?: Record<string, unknown>;
   errorMessage?: string;
 }
 
@@ -54,7 +54,7 @@ export interface ConversationMessage {
   message: string;
   messageType: MessageType;
   timestamp: string;
-  metadata?: any;
+  metadata?: Record<string, unknown>;
   correlationId?: string;
 }
 
@@ -98,7 +98,7 @@ export interface AgentStatusInput {
   status: AgentStatusEnum;
   currentTask?: string;
   progress?: number;
-  metadata?: any;
+  metadata?: Record<string, unknown>;
   errorMessage?: string;
 }
 
@@ -116,7 +116,7 @@ export interface ConversationMessageInput {
   agentId: string;
   message: string;
   messageType: MessageType;
-  metadata?: any;
+  metadata?: Record<string, unknown>;
   correlationId?: string;
 }
 
@@ -300,7 +300,7 @@ export interface AgentEvent {
   eventType: string;
   projectId: string;
   agentId?: string;
-  payload: any;
+  payload: unknown;
   timestamp: string;
   correlationId?: string;
 }
@@ -313,18 +313,38 @@ export interface AuthContext {
   roles?: string[];
 }
 
+// Identity payload shape observed by the governance resolvers. Depending on
+// the AppSync auth mode, the role/group claims appear either at the top
+// level or nested under `claims`, so both locations are modelled.
+export interface GovernanceEventIdentity {
+  sub?: string;
+  username?: string;
+  'custom:role'?: string;
+  'cognito:groups'?: string[];
+  claims?: { 'custom:role'?: string; [claim: string]: unknown };
+}
+
+// Minimal AppSync event shape shared by the governance resolvers (ADR,
+// ExecutionSpecification, InterrogationRound, AgentDesignAssessment,
+// ProgramReview). TArgs is the resolver-specific merged arguments view.
+export interface GovernanceResolverEvent<TArgs = Record<string, unknown>> {
+  info?: { fieldName?: string };
+  identity?: GovernanceEventIdentity;
+  arguments: TArgs;
+}
+
 // Service layer integration types
 export interface ServiceLayerRequest {
   agentId: string;
   projectId: string;
   action: string;
-  payload: any;
+  payload: unknown;
   correlationId: string;
 }
 
 export interface ServiceLayerResponse {
   success: boolean;
-  data?: any;
+  data?: unknown;
   error?: string;
   correlationId: string;
 }


### PR DESCRIPTION
## Summary

Lint-debt burn-down, part 5: all lambda resolver sources plus shared types.

- Eliminates 238 warnings across 44 source files using the house pattern — typed AppSync-style event interfaces, shared types from `src/types`, `catch
(err: unknown)` with narrowing
- Exported Lambda handler signatures keep identical parameter counts and runtime semantics (annotation-only changes); the one `require` hoist is Node's
built-in `vm` module (zero-cost)
- Two warnings deliberately remain: `agent-message-handler`'s lazy `require` of credential-manager is a documented cold-start optimization — hoisting it
would change module-load behavior, which a lint pass must not do
- Ratchets `--max-warnings` 421 → 183; no `eslint-disable`, no `any`

## Testing

- Full backend suite green (3,932 tests) — the cluster-4-typed resolver suites act as the behavior lock for these signature-sensitive files
- Whole-project tsc and build pass; scope globs report 0 remaining problems