### PR TITLE
fix(intake): tolerate reasoning blocks in Converse response parsing

### DIFF
--- a/service/agent_intake_single/tests/test_converse_utils.py
+++ b/service/agent_intake_single/tests/test_converse_utils.py
@@ -1,0 +1,125 @@
+"""
+Tests for tools/converse_utils.extract_text — guarded Bedrock Converse parsing.
+
+Reasoning-enabled models prepend a reasoningContent block to
+output.message.content, so content[0] has no 'text' key and the old
+unguarded `resp['output']['message']['content'][0]['text']` idiom raised
+KeyError: 'text'. extract_text must return the first block that carries
+'text' (stripped), skipping reasoningContent/toolUse/other blocks, and
+raise a clear ValueError (never KeyError) naming the block types found
+when no text block exists.
+
+Also includes one integration-shaped test per consuming module
+(fabricate / plan / design / extract) proving each call site survives a
+reasoningContent-first response.
+
+Run with:
+    PYTHONPATH=. pytest tests/test_converse_utils.py -q
+from the service/agent_intake_single directory.
+"""
+import os
+import sys
+from unittest import mock
+
+import pytest
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+
+
+def _resp(content_blocks: list) -> dict:
+    """Build a minimal Converse response with the given content blocks."""
+    return {"output": {"message": {"role": "assistant", "content": content_blocks}}}
+
+
+REASONING_BLOCK = {
+    "reasoningContent": {"reasoningText": {"text": "thinking about it..."}}
+}
+TOOL_USE_BLOCK = {"toolUse": {"toolUseId": "t1", "name": "some_tool", "input": {}}}
+
+
+# ---------------------------------------------------------------------------
+# Unit tests — extract_text
+# ---------------------------------------------------------------------------
+
+class TestExtractText:
+    def test_text_only_content_returns_stripped_text(self):
+        from tools.converse_utils import extract_text
+        assert extract_text(_resp([{"text": "  hello world \n"}])) == "hello world"
+
+    def test_reasoning_content_first_then_text_returns_text(self):
+        # THE bug: content[0] is reasoningContent, text is second.
+        from tools.converse_utils import extract_text
+        resp = _resp([REASONING_BLOCK, {"text": " the answer "}])
+        assert extract_text(resp) == "the answer"
+
+    def test_skips_tool_use_and_other_unknown_blocks(self):
+        from tools.converse_utils import extract_text
+        resp = _resp([REASONING_BLOCK, TOOL_USE_BLOCK, {"somethingNew": {}}, {"text": "ok"}])
+        assert extract_text(resp) == "ok"
+
+    def test_no_text_block_raises_value_error_naming_block_types(self):
+        from tools.converse_utils import extract_text
+        resp = _resp([REASONING_BLOCK, TOOL_USE_BLOCK])
+        with pytest.raises(ValueError) as exc_info:
+            extract_text(resp)
+        msg = str(exc_info.value)
+        assert "reasoningContent" in msg
+        assert "toolUse" in msg
+
+    def test_empty_content_list_raises_value_error(self):
+        from tools.converse_utils import extract_text
+        with pytest.raises(ValueError):
+            extract_text(_resp([]))
+
+
+# ---------------------------------------------------------------------------
+# Integration-shaped tests — one per consuming module, each with a mocked
+# converse response whose first content block is reasoningContent.
+# ---------------------------------------------------------------------------
+
+def _mock_bedrock(text: str) -> mock.MagicMock:
+    client = mock.MagicMock()
+    client.converse.return_value = _resp([REASONING_BLOCK, {"text": text}])
+    return client
+
+
+class TestConsumingModulesSurviveReasoningContent:
+    def test_fabricate_llm_extracts_text_after_reasoning_block(self, monkeypatch):
+        import tools.fabricate as fab
+        monkeypatch.setattr(fab, "bedrock", _mock_bedrock('["extracted"]'))
+        assert fab._llm("system", "user") == '["extracted"]'
+
+    def test_plan_generate_planning_doc_extracts_text_after_reasoning_block(self, monkeypatch):
+        import tools.plan as plan
+        monkeypatch.setattr(plan, "bedrock", _mock_bedrock("SECTION BODY"))
+        monkeypatch.setattr(plan, "_assessment_summary", lambda sid: "assessment")
+        monkeypatch.setattr(plan, "_rolling_summary", lambda sid: "summary")
+        monkeypatch.setattr(plan, "s3_get", lambda key: "")
+        template = {
+            "document_title": "Business Plan",
+            "sections": [{
+                "id": "1", "title": "Overview",
+                "description": "d", "required_content": ["x"],
+            }],
+        }
+        doc = plan._generate_planning_doc("sess-1", template)
+        assert "SECTION BODY" in doc
+
+    def test_design_generate_section_extracts_text_after_reasoning_block(self, monkeypatch):
+        import tools.design as design
+        monkeypatch.setattr(design, "bedrock", _mock_bedrock("## 1. Overview\ncontent"))
+        monkeypatch.setattr(design, "kb_query", lambda q, sid: "kb context")
+        monkeypatch.setattr(design, "s3_get", lambda key: "")  # _rolling_summary
+        section = {
+            "id": "1", "title": "Overview",
+            "description": "d", "required_content": ["x"],
+        }
+        result = design._generate_section("sess-1", section, "assessment")
+        assert result == "## 1. Overview\ncontent"
+
+    def test_extract_field_with_llm_extracts_text_after_reasoning_block(self, monkeypatch):
+        import tools.extract as ext
+        monkeypatch.setattr(ext, "bedrock", _mock_bedrock('{"value": "42"}'))
+        field = {"label": "Process name", "kb_hint": "name of the process"}
+        value = ext._extract_field_with_llm("sess-1", field, "kb ctx", [], [])
+        assert value == "42"

