### PR TITLE
Fix Agent Catalog JSON parse crash, missing name, and empty code tab

### DIFF
--- a/backend/src/lambda/__tests__/agent-code-resolver.test.ts
+++ b/backend/src/lambda/__tests__/agent-code-resolver.test.ts
@@ -85,12 +85,21 @@ describe('agent-code-resolver', () => {
       expect(result.version).toBeNull();
     });
 
-    test('throws when agent config not found', async () => {
+    test('falls back to agentId.py in S3 when no DynamoDB config exists (registry-based agent)', async () => {
       dynamoMock.on(GetCommand).resolves({});
 
-      await expect(
-        handler(makeEvent('getAgentCode', { agentId: 'missing' }))
-      ).rejects.toThrow('Agent config not found');
+      const noSuchKeyError = new Error('NoSuchKey');
+      noSuchKeyError.name = 'NoSuchKey';
+      s3Mock.on(GetObjectCommand).rejects(noSuchKeyError);
+
+      const result = await invoke(makeEvent('getAgentCode', { agentId: 'missing' }));
+
+      expect(result.agentId).toBe('missing');
+      expect(result.code).toContain('def handler');
+      expect(result.version).toBeNull();
+
+      const getCalls = s3Mock.commandCalls(GetObjectCommand);
+      expect(getCalls[0].args[0].input.Key).toBe('agents/missing.py');
     });
   });
 
@@ -113,14 +122,19 @@ describe('agent-code-resolver', () => {
       expect(putCalls[0].args[0].input.Key).toBe('agents/my_agent.py');
     });
 
-    test('throws when agent config not found', async () => {
+    test('falls back to agentId.py in S3 when no DynamoDB config exists (registry-based agent)', async () => {
       dynamoMock.on(GetCommand).resolves({});
+      s3Mock.on(PutObjectCommand).resolves({ VersionId: 'v3' });
 
-      await expect(
-        handler(makeEvent('updateAgentCode', {
-          input: { agentId: 'missing', code: 'x' },
-        }))
-      ).rejects.toThrow('Failed to update agent code');
+      const result = await invoke(makeEvent('updateAgentCode', {
+        input: { agentId: 'missing', code: 'x' },
+      }));
+
+      expect(result.agentId).toBe('missing');
+      expect(result.code).toBe('x');
+
+      const putCalls = s3Mock.commandCalls(PutObjectCommand);
+      expect(putCalls[0].args[0].input.Key).toBe('agents/missing.py');
     });
   });
 

