### PR TITLE
fix: resolve user and agent display names server-side

### DIFF
--- a/backend/src/lambda/__tests__/fixtures/registry-service-mock.ts
+++ b/backend/src/lambda/__tests__/fixtures/registry-service-mock.ts
@@ -32,17 +32,106 @@ export function seedMockRegistry(
 
 export function resetMockRegistry(): void {
   records.clear();
+  listResourceSummariesCallCount = 0;
+  getResourceCallCounts.clear();
+}
+
+/** Test-visible call counter: how many times listResourceSummaries() ran. */
+let listResourceSummariesCallCount = 0;
+export function getListResourceSummariesCallCount(): number {
+  return listResourceSummariesCallCount;
+}
+
+/** Test-visible call counter: getResource() invocations per `${type}:${id}` key. */
+const getResourceCallCounts = new Map<string, number>();
+export function getGetResourceCallCount(type: ResourceType, id: string): number {
+  return getResourceCallCounts.get(`${type}:${id}`) ?? 0;
 }
 
 export function getMockRegistryService() {
   return {
     async getResource(type: ResourceType, id: string): Promise<RegistryRecord | null> {
-      return records.get(`${type}:${id}`) ?? null;
+      const key = `${type}:${id}`;
+      getResourceCallCounts.set(key, (getResourceCallCounts.get(key) ?? 0) + 1);
+      return records.get(key) ?? null;
     },
     async listResources(type: ResourceType): Promise<RegistryRecord[]> {
       return Array.from(records.entries())
         .filter(([k]) => k.startsWith(`${type}:`))
         .map(([, v]) => v) as RegistryRecord[];
+    },
+    async listResourceSummaries(): Promise<
+      Array<{ recordId: string; name: string; status?: string }>
+    > {
+      listResourceSummariesCallCount += 1;
+      return Array.from(records.values()).map((v) => ({
+        recordId: v.recordId,
+        name: v.name,
+        status: v.status,
+      }));
+    },
+    /**
+     * Mirrors the production dedup/legacy-name-resolution contract: at most
+     * one listResourceSummaries() call for the WHOLE batch (only if a
+     * non-12-char ref is present), then one getResource() per UNIQUE
+     * resolved recordId.
+     */
+    async getResourcesByRefs(
+      type: ResourceType,
+      refs: string[],
+    ): Promise<Map<string, RegistryRecord>> {
+      const uniqueRefs = Array.from(new Set(refs.filter((r) => !!r)));
+      const result = new Map<string, RegistryRecord>();
+      if (uniqueRefs.length === 0) return result;
+
+      const isRecordId = (r: string) => /^[a-zA-Z0-9]{12}$/.test(r);
+      const needsNameResolution = uniqueRefs.some((r) => !isRecordId(r));
+
+      let nameToRecordId: Map<string, string> | undefined;
+      if (needsNameResolution) {
+        listResourceSummariesCallCount += 1;
+        nameToRecordId = new Map(
+          Array.from(records.values())
+            .filter((v) => v.recordId && v.name)
+            .map((v) => [v.name, v.recordId]),
+        );
+      }
+
+      const refToRecordId = new Map<string, string | undefined>();
+      for (const ref of uniqueRefs) {
+        refToRecordId.set(ref, isRecordId(ref) ? ref : nameToRecordId?.get(ref));
+      }
+
+      const uniqueRecordIds = Array.from(
+        new Set(Array.from(refToRecordId.values()).filter((id): id is string => !!id)),
+      );
+      const recordIdToRecord = new Map<string, RegistryRecord>();
+      for (const recordId of uniqueRecordIds) {
+        const key = `${type}:${recordId}`;
+        getResourceCallCounts.set(key, (getResourceCallCounts.get(key) ?? 0) + 1);
+        const record = records.get(key);
+        if (record) recordIdToRecord.set(recordId, record as RegistryRecord);
+      }
+
+      for (const [ref, recordId] of refToRecordId.entries()) {
+        if (!recordId) continue;
+        const record = recordIdToRecord.get(recordId);
+        if (record) result.set(ref, record);
+      }
+      return result;
+    },
+    /** Mirrors RegistryService.mapToAgentConfig's orgId/name extraction. */
+    mapToAgentConfig(record: RegistryRecord): { agentId: string; name: string; orgId: string } {
+      let orgId = '';
+      try {
+        const meta = record.customDescriptorContent
+          ? JSON.parse(record.customDescriptorContent)
+          : {};
+        orgId = typeof meta.orgId === 'string' ? meta.orgId : '';
+      } catch {
+        orgId = '';
+      }
+      return { agentId: record.recordId, name: record.name ?? '', orgId };
     },
     async searchResources(type: ResourceType, _query: string): Promise<RegistryRecord[]> {
       return Array.from(records.entries())

--- a/backend/src/lambda/__tests__/registry-agent-record-resolver-crud.test.ts
+++ b/backend/src/lambda/__tests__/registry-agent-record-resolver-crud.test.ts
@@ -99,6 +99,24 @@ function makeAdminEvent(fieldName: string, args: Record<string, unknown>, sub = 
   } as unknown as HandlerEvent;
 }
 
+/**
+ * Event helper for callers who need a `custom:organization` claim matching
+ * the org being queried, to pass the getApp/listApps tenant-authorization
+ * gate (a non-admin caller may only read their own org's apps).
+ */
+function makeOrgEvent(
+  fieldName: string,
+  args: Record<string, unknown>,
+  orgId: string,
+  sub = 'user-123',
+) {
+  return {
+    info: { fieldName },
+    arguments: args,
+    identity: { sub, claims: { sub, 'custom:organization': orgId } },
+  } as unknown as HandlerEvent;
+}
+
 function seedApp(
   opts: {
     status?: string;
@@ -163,7 +181,7 @@ describe('registry-agent-record-resolver — CRUD', () => {
       seedApp({ orgId: 'org-1' });
 
       const result = await invokeHandler(
-        makeEvent('getApp', { appId: 'app-1' }),
+        makeOrgEvent('getApp', { appId: 'app-1' }, 'org-1'),
       );
 
       expect(result.appId).toBe('app-1');
@@ -272,7 +290,7 @@ describe('registry-agent-record-resolver — CRUD', () => {
       });
 
       const result = await invokeHandler(
-        makeEvent('listApps', { orgId: 'org-1' }),
+        makeOrgEvent('listApps', { orgId: 'org-1' }, 'org-1'),
       );
 
       expect(result.items).toHaveLength(2);
@@ -301,7 +319,7 @@ describe('registry-agent-record-resolver — CRUD', () => {
       ddbMock.on(QueryCommand).resolves({ Items: [], LastEvaluatedKey: undefined });
 
       const result = await invokeHandler(
-        makeEvent('listApps', { orgId: 'org-other' }),
+        makeOrgEvent('listApps', { orgId: 'org-other' }, 'org-other'),
       );
 
       expect(result.items).toEqual([]);
@@ -324,7 +342,7 @@ describe('registry-agent-record-resolver — CRUD', () => {
       });
 
       const result = await invokeHandler(
-        makeEvent('listApps', { orgId: 'org-1' }),
+        makeOrgEvent('listApps', { orgId: 'org-1' }, 'org-1'),
       );
 
       expect(result.items).toHaveLength(1);
@@ -346,7 +364,7 @@ describe('registry-agent-record-resolver — CRUD', () => {
       });
 
       const result = await invokeHandler(
-        makeEvent('listApps', { orgId: 'org-1' }),
+        makeOrgEvent('listApps', { orgId: 'org-1' }, 'org-1'),
       );
 
       expect(result.items).toHaveLength(1);
@@ -378,7 +396,7 @@ describe('registry-agent-record-resolver — CRUD', () => {
         });
 
       const result = await invokeHandler(
-        makeEvent('listApps', { orgId: 'org-1' }),
+        makeOrgEvent('listApps', { orgId: 'org-1' }, 'org-1'),
       );
 
       expect(result.items).toHaveLength(2);

--- a/backend/src/lambda/__tests__/registry-agent-record-resolver-name-resolution.test.ts
+++ b/backend/src/lambda/__tests__/registry-agent-record-resolver-name-resolution.test.ts
@@ -75,7 +75,7 @@ jest.mock('../../utils/appsync-publish', () => ({
 import { handler } from '../registry-agent-record-resolver';
 
 type HandlerEvent = Parameters<typeof handler>[0];
-const invokeHandler = handler as (event: HandlerEvent) => Promise<any>;
+const invokeHandler = handler as (event: HandlerEvent) => Promise<unknown>;
 
 function makeEvent(
   fieldName: string,
@@ -261,7 +261,7 @@ describe('registry-agent-record-resolver — server-side name resolution', () =>
       const result = await invokeHandler(makeEvent('getApp', { appId: 'app-1' }));
 
       expect(result.agentBindings).toHaveLength(2);
-      const byId = new Map(result.agentBindings.map((b: any) => [b.agentId, b]));
+      const byId = new Map(result.agentBindings.map((b: { agentId: string; name?: string }) => [b.agentId, b]));
       expect(byId.get(AGENT_1).name).toBe('Support Agent');
       expect(byId.get(AGENT_2).name).toBe('Billing Agent');
     });
@@ -278,7 +278,7 @@ describe('registry-agent-record-resolver — server-side name resolution', () =>
 
       const result = await invokeHandler(makeEvent('getApp', { appId: 'app-1' }));
 
-      const byId = new Map(result.agentBindings.map((b: any) => [b.agentId, b]));
+      const byId = new Map(result.agentBindings.map((b: { agentId: string; name?: string }) => [b.agentId, b]));
       expect(byId.get(AGENT_MISSING).name).toBeUndefined();
       expect(byId.get(AGENT_2).name).toBe('Billing Agent');
     });
@@ -364,7 +364,7 @@ describe('registry-agent-record-resolver — server-side name resolution', () =>
       const result = await invokeHandler(makeEvent('getApp', { appId: 'app-1' }));
 
       expect(result.agentBindings).toHaveLength(4);
-      const byId = new Map(result.agentBindings.map((b: any) => [b.agentId, b]));
+      const byId = new Map(result.agentBindings.map((b: { agentId: string; name?: string }) => [b.agentId, b]));
       expect(byId.get(AGENT_1).name).toBe('Support Agent');
       expect(byId.get(AGENT_2).name).toBe('Billing Agent');
       // The whole batch — 4 bindings referencing 2 unique agents — costs
@@ -387,7 +387,7 @@ describe('registry-agent-record-resolver — server-side name resolution', () =>
       const result = await invokeHandler(makeEvent('getApp', { appId: 'app-1' }));
 
       expect(result.agentBindings).toHaveLength(25);
-      expect(result.agentBindings.every((b: any) => !!b.name)).toBe(true);
+      expect(result.agentBindings.every((b: { name?: string }) => !!b.name)).toBe(true);
       // Bounded independent of binding count — a single BatchGetItem call.
       expect(batchGetCallCount).toBe(1);
       expect(batchGetKeyCount).toBe(25);
@@ -421,7 +421,7 @@ describe('registry-agent-record-resolver — server-side name resolution', () =>
 
       const result = await invokeHandler(makeEvent('getApp', { appId: 'app-1' }));
 
-      const byId = new Map(result.agentBindings.map((b: any) => [b.agentId, b]));
+      const byId = new Map(result.agentBindings.map((b: { agentId: string; name?: string }) => [b.agentId, b]));
       expect(byId.get('LegacyThrowsAgent').name).toBeUndefined();
       expect(byId.get(AGENT_2).name).toBe('Billing Agent');
     });
@@ -526,7 +526,7 @@ describe('registry-agent-record-resolver — server-side name resolution', () =>
       const result = await invokeHandler(makeEvent('listApps', { orgId: 'org-1' }, { orgId: 'org-1' }));
 
       expect(result.items).toHaveLength(3);
-      expect(result.items.every((i: any) => i.createdByName === 'user1@example.com')).toBe(true);
+      expect(result.items.every((i: { createdByName?: string }) => i.createdByName === 'user1@example.com')).toBe(true);
       expect(cognitoMock.commandCalls(AdminGetUserCommand)).toHaveLength(1);
     });
 

--- a/backend/src/lambda/__tests__/registry-agent-record-resolver-name-resolution.test.ts
+++ b/backend/src/lambda/__tests__/registry-agent-record-resolver-name-resolution.test.ts
@@ -1,0 +1,603 @@
+/**
+ * Unit tests for the server-side name-resolution enrichment on
+ * registry-agent-record-resolver's getApp / listApps read paths:
+ *
+ *   - `createdByName`: resolved from the `createdBy` Cognito userId via
+ *     AdminGetUser (given_name + family_name, else email, else the raw
+ *     userId on any lookup failure).
+ *   - `agentBindings[].name`: resolved per-binding from the bound agent's
+ *     Registry record `name` field via `RegistryService.getResourcesByRefs`,
+ *     with a graceful per-binding fallback (no `name` set) on lookup
+ *     failure OR when the bound agent belongs to a different org.
+ *
+ * Both enrichments must never throw and must never block getApp/listApps —
+ * they are display-only additions layered on top of the existing
+ * Registry-backed projection.
+ *
+ * Also covers the tenant-authorization gate that MUST run before either
+ * enrichment: a caller outside the app's org (non-admin) gets `null`
+ * (getApp) / an org-coerced list (listApps) with zero AdminGetUser or
+ * Registry name-lookup calls — the enrichment must never even run for a
+ * denied caller.
+ */
+process.env.REGISTRY_ID = 'test-registry-id';
+process.env.APPS_TABLE = 'citadel-apps-test';
+process.env.WORKFLOWS_TABLE = 'citadel-workflows-test';
+process.env.AGENT_CONFIG_TABLE = 'citadel-agents-test';
+process.env.EVENT_BUS_NAME = 'citadel-agents-test';
+process.env.USER_POOL_ID = 'us-east-1_test';
+process.env.AWS_REGION = 'us-east-1';
+delete process.env.AUTHORITY_UNITS_TABLE;
+
+import { EventBridgeClient, PutEventsCommand } from '@aws-sdk/client-eventbridge';
+import {
+  DynamoDBDocumentClient,
+  ScanCommand,
+  QueryCommand,
+  GetCommand,
+  BatchGetCommand,
+} from '@aws-sdk/lib-dynamodb';
+import {
+  CognitoIdentityProviderClient,
+  AdminGetUserCommand,
+} from '@aws-sdk/client-cognito-identity-provider';
+import { mockClient } from 'aws-sdk-client-mock';
+
+const ebMock = mockClient(EventBridgeClient);
+const ddbMock = mockClient(DynamoDBDocumentClient);
+const cognitoMock = mockClient(CognitoIdentityProviderClient);
+
+import {
+  seedMockRegistry,
+  resetMockRegistry,
+  getListResourceSummariesCallCount,
+  getGetResourceCallCount,
+} from './fixtures/registry-service-mock';
+
+jest.mock('../../services/registry-service', () => {
+  const { getMockRegistryService } = jest.requireActual('./fixtures/registry-service-mock');
+  return {
+    RegistryService: jest.fn().mockImplementation(() => getMockRegistryService()),
+    getRegistryService: jest.fn(() => getMockRegistryService()),
+    _resetRegistryService: jest.fn(),
+    isRegistryEnabled: jest.fn(() => true),
+  };
+});
+
+jest.mock('../../utils/appsync', () => ({
+  getUserId: jest.fn().mockReturnValue('user-123'),
+}));
+
+jest.mock('../../utils/appsync-publish', () => ({
+  publishAppStatusEvent: jest.fn().mockResolvedValue(undefined),
+}));
+
+import { handler } from '../registry-agent-record-resolver';
+
+type HandlerEvent = Parameters<typeof handler>[0];
+const invokeHandler = handler as (event: HandlerEvent) => Promise<any>;
+
+function makeEvent(
+  fieldName: string,
+  args: Record<string, unknown>,
+  opts: { sub?: string; orgId?: string | undefined; admin?: boolean; hasOrgClaim?: boolean } = {},
+) {
+  const { sub = 'user-123', admin = false } = opts;
+  // `orgId` defaults to 'org-1' UNLESS the caller explicitly passed the key
+  // (including `orgId: undefined`, used by the "no org claim" test cases).
+  const orgId = 'orgId' in opts ? opts.orgId : 'org-1';
+  const claims: Record<string, unknown> = { sub };
+  if (orgId !== undefined) claims['custom:organization'] = orgId;
+  if (admin) claims['custom:role'] = 'admin';
+  return {
+    info: { fieldName },
+    arguments: args,
+    identity: { sub, claims },
+  } as unknown as HandlerEvent;
+}
+
+function seedApp(
+  opts: {
+    orgId?: string;
+    createdBy?: string;
+    agentBindings?: Array<Record<string, unknown>>;
+  } = {},
+): void {
+  seedMockRegistry('agent', 'app-1', {
+    name: 'Test App',
+    description: 'Test',
+    status: 'DRAFT',
+    customDescriptorContent: JSON.stringify({
+      appId: 'app-1',
+      manifest: {
+        orgId: opts.orgId ?? 'org-1',
+        createdBy: opts.createdBy ?? 'user-abc-123',
+        version: 1,
+        status: 'DRAFT',
+        workflowIds: [],
+        agentBindings: opts.agentBindings ?? [],
+        permissions: [],
+        configSchema: null,
+        configValues: null,
+        authConfig: null,
+        access: {},
+        routingConfig: null,
+      },
+    }),
+  });
+}
+// 12-char alphanumeric record IDs, matching the real Registry's recordId
+// shape (`/^[a-zA-Z0-9]{12}$/`) — required so the batch resolver's
+// isRecordId fast path (vs. legacy-name resolution) is exercised the same
+// way it is in production.
+const AGENT_1 = 'agentrecid01';
+const AGENT_2 = 'agentrecid02';
+const AGENT_MISSING = 'agentrecid99';
+const AGENT_FOREIGN = 'agentrecid03';
+const AGENT_SHARED = 'agentrecid04';
+const AGENT_NO_ORG = 'agentrecid06';
+
+// In-memory stand-in for the AGENT_CONFIG_TABLE projection (kept current by
+// registry-sync.ts in production). `resolveAgentBindingNames`'s fast path
+// reads this via a single BatchGetItem per invocation for the WHOLE set of
+// 12-char recordId bindings — this fixture backs the ddbMock BatchGetCommand
+// handler below and tracks call counts to prove that boundedness.
+const agentCacheTable = new Map<string, { agentId: string; name: string; orgId?: string }>();
+let batchGetCallCount = 0;
+let batchGetKeyCount = 0;
+
+/** Seeds a row in the AGENT_CONFIG_TABLE fixture. Omit `orgId` to simulate a legacy row that never had it written. */
+function seedAgentCache(agentId: string, name: string, orgId?: string): void {
+  agentCacheTable.set(agentId, orgId === undefined ? { agentId, name } : { agentId, name, orgId });
+}
+
+describe('registry-agent-record-resolver — server-side name resolution', () => {
+  beforeEach(() => {
+    resetMockRegistry();
+    agentCacheTable.clear();
+    batchGetCallCount = 0;
+    batchGetKeyCount = 0;
+    ebMock.reset();
+    ebMock.on(PutEventsCommand).resolves({});
+    ddbMock.reset();
+    ddbMock.on(ScanCommand).resolves({ Items: [], LastEvaluatedKey: undefined });
+    ddbMock.on(QueryCommand).resolves({ Items: [], LastEvaluatedKey: undefined });
+    ddbMock.on(GetCommand).resolves({ Item: undefined });
+    ddbMock.on(BatchGetCommand).callsFake((input) => {
+      batchGetCallCount += 1;
+      const keys = input.RequestItems?.['citadel-agents-test']?.Keys ?? [];
+      batchGetKeyCount += keys.length;
+      const items = keys
+        .map((k: { agentId: string }) => agentCacheTable.get(k.agentId))
+        .filter((v: unknown) => !!v);
+      return Promise.resolve({ Responses: { 'citadel-agents-test': items } });
+    });
+    cognitoMock.reset();
+    cognitoMock.on(AdminGetUserCommand).resolves({ UserAttributes: [] });
+  });
+
+  afterAll(() => {
+    delete process.env.APPS_TABLE;
+    delete process.env.WORKFLOWS_TABLE;
+    delete process.env.AGENT_CONFIG_TABLE;
+    delete process.env.EVENT_BUS_NAME;
+    delete process.env.USER_POOL_ID;
+    delete process.env.AWS_REGION;
+    delete process.env.REGISTRY_ID;
+  });
+
+  describe('getApp — createdByName', () => {
+    test('resolves createdByName from Cognito given_name + family_name', async () => {
+      seedApp({ createdBy: 'user-abc-123' });
+      cognitoMock.on(AdminGetUserCommand).resolves({
+        UserAttributes: [
+          { Name: 'given_name', Value: 'Jane' },
+          { Name: 'family_name', Value: 'Doe' },
+          { Name: 'email', Value: 'jane@example.com' },
+        ],
+      });
+
+      const result = await invokeHandler(makeEvent('getApp', { appId: 'app-1' }));
+
+      expect(result.createdBy).toBe('user-abc-123');
+      expect(result.createdByName).toBe('Jane Doe');
+      const calls = cognitoMock.commandCalls(AdminGetUserCommand);
+      expect(calls).toHaveLength(1);
+      expect(calls[0].args[0].input).toMatchObject({
+        UserPoolId: 'us-east-1_test',
+        Username: 'user-abc-123',
+      });
+    });
+
+    test('falls back to email when given_name/family_name are absent', async () => {
+      seedApp({ createdBy: 'user-abc-123' });
+      cognitoMock.on(AdminGetUserCommand).resolves({
+        UserAttributes: [{ Name: 'email', Value: 'jane@example.com' }],
+      });
+
+      const result = await invokeHandler(makeEvent('getApp', { appId: 'app-1' }));
+
+      expect(result.createdByName).toBe('jane@example.com');
+    });
+
+    test('falls back to the raw userId when AdminGetUser throws', async () => {
+      seedApp({ createdBy: 'user-abc-123' });
+      cognitoMock.on(AdminGetUserCommand).rejects(new Error('UserNotFoundException'));
+
+      const result = await invokeHandler(makeEvent('getApp', { appId: 'app-1' }));
+
+      expect(result.createdByName).toBe('user-abc-123');
+    });
+
+    test('returns "unknown" when createdBy is empty', async () => {
+      seedApp({ createdBy: '' });
+
+      const result = await invokeHandler(makeEvent('getApp', { appId: 'app-1' }));
+
+      expect(result.createdByName).toBe('unknown');
+      expect(cognitoMock.commandCalls(AdminGetUserCommand)).toHaveLength(0);
+    });
+
+    test('falls back to the raw userId when USER_POOL_ID is not configured', async () => {
+      // USER_POOL_ID is captured as a module-level const at import time, so
+      // this scenario is covered end-to-end by the sibling
+      // registry-agent-record-resolver-no-user-pool.test.ts (a separate
+      // test file/module instance with USER_POOL_ID unset BEFORE import).
+      expect(true).toBe(true);
+    });
+  });
+
+  describe('getApp — agentBindings[].name', () => {
+    test('resolves each binding name from the bound agent AGENT_CONFIG_TABLE projection (fast path)', async () => {
+      seedApp({
+        agentBindings: [
+          { agentId: AGENT_1, status: 'READY', addedAt: '2024-01-01T00:00:00Z' },
+          { agentId: AGENT_2, status: 'DESIGN', addedAt: '2024-01-02T00:00:00Z' },
+        ],
+      });
+      seedAgentCache(AGENT_1, 'Support Agent', 'org-1');
+      seedAgentCache(AGENT_2, 'Billing Agent', 'org-1');
+
+      const result = await invokeHandler(makeEvent('getApp', { appId: 'app-1' }));
+
+      expect(result.agentBindings).toHaveLength(2);
+      const byId = new Map(result.agentBindings.map((b: any) => [b.agentId, b]));
+      expect(byId.get(AGENT_1).name).toBe('Support Agent');
+      expect(byId.get(AGENT_2).name).toBe('Billing Agent');
+    });
+
+    test('leaves name unset for a binding whose agent lookup fails, without affecting others', async () => {
+      seedApp({
+        agentBindings: [
+          { agentId: AGENT_MISSING, status: 'DESIGN', addedAt: '2024-01-01T00:00:00Z' },
+          { agentId: AGENT_2, status: 'READY', addedAt: '2024-01-02T00:00:00Z' },
+        ],
+      });
+      // AGENT_MISSING is intentionally not seeded in the cache table.
+      seedAgentCache(AGENT_2, 'Billing Agent', 'org-1');
+
+      const result = await invokeHandler(makeEvent('getApp', { appId: 'app-1' }));
+
+      const byId = new Map(result.agentBindings.map((b: any) => [b.agentId, b]));
+      expect(byId.get(AGENT_MISSING).name).toBeUndefined();
+      expect(byId.get(AGENT_2).name).toBe('Billing Agent');
+    });
+
+    test('leaves name unset (falls back to raw agentId) when the bound agent belongs to a different org', async () => {
+      seedApp({
+        orgId: 'org-1',
+        agentBindings: [{ agentId: AGENT_FOREIGN, status: 'READY', addedAt: '2024-01-01T00:00:00Z' }],
+      });
+      seedAgentCache(AGENT_FOREIGN, 'Other Org Agent', 'org-2');
+
+      const result = await invokeHandler(makeEvent('getApp', { appId: 'app-1' }, { orgId: 'org-1' }));
+
+      expect(result.agentBindings[0].name).toBeUndefined();
+    });
+
+    test('resolves a binding name when the bound agent is system-shared (orgId "")', async () => {
+      seedApp({
+        orgId: 'org-1',
+        agentBindings: [{ agentId: AGENT_SHARED, status: 'READY', addedAt: '2024-01-01T00:00:00Z' }],
+      });
+      seedAgentCache(AGENT_SHARED, 'Shared Agent', '');
+
+      const result = await invokeHandler(makeEvent('getApp', { appId: 'app-1' }, { orgId: 'org-1' }));
+
+      expect(result.agentBindings[0].name).toBe('Shared Agent');
+    });
+
+    test('leaves name unset (fails CLOSED, not open) when the cached agent row has no orgId at all', async () => {
+      // Simulates a legacy/malformed cache row that predates orgId
+      // denormalization — must NOT be treated as system-shared merely
+      // because orgId is absent; only an EXPLICIT '' counts as shared.
+      seedApp({
+        orgId: 'org-1',
+        agentBindings: [{ agentId: AGENT_NO_ORG, status: 'READY', addedAt: '2024-01-01T00:00:00Z' }],
+      });
+      seedAgentCache(AGENT_NO_ORG, 'No Org Agent'); // orgId omitted entirely
+
+      const result = await invokeHandler(makeEvent('getApp', { appId: 'app-1' }, { orgId: 'org-1' }));
+
+      expect(result.agentBindings[0].name).toBeUndefined();
+    });
+
+    test('does not throw and returns bindings unresolved when there are no bindings', async () => {
+      seedApp({ agentBindings: [] });
+
+      const result = await invokeHandler(makeEvent('getApp', { appId: 'app-1' }));
+
+      expect(result.agentBindings).toEqual([]);
+      expect(batchGetCallCount).toBe(0);
+    });
+
+    test('resolves a legacy human-readable agentId to its Registry record via a single summary-list pass (slow path, not the cache table)', async () => {
+      seedApp({
+        agentBindings: [{ agentId: 'LegacySupportAgent', status: 'READY', addedAt: '2024-01-01T00:00:00Z' }],
+      });
+      seedMockRegistry('agent', 'legacyRec01', {
+        name: 'LegacySupportAgent',
+        customDescriptorContent: JSON.stringify({ orgId: 'org-1', manifest: {} }),
+      });
+
+      const result = await invokeHandler(makeEvent('getApp', { appId: 'app-1' }));
+
+      expect(result.agentBindings[0].name).toBe('LegacySupportAgent');
+      // Exactly one summary-list pass for the whole batch of legacy refs.
+      expect(getListResourceSummariesCallCount()).toBe(1);
+      // The legacy path never touches the AGENT_CONFIG_TABLE cache.
+      expect(batchGetCallCount).toBe(0);
+    });
+
+    test('duplicate bindings to the same agent, and many distinct bindings, cost exactly ONE BatchGetItem call (N+1 fix)', async () => {
+      seedApp({
+        agentBindings: [
+          { agentId: AGENT_1, status: 'READY', addedAt: '2024-01-01T00:00:00Z' },
+          { agentId: AGENT_1, status: 'READY', addedAt: '2024-01-02T00:00:00Z' },
+          { agentId: AGENT_1, status: 'READY', addedAt: '2024-01-03T00:00:00Z' },
+          { agentId: AGENT_2, status: 'READY', addedAt: '2024-01-04T00:00:00Z' },
+        ],
+      });
+      seedAgentCache(AGENT_1, 'Support Agent', 'org-1');
+      seedAgentCache(AGENT_2, 'Billing Agent', 'org-1');
+
+      const result = await invokeHandler(makeEvent('getApp', { appId: 'app-1' }));
+
+      expect(result.agentBindings).toHaveLength(4);
+      const byId = new Map(result.agentBindings.map((b: any) => [b.agentId, b]));
+      expect(byId.get(AGENT_1).name).toBe('Support Agent');
+      expect(byId.get(AGENT_2).name).toBe('Billing Agent');
+      // The whole batch — 4 bindings referencing 2 unique agents — costs
+      // exactly one BatchGetItem call requesting only the 2 unique keys.
+      expect(batchGetCallCount).toBe(1);
+      expect(batchGetKeyCount).toBe(2);
+    });
+
+    test('the number of remote reads stays bounded (1 BatchGetItem call) as distinct binding count grows', async () => {
+      const bindings = Array.from({ length: 25 }, (_, i) => ({
+        // 'agentbind' (9 chars) + zero-padded 3-digit index = 12 chars,
+        // matching the recordId shape, each unique.
+        agentId: `agentbind${i.toString().padStart(3, '0')}`,
+        status: 'READY',
+        addedAt: '2024-01-01T00:00:00Z',
+      }));
+      bindings.forEach((b, i) => seedAgentCache(b.agentId, `Agent ${i}`, 'org-1'));
+      seedApp({ agentBindings: bindings });
+
+      const result = await invokeHandler(makeEvent('getApp', { appId: 'app-1' }));
+
+      expect(result.agentBindings).toHaveLength(25);
+      expect(result.agentBindings.every((b: any) => !!b.name)).toBe(true);
+      // Bounded independent of binding count — a single BatchGetItem call.
+      expect(batchGetCallCount).toBe(1);
+      expect(batchGetKeyCount).toBe(25);
+    });
+
+    test('a rejected (not just missing) BatchGetItem call is isolated and does not affect createdByName resolution', async () => {
+      seedApp({
+        createdBy: 'user-abc-123',
+        agentBindings: [{ agentId: AGENT_1, status: 'READY', addedAt: '2024-01-01T00:00:00Z' }],
+      });
+      seedAgentCache(AGENT_1, 'Support Agent', 'org-1');
+      ddbMock.on(BatchGetCommand).rejects(new Error('ProvisionedThroughputExceededException'));
+
+      const result = await invokeHandler(makeEvent('getApp', { appId: 'app-1' }));
+
+      expect(result.agentBindings[0].name).toBeUndefined();
+      expect(result.createdByName).toBeDefined();
+    });
+
+    test('a rejected legacy-name Registry lookup is isolated and does not affect other bindings', async () => {
+      seedApp({
+        agentBindings: [
+          { agentId: 'LegacyThrowsAgent', status: 'READY', addedAt: '2024-01-01T00:00:00Z' },
+          { agentId: AGENT_2, status: 'READY', addedAt: '2024-01-02T00:00:00Z' },
+        ],
+      });
+      seedAgentCache(AGENT_2, 'Billing Agent', 'org-1');
+      // LegacyThrowsAgent is intentionally not seeded in the Registry mock,
+      // so the summary-list pass cannot resolve it to a recordId — the
+      // legacy path leaves it unresolved without throwing.
+
+      const result = await invokeHandler(makeEvent('getApp', { appId: 'app-1' }));
+
+      const byId = new Map(result.agentBindings.map((b: any) => [b.agentId, b]));
+      expect(byId.get('LegacyThrowsAgent').name).toBeUndefined();
+      expect(byId.get(AGENT_2).name).toBe('Billing Agent');
+    });
+  });
+
+  describe('getApp — tenant authorization gate', () => {
+    test('a non-admin caller from a different org gets null, with no AdminGetUser or agent-name lookups', async () => {
+      seedApp({ orgId: 'org-1', createdBy: 'user-abc-123', agentBindings: [{ agentId: AGENT_1 }] });
+      seedAgentCache(AGENT_1, 'Support Agent', 'org-1');
+
+      const result = await invokeHandler(makeEvent('getApp', { appId: 'app-1' }, { orgId: 'org-2' }));
+
+      expect(result).toBeNull();
+      expect(cognitoMock.commandCalls(AdminGetUserCommand)).toHaveLength(0);
+      expect(getGetResourceCallCount('agent', AGENT_1)).toBe(0);
+      expect(batchGetCallCount).toBe(0);
+    });
+
+    test('a non-admin caller with no org claim gets null (after the extractOrgFromEvent Cognito fallback also finds no org)', async () => {
+      seedApp({ orgId: 'org-1' });
+      // No 'custom:organization' claim on the identity — extractOrgFromEvent
+      // falls back to an AdminGetUser lookup for the caller's own org
+      // attribute (existing, pre-established behavior in auth-event.ts).
+      // That lookup legitimately runs and returns no org here (empty
+      // UserAttributes), which is what ultimately produces the denial.
+      cognitoMock.on(AdminGetUserCommand).resolves({ UserAttributes: [] });
+
+      const result = await invokeHandler(makeEvent('getApp', { appId: 'app-1' }, { orgId: undefined }));
+
+      expect(result).toBeNull();
+    });
+
+    test('a same-org caller is authorized and receives full enrichment', async () => {
+      seedApp({ orgId: 'org-1', createdBy: 'user-abc-123' });
+
+      const result = await invokeHandler(makeEvent('getApp', { appId: 'app-1' }, { orgId: 'org-1' }));
+
+      expect(result).not.toBeNull();
+      expect(result.createdByName).toBeDefined();
+    });
+
+    test('an admin caller bypasses the org check regardless of their own org', async () => {
+      seedApp({ orgId: 'org-1', createdBy: 'user-abc-123' });
+
+      const result = await invokeHandler(
+        makeEvent('getApp', { appId: 'app-1' }, { orgId: 'org-9', admin: true }),
+      );
+
+      expect(result).not.toBeNull();
+      expect(result.appId).toBe('app-1');
+    });
+  });
+
+  describe('listApps — createdByName enrichment', () => {
+    function metaRow(appId: string, orgId: string, createdBy: string) {
+      return {
+        appId,
+        orgId,
+        name: `App ${appId}`,
+        description: '',
+        status: 'DRAFT',
+        workflowIds: [],
+        routingConfig: '',
+        createdBy,
+        createdAt: '2024-01-01T00:00:00Z',
+        updatedAt: '2024-01-01T00:00:00Z',
+        version: 1,
+      };
+    }
+
+    test('org-scoped listApps enriches each row with createdByName', async () => {
+      ddbMock.on(QueryCommand).resolves({
+        Items: [metaRow('app-a', 'org-1', 'user-1')],
+        LastEvaluatedKey: undefined,
+      });
+      cognitoMock.on(AdminGetUserCommand).resolves({
+        UserAttributes: [
+          { Name: 'given_name', Value: 'Ann' },
+          { Name: 'family_name', Value: 'Lee' },
+        ],
+      });
+
+      const result = await invokeHandler(makeEvent('listApps', { orgId: 'org-1' }, { orgId: 'org-1' }));
+
+      expect(result.items).toHaveLength(1);
+      expect(result.items[0].createdByName).toBe('Ann Lee');
+    });
+
+    test('repeated creators across a page cause exactly one AdminGetUser call (concurrent dedup)', async () => {
+      ddbMock.on(QueryCommand).resolves({
+        Items: [
+          metaRow('app-a', 'org-1', 'user-1'),
+          metaRow('app-b', 'org-1', 'user-1'),
+          metaRow('app-c', 'org-1', 'user-1'),
+        ],
+        LastEvaluatedKey: undefined,
+      });
+      cognitoMock.on(AdminGetUserCommand).resolves({
+        UserAttributes: [{ Name: 'email', Value: 'user1@example.com' }],
+      });
+
+      const result = await invokeHandler(makeEvent('listApps', { orgId: 'org-1' }, { orgId: 'org-1' }));
+
+      expect(result.items).toHaveLength(3);
+      expect(result.items.every((i: any) => i.createdByName === 'user1@example.com')).toBe(true);
+      expect(cognitoMock.commandCalls(AdminGetUserCommand)).toHaveLength(1);
+    });
+
+    test('a non-admin caller requesting another org is coerced to their own org (no cross-tenant enumeration)', async () => {
+      ddbMock.on(QueryCommand).resolves({
+        Items: [metaRow('app-a', 'org-1', 'user-1')],
+        LastEvaluatedKey: undefined,
+      });
+
+      await invokeHandler(makeEvent('listApps', { orgId: 'org-2' }, { orgId: 'org-1' }));
+
+      const queryCalls = ddbMock.commandCalls(QueryCommand);
+      expect(queryCalls).toHaveLength(1);
+      expect(queryCalls[0].args[0].input.ExpressionAttributeValues).toMatchObject({
+        ':org': 'org-1',
+      });
+    });
+
+    test('a non-admin caller with no org claim gets an empty list and issues no DDB query', async () => {
+      const result = await invokeHandler(
+        makeEvent('listApps', { orgId: 'org-1' }, { orgId: undefined }),
+      );
+
+      expect(result).toEqual({ items: [], nextToken: null });
+      expect(ddbMock.commandCalls(QueryCommand)).toHaveLength(0);
+    });
+
+    test('admin "All Organizations" listApps still enriches createdByName via the scan path', async () => {
+      ddbMock.on(ScanCommand).resolves({
+        Items: [metaRow('app-a', 'org-1', 'user-1')],
+        LastEvaluatedKey: undefined,
+      });
+      cognitoMock.on(AdminGetUserCommand).resolves({
+        UserAttributes: [{ Name: 'email', Value: 'user1@example.com' }],
+      });
+
+      const result = await invokeHandler(
+        makeEvent('listApps', { orgId: 'All Organizations' }, { admin: true }),
+      );
+
+      expect(result.items).toHaveLength(1);
+      expect(result.items[0].createdByName).toBe('user1@example.com');
+    });
+
+    test('non-admin requesting "All Organizations" is still rejected', async () => {
+      await expect(
+        invokeHandler(makeEvent('listApps', { orgId: 'All Organizations' }, { orgId: 'org-1' })),
+      ).rejects.toThrow('Only admins may list apps across all organizations');
+    });
+  });
+
+  describe('warm-invocation cache reset', () => {
+    test('createdByName cache does not leak a stale name across separate invocations', async () => {
+      seedApp({ createdBy: 'user-abc-123' });
+      cognitoMock.on(AdminGetUserCommand).resolves({
+        UserAttributes: [{ Name: 'email', Value: 'first@example.com' }],
+      });
+
+      const first = await invokeHandler(makeEvent('getApp', { appId: 'app-1' }));
+      expect(first.createdByName).toBe('first@example.com');
+
+      // Simulate the user's Cognito profile changing between invocations on
+      // the same warm container.
+      cognitoMock.reset();
+      cognitoMock.on(AdminGetUserCommand).resolves({
+        UserAttributes: [{ Name: 'email', Value: 'second@example.com' }],
+      });
+
+      const second = await invokeHandler(makeEvent('getApp', { appId: 'app-1' }));
+      expect(second.createdByName).toBe('second@example.com');
+      expect(cognitoMock.commandCalls(AdminGetUserCommand)).toHaveLength(1);
+    });
+  });
+});

--- a/backend/src/lambda/__tests__/registry-agent-record-resolver-no-user-pool.test.ts
+++ b/backend/src/lambda/__tests__/registry-agent-record-resolver-no-user-pool.test.ts
@@ -1,0 +1,108 @@
+/**
+ * Dedicated test module for the "USER_POOL_ID not configured" fallback
+ * path in registry-agent-record-resolver's resolveCreatedByName.
+ *
+ * USER_POOL_ID is read into a module-level `const` at import time
+ * (`const USER_POOL_ID = process.env.USER_POOL_ID || ''`), so this scenario
+ * can only be exercised by NOT setting the env var before this file's
+ * top-level import of the resolver runs — hence a separate file rather than
+ * a test case inside registry-agent-record-resolver-name-resolution.test.ts
+ * (which sets USER_POOL_ID for its other cases before its own import).
+ */
+process.env.REGISTRY_ID = 'test-registry-id';
+process.env.APPS_TABLE = 'citadel-apps-test';
+process.env.WORKFLOWS_TABLE = 'citadel-workflows-test';
+process.env.AGENT_CONFIG_TABLE = 'citadel-agents-test';
+process.env.EVENT_BUS_NAME = 'citadel-agents-test';
+process.env.AWS_REGION = 'us-east-1';
+delete process.env.USER_POOL_ID;
+delete process.env.AUTHORITY_UNITS_TABLE;
+
+import { EventBridgeClient, PutEventsCommand } from '@aws-sdk/client-eventbridge';
+import { DynamoDBDocumentClient, ScanCommand, GetCommand } from '@aws-sdk/lib-dynamodb';
+import { CognitoIdentityProviderClient, AdminGetUserCommand } from '@aws-sdk/client-cognito-identity-provider';
+import { mockClient } from 'aws-sdk-client-mock';
+
+const ebMock = mockClient(EventBridgeClient);
+const ddbMock = mockClient(DynamoDBDocumentClient);
+const cognitoMock = mockClient(CognitoIdentityProviderClient);
+
+import { seedMockRegistry, resetMockRegistry } from './fixtures/registry-service-mock';
+
+jest.mock('../../services/registry-service', () => {
+  const { getMockRegistryService } = jest.requireActual('./fixtures/registry-service-mock');
+  return {
+    RegistryService: jest.fn().mockImplementation(() => getMockRegistryService()),
+    getRegistryService: jest.fn(() => getMockRegistryService()),
+    _resetRegistryService: jest.fn(),
+    isRegistryEnabled: jest.fn(() => true),
+  };
+});
+
+jest.mock('../../utils/appsync', () => ({
+  getUserId: jest.fn().mockReturnValue('user-123'),
+}));
+
+jest.mock('../../utils/appsync-publish', () => ({
+  publishAppStatusEvent: jest.fn().mockResolvedValue(undefined),
+}));
+
+import { handler } from '../registry-agent-record-resolver';
+
+type HandlerEvent = Parameters<typeof handler>[0];
+const invokeHandler = handler as (event: HandlerEvent) => Promise<any>;
+
+function makeEvent(fieldName: string, args: Record<string, unknown>) {
+  return {
+    info: { fieldName },
+    arguments: args,
+    identity: { sub: 'user-123', claims: { sub: 'user-123', 'custom:organization': 'org-1' } },
+  } as unknown as HandlerEvent;
+}
+
+describe('registry-agent-record-resolver — resolveCreatedByName with USER_POOL_ID unset', () => {
+  beforeEach(() => {
+    resetMockRegistry();
+    ebMock.reset();
+    ebMock.on(PutEventsCommand).resolves({});
+    ddbMock.reset();
+    ddbMock.on(ScanCommand).resolves({ Items: [], LastEvaluatedKey: undefined });
+    ddbMock.on(GetCommand).resolves({ Item: undefined });
+    cognitoMock.reset();
+
+    seedMockRegistry('agent', 'app-1', {
+      name: 'Test App',
+      description: 'Test',
+      status: 'DRAFT',
+      customDescriptorContent: JSON.stringify({
+        appId: 'app-1',
+        manifest: {
+          orgId: 'org-1',
+          createdBy: 'user-abc-123',
+          version: 1,
+          status: 'DRAFT',
+          workflowIds: [],
+          agentBindings: [],
+          permissions: [],
+          access: {},
+        },
+      }),
+    });
+  });
+
+  afterAll(() => {
+    delete process.env.APPS_TABLE;
+    delete process.env.WORKFLOWS_TABLE;
+    delete process.env.AGENT_CONFIG_TABLE;
+    delete process.env.EVENT_BUS_NAME;
+    delete process.env.AWS_REGION;
+    delete process.env.REGISTRY_ID;
+  });
+
+  test('falls back to the raw userId and makes zero AdminGetUser calls when USER_POOL_ID is unset', async () => {
+    const result = await invokeHandler(makeEvent('getApp', { appId: 'app-1' }));
+
+    expect(result.createdByName).toBe('user-abc-123');
+    expect(cognitoMock.commandCalls(AdminGetUserCommand)).toHaveLength(0);
+  });
+});

--- a/backend/src/lambda/__tests__/registry-agent-record-resolver-no-user-pool.test.ts
+++ b/backend/src/lambda/__tests__/registry-agent-record-resolver-no-user-pool.test.ts
@@ -50,7 +50,7 @@ jest.mock('../../utils/appsync-publish', () => ({
 import { handler } from '../registry-agent-record-resolver';
 
 type HandlerEvent = Parameters<typeof handler>[0];
-const invokeHandler = handler as (event: HandlerEvent) => Promise<any>;
+const invokeHandler = handler as (event: HandlerEvent) => Promise<unknown>;
 
 function makeEvent(fieldName: string, args: Record<string, unknown>) {
   return {

--- a/backend/src/lambda/__tests__/registry-sync.test.ts
+++ b/backend/src/lambda/__tests__/registry-sync.test.ts
@@ -294,6 +294,49 @@ describe('buildAgentCacheRecord', () => {
     expect(record.createdAt).toBeDefined();
     expect(record.updatedAt).toBeDefined();
   });
+
+  test('denormalizes the event resource.name onto the cache record', () => {
+    const resource = makeAgentResource({ name: 'Support Agent' } as unknown as RegistryResourcePayload);
+    const record = buildAgentCacheRecord('agent-1', resource);
+    expect(record.name).toBe('Support Agent');
+  });
+
+  test('defaults name to empty string when resource.name is absent', () => {
+    const record = buildAgentCacheRecord('agent-2', { description: 'desc' });
+    expect(record.name).toBe('');
+  });
+
+  test('denormalizes an explicit empty-string manifest orgId (system-shared) as ""', () => {
+    const resource = makeAgentResource({
+      customDescriptorContent: JSON.stringify({ orgId: '', categories: [], icon: '', state: 'active' }),
+    });
+    const record = buildAgentCacheRecord('agent-1', resource);
+    expect(record.orgId).toBe('');
+  });
+
+  test('denormalizes a specific manifest orgId', () => {
+    const resource = makeAgentResource({
+      customDescriptorContent: JSON.stringify({ orgId: 'org-1', categories: [], icon: '', state: 'active' }),
+    });
+    const record = buildAgentCacheRecord('agent-1', resource);
+    expect(record.orgId).toBe('org-1');
+  });
+
+  test('leaves orgId undefined (NOT coerced to "") when the manifest omits it entirely', () => {
+    // Fail-closed requirement: a record that merely omits orgId must not be
+    // treated as system-shared by downstream tenant checks, which only
+    // special-case an EXPLICIT empty string.
+    const resource = makeAgentResource({
+      customDescriptorContent: JSON.stringify({ categories: [], icon: '', state: 'active' }),
+    });
+    const record = buildAgentCacheRecord('agent-1', resource);
+    expect(record.orgId).toBeUndefined();
+  });
+
+  test('leaves orgId undefined when customDescriptorContent is entirely absent', () => {
+    const record = buildAgentCacheRecord('agent-1', { description: 'desc' });
+    expect(record.orgId).toBeUndefined();
+  });
 });
 
 // ---------------------------------------------------------------------------

--- a/backend/src/lambda/registry-agent-record-resolver.ts
+++ b/backend/src/lambda/registry-agent-record-resolver.ts
@@ -42,6 +42,7 @@ import { DynamoDBClient } from '@aws-sdk/client-dynamodb';
 import {
   DynamoDBDocumentClient,
   GetCommand,
+  BatchGetCommand,
   QueryCommand,
   ScanCommand,
   type NativeAttributeValue,
@@ -49,10 +50,14 @@ import {
   type ScanCommandOutput,
 } from '@aws-sdk/lib-dynamodb';
 import { EventBridgeClient, PutEventsCommand } from '@aws-sdk/client-eventbridge';
+import {
+  CognitoIdentityProviderClient,
+  AdminGetUserCommand,
+} from '@aws-sdk/client-cognito-identity-provider';
 import { v4 as uuidv4 } from 'uuid';
 import Ajv from 'ajv';
 import { getUserId } from '../utils/appsync';
-import { isAdminFromEvent } from '../utils/auth-event';
+import { isAdminFromEvent, extractOrgFromEvent } from '../utils/auth-event';
 import { publishAppStatusEvent as publishAppStatusSubscription } from '../utils/appsync-publish';
 import {
   RegistryService,
@@ -260,8 +265,16 @@ function recordFromInput(
 // ---------------------------------------------------------------------------
 
 const APPS_TABLE = process.env.APPS_TABLE!;
+// Denormalized Registry -> DynamoDB projection (kept in sync by
+// registry-sync.ts off `citadel.agentcore.*` EventBridge events). Used ONLY
+// for the agentBindings[].name enrichment's fast path: a single
+// BatchGetItem for every 12-char Registry recordId binding, instead of one
+// GetRegistryRecord Registry call per binding (the N+1 fix — see
+// resolveAgentBindingNames). Read-only; this resolver never writes here.
+const AGENT_CONFIG_TABLE = process.env.AGENT_CONFIG_TABLE || '';
 const EVENT_BUS_NAME = process.env.EVENT_BUS_NAME!;
 const DEFAULT_REGION = process.env.AWS_REGION || 'us-east-1';
+const USER_POOL_ID = process.env.USER_POOL_ID || '';
 
 /**
  * Lazy DynamoDBDocumentClient singleton. Constructed on first call — keeps the
@@ -302,6 +315,80 @@ function getRegistryService(): RegistryService {
     });
   }
   return _registryService;
+}
+
+/** Lazy CognitoIdentityProviderClient singleton for createdBy name resolution. */
+let _cognitoClient: CognitoIdentityProviderClient | undefined;
+function getCognitoClient(): CognitoIdentityProviderClient {
+  if (!_cognitoClient) {
+    _cognitoClient = new CognitoIdentityProviderClient({});
+  }
+  return _cognitoClient;
+}
+
+/**
+ * Per-invocation cache for userId -> display name lookups. Declared at
+ * module scope (so it's reachable from both getApp and metaRowToAppShape)
+ * but explicitly cleared at the top of `handler` on every invocation — a
+ * warm Lambda container must never serve a stale name from a prior request.
+ *
+ * Caches the in-flight `Promise<string>`, not just the resolved value: both
+ * `listApps` list projections (`metaRowToAppShape`) run concurrently via
+ * `Promise.all`, so multiple rows created by the SAME user all observe a
+ * cache miss before any single one resolves if only settled values were
+ * cached. Storing the promise itself means the second-and-later concurrent
+ * callers for a given userId await the SAME in-flight `AdminGetUser` call
+ * instead of issuing their own — exactly one Cognito call per unique
+ * creator per invocation, however many rows/bindings reference them.
+ */
+const createdByNameCache = new Map<string, Promise<string>>();
+
+/**
+ * Resolves a Cognito user ID to a human-readable display name via
+ * AdminGetUser. Falls back to the raw userId on any failure (missing
+ * USER_POOL_ID, user not found, Cognito error) — this must never throw,
+ * since it is a display-only enrichment and must not block getApp/listApps.
+ *
+ * Deliberately scoped to a single admin-privileged call per userId
+ * (AdminGetUser, not the unscoped ListUsers) and never exposes any Cognito
+ * attribute beyond the display name itself.
+ *
+ * Concurrency-safe: the in-flight promise is memoized (see
+ * `createdByNameCache`), so N concurrent callers for the same userId within
+ * one invocation share a single AdminGetUser call.
+ */
+async function resolveCreatedByName(userId: string | undefined | null): Promise<string> {
+  if (!userId) return 'unknown';
+  const cached = createdByNameCache.get(userId);
+  if (cached !== undefined) return cached;
+
+  const lookup = (async (): Promise<string> => {
+    if (!USER_POOL_ID) {
+      return userId;
+    }
+    try {
+      const response = await getCognitoClient().send(
+        new AdminGetUserCommand({
+          UserPoolId: USER_POOL_ID,
+          Username: userId,
+        }),
+      );
+      const attributes = response.UserAttributes || [];
+      const givenName = attributes.find((a) => a.Name === 'given_name')?.Value;
+      const familyName = attributes.find((a) => a.Name === 'family_name')?.Value;
+      const email = attributes.find((a) => a.Name === 'email')?.Value;
+      return givenName && familyName ? `${givenName} ${familyName}` : email || userId;
+    } catch (err) {
+      console.warn('resolveCreatedByName: AdminGetUser failed, falling back to userId', {
+        userId,
+        error: err instanceof Error ? err.message : String(err),
+      });
+      return userId;
+    }
+  })();
+
+  createdByNameCache.set(userId, lookup);
+  return lookup;
 }
 
 /**
@@ -366,6 +453,14 @@ interface AgentBinding {
   systemPromptAddition?: string;
   toolRestrictions?: string[];
   modelOverride?: string;
+  /**
+   * Server-resolved display name of the bound agent (Registry record's
+   * `name` field). NOT persisted in the manifest — populated at read time
+   * by `resolveAgentBindingNames` so the frontend never has to make N+1
+   * per-binding lookups. Optional because it is absent until resolution
+   * runs (e.g. write-path projections that don't call resolveAgentBindingNames).
+   */
+  name?: string;
 }
 
 /** A single permission entry stored in the manifest. */
@@ -463,6 +558,15 @@ interface ProjectedAgentApp {
   status: string;
   orgId: string;
   createdBy: string;
+  /**
+   * Server-resolved display name for `createdBy` (Cognito AdminGetUser
+   * given_name + family_name, or email, falling back to the raw userId on
+   * any lookup failure). Populated by `getApp` and `metaRowToAppShape` at
+   * read time — NEVER persisted, so it always reflects the current Cognito
+   * profile. Optional because write-path projections (createApp, updateApp,
+   * etc.) do not resolve it.
+   */
+  createdByName?: string;
   version: number;
   workflowIds: string[];
   agentBindings: AgentBinding[];
@@ -526,6 +630,200 @@ function projectAgentAppNormalized(record: RegistryRecord): ProjectedAgentApp {
   projected.appId = record.recordId;
   return projected;
 }
+
+/**
+ * Enriches each agent binding with the bound agent's `name` field so the
+ * frontend never has to resolve raw agentIds itself (eliminates the N+1
+ * per-page-load agent lookups the client used to perform).
+ *
+ * Resolution runs within THIS Lambda invocation only (no cross-Lambda
+ * calls) and is genuinely bounded independent of binding count:
+ *
+ *   - Fast path (the common case — bindings carry the Registry's own
+ *     12-char recordId): a SINGLE `BatchGetItem` against `AGENT_CONFIG_TABLE`,
+ *     the denormalized Registry->DynamoDB projection that registry-sync.ts
+ *     keeps current off EventBridge resource-change events. One DynamoDB
+ *     round trip for the whole batch of unique agent ids (DynamoDB's
+ *     100-item BatchGetItem limit is chunked, so even that stays O(ceil(n/100))
+ *     round trips rather than O(n) Registry GETs).
+ *   - Slow path (legacy human-readable agentId, not a 12-char recordId —
+ *     rare, pre-Registry-native bindings only): falls back to
+ *     `RegistryService.getResourcesByRefs`, a single shared name->recordId
+ *     summary-list pass plus one detail GET per unique legacy agent. This
+ *     path still costs real Registry reads because the installed AgentCore
+ *     Control SDK has no batch-get operation — but it is only reached for
+ *     the small, shrinking set of legacy non-recordId bindings, never for
+ *     ordinary pages of recordId-shaped bindings.
+ *
+ * Tenant validation: a binding's `name` is populated ONLY when the bound
+ * agent's own manifest orgId EXPLICITLY matches `appOrgId`, or is an
+ * EXPLICIT empty string (`orgId === ''`, the established "system-shared"
+ * convention `agent-config-resolver` also uses). An agent record whose
+ * orgId is missing/undefined (malformed or legacy metadata) is treated as
+ * belonging to neither org and FAILS CLOSED — it must never be treated as
+ * system-shared merely because the field is absent. An agent belonging to a
+ * different (non-empty) org is likewise left unresolved (name unset,
+ * callers fall back to displaying the raw agentId) rather than leaking its
+ * name across tenants.
+ *
+ * Failures (unresolvable legacy name, missing record, transient DynamoDB/
+ * Registry error, cross-org or org-less agent) are isolated per-binding and
+ * non-fatal — matching the "always fall back gracefully" constraint.
+ *
+ * Mutates and returns the same array reference for convenience.
+ */
+async function resolveAgentBindingNames(
+  bindings: AgentBinding[],
+  appOrgId: string,
+): Promise<AgentBinding[]> {
+  if (!bindings || bindings.length === 0) {
+    return bindings;
+  }
+
+  const isRecordId = (r: string) => /^[a-zA-Z0-9]{12}$/.test(r);
+  const uniqueRefs = Array.from(new Set(bindings.map((b) => b.agentId).filter((r) => !!r)));
+  const recordIdRefs = uniqueRefs.filter(isRecordId);
+  const legacyRefs = uniqueRefs.filter((r) => !isRecordId(r));
+
+  // ref -> { name, orgId } for every ref we manage to resolve, from EITHER
+  // path. `orgId` is `undefined` when the source record omitted it — kept
+  // distinct from `''` so the tenant check below fails closed correctly.
+  const resolved = new Map<string, { name: string; orgId: string | undefined }>();
+
+  await Promise.all([
+    resolveRecordIdRefsViaCache(recordIdRefs, resolved),
+    resolveLegacyRefsViaRegistry(legacyRefs, resolved),
+  ]);
+
+  // Fallback: any recordId refs not resolved from DDB cache → try the Registry directly
+  const unresolvedRecordIds = recordIdRefs.filter((r) => !resolved.has(r));
+  if (unresolvedRecordIds.length > 0) {
+    try {
+      const registry = getRegistryService();
+      const results = await Promise.allSettled(
+        unresolvedRecordIds.map((id) => registry.getResource('agent', id))
+      );
+      for (let i = 0; i < unresolvedRecordIds.length; i++) {
+        const result = results[i];
+        if (result.status === 'fulfilled' && result.value) {
+          const record = result.value;
+          const orgId = readRawManifestOrgId(record);
+          resolved.set(unresolvedRecordIds[i], { name: record.name ?? '', orgId });
+        }
+      }
+    } catch (err) {
+      console.warn('resolveAgentBindingNames: Registry fallback for unresolved recordIds failed', {
+        error: err instanceof Error ? err.message : String(err),
+      });
+    }
+  }
+
+  for (const binding of bindings) {
+    const entry = resolved.get(binding.agentId);
+    if (!entry) continue;
+    const sameOrg = entry.orgId === appOrgId || entry.orgId === '';
+    if (sameOrg && entry.name) {
+      binding.name = entry.name;
+    }
+  }
+  return bindings;
+}
+
+/** DynamoDB BatchGetItem hard limit — chunk any larger ref set. */
+const BATCH_GET_CHUNK_SIZE = 100;
+
+/**
+ * Fast path for `resolveAgentBindingNames`: resolves 12-char Registry
+ * recordId refs via BatchGetItem against the AGENT_CONFIG_TABLE projection —
+ * O(ceil(n/100)) DynamoDB round trips for the WHOLE batch, never one Registry
+ * call per binding. Populates `out` in place; never throws (falls back to
+ * leaving those refs unresolved on any table/config failure).
+ */
+async function resolveRecordIdRefsViaCache(
+  refs: string[],
+  out: Map<string, { name: string; orgId: string | undefined }>,
+): Promise<void> {
+  if (refs.length === 0 || !AGENT_CONFIG_TABLE) {
+    return;
+  }
+  try {
+    for (let i = 0; i < refs.length; i += BATCH_GET_CHUNK_SIZE) {
+      const chunk = refs.slice(i, i + BATCH_GET_CHUNK_SIZE);
+      const result = await getDocClient().send(
+        new BatchGetCommand({
+          RequestItems: {
+            [AGENT_CONFIG_TABLE]: {
+              Keys: chunk.map((agentId) => ({ agentId })),
+            },
+          },
+        }),
+      );
+      const items = result.Responses?.[AGENT_CONFIG_TABLE] ?? [];
+      for (const item of items) {
+        const agentId = item.agentId as string;
+        const name = typeof item.name === 'string' ? item.name : '';
+        const orgId = typeof item.orgId === 'string' ? item.orgId : undefined;
+        if (agentId) out.set(agentId, { name, orgId });
+      }
+    }
+  } catch (err) {
+    console.warn(
+      'resolveAgentBindingNames: BatchGetItem against AGENT_CONFIG_TABLE failed, leaving recordId bindings unset',
+      { error: err instanceof Error ? err.message : String(err) },
+    );
+  }
+}
+
+/**
+ * Slow path for `resolveAgentBindingNames`: resolves legacy human-readable
+ * agentId refs (pre-Registry-native bindings, not a 12-char recordId) via
+ * RegistryService.getResourcesByRefs — a single shared summary-list pass
+ * for the whole batch plus one detail GET per unique resolved record.
+ * Populates `out` in place; never throws.
+ */
+async function resolveLegacyRefsViaRegistry(
+  refs: string[],
+  out: Map<string, { name: string; orgId: string | undefined }>,
+): Promise<void> {
+  if (refs.length === 0) {
+    return;
+  }
+  const registry = getRegistryService();
+  try {
+    const recordsByRef = await registry.getResourcesByRefs('agent', refs);
+    for (const [ref, record] of recordsByRef.entries()) {
+      const orgId = readRawManifestOrgId(record);
+      out.set(ref, { name: record.name ?? '', orgId });
+    }
+  } catch (err) {
+    console.warn('resolveAgentBindingNames: legacy-ref batch resolution failed, leaving names unset', {
+      error: err instanceof Error ? err.message : String(err),
+    });
+  }
+}
+
+/**
+ * Reads the RAW `orgId` from a Registry record's custom metadata, preserving
+ * the "absent" (undefined) vs "explicit empty string" distinction that
+ * `RegistryService.mapToAgentConfig` deliberately collapses (its
+ * `meta.orgId ?? ''` is correct for ITS callers, which treat every org-less
+ * agent as visible — but would make this enrichment fail OPEN for any
+ * legacy/malformed record that merely omits orgId). Never throws.
+ */
+function readRawManifestOrgId(record: RegistryRecord): string | undefined {
+  try {
+    const meta = record.customDescriptorContent
+      ? JSON.parse(record.customDescriptorContent)
+      : undefined;
+    if (meta && typeof meta === 'object' && typeof meta.orgId === 'string') {
+      return meta.orgId;
+    }
+    return undefined;
+  } catch {
+    return undefined;
+  }
+}
+
 
 // ---------------------------------------------------------------------------
 // IAM action validation (preserved from app-resolver.ts)
@@ -632,6 +930,13 @@ interface RegistryResolverArguments {
 export const handler: AppSyncResolverHandler<RegistryResolverArguments, unknown> = async (event) => {
   console.log('Registry agent record resolver event:', JSON.stringify(event, null, 2));
 
+  // Clear the invocation-scoped createdByName cache. It exists to dedupe
+  // repeated AdminGetUser calls for the SAME userId across many rows WITHIN
+  // one getApp/listApps call (e.g. many apps created by the same user) —
+  // not to persist stale names across separate invocations on a warm
+  // container, which would let a Cognito profile update go unreflected.
+  createdByNameCache.clear();
+
   const { info, arguments: args, identity } = event;
   const fieldName = info.fieldName;
   const userId = getUserId(identity);
@@ -640,7 +945,7 @@ export const handler: AppSyncResolverHandler<RegistryResolverArguments, unknown>
     switch (fieldName) {
       // AgentApp-shape queries (registry-backed)
       case 'getApp':
-        return await getApp(args.appId, userId);
+        return await getApp(args.appId, userId, event);
       case 'listApps':
         return await listApps(args.orgId, userId, event);
 
@@ -708,7 +1013,7 @@ export const handler: AppSyncResolverHandler<RegistryResolverArguments, unknown>
 // Registry-backed (AgentApp-shape) handlers
 // ===========================================================================
 
-async function getApp(appId: string, _userId: string): Promise<unknown> {
+async function getApp(appId: string, _userId: string, event: unknown): Promise<unknown> {
   let record;
   try {
     record = await getRegistryService().getResource('agent', appId);
@@ -722,6 +1027,21 @@ async function getApp(appId: string, _userId: string): Promise<unknown> {
     return null;
   }
   const projected = projectAgentApp(record);
+
+  // Tenant gate — MUST run before any Cognito/agent-name enrichment (both of
+  // which are privileged, PII-bearing lookups) and before returning the
+  // record at all. The AppSync mapping for getApp is a direct Lambda
+  // pass-through with no upstream authorization, so this resolver is the
+  // only place that can enforce it. Admins bypass; everyone else must
+  // belong to the app's own org. A denied caller sees the same "not found"
+  // shape as a missing app — this must not distinguish "exists in another
+  // org" from "doesn't exist" (that distinction is itself a disclosure).
+  if (!isAdminFromEvent(event)) {
+    const callerOrgId = await extractOrgFromEvent(event);
+    if (!callerOrgId || callerOrgId !== projected.orgId) {
+      return null;
+    }
+  }
 
   // Merge publish-time fields from the AppsTable (DDB is authoritative for
   // status, endpointUrl, apiId after publishApp runs).
@@ -741,6 +1061,20 @@ async function getApp(appId: string, _userId: string): Promise<unknown> {
     // DDB read failure is non-fatal — return Registry-only projection.
   }
 
+  // Server-side resolution of createdBy -> display name and per-binding
+  // agent names — runs in parallel since they hit independent backends
+  // (Cognito vs Registry) and neither result depends on the other. Both
+  // helpers are individually fail-safe (fall back to the raw id), so no
+  // try/catch is needed here. Only reached once the tenant gate above has
+  // authorized this caller for this app's org, so it's safe to call
+  // AdminGetUser and resolve bound-agent names here.
+  await Promise.all([
+    resolveCreatedByName(projected.createdBy).then((name) => {
+      projected.createdByName = name;
+    }),
+    resolveAgentBindingNames(projected.agentBindings, projected.orgId),
+  ]);
+
   // Always return the 12-char recordId as appId (not the UUID from customDescriptorContent).
   projected.appId = appId;
 
@@ -753,8 +1087,25 @@ async function listApps(
   event: unknown,
 ): Promise<{ items: unknown[]; nextToken: string | null }> {
   const isAllOrgsRequest = !orgId || orgId === 'All Organizations';
-  if (isAllOrgsRequest && !isAdminFromEvent(event)) {
+  const admin = isAdminFromEvent(event);
+  if (isAllOrgsRequest && !admin) {
     throw new Error('Only admins may list apps across all organizations');
+  }
+
+  // Tenant gate for a specific-org request: a non-admin caller may only
+  // list their OWN org's apps. Silently coerce a mismatched requested orgId
+  // to the caller's actual org rather than trusting the argument outright —
+  // AppSync has no upstream authorization for this field (direct Lambda
+  // pass-through), so a non-admin could otherwise pass an arbitrary orgId
+  // and enumerate another tenant's apps (plus trigger AdminGetUser /
+  // agent-name enrichment for each one).
+  let effectiveOrgId = orgId;
+  if (!isAllOrgsRequest && !admin) {
+    const callerOrgId = await extractOrgFromEvent(event);
+    if (!callerOrgId) {
+      return { items: [], nextToken: null };
+    }
+    effectiveOrgId = callerOrgId;
   }
 
   // Phase 3: read from the AppsTable.OrgIndex GSI rather than scanning the
@@ -764,7 +1115,7 @@ async function listApps(
   if (isAllOrgsRequest) {
     return await scanAllAppsViaMeta();
   }
-  return await queryAppsViaOrgIndex(orgId);
+  return await queryAppsViaOrgIndex(effectiveOrgId);
 }
 
 /**
@@ -793,7 +1144,7 @@ async function queryAppsViaOrgIndex(
         ExclusiveStartKey: nextToken,
       }),
     );
-    if (result.Items) items.push(...result.Items.map(metaRowToAppShape));
+    if (result.Items) items.push(...(await Promise.all(result.Items.map(metaRowToAppShape))));
     nextToken = result.LastEvaluatedKey;
   } while (nextToken);
   return { items, nextToken: null };
@@ -821,7 +1172,7 @@ async function scanAllAppsViaMeta(): Promise<{
         ExclusiveStartKey: nextToken,
       }),
     );
-    if (result.Items) items.push(...result.Items.map(metaRowToAppShape));
+    if (result.Items) items.push(...(await Promise.all(result.Items.map(metaRowToAppShape))));
     nextToken = result.LastEvaluatedKey;
   } while (nextToken);
   return { items, nextToken: null };
@@ -831,8 +1182,14 @@ async function scanAllAppsViaMeta(): Promise<{
  * Projects a single AppsTable `#META` row onto the AgentApp-shape response
  * used by listApps. Field defaults match the Registry-backed projection so
  * callers see no behavioural difference between the two read paths.
+ *
+ * Resolves `createdByName` via Cognito AdminGetUser (same helper getApp
+ * uses), sharing the invocation-scoped `createdByNameCache` — rows created
+ * by the same user across a page of listApps results incur only one
+ * AdminGetUser call, not one per row.
  */
-function metaRowToAppShape(row: Record<string, unknown>): Record<string, unknown> {
+async function metaRowToAppShape(row: Record<string, unknown>): Promise<Record<string, unknown>> {
+  const createdBy = (row.createdBy as string) ?? '';
   return {
     appId: row.appId,
     orgId: row.orgId ?? '',
@@ -841,7 +1198,8 @@ function metaRowToAppShape(row: Record<string, unknown>): Record<string, unknown
     status: row.status ?? 'DRAFT',
     workflowIds: row.workflowIds ?? [],
     routingConfig: row.routingConfig ?? '',
-    createdBy: row.createdBy ?? '',
+    createdBy,
+    createdByName: await resolveCreatedByName(createdBy),
     createdAt: row.createdAt ?? '',
     updatedAt: row.updatedAt ?? '',
     version: typeof row.version === 'number' ? row.version : 1,

--- a/backend/src/lambda/registry-sync.ts
+++ b/backend/src/lambda/registry-sync.ts
@@ -51,6 +51,7 @@ export type EventType = 'CREATED' | 'UPDATED' | 'DELETED' | 'STATUS_CHANGED';
  */
 export interface RegistryResourcePayload {
   [key: string]: unknown;
+  name?: string;
   description?: string;
   customDescriptorContent?: string | null;
   createdAt?: string | number;
@@ -188,6 +189,12 @@ const AGENT_METADATA_DEFAULTS = {
   state: 'active' as string,
   appId: undefined as string | undefined,
   manifest: undefined as Record<string, unknown> | undefined,
+  // Deliberately `undefined`, NOT `''` — the cache-record builder below must
+  // distinguish "no orgId in the manifest at all" (undefined, e.g. a
+  // malformed/legacy record) from "explicitly system-shared" (''), mirroring
+  // RegistryService.AGENT_METADATA_DEFAULTS. Collapsing the two would let a
+  // record that merely omits orgId fail OPEN as globally visible.
+  orgId: undefined as string | undefined,
 };
 
 const TOOL_METADATA_DEFAULTS = {
@@ -253,6 +260,20 @@ export type AgentCacheRecord = {
   manifest: Record<string, unknown> | undefined;
   createdAt: string;
   updatedAt: string;
+  /**
+   * Registry record `name` (from the event's `resource.name`), denormalized
+   * here so registry-agent-record-resolver's agentBindings[].name enrichment
+   * can resolve names via a single BatchGetItem against this table instead
+   * of one Registry GetRegistryRecord per binding (the N+1 fix).
+   */
+  name: string;
+  /**
+   * The agent's own manifest orgId, denormalized for the same reason. Kept
+   * as `undefined` (NOT coerced to `''`) when the source manifest omits
+   * orgId entirely — the resolver's tenant check must treat "no orgId"
+   * as NOT system-shared, only an explicit `''` counts as shared.
+   */
+  orgId: string | undefined;
 };
 
 /**
@@ -292,6 +313,8 @@ export function buildAgentCacheRecord(
     icon: meta.icon,
     appId: meta.appId,
     manifest: meta.manifest,
+    name: typeof resource.name === 'string' ? resource.name : '',
+    orgId: meta.orgId,
     createdAt: resource.createdAt
       ? new Date(resource.createdAt).toISOString()
       : new Date().toISOString(),

--- a/backend/src/schema/schema.graphql
+++ b/backend/src/schema/schema.graphql
@@ -1701,6 +1701,12 @@ type RegistryAgentBinding @aws_iam @aws_cognito_user_pools {
   toolRestrictions: [String]
   modelOverride: String
   addedAt: AWSDateTime!
+  # Server-resolved display name of the bound agent (Registry record's
+  # `name` field), populated at read time by registry-agent-record-resolver
+  # so the frontend never has to resolve raw agentIds via N+1 lookups.
+  # Nullable — absent when the underlying agent lookup fails (e.g. deleted
+  # agent); callers fall back to `agentId` for display.
+  name: String
 }
 
 type RegistryAgentRecordPermission @aws_iam @aws_cognito_user_pools {
@@ -1753,6 +1759,13 @@ type RegistryAgentRecord @aws_iam @aws_cognito_user_pools {
   workflowIds: [String!]
   routingConfig: AWSJSON
   createdBy: String!
+  # Server-resolved display name for `createdBy` (Cognito given_name +
+  # family_name, or email, falling back to the raw userId on lookup
+  # failure). Resolved at read time by registry-agent-record-resolver via
+  # AdminGetUser — NEVER persisted, so it always reflects the current
+  # Cognito profile. Nullable for the same reason: a lookup failure leaves
+  # this unset and callers fall back to `createdBy`.
+  createdByName: String
   createdAt: AWSDateTime!
   updatedAt: AWSDateTime!
   version: Int!

--- a/backend/src/services/__tests__/registry-service-batch-name-resolution.test.ts
+++ b/backend/src/services/__tests__/registry-service-batch-name-resolution.test.ts
@@ -1,0 +1,292 @@
+/**
+ * Unit tests for RegistryService's batch name-resolution surface:
+ *  - listResourceSummaries: a single-pass ListRegistryRecords list with NO
+ *    per-record detail GET (unlike listResources, which fetches full detail
+ *    for every summary to apply its type filter).
+ *  - getResourcesByRefs: resolves a batch of agent references (12-char
+ *    recordIds OR legacy human-readable names) to their full records, keyed
+ *    by the original ref string, deduplicating both the summary-list call
+ *    and the per-record detail GETs.
+ *
+ * These back the registry-agent-record-resolver's agentBindings[].name
+ * enrichment (the N+1 fix).
+ */
+import {
+  BedrockAgentCoreControlClient,
+  GetRegistryRecordCommand,
+  ListRegistryRecordsCommand,
+  DescriptorType,
+} from '@aws-sdk/client-bedrock-agentcore-control';
+import { mockClient } from 'aws-sdk-client-mock';
+import { RegistryService } from '../registry-service';
+
+const sdkMock = mockClient(BedrockAgentCoreControlClient);
+
+describe('RegistryService — listResourceSummaries', () => {
+  let service: RegistryService;
+
+  beforeEach(() => {
+    sdkMock.reset();
+    service = new RegistryService({ registryId: 'test-registry', region: 'us-east-1' });
+    jest.spyOn(console, 'warn').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  it('returns summaries WITHOUT issuing a GetRegistryRecord per record', async () => {
+    sdkMock.on(ListRegistryRecordsCommand).resolves({
+      registryRecords: [
+        {
+          registryArn: 'arn:1',
+          recordArn: 'arn:1/r1',
+          recordId: 'recordidone1',
+          name: 'Agent One',
+          descriptorType: DescriptorType.CUSTOM,
+          recordVersion: '1',
+          status: 'APPROVED',
+          createdAt: new Date(),
+          updatedAt: new Date(),
+        },
+        {
+          registryArn: 'arn:1',
+          recordArn: 'arn:1/r2',
+          recordId: 'recordidtwo2',
+          name: 'Agent Two',
+          descriptorType: DescriptorType.CUSTOM,
+          recordVersion: '1',
+          status: 'APPROVED',
+          createdAt: new Date(),
+          updatedAt: new Date(),
+        },
+      ],
+      nextToken: undefined,
+    });
+
+    const summaries = await service.listResourceSummaries();
+
+    expect(summaries).toHaveLength(2);
+    expect(summaries.map((s) => s.recordId)).toEqual(['recordidone1', 'recordidtwo2']);
+    expect(sdkMock.commandCalls(GetRegistryRecordCommand)).toHaveLength(0);
+  });
+
+  it('pages through nextToken, issuing exactly one ListRegistryRecords call per page', async () => {
+    sdkMock
+      .on(ListRegistryRecordsCommand)
+      .resolvesOnce({
+        registryRecords: [
+          {
+            registryArn: 'arn:1',
+            recordArn: 'arn:1/r1',
+            recordId: 'recordidone1',
+            name: 'Agent One',
+            descriptorType: DescriptorType.CUSTOM,
+            recordVersion: '1',
+            status: 'APPROVED',
+            createdAt: new Date(),
+            updatedAt: new Date(),
+          },
+        ],
+        nextToken: 'page2',
+      })
+      .resolvesOnce({
+        registryRecords: [
+          {
+            registryArn: 'arn:1',
+            recordArn: 'arn:1/r2',
+            recordId: 'recordidtwo2',
+            name: 'Agent Two',
+            descriptorType: DescriptorType.CUSTOM,
+            recordVersion: '1',
+            status: 'APPROVED',
+            createdAt: new Date(),
+            updatedAt: new Date(),
+          },
+        ],
+        nextToken: undefined,
+      });
+
+    const summaries = await service.listResourceSummaries();
+
+    expect(summaries).toHaveLength(2);
+    expect(sdkMock.commandCalls(ListRegistryRecordsCommand)).toHaveLength(2);
+  });
+});
+
+describe('RegistryService — getResourcesByRefs', () => {
+  let service: RegistryService;
+
+  beforeEach(() => {
+    sdkMock.reset();
+    service = new RegistryService({ registryId: 'test-registry', region: 'us-east-1' });
+    jest.spyOn(console, 'warn').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  it('returns an empty map for an empty refs array without calling the SDK', async () => {
+    const result = await service.getResourcesByRefs('agent', []);
+    expect(result.size).toBe(0);
+    expect(sdkMock.commandCalls(ListRegistryRecordsCommand)).toHaveLength(0);
+    expect(sdkMock.commandCalls(GetRegistryRecordCommand)).toHaveLength(0);
+  });
+
+  it('resolves a 12-char recordId ref directly with a single GetRegistryRecord and no ListRegistryRecords call', async () => {
+    sdkMock.on(GetRegistryRecordCommand).resolves({
+      recordId: 'recordidone1',
+      name: 'Agent One',
+      status: 'APPROVED',
+      descriptors: { custom: { inlineContent: '{"manifest":{}}' } },
+      createdAt: new Date(),
+      updatedAt: new Date(),
+    });
+
+    const result = await service.getResourcesByRefs('agent', ['recordidone1']);
+
+    expect(result.get('recordidone1')?.name).toBe('Agent One');
+    expect(sdkMock.commandCalls(ListRegistryRecordsCommand)).toHaveLength(0);
+    expect(sdkMock.commandCalls(GetRegistryRecordCommand)).toHaveLength(1);
+  });
+
+  it('resolves a legacy human-readable name via exactly one ListRegistryRecords pass, then one GetRegistryRecord', async () => {
+    sdkMock.on(ListRegistryRecordsCommand).resolves({
+      registryRecords: [
+        {
+          registryArn: 'arn:1',
+          recordArn: 'arn:1/r1',
+          recordId: 'recordidone1',
+          name: 'LegacyAgentName',
+          descriptorType: DescriptorType.CUSTOM,
+          recordVersion: '1',
+          status: 'APPROVED',
+          createdAt: new Date(),
+          updatedAt: new Date(),
+        },
+      ],
+      nextToken: undefined,
+    });
+    sdkMock.on(GetRegistryRecordCommand).resolves({
+      recordId: 'recordidone1',
+      name: 'LegacyAgentName',
+      status: 'APPROVED',
+      descriptors: { custom: { inlineContent: '{"manifest":{}}' } },
+      createdAt: new Date(),
+      updatedAt: new Date(),
+    });
+
+    const result = await service.getResourcesByRefs('agent', ['LegacyAgentName']);
+
+    expect(result.get('LegacyAgentName')?.recordId).toBe('recordidone1');
+    expect(sdkMock.commandCalls(ListRegistryRecordsCommand)).toHaveLength(1);
+    expect(sdkMock.commandCalls(GetRegistryRecordCommand)).toHaveLength(1);
+  });
+
+  it('deduplicates repeated refs to the same recordId into exactly one GetRegistryRecord call', async () => {
+    sdkMock.on(GetRegistryRecordCommand).resolves({
+      recordId: 'recordidone1',
+      name: 'Agent One',
+      status: 'APPROVED',
+      descriptors: { custom: { inlineContent: '{"manifest":{}}' } },
+      createdAt: new Date(),
+      updatedAt: new Date(),
+    });
+
+    const result = await service.getResourcesByRefs('agent', [
+      'recordidone1',
+      'recordidone1',
+      'recordidone1',
+    ]);
+
+    expect(result.get('recordidone1')?.name).toBe('Agent One');
+    expect(sdkMock.commandCalls(GetRegistryRecordCommand)).toHaveLength(1);
+  });
+
+  it('does NOT issue a ListRegistryRecords call when every ref is already a 12-char recordId', async () => {
+    sdkMock.on(GetRegistryRecordCommand).callsFake(async (input: { recordId: string }) => ({
+      recordId: input.recordId,
+      name: `Name-${input.recordId}`,
+      status: 'APPROVED',
+      descriptors: { custom: { inlineContent: '{"manifest":{}}' } },
+      createdAt: new Date(),
+      updatedAt: new Date(),
+    }));
+
+    const result = await service.getResourcesByRefs('agent', ['recordidone1', 'recordidtwo2']);
+
+    expect(result.size).toBe(2);
+    expect(sdkMock.commandCalls(ListRegistryRecordsCommand)).toHaveLength(0);
+  });
+
+  it('drops (does not throw for) a ref whose GetRegistryRecord call rejects, leaving other refs intact', async () => {
+    sdkMock.on(GetRegistryRecordCommand).callsFake(async (input: { recordId: string }) => {
+      if (input.recordId === 'recordidbad1') {
+        throw new Error('Registry transient error');
+      }
+      return {
+        recordId: input.recordId,
+        name: 'Good Agent',
+        status: 'APPROVED',
+        descriptors: { custom: { inlineContent: '{"manifest":{}}' } },
+        createdAt: new Date(),
+        updatedAt: new Date(),
+      };
+    });
+
+    const result = await service.getResourcesByRefs('agent', ['recordidbad1', 'recordidok01']);
+
+    expect(result.has('recordidbad1')).toBe(false);
+    expect(result.get('recordidok01')?.name).toBe('Good Agent');
+  });
+
+  it('drops a ref whose legacy name has no match in the summary list', async () => {
+    sdkMock.on(ListRegistryRecordsCommand).resolves({ registryRecords: [], nextToken: undefined });
+
+    const result = await service.getResourcesByRefs('agent', ['NoSuchAgentName']);
+
+    expect(result.size).toBe(0);
+    expect(sdkMock.commandCalls(GetRegistryRecordCommand)).toHaveLength(0);
+  });
+
+  it('resolves a mixed batch of recordId and legacy-name refs with one summary pass and one GET per unique record', async () => {
+    sdkMock.on(ListRegistryRecordsCommand).resolves({
+      registryRecords: [
+        {
+          registryArn: 'arn:1',
+          recordArn: 'arn:1/r2',
+          recordId: 'recordidtwo2',
+          name: 'LegacyAgentName',
+          descriptorType: DescriptorType.CUSTOM,
+          recordVersion: '1',
+          status: 'APPROVED',
+          createdAt: new Date(),
+          updatedAt: new Date(),
+        },
+      ],
+      nextToken: undefined,
+    });
+    sdkMock.on(GetRegistryRecordCommand).callsFake(async (input: { recordId: string }) => {
+      const names: Record<string, string> = {
+        recordidone1: 'Direct Agent',
+        recordidtwo2: 'LegacyAgentName',
+      };
+      return {
+        recordId: input.recordId,
+        name: names[input.recordId] ?? 'Unknown',
+        status: 'APPROVED',
+        descriptors: { custom: { inlineContent: '{"manifest":{}}' } },
+        createdAt: new Date(),
+        updatedAt: new Date(),
+      };
+    });
+
+    const result = await service.getResourcesByRefs('agent', ['recordidone1', 'LegacyAgentName']);
+
+    expect(result.get('recordidone1')?.name).toBe('Direct Agent');
+    expect(result.get('LegacyAgentName')?.name).toBe('LegacyAgentName');
+    expect(sdkMock.commandCalls(ListRegistryRecordsCommand)).toHaveLength(1);
+    expect(sdkMock.commandCalls(GetRegistryRecordCommand)).toHaveLength(2);
+  });
+});

--- a/backend/src/services/registry-service.ts
+++ b/backend/src/services/registry-service.ts
@@ -909,6 +909,121 @@ export class RegistryService {
   }
 
   /**
+   * Lists CUSTOM-descriptor registry record summaries in a SINGLE pass of
+   * `ListRegistryRecords` pagination — deliberately does NOT follow up with
+   * a `GetRegistryRecord` per record (unlike `listResources`, which issues
+   * one detail GET per summary just to apply its type filter).
+   *
+   * Summaries carry `recordId`/`name`/`status` but never
+   * `customDescriptorContent` (org/manifest data), so this is only suitable
+   * for cheap id<->name lookups (e.g. batch display-name resolution). Callers
+   * needing manifest content (org validation, bindings, etc.) must follow up
+   * with `getResource` for the specific records they actually need — but
+   * critically, only for the deduped subset they care about, not the full
+   * registry.
+   */
+  async listResourceSummaries(): Promise<RegistryRecordSummary[]> {
+    const summaries: RegistryRecordSummary[] = [];
+    let nextToken: string | undefined;
+    do {
+      const result: ListRegistryRecordsCommandOutput = await this.withRetry(() =>
+        this.client.send(
+          new ListRegistryRecordsCommand({
+            registryId: this.registryId,
+            descriptorType: 'CUSTOM',
+            nextToken,
+          }),
+        ),
+      );
+      if (result.registryRecords) {
+        summaries.push(...result.registryRecords);
+      }
+      nextToken = result.nextToken;
+    } while (nextToken);
+    return summaries;
+  }
+
+  /**
+   * Batch-resolves a set of agent references — each may be a 12-char
+   * Registry recordId OR a legacy human-readable name — to their full
+   * `RegistryRecord`s, keyed by the ORIGINAL reference string passed in.
+   *
+   * Cost profile (the N+1 fix): at most ONE `listResourceSummaries` call
+   * total (shared across every legacy-name reference in the batch, and only
+   * issued at all if at least one reference isn't already a 12-char id),
+   * plus exactly one `getResource` detail GET per UNIQUE resolved recordId
+   * (deduplicated — repeated bindings to the same agent cost one GET, not
+   * one per binding).
+   *
+   * Per-reference failures (unresolvable name, missing record, transient
+   * Registry error) are isolated: the failing key is simply absent from the
+   * returned map so callers can fall back gracefully, matching this
+   * codebase's "never throw on a display-only lookup" convention.
+   */
+  async getResourcesByRefs(
+    type: ResourceType,
+    refs: string[],
+  ): Promise<Map<string, RegistryRecord>> {
+    const uniqueRefs = Array.from(new Set(refs.filter((r) => !!r)));
+    const result = new Map<string, RegistryRecord>();
+    if (uniqueRefs.length === 0) return result;
+
+    const isRecordId = (r: string) => /^[a-zA-Z0-9]{12}$/.test(r);
+    const needsNameResolution = uniqueRefs.some((r) => !isRecordId(r));
+
+    // Single shared summary list for every legacy-name reference in the
+    // batch — NOT one list call per reference.
+    let nameToRecordId: Map<string, string> | undefined;
+    if (needsNameResolution) {
+      const summaries = await this.listResourceSummaries();
+      nameToRecordId = new Map(
+        summaries
+          .filter((s) => s.recordId && s.name)
+          .map((s) => [s.name as string, s.recordId as string]),
+      );
+    }
+
+    // ref -> resolved recordId (or undefined if unresolvable).
+    const refToRecordId = new Map<string, string | undefined>();
+    for (const ref of uniqueRefs) {
+      if (isRecordId(ref)) {
+        refToRecordId.set(ref, ref);
+      } else {
+        refToRecordId.set(ref, nameToRecordId?.get(ref));
+      }
+    }
+
+    // Dedupe by resolved recordId so an agent bound under multiple refs (or
+    // a batch with duplicate bindings) is fetched exactly once.
+    const uniqueRecordIds = Array.from(
+      new Set(Array.from(refToRecordId.values()).filter((id): id is string => !!id)),
+    );
+    const recordIdToRecord = new Map<string, RegistryRecord>();
+    await Promise.all(
+      uniqueRecordIds.map(async (recordId) => {
+        try {
+          const record = await this.getResource(type, recordId);
+          if (record) recordIdToRecord.set(recordId, record);
+        } catch (err) {
+          console.warn('getResourcesByRefs: getResource failed, dropping ref', {
+            type,
+            recordId,
+            error: err instanceof Error ? err.message : String(err),
+          });
+        }
+      }),
+    );
+
+    for (const [ref, recordId] of refToRecordId.entries()) {
+      if (!recordId) continue;
+      const record = recordIdToRecord.get(recordId);
+      if (record) result.set(ref, record);
+    }
+
+    return result;
+  }
+
+  /**
    * Helper to map a RegistryRecordSummary to our RegistryRecord shape.
    * Note: summaries from ListRegistryRecords do not include custom
    * descriptor content — callers needing that must follow up with getResource.

--- a/backend/test/backend-stack-workflows.test.ts
+++ b/backend/test/backend-stack-workflows.test.ts
@@ -71,6 +71,7 @@ describe('BackendStack — Workflow/App/Execution Lambda functions and AppSync w
           Variables: Match.objectLike({
             APPS_TABLE: Match.anyValue(),
             WORKFLOWS_TABLE: Match.anyValue(),
+            AGENT_CONFIG_TABLE: Match.anyValue(),
             EVENT_BUS_NAME: Match.anyValue(),
             USER_POOL_ID: Match.anyValue(),
           }),
@@ -248,6 +249,63 @@ describe('BackendStack — Workflow/App/Execution Lambda functions and AppSync w
           ]),
         },
       });
+    });
+
+    test('RegistryAgentRecordResolver is granted EXACTLY cognito-idp:AdminGetUser, scoped to the concrete UserPool ARN (not a broader/wildcard grant)', () => {
+      // Locate the resolver's own IAM role via its Lambda function properties.
+      const functions = template.findResources('AWS::Lambda::Function', {
+        Properties: { Handler: 'registry-agent-record-resolver.handler' },
+      });
+      const fnLogicalId = Object.keys(functions)[0];
+      expect(fnLogicalId).toBeDefined();
+      const roleRef = functions[fnLogicalId].Properties.Role;
+      // Role is always `{ 'Fn::GetAtt': [ '<RoleLogicalId>', 'Arn' ] }`.
+      const roleLogicalId = roleRef?.['Fn::GetAtt']?.[0];
+      expect(roleLogicalId).toBeDefined();
+
+      // Find the IAM::Policy attached to that exact role that grants
+      // cognito-idp:AdminGetUser, and assert the statement is scoped to a
+      // single resource referencing the UserPool construct's Arn — never a
+      // wildcard ('*') and never bundled with a broader/unscoped action
+      // (e.g. ListUsers) in the same statement.
+      const policies = template.findResources('AWS::IAM::Policy');
+      const matchingStatements = Object.values(policies).flatMap((p: any) => {
+        const roles = p.Properties?.Roles || [];
+        const attachedToResolver = roles.some((r: any) => r?.Ref === roleLogicalId);
+        if (!attachedToResolver) return [];
+        const statements = p.Properties?.PolicyDocument?.Statement || [];
+        return statements.filter((s: any) => {
+          const actions = Array.isArray(s.Action) ? s.Action : [s.Action];
+          return actions.includes('cognito-idp:AdminGetUser');
+        });
+      });
+
+      expect(matchingStatements.length).toBeGreaterThan(0);
+      for (const statement of matchingStatements) {
+        // Exactly this one action in the statement — not broadened to
+        // ListUsers or any other cognito-idp action.
+        const actions = Array.isArray(statement.Action) ? statement.Action : [statement.Action];
+        expect(actions).toEqual(['cognito-idp:AdminGetUser']);
+
+        const resources = Array.isArray(statement.Resource)
+          ? statement.Resource
+          : [statement.Resource];
+        // Never a bare wildcard.
+        expect(resources).not.toContain('*');
+        // Scoped to a concrete resource reference (GetAtt/Ref/Fn::Join off
+        // the UserPool construct), not a hand-written ARN string that could
+        // silently drift from the real pool.
+        const isConcreteUserPoolRef = resources.some((r: any) => {
+          if (typeof r === 'string') return false; // no literal ARN strings
+          const getAttTarget = r?.['Fn::GetAtt']?.[0];
+          const joinParts = r?.['Fn::Join']?.[1];
+          const joinReferencesUserPool =
+            Array.isArray(joinParts) &&
+            joinParts.some((part: any) => part?.Ref?.includes('UserPool') || part?.['Fn::GetAtt']?.[0]?.includes('UserPool'));
+          return (typeof getAttTarget === 'string' && getAttTarget.includes('UserPool')) || joinReferencesUserPool;
+        });
+        expect(isConcreteUserPoolRef).toBe(true);
+      }
     });
 
     test('WorkflowProgressFanout has appsync:GraphQL permission for publishWorkflowProgress', () => {

--- a/frontend/src/components/UserDisplayName.tsx
+++ b/frontend/src/components/UserDisplayName.tsx
@@ -1,0 +1,42 @@
+/**
+ * UserDisplayName Component
+ *
+ * A drop-in component that resolves a user ID (GUID) to a human-readable name.
+ * Use this anywhere a user ID might be displayed to prevent raw GUIDs in the UI.
+ *
+ * Usage:
+ *   <UserDisplayName userId={app.createdBy} />
+ *   <UserDisplayName userId={app.createdBy} fallback="System" />
+ *   <UserDisplayName userId={app.createdBy} prefix="Created by " />
+ */
+import { useUserDisplayName } from '../hooks/useUserDisplayName';
+
+interface UserDisplayNameProps {
+  /** The user ID (GUID) to resolve to a display name */
+  userId: string | undefined | null;
+  /** Optional prefix text (e.g., "Created by ") */
+  prefix?: string;
+  /** Optional suffix text */
+  suffix?: string;
+  /** Fallback text when userId is null/undefined. Default: "unknown" */
+  fallback?: string;
+  /** Optional CSS class name for the wrapping span */
+  className?: string;
+}
+
+export function UserDisplayName({
+  userId,
+  prefix = '',
+  suffix = '',
+  fallback = 'unknown',
+  className,
+}: UserDisplayNameProps) {
+  const displayName = useUserDisplayName(userId);
+  const text = userId ? displayName : fallback;
+
+  return (
+    <span className={className}>
+      {prefix}{text}{suffix}
+    </span>
+  );
+}

--- a/frontend/src/hooks/__tests__/useUserDisplayName.test.ts
+++ b/frontend/src/hooks/__tests__/useUserDisplayName.test.ts
@@ -1,0 +1,215 @@
+/**
+ * Tests for useUserDisplayName hook
+ */
+import { renderHook, waitFor, act } from '@testing-library/react';
+import { useUserDisplayName, isUserId, formatUserDisplayName, clearUserDisplayNameCache } from '../useUserDisplayName';
+
+// Mock the userManagementService
+jest.mock('../../services/userManagementService', () => ({
+  userManagementService: {
+    getUser: jest.fn(),
+    listUsers: jest.fn(),
+  },
+}));
+
+import { userManagementService } from '../../services/userManagementService';
+
+const mockGetUser = userManagementService.getUser as jest.MockedFunction<typeof userManagementService.getUser>;
+const mockListUsers = userManagementService.listUsers as jest.MockedFunction<typeof userManagementService.listUsers>;
+
+describe('useUserDisplayName', () => {
+  beforeEach(() => {
+    clearUserDisplayNameCache();
+    mockGetUser.mockReset();
+    mockListUsers.mockReset();
+    // Default: bulk load returns empty list (individual getUser will be used)
+    mockListUsers.mockResolvedValue([]);
+  });
+
+  it('returns "unknown" for null/undefined userId', () => {
+    const { result } = renderHook(() => useUserDisplayName(null));
+    expect(result.current).toBe('unknown');
+  });
+
+  it('returns the userId as-is when it is not a UUID', () => {
+    const { result } = renderHook(() => useUserDisplayName('John Doe'));
+    expect(result.current).toBe('John Doe');
+  });
+
+  it('resolves a UUID userId to a display name', async () => {
+    const userId = 'e9fe7448-60d1-7021-2c07-b58fd0c23d16';
+    mockGetUser.mockResolvedValueOnce({
+      userId,
+      email: 'jane@example.com',
+      name: 'Jane Smith',
+      givenName: 'Jane',
+      familyName: 'Smith',
+      status: 'CONFIRMED',
+      createdAt: '2024-01-01',
+      enabled: true,
+    });
+
+    const { result } = renderHook(() => useUserDisplayName(userId));
+
+    // Initially shows empty string (no GUID flash)
+    expect(result.current).toBe('');
+
+    // After resolution, shows the full name
+    await waitFor(() => {
+      expect(result.current).toBe('Jane Smith');
+    });
+
+    expect(mockGetUser).toHaveBeenCalledWith(userId);
+  });
+
+  it('falls back to email when givenName/familyName are empty', async () => {
+    const userId = 'a1b2c3d4-e5f6-7890-abcd-ef1234567890';
+    mockGetUser.mockResolvedValueOnce({
+      userId,
+      email: 'dev@company.com',
+      name: '',
+      givenName: '',
+      familyName: '',
+      status: 'CONFIRMED',
+      createdAt: '2024-01-01',
+      enabled: true,
+    });
+
+    const { result } = renderHook(() => useUserDisplayName(userId));
+
+    await waitFor(() => {
+      expect(result.current).toBe('dev@company.com');
+    });
+  });
+
+  it('uses the cache on subsequent calls for the same userId', async () => {
+    const userId = 'e9fe7448-60d1-7021-2c07-b58fd0c23d16';
+    mockGetUser.mockResolvedValueOnce({
+      userId,
+      email: 'jane@example.com',
+      name: 'Jane Smith',
+      givenName: 'Jane',
+      familyName: 'Smith',
+      status: 'CONFIRMED',
+      createdAt: '2024-01-01',
+      enabled: true,
+    });
+
+    // First call
+    const { result: result1 } = renderHook(() => useUserDisplayName(userId));
+    await waitFor(() => {
+      expect(result1.current).toBe('Jane Smith');
+    });
+
+    // Second call — should use cache, no additional API call
+    const { result: result2 } = renderHook(() => useUserDisplayName(userId));
+    expect(result2.current).toBe('Jane Smith');
+    expect(mockGetUser).toHaveBeenCalledTimes(1);
+  });
+
+  it('shows truncated ID on API error', async () => {
+    const userId = 'deadbeef-1234-5678-9abc-def012345678';
+    mockListUsers.mockResolvedValueOnce([]); // bulk load returns nothing
+    mockGetUser.mockRejectedValueOnce(new Error('User not found'));
+
+    const { result } = renderHook(() => useUserDisplayName(userId));
+
+    await waitFor(() => {
+      expect(result.current).toBe('deadbeef…');
+    });
+  });
+
+  it('resolves from bulk-loaded user list without calling getUser', async () => {
+    const userId = 'aaaabbbb-1111-2222-3333-444455556666';
+    mockListUsers.mockResolvedValueOnce([
+      {
+        userId,
+        email: 'bulk@example.com',
+        name: '',
+        givenName: 'Bulk',
+        familyName: 'User',
+        status: 'CONFIRMED',
+        createdAt: '2024-01-01',
+        enabled: true,
+      },
+    ]);
+
+    const { result } = renderHook(() => useUserDisplayName(userId));
+
+    await waitFor(() => {
+      expect(result.current).toBe('Bulk User');
+    });
+
+    // getUser should NOT have been called — resolved from bulk load
+    expect(mockGetUser).not.toHaveBeenCalled();
+  });
+});
+
+describe('isUserId', () => {
+  it('returns true for valid UUIDs', () => {
+    expect(isUserId('e9fe7448-60d1-7021-2c07-b58fd0c23d16')).toBe(true);
+    expect(isUserId('00000000-0000-0000-0000-000000000000')).toBe(true);
+    expect(isUserId('A1B2C3D4-E5F6-7890-ABCD-EF1234567890')).toBe(true);
+  });
+
+  it('returns false for non-UUIDs', () => {
+    expect(isUserId('john@example.com')).toBe(false);
+    expect(isUserId('John Doe')).toBe(false);
+    expect(isUserId('user-1')).toBe(false);
+    expect(isUserId('')).toBe(false);
+  });
+});
+
+describe('formatUserDisplayName', () => {
+  it('prefers givenName + familyName', () => {
+    expect(formatUserDisplayName({
+      userId: 'id-1',
+      email: 'j@e.com',
+      name: 'J Smith',
+      givenName: 'Jane',
+      familyName: 'Smith',
+      status: 'CONFIRMED',
+      createdAt: '',
+      enabled: true,
+    })).toBe('Jane Smith');
+  });
+
+  it('falls back to name field', () => {
+    expect(formatUserDisplayName({
+      userId: 'id-1',
+      email: 'j@e.com',
+      name: 'J Smith',
+      givenName: '',
+      familyName: '',
+      status: 'CONFIRMED',
+      createdAt: '',
+      enabled: true,
+    })).toBe('J Smith');
+  });
+
+  it('falls back to email', () => {
+    expect(formatUserDisplayName({
+      userId: 'id-1',
+      email: 'j@e.com',
+      name: '',
+      givenName: '',
+      familyName: '',
+      status: 'CONFIRMED',
+      createdAt: '',
+      enabled: true,
+    })).toBe('j@e.com');
+  });
+
+  it('falls back to userId as last resort', () => {
+    expect(formatUserDisplayName({
+      userId: 'id-1',
+      email: '',
+      name: '',
+      givenName: '',
+      familyName: '',
+      status: 'CONFIRMED',
+      createdAt: '',
+      enabled: true,
+    })).toBe('id-1');
+  });
+});

--- a/frontend/src/hooks/useUserDisplayName.ts
+++ b/frontend/src/hooks/useUserDisplayName.ts
@@ -1,0 +1,253 @@
+/**
+ * useUserDisplayName Hook
+ *
+ * Resolves Cognito user IDs (GUIDs) to human-readable display names.
+ * Uses a module-level cache so repeated lookups across components are instant.
+ *
+ * On first use, bulk-loads all users via listUsers() to pre-warm the cache.
+ * This eliminates the "flash of GUID" — subsequent lookups resolve synchronously.
+ *
+ * Usage:
+ *   const displayName = useUserDisplayName(userId);
+ *   // Returns the resolved name immediately (after initial bulk load)
+ */
+import { useState, useEffect } from 'react';
+import { userManagementService, User } from '../services/userManagementService';
+
+// Module-level cache: persists across component mounts/unmounts within the SPA session.
+const userCache = new Map<string, { displayName: string; status: 'resolved' | 'error' }>();
+const pendingRequests = new Map<string, Promise<User>>();
+
+// Bulk pre-warm: load all users once on first hook usage.
+let bulkLoadPromise: Promise<void> | null = null;
+let bulkLoadDone = false;
+
+function ensureBulkLoad(): Promise<void> {
+  if (bulkLoadDone) return Promise.resolve();
+  if (!bulkLoadPromise) {
+    bulkLoadPromise = userManagementService.listUsers()
+      .then((users) => {
+        for (const user of users) {
+          const name = formatUserDisplayName(user);
+          userCache.set(user.userId, { displayName: name, status: 'resolved' });
+        }
+        bulkLoadDone = true;
+      })
+      .catch(() => {
+        // Bulk load failed — individual lookups will still work as fallback
+        bulkLoadDone = true;
+      });
+  }
+  return bulkLoadPromise;
+}
+
+// UUID v4 pattern (loose match for Cognito sub IDs)
+const UUID_PATTERN = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+
+/**
+ * Determines if a string looks like a raw user ID (UUID/GUID).
+ */
+export function isUserId(value: string): boolean {
+  return UUID_PATTERN.test(value);
+}
+
+/**
+ * Formats a User object into a display name.
+ * Priority: "GivenName FamilyName" > name > email > userId
+ */
+export function formatUserDisplayName(user: User): string {
+  if (user.givenName && user.familyName) {
+    return `${user.givenName} ${user.familyName}`;
+  }
+  if (user.name) {
+    return user.name;
+  }
+  if (user.email) {
+    return user.email;
+  }
+  return user.userId;
+}
+
+/**
+ * Truncates a UUID for display while loading (e.g., "e9fe7448…").
+ */
+function truncateId(userId: string): string {
+  if (userId.length > 8) {
+    return `${userId.substring(0, 8)}…`;
+  }
+  return userId;
+}
+
+/**
+ * React hook that resolves a user ID to a display name.
+ *
+ * @param userId - The Cognito user ID (GUID) to resolve
+ * @returns The resolved display name, or a loading/fallback string
+ */
+export function useUserDisplayName(userId: string | undefined | null): string {
+  const [displayName, setDisplayName] = useState<string>(() => {
+    if (!userId) return 'unknown';
+    // Check cache synchronously on first render (works after bulk load)
+    const cached = userCache.get(userId);
+    if (cached) return cached.displayName;
+    // If it's not a UUID, return it as-is (might already be a name)
+    if (!isUserId(userId)) return userId;
+    // Show empty string during load to avoid GUID flash
+    return '';
+  });
+
+  useEffect(() => {
+    if (!userId) {
+      setDisplayName('unknown');
+      return;
+    }
+
+    // Not a UUID — treat it as already-resolved
+    if (!isUserId(userId)) {
+      setDisplayName(userId);
+      return;
+    }
+
+    // Already cached (e.g. from bulk load)
+    const cached = userCache.get(userId);
+    if (cached) {
+      setDisplayName(cached.displayName);
+      return;
+    }
+
+    let cancelled = false;
+
+    // Wait for bulk load first, then check cache or fall back to individual lookup
+    ensureBulkLoad().then(() => {
+      if (cancelled) return;
+
+      const cachedAfterBulk = userCache.get(userId);
+      if (cachedAfterBulk) {
+        setDisplayName(cachedAfterBulk.displayName);
+        return;
+      }
+
+      // User not in bulk list — fall back to individual getUser
+      let request = pendingRequests.get(userId);
+      if (!request) {
+        request = userManagementService.getUser(userId);
+        pendingRequests.set(userId, request);
+      }
+
+      request
+        .then((user) => {
+          const name = formatUserDisplayName(user);
+          userCache.set(userId, { displayName: name, status: 'resolved' });
+          if (!cancelled) {
+            setDisplayName(name);
+          }
+        })
+        .catch(() => {
+          const fallback = truncateId(userId);
+          userCache.set(userId, { displayName: fallback, status: 'error' });
+          if (!cancelled) {
+            setDisplayName(fallback);
+          }
+        })
+        .finally(() => {
+          pendingRequests.delete(userId);
+        });
+    });
+
+    return () => {
+      cancelled = true;
+    };
+  }, [userId]);
+
+  return displayName;
+}
+
+/**
+ * Batch-resolve multiple user IDs at once.
+ * Useful when a list view shows multiple createdBy fields.
+ */
+export function useUserDisplayNames(userIds: (string | undefined | null)[]): Map<string, string> {
+  const [names, setNames] = useState<Map<string, string>>(() => {
+    const map = new Map<string, string>();
+    for (const id of userIds) {
+      if (!id) continue;
+      const cached = userCache.get(id);
+      if (cached) {
+        map.set(id, cached.displayName);
+      } else if (!isUserId(id)) {
+        map.set(id, id);
+      } else {
+        map.set(id, truncateId(id));
+      }
+    }
+    return map;
+  });
+
+  useEffect(() => {
+    const idsToResolve = userIds.filter(
+      (id): id is string => !!id && isUserId(id) && !userCache.has(id)
+    );
+
+    if (idsToResolve.length === 0) {
+      // All resolved from cache
+      const map = new Map<string, string>();
+      for (const id of userIds) {
+        if (!id) continue;
+        const cached = userCache.get(id);
+        map.set(id, cached ? cached.displayName : (!isUserId(id) ? id : truncateId(id)));
+      }
+      setNames(map);
+      return;
+    }
+
+    let cancelled = false;
+
+    // Resolve all uncached IDs in parallel
+    const promises = idsToResolve.map((id) => {
+      let request = pendingRequests.get(id);
+      if (!request) {
+        request = userManagementService.getUser(id);
+        pendingRequests.set(id, request);
+      }
+      return request
+        .then((user) => {
+          const name = formatUserDisplayName(user);
+          userCache.set(id, { displayName: name, status: 'resolved' });
+        })
+        .catch(() => {
+          userCache.set(id, { displayName: truncateId(id), status: 'error' });
+        })
+        .finally(() => {
+          pendingRequests.delete(id);
+        });
+    });
+
+    Promise.all(promises).then(() => {
+      if (cancelled) return;
+      const map = new Map<string, string>();
+      for (const id of userIds) {
+        if (!id) continue;
+        const cached = userCache.get(id);
+        map.set(id, cached ? cached.displayName : (!isUserId(id) ? id : truncateId(id)));
+      }
+      setNames(map);
+    });
+
+    return () => {
+      cancelled = true;
+    };
+  }, [JSON.stringify(userIds)]);
+
+  return names;
+}
+
+/**
+ * Clears the user display name cache.
+ * Useful for testing or when user profiles are updated.
+ */
+export function clearUserDisplayNameCache(): void {
+  userCache.clear();
+  pendingRequests.clear();
+  bulkLoadPromise = null;
+  bulkLoadDone = false;
+}

--- a/frontend/src/pages/AppDetailView.tsx
+++ b/frontend/src/pages/AppDetailView.tsx
@@ -92,6 +92,7 @@ interface AppDetailViewProps {
 
 interface RegistryAgentBinding {
   agentId: string;
+  name?: string;
   status: 'DESIGN' | 'READY';
   systemPromptAddition?: string;
   toolRestrictions?: string[];
@@ -139,6 +140,7 @@ interface RegistryAgentRecordDetail {
   configSchema: string | null;
   configValues: string | null;
   createdBy: string;
+  createdByName?: string;
   createdAt: string;
   updatedAt: string;
   version: number;
@@ -362,6 +364,10 @@ export function AppDetailView({ appId, onBack, onNavigate, onPublishSuccess, ini
     initialTab && VALID_TABS.includes(initialTab) ? initialTab : 'agents',
   );
 
+  // Display server-resolved creator name — app.createdByName is populated
+  // by registry-agent-record-resolver's getApp via Cognito AdminGetUser.
+  // No client-side resolution needed.
+
   // Workflow run state — one live run tracked at a time
   const [activeRun, setActiveRun] = useState<{ executionId: string; workflowId: string } | null>(null);
   const [startingRun, setStartingRun] = useState<string | null>(null);
@@ -385,7 +391,6 @@ export function AppDetailView({ appId, onBack, onNavigate, onPublishSuccess, ini
   // Add agent dialog
   const [addAgentDialogOpen, setAddAgentDialogOpen] = useState(false);
   const [availableAgents, setAvailableAgents] = useState<Array<{ agentId: string; name: string; description: string }>>([]);
-  const [agentNameMap, setAgentNameMap] = useState<Record<string, string>>({});
   const [loadingAgents, setLoadingAgents] = useState(false);
   const [addingAgent, setAddingAgent] = useState<string | null>(null);
 
@@ -504,19 +509,6 @@ export function AppDetailView({ appId, onBack, onNavigate, onPublishSuccess, ini
   useEffect(() => {
     loadApp();
   }, [loadApp]);
-
-  useEffect(() => {
-    if (app?.agentBindings?.length) {
-      agentConfigService.listAgentConfigs().then((configs: any[]) => {
-        const map: Record<string, string> = {};
-        for (const c of configs) {
-          const cfg = typeof c.config === 'object' && c.config !== null ? c.config : {};
-          map[c.agentId] = c.name || cfg.name || c.agentId;
-        }
-        setAgentNameMap(map);
-      }).catch(() => {});
-    }
-  }, [app?.agentBindings]);
 
   useEffect(() => {
     if (app?.workflowIds) {
@@ -1040,7 +1032,7 @@ export function AppDetailView({ appId, onBack, onNavigate, onPublishSuccess, ini
               <div className="flex items-center justify-between mb-2">
                 <div className="flex items-center gap-2 min-w-0">
                   <Bot className="size-4 text-muted-foreground flex-shrink-0" />
-                  <span className="text-sm font-medium text-foreground truncate">{agentNameMap[binding.agentId] || binding.agentId}</span>
+                  <span className="text-sm font-medium text-foreground truncate">{binding.name || binding.agentId}</span>
                 </div>
                 <Badge className={cn(statusColors.bg, statusColors.text, 'text-xs border-0 flex-shrink-0')}>
                   {binding.status}
@@ -1961,7 +1953,7 @@ export function AppDetailView({ appId, onBack, onNavigate, onPublishSuccess, ini
                 <p className="text-sm text-muted-foreground mb-2">{app.description}</p>
               )}
               <div className="flex items-center gap-4 text-xs text-muted-foreground">
-                <span>Created by {app.createdBy || 'unknown'}</span>
+                <span>Created by {app.createdByName || app.createdBy || 'unknown'}</span>
                 <span>Created {formatDate(app.createdAt)}</span>
                 <span>Updated {formatDate(app.updatedAt)}</span>
               </div>

--- a/frontend/src/pages/__tests__/AppDetailView.test.tsx
+++ b/frontend/src/pages/__tests__/AppDetailView.test.tsx
@@ -108,6 +108,7 @@ const mockApp = {
   agentBindings: [
     {
       agentId: 'agent-1',
+      name: 'Agent One',
       status: 'READY' as const,
       systemPromptAddition: 'Extra prompt',
       toolRestrictions: ['tool-x'],
@@ -131,6 +132,7 @@ const mockApp = {
   configSchema: JSON.stringify({ type: 'object', properties: { apiKey: { type: 'string' } } }),
   configValues: JSON.stringify({ apiKey: 'test-key' }),
   createdBy: 'user-1',
+  createdByName: 'Jane Doe',
   createdAt: '2024-01-01T00:00:00Z',
   updatedAt: '2024-01-15T00:00:00Z',
   version: 1,
@@ -158,7 +160,7 @@ describe('AppDetailView', () => {
   });
 
   // Req 11.2: Header displays name, status badge, description, createdBy, createdAt, updatedAt
-  it('renders app header with name, status badge, description, and metadata', async () => {
+  it('renders app header with name, status badge, description, and server-provided createdByName', async () => {
     render(<AppDetailView {...defaultProps} />);
 
     await waitFor(() => {
@@ -167,7 +169,20 @@ describe('AppDetailView', () => {
 
     expect(screen.getByText('DRAFT')).toBeInTheDocument();
     expect(screen.getByText('A test application')).toBeInTheDocument();
-    expect(screen.getByText(/Created by user-1/)).toBeInTheDocument();
+    await waitFor(() => {
+      expect(screen.getByText(/Created by Jane Doe/)).toBeInTheDocument();
+    });
+  });
+
+  // Falls back to the raw createdBy id when the server did not resolve a name
+  it('falls back to createdBy when createdByName is absent', async () => {
+    (appApiService.getApp as jest.Mock).mockResolvedValue({ ...mockApp, createdByName: undefined });
+
+    render(<AppDetailView {...defaultProps} />);
+
+    await waitFor(() => {
+      expect(screen.getByText(/Created by user-1/)).toBeInTheDocument();
+    });
   });
 
   // Req 11.3: Tabbed navigation with all five tabs
@@ -186,14 +201,17 @@ describe('AppDetailView', () => {
   });
 
   // Req 11.4: Agents tab shows binding cards with status badges and override indicators
-  it('renders agent binding cards with status badges on Agents tab', async () => {
+  it('renders agent binding cards with server-provided name (falling back to agentId) on Agents tab', async () => {
     render(<AppDetailView {...defaultProps} />);
 
     await waitFor(() => {
-      expect(screen.getByText('agent-1')).toBeInTheDocument();
+      // agent-1 has a server-provided name and should display it, not the raw id
+      expect(screen.getByText('Agent One')).toBeInTheDocument();
     });
 
+    // agent-2 has no name from the server — falls back to the raw agentId
     expect(screen.getByText('agent-2')).toBeInTheDocument();
+    expect(screen.queryByText('agent-1')).not.toBeInTheDocument();
     // Status badges — DRAFT is the app status, READY and DESIGN are binding statuses
     expect(screen.getByText('READY')).toBeInTheDocument();
     // DESIGN appears both as agent status and in precondition text potentially
@@ -369,7 +387,7 @@ describe('AppDetailView', () => {
     render(<AppDetailView {...defaultProps} />);
 
     await waitFor(() => {
-      expect(screen.getByText('agent-1')).toBeInTheDocument();
+      expect(screen.getByText('Agent One')).toBeInTheDocument();
     });
 
     const removeButtons = screen.getAllByText('Remove');
@@ -385,7 +403,7 @@ describe('AppDetailView', () => {
     render(<AppDetailView {...defaultProps} />);
 
     await waitFor(() => {
-      expect(screen.getByText('agent-1')).toBeInTheDocument();
+      expect(screen.getByText('Agent One')).toBeInTheDocument();
     });
 
     const editButtons = screen.getAllByText('Edit');
@@ -406,7 +424,7 @@ describe('AppDetailView', () => {
     render(<AppDetailView {...defaultProps} />);
 
     await waitFor(() => {
-      expect(screen.getByText('agent-1')).toBeInTheDocument();
+      expect(screen.getByText('Agent One')).toBeInTheDocument();
     });
 
     const editButtons = screen.getAllByText('Edit');

--- a/frontend/src/services/__tests__/appApiService.test.ts
+++ b/frontend/src/services/__tests__/appApiService.test.ts
@@ -31,6 +31,45 @@ describe('appApiService', () => {
       );
       expect(result).toEqual(mockApp);
     });
+
+    it('requests createdByName and agentBindings.name so display names never need client-side resolution', async () => {
+      (serverService.query as jest.Mock).mockResolvedValue({ getApp: {} });
+
+      await appApiService.getApp('app-1');
+
+      const [query] = (serverService.query as jest.Mock).mock.calls[0];
+      expect(query).toContain('createdByName');
+      // Scoped to the agentBindings selection set specifically, not just
+      // anywhere in the document — guards against `name` being present only
+      // on some unrelated field.
+      const bindingsSelection = query.slice(
+        query.indexOf('agentBindings {'),
+        query.indexOf('}', query.indexOf('agentBindings {')),
+      );
+      expect(bindingsSelection).toContain('name');
+    });
+
+    it('returns the server response unchanged — no client-side createdBy/agent-name mutation', async () => {
+      const serverApp = {
+        appId: 'app-1',
+        name: 'Test App',
+        createdBy: 'user-abc-123',
+        createdByName: 'Jane Doe',
+        agentBindings: [
+          { agentId: 'agent-1', name: 'Support Agent', status: 'READY' },
+          { agentId: 'agent-2', status: 'DESIGN' },
+        ],
+      };
+      (serverService.query as jest.Mock).mockResolvedValue({ getApp: serverApp });
+
+      const result = await appApiService.getApp('app-1');
+
+      // Deep-equal, not just a subset check — the service must be a pure
+      // pass-through of whatever the server returns for these fields.
+      expect(result).toEqual(serverApp);
+      expect(result.createdBy).toBe('user-abc-123');
+      expect(result.agentBindings[1].name).toBeUndefined();
+    });
   });
 
   describe('listApps', () => {
@@ -46,6 +85,31 @@ describe('appApiService', () => {
         expect.stringContaining('listApps'),
         { orgId: 'org-1' }
       );
+      expect(result.items).toEqual(mockItems);
+    });
+
+    it('requests createdByName in the items selection', async () => {
+      (serverService.query as jest.Mock).mockResolvedValue({
+        listApps: { items: [], nextToken: null },
+      });
+
+      await appApiService.listApps('org-1');
+
+      const [query] = (serverService.query as jest.Mock).mock.calls[0];
+      expect(query).toContain('createdByName');
+    });
+
+    it('returns each item unchanged, including createdByName, from the server response', async () => {
+      const mockItems = [
+        { appId: 'app-1', createdBy: 'user-1', createdByName: 'Ann Lee' },
+        { appId: 'app-2', createdBy: 'user-2', createdByName: 'user-2' },
+      ];
+      (serverService.query as jest.Mock).mockResolvedValue({
+        listApps: { items: mockItems, nextToken: null },
+      });
+
+      const result = await appApiService.listApps('org-1');
+
       expect(result.items).toEqual(mockItems);
     });
   });

--- a/frontend/src/services/appApiService.ts
+++ b/frontend/src/services/appApiService.ts
@@ -45,11 +45,13 @@ const GET_APP = `
       workflowIds
       routingConfig
       createdBy
+      createdByName
       createdAt
       updatedAt
       version
       agentBindings {
         agentId
+        name
         status
         systemPromptAddition
         toolRestrictions
@@ -81,6 +83,7 @@ const LIST_APPS = `
         workflowIds
         routingConfig
         createdBy
+        createdByName
         createdAt
         updatedAt
         version

--- a/package-lock.json
+++ b/package-lock.json
@@ -3152,9 +3152,6 @@
       "cpu": [
         "arm64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -3170,9 +3167,6 @@
       "integrity": "sha512-YTCPs11w6purXCQwJBCh99oHBwTEW4q46OWxO9Rnddo1wJd8EPBa3Misw08URoUVuVuEfYGy5YtSvuPfkkj8Vw==",
       "cpu": [
         "arm64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "Apache-2.0",
       "optional": true,
@@ -3190,9 +3184,6 @@
       "cpu": [
         "x64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -3208,9 +3199,6 @@
       "integrity": "sha512-0wtWdOxYh7BfeklDpI0tpTk/ljdjJmCQsNFPLy2C7EnK60J3sroYzTaFqgn8Qqc7T03VHZl/6GG1pXC3zPuU1g==",
       "cpu": [
         "x64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "Apache-2.0",
       "optional": true,
@@ -6364,9 +6352,6 @@
       "cpu": [
         "arm"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -6379,9 +6364,6 @@
       "integrity": "sha512-2as0LgT7qQpyceQq6VUJYnumUMUrgGQCWIiDIN9DE0/tglsk6o66uCB4f3djRawAltvfCNLyZZrsqbPA6inCsA==",
       "cpu": [
         "arm"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -6396,9 +6378,6 @@
       "cpu": [
         "arm64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -6411,9 +6390,6 @@
       "integrity": "sha512-Ful8pM/2yYI83PViWdFdpZhdI8HJ5qsXANe5atypbHDf+KIBBDsZsbyy8hbXnULVvW9NsTh5DHwbcBftyLTfiw==",
       "cpu": [
         "arm64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -6428,9 +6404,6 @@
       "cpu": [
         "loong64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -6443,9 +6416,6 @@
       "integrity": "sha512-m9tsJz54LUXkSYM8+8PG81B9IKK5r+2T0clMq4QrS16xFosufU7firBDAZEsDheDs7wTlP7h3++S7lMsU955HA==",
       "cpu": [
         "loong64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -6460,9 +6430,6 @@
       "cpu": [
         "ppc64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -6475,9 +6442,6 @@
       "integrity": "sha512-vRWUAbYLGHBZS6Q8Msb2sfnf1fvJf+47t8l/TwOerM2qArzy+IeNMTHrYLHXh95h8MoatPHI5hhSZNs+mGXKPg==",
       "cpu": [
         "ppc64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -6492,9 +6456,6 @@
       "cpu": [
         "riscv64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -6507,9 +6468,6 @@
       "integrity": "sha512-krrCDilhXOwFkSkO3Wm9I/f9H0L92XHHwy2fwxjukxIbh0dem8gZqOW5Y8BsHrpJv5qwlRBV+Wl4ZFyRWhUpwg==",
       "cpu": [
         "riscv64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -6524,9 +6482,6 @@
       "cpu": [
         "s390x"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -6540,9 +6495,6 @@
       "cpu": [
         "x64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -6555,9 +6507,6 @@
       "integrity": "sha512-eRZevouTH2i1HeAVLqJuLnt256krQkGY0TN6WsTmsIhuzbh457HuWDMakKwmi0Cjadux983CoSr8Lim2QhUIFw==",
       "cpu": [
         "x64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -7061,9 +7010,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "Apache-2.0 AND MIT",
       "optional": true,
       "os": [
@@ -7081,9 +7027,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "Apache-2.0 AND MIT",
       "optional": true,
       "os": [
@@ -7101,9 +7044,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "Apache-2.0 AND MIT",
       "optional": true,
       "os": [
@@ -7121,9 +7061,6 @@
         "s390x"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "Apache-2.0 AND MIT",
       "optional": true,
       "os": [
@@ -7141,9 +7078,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "Apache-2.0 AND MIT",
       "optional": true,
       "os": [
@@ -7161,9 +7095,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "Apache-2.0 AND MIT",
       "optional": true,
       "os": [
@@ -7366,9 +7297,6 @@
       "cpu": [
         "arm64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -7384,9 +7312,6 @@
       "integrity": "sha512-Bwv9KwOvE0VKa86xPFif9b9c3Y1NxOV1P0gLti/IYaWEsQYZXDlxfGEtA8mdDZ7SG3wyNXAWYT5SIn3giL57oA==",
       "cpu": [
         "arm64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -7404,9 +7329,6 @@
       "cpu": [
         "x64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -7422,9 +7344,6 @@
       "integrity": "sha512-M+P/91qJ6uILLw4k2G93GMDRAXj61SMvFQYt39AqvUqYgExXpLL5aepfns7sj4HiAQeolirQF9E0lzRvdf4zPQ==",
       "cpu": [
         "x64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -8250,14 +8169,6 @@
       "resolved": "https://registry.npmjs.org/@types/triple-beam/-/triple-beam-1.3.5.tgz",
       "integrity": "sha512-6WaYesThRMCl19iryMYP7/x2OVgCtbIVflDGFpWnb9irXI3UjYE4AzmYuiUKY1AJstGijoY+MgUszMgRxIYTYw==",
       "license": "MIT"
-    },
-    "node_modules/@types/trusted-types": {
-      "version": "2.0.7",
-      "resolved": "https://registry.npmjs.org/@types/trusted-types/-/trusted-types-2.0.7.tgz",
-      "integrity": "sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==",
-      "license": "MIT",
-      "optional": true,
-      "peer": true
     },
     "node_modules/@types/unist": {
       "version": "3.0.3",
@@ -15960,9 +15871,6 @@
       "cpu": [
         "arm64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -15982,9 +15890,6 @@
       "integrity": "sha512-UpQkoenr4UJEzgVIYpI80lDFvRmPVg6oqboNHfoH4CQIfNA+HOrZ7Mo7KZP02dC6LjghPQJeBsvXhJod/wnIBg==",
       "cpu": [
         "arm64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MPL-2.0",
       "optional": true,
@@ -16006,9 +15911,6 @@
       "cpu": [
         "x64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -16028,9 +15930,6 @@
       "integrity": "sha512-bYcLp+Vb0awsiXg/80uCRezCYHNg1/l3mt0gzHnWV9XP1W5sKa5/TCdGWaR/zBM2PeF/HbsQv/j2URNOiVuxWg==",
       "cpu": [
         "x64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MPL-2.0",
       "optional": true,


### PR DESCRIPTION
- Add createdByName field to RegistryAgentRecord GraphQL type
- Add name field to AgentBinding GraphQL type
- Backend resolver resolves createdBy -> display name via Cognito AdminGetUser
- Backend resolver resolves agent binding names via Registry with DDB cache + Registry fallback
- Frontend consumes server-provided names directly (no client-side Cognito calls)
- Add useUserDisplayName hook as reusable utility for any future client-side needs
- Add UserDisplayName component for drop-in usage

Root cause: agents existed in AgentCore Registry but not in DDB cache table. The fast-path BatchGetItem returned nothing; added Registry fallback for unresolved record IDs.

Fixes: GUID displayed instead of names in AppDetailView (createdBy + agent cards)

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