--- a/service/agent_intake_single/tools/converse_utils.py
+++ b/service/agent_intake_single/tools/converse_utils.py
@@ -1,0 +1,35 @@
+"""Shared Bedrock Converse response parsing helpers."""
+
+
+def extract_text(resp: dict) -> str:
+    """Return the first text block from a Bedrock Converse response, stripped.
+
+    Reasoning-enabled models prepend a reasoningContent block to
+    output.message.content, so content[0] is not guaranteed to carry a
+    'text' key — the old ``resp['output']['message']['content'][0]['text']``
+    idiom raised KeyError: 'text'. This iterates the content blocks and
+    returns the first one that has 'text', skipping reasoningContent,
+    toolUse, and any other block types.
+
+    Args:
+        resp: The raw bedrock.converse() response dict.
+
+    Returns:
+        The first text block's content, stripped of surrounding whitespace.
+
+    Raises:
+        ValueError: When no text block exists (never KeyError), naming the
+            block types that were found so the failure is diagnosable.
+    """
+    content = ((resp.get("output") or {}).get("message") or {}).get("content") or []
+    for block in content:
+        if isinstance(block, dict) and "text" in block:
+            return block["text"].strip()
+    block_types = [
+        ", ".join(sorted(block.keys())) if isinstance(block, dict) else type(block).__name__
+        for block in content
+    ]
+    raise ValueError(
+        "No text block in Converse response output.message.content; "
+        f"found block types: {block_types if block_types else '(empty content)'}"
+    )

--- a/service/agent_intake_single/tools/design.py
+++ b/service/agent_intake_single/tools/design.py
@@ -3,6 +3,7 @@ import json
 import os
 from strands.tools import tool
 from tools.kb import kb_query, load_json_from_s3, save_json_to_s3, s3_get, s3_put
+from tools.converse_utils import extract_text
 from concurrent.futures import ThreadPoolExecutor, as_completed
 from config import bedrock, AGENT_MODEL_ID
 
@@ -108,7 +109,7 @@ After the section content, add a final line in this exact format (do not omit it
         messages=[{'role': 'user', 'content': [{'text': user_message}]}],
         inferenceConfig={'maxTokens': 8192},
     )
-    return response['output']['message']['content'][0]['text']
+    return extract_text(response)
 
 
 @tool
@@ -234,7 +235,7 @@ Return JSON:
         messages=[{'role': 'user', 'content': [{'text': prompt}]}],
         inferenceConfig={'maxTokens': 2048},
     )
-    raw = response['output']['message']['content'][0]['text']
+    raw = extract_text(response)
     import re
     match = re.search(r'\{.*\}', raw, re.DOTALL)
     return json.loads(match.group(0)) if match else {}