--- a/backend/src/lambda/agent-code-resolver.ts
+++ b/backend/src/lambda/agent-code-resolver.ts
@@ -55,17 +55,24 @@ async function getAgentCode(args: GetAgentCodeArgs) {
 
     const configResponse = await docClient.send(getConfigCommand);
     
-    if (!configResponse.Item) {
-      throw new Error(`Agent config not found for agentId: ${agentId}`);
+    let filename: string;
+    if (configResponse.Item) {
+      // Parse config to get filename
+      let config = configResponse.Item.config;
+      if (typeof config === 'string') {
+        try {
+          config = JSON.parse(config);
+        } catch {
+          config = {};
+        }
+      }
+      filename = config.filename || `${agentId}.py`;
+    } else {
+      // Registry-based agent: DynamoDB has no record.
+      // Try using agentId directly as filename.
+      filename = `${agentId}.py`;
     }
 
-    // Parse config to get filename
-    let config = configResponse.Item.config;
-    if (typeof config === 'string') {
-      config = JSON.parse(config);
-    }
-
-    const filename = config.filename || `${agentId}.py`;
     const key = `agents/${filename}`;
 
     // Get code from S3
@@ -125,17 +132,23 @@ async function updateAgentCode(args: UpdateAgentCodeArgs) {
 
     const configResponse = await docClient.send(getConfigCommand);
     
-    if (!configResponse.Item) {
-      throw new Error(`Agent config not found for agentId: ${agentId}`);
+    let filename: string;
+    if (configResponse.Item) {
+      // Parse config to get filename
+      let config = configResponse.Item.config;
+      if (typeof config === 'string') {
+        try {
+          config = JSON.parse(config);
+        } catch {
+          config = {};
+        }
+      }
+      filename = config.filename || `${agentId}.py`;
+    } else {
+      // Registry-based agent: DynamoDB has no record.
+      filename = `${agentId}.py`;
     }
 
-    // Parse config to get filename
-    let config = configResponse.Item.config;
-    if (typeof config === 'string') {
-      config = JSON.parse(config);
-    }
-
-    const filename = config.filename || `${agentId}.py`;
     const key = `agents/${filename}`;
 
     // Update code in S3

--- a/frontend/src/components/AgentDetails.tsx
+++ b/frontend/src/components/AgentDetails.tsx
@@ -38,7 +38,6 @@ export const AgentDetails: React.FC<AgentDetailsProps> = ({
   useEffect(() => {
     if (agentId && !isCreating) {
       loadAgent();
-      loadAgentCode();
     } else if (isCreating) {
       // Initialize form for creating new agent
       const initialConfig = {
@@ -98,7 +97,12 @@ def handler(event, context):
         let config = data.config;
         if (typeof config === 'string') {
           console.debug('Parsing config from string');
-          config = JSON.parse(config);
+          try {
+            config = config.trim() ? JSON.parse(config) : {};
+          } catch {
+            console.warn('Agent config is not valid JSON, treating as empty:', config);
+            config = {};
+          }
         }
         console.debug('Final config:', config);
         console.debug('Final config type:', typeof config);
@@ -114,6 +118,11 @@ def handler(event, context):
           agentId: agentWithParsedConfig.agentId,
           config: agentWithParsedConfig.config,
         });
+
+        // Load code using the agent's name (which matches the S3 key)
+        // rather than the recordId which doesn't have a corresponding file.
+        const codeLookupId = data.name || (config as any)?.name || agentId;
+        loadAgentCode(codeLookupId);
       }
     } catch (err: any) {
       setError(err.message || 'Failed to load agent');
@@ -122,11 +131,12 @@ def handler(event, context):
     }
   };
 
-  const loadAgentCode = async () => {
-    if (!agentId) return;
+  const loadAgentCode = async (nameOverride?: string) => {
+    const codeId = nameOverride || agentId;
+    if (!codeId) return;
 
     try {
-      const codeData = await agentConfigService.getAgentCode(agentId);
+      const codeData = await agentConfigService.getAgentCode(codeId);
       if (codeData) {
         console.debug('Loaded code length:', codeData.code.length);
         console.debug('Loaded code:', codeData.code);
@@ -263,7 +273,7 @@ def handler(event, context):
 
   const handleDelete = async () => {
     if (!agent) return;
-    if (!window.confirm(`Are you sure you want to delete agent "${agent.agentId}"?`)) {
+    if (!window.confirm(`Are you sure you want to delete agent "${agent.name || (agent.config as any)?.name || agent.agentId}"?`)) {
       return;
     }
 
@@ -332,7 +342,7 @@ def handler(event, context):
         <div className="agent-details-header">
           <div>
             <h2 className="agent-details-title">
-              {isCreating ? 'Create New Agent' : agent?.agentId}
+              {isCreating ? 'Create New Agent' : (agent?.name || (agent?.config as any)?.name || agent?.agentId)}
             </h2>
             {agent && !isCreating && (
               <div className="agent-details-meta">

--- a/frontend/src/components/CreateAgentWizard.tsx
+++ b/frontend/src/components/CreateAgentWizard.tsx
@@ -349,7 +349,7 @@ export function CreateAgentWizard({ onBack, onComplete, onRequestSubmitted }: Cr
 
             <div className="selection-grid">
               {availableTools.map((tool) => {
-                const config = typeof tool.config === 'string' ? JSON.parse(tool.config) : tool.config;
+                const config = typeof tool.config === 'string' ? (() => { try { return tool.config.trim() ? JSON.parse(tool.config) : {}; } catch { return {}; } })() : tool.config;
                 const isSelected = selectedTools.includes(tool.toolId);
 
                 return (

--- a/frontend/src/components/ToolCard.tsx
+++ b/frontend/src/components/ToolCard.tsx
@@ -35,7 +35,7 @@ export function ToolCard({ tool, onToggleState, onConfigure, userRole, orgId, co
   const [showSandbox, setShowSandbox] = useState(false);
   // Parse config if it's a string
   const config = typeof tool.config === 'string' 
-    ? JSON.parse(tool.config) 
+    ? (() => { try { return tool.config.trim() ? JSON.parse(tool.config) : {}; } catch { return {}; } })()
     : tool.config;
 
   // Only show config button for admin and developer roles

--- a/frontend/src/components/ToolTestingSandbox.tsx
+++ b/frontend/src/components/ToolTestingSandbox.tsx
@@ -118,7 +118,7 @@ function matchFieldToBinding(
 }
 
 export function ToolTestingSandbox({ tool, orgId, onClose }: ToolTestingSandboxProps) {
-  const config = typeof tool.config === 'string' ? JSON.parse(tool.config) : tool.config;
+  const config = typeof tool.config === 'string' ? (() => { try { return tool.config.trim() ? JSON.parse(tool.config) : {}; } catch { return {}; } })() : tool.config;
   const schema = config?.schema?.properties;
   const hasSchema = schema && Object.keys(schema).length > 0;
 

--- a/frontend/src/pages/Integrations.tsx
+++ b/frontend/src/pages/Integrations.tsx
@@ -834,7 +834,7 @@ export function Integrations() {
                 
                 // Parse config if it's a string
                 const parsedConfig = typeof selectedIntegration.config === 'string' 
-                  ? JSON.parse(selectedIntegration.config) 
+                  ? (() => { try { return selectedIntegration.config.trim() ? JSON.parse(selectedIntegration.config) : {}; } catch { return {}; } })()
                   : selectedIntegration.config;
                 
                 if (connectorDef.formConfig.authFields && parsedConfig) {

--- a/frontend/src/services/agentConfigService.ts
+++ b/frontend/src/services/agentConfigService.ts
@@ -38,6 +38,7 @@ const getAgentConfigQuery = `
   query GetAgentConfig($agentId: String!) {
     getAgentConfig(agentId: $agentId) {
       agentId
+      name
       config
       state
       categories
@@ -51,6 +52,7 @@ const searchAgentConfigsQuery = `
   query SearchAgentConfigs($query: String!) {
     searchAgentConfigs(query: $query) {
       agentId
+      name
       config
       state
       categories

--- a/frontend/src/services/toolConfigService.ts
+++ b/frontend/src/services/toolConfigService.ts
@@ -111,6 +111,15 @@ const deleteToolConfigMutation = `
   }
 `;
 
+function safeParseConfig(raw: unknown): unknown {
+  if (typeof raw !== 'string') return raw;
+  try {
+    return raw.trim() ? JSON.parse(raw) : {};
+  } catch {
+    return {};
+  }
+}
+
 export const toolConfigService = {
   async listToolConfigs(): Promise<ToolConfig[]> {
     try {
@@ -120,7 +129,7 @@ export const toolConfigService = {
       
       return (response.listToolConfigs || []).map((tool: any) => ({
         ...tool,
-        config: typeof tool.config === 'string' ? JSON.parse(tool.config) : tool.config,
+        config: safeParseConfig(tool.config),
       }));
     } catch (error) {
       console.error('Error listing tool configs:', error);
@@ -140,7 +149,7 @@ export const toolConfigService = {
       
       return {
         ...tool,
-        config: typeof tool.config === 'string' ? JSON.parse(tool.config) : tool.config,
+        config: safeParseConfig(tool.config),
       };
     } catch (error) {
       console.error('Error getting tool config:', error);
@@ -157,7 +166,7 @@ export const toolConfigService = {
 
       return (response.searchToolConfigs || []).map((tool: any) => ({
         ...tool,
-        config: typeof tool.config === 'string' ? JSON.parse(tool.config) : tool.config,
+        config: safeParseConfig(tool.config),
       }));
     } catch (error) {
       console.warn('Semantic search failed, falling back to client-side filtering:', error);
@@ -202,7 +211,7 @@ export const toolConfigService = {
       const tool = response.createToolConfig;
       return {
         ...tool,
-        config: typeof tool.config === 'string' ? JSON.parse(tool.config) : tool.config,
+        config: safeParseConfig(tool.config),
       };
     } catch (error) {
       console.error('Error creating tool config:', error);
@@ -232,7 +241,7 @@ export const toolConfigService = {
       const tool = response.updateToolConfig;
       return {
         ...tool,
-        config: typeof tool.config === 'string' ? JSON.parse(tool.config) : tool.config,
+        config: safeParseConfig(tool.config),
       };
     } catch (error) {
       console.error('Error updating tool config:', error);


### PR DESCRIPTION
Agent detail pages threw "JSON.parse: unexpected character at line 1 column 1" for every agent and showed the raw record ID instead of the agent's name, with the Code tab always falling back to placeholder text.

Root causes:
- AgentDetails.tsx called JSON.parse() on the agent config string with no error handling, so an empty/blank config (returned by the registry for agents with no description) crashed the whole page.
- Several other components (ToolCard, CreateAgentWizard, ToolTestingSandbox, Integrations, toolConfigService) had the same unguarded JSON.parse(config) pattern and were vulnerable to the same crash for tool/integration configs.
- getAgentConfigQuery and searchAgentConfigsQuery were missing the `name` field, so the detail view had no way to show anything but the agentId (a 12-char registry record ID) even though the list view already resolved names correctly.
- agent-code-resolver's getAgentCode/updateAgentCode assumed every agentId maps to a DynamoDB row; registry-backed agents have no such row, so the S3 lookup silently used the record ID as a filename and always missed, returning the "Agent code not found" placeholder.

Fixes:
- Wrap JSON.parse(config) calls in try/catch, treating unparseable or empty config as {} instead of throwing.
- Add `name` to the getAgentConfig/searchAgentConfigs GraphQL selections and prefer agent.name / config.name over agentId when rendering the detail page title and delete confirmation.
- Load agent code using the resolved agent name (matching the S3 key the code was actually saved under) instead of the raw agentId.
- Harden agent-code-resolver's DynamoDB lookup to fall back gracefully instead of assuming a config row always exists.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