@@ -430,7 +431,7 @@ Current defaults:
         messages=[{'role': 'user', 'content': [{'text': prompt}]}],
         inferenceConfig={'maxTokens': 2048},
     )
-    raw = response['output']['message']['content'][0]['text']
+    raw = extract_text(response)
     import re
     match = re.search(r'\{.*\}', raw, re.DOTALL)
     if not match:

--- a/service/agent_intake_single/tools/extract.py
+++ b/service/agent_intake_single/tools/extract.py
@@ -4,6 +4,7 @@ import os
 from concurrent.futures import ThreadPoolExecutor, as_completed
 from strands.tools import tool
 from tools.kb import kb_query, load_json_from_s3, save_json_to_s3
+from tools.converse_utils import extract_text
 from config import bedrock, AWS_REGION
 from region import cross_region_prefix
 from model_config_loader import load_extraction_model_id
@@ -131,7 +132,7 @@ JSON only, no explanation."""
         messages=[{'role': 'user', 'content': [{'text': prompt}]}],
         inferenceConfig={'maxTokens': 256},
     )
-    raw = response['output']['message']['content'][0]['text'].strip()
+    raw = extract_text(response)
     # Strip markdown code fences if present
     if raw.startswith('```'):
         raw = raw.split('```')[1]

--- a/service/agent_intake_single/tools/fabricate.py
+++ b/service/agent_intake_single/tools/fabricate.py
@@ -7,6 +7,7 @@ from datetime import datetime, timezone
 import boto3
 from strands.tools import tool
 from tools.kb import s3_get, s3_put
+from tools.converse_utils import extract_text
 from config import bedrock, AGENT_MODEL_ID
 
 logger = logging.getLogger(__name__)
@@ -95,7 +96,7 @@ def _llm(system: str, user: str, max_tokens: int = 8192) -> str:
         messages=[{"role": "user", "content": [{"text": user}]}],
         inferenceConfig={"maxTokens": max_tokens},
     )
-    raw = resp["output"]["message"]["content"][0]["text"].strip()
+    raw = extract_text(resp)
     if raw.startswith("```"):
         raw = raw.split("```")[1]
         if raw.startswith("json"):

--- a/service/agent_intake_single/tools/plan.py
+++ b/service/agent_intake_single/tools/plan.py
@@ -3,6 +3,7 @@ import json
 import os
 from strands.tools import tool
 from tools.kb import s3_get, s3_put, load_json_from_s3, save_json_to_s3
+from tools.converse_utils import extract_text
 from tools.design import SECTION_KEY, RESOURCING_KEY, RESOURCING_INPUTS_KEY, SYSTEM_PROMPT, _assessment_summary, _rolling_summary
 from config import bedrock, AGENT_MODEL_ID
 
@@ -52,7 +53,7 @@ Write in markdown. Start with ## {section['title']}. Be specific and concise —
             messages=[{'role': 'user', 'content': [{'text': prompt}]}],
             inferenceConfig={'maxTokens': 4096},
         )
-        content = response['output']['message']['content'][0]['text']
+        content = extract_text(response)
         parts.append(content)
         parts.append("\n\n---\n\n")
 
@@ -206,7 +207,7 @@ Current config:
             inferenceConfig={'maxTokens': 256},
         )
         import re
-        raw = response['output']['message']['content'][0]['text']
+        raw = extract_text(response)
         match = re.search(r'\{.*\}', raw, re.DOTALL)
         if match:
             config = json.loads(match.group(0))


### PR DESCRIPTION
## Summary

Fixes the Intake Requests failure during Fabrication Plan generation: `KeyError - 'text'` from `plan_fabrication`.

- Root cause: seven unguarded `resp['output']['message']['content'][0]['text']` accesses across the intake agent's fabricate/plan/design/extract tools. Reasoning-enabled Bedrock models prepend a `reasoningContent` block, so `content[0]` carries no `text` key. Confirmed against a live AgentCore trace (2026-07-18).
- Fix: shared `extract_text` helper — returns the first text block, skips `reasoningContent`/`toolUse` blocks, raises an informative `ValueError` naming the block types when no text exists. All seven sites swapped; surrounding logic untouched.

## Testing

- Red-first TDD: 9 new tests, with the four integration-shaped ones reproducing the exact production KeyError per module before the fix
- Suite: 49 → 58 passing; independent review verified zero remaining unguarded sites and no behavior creep