### PR TITLE
fix: org-scoped project visibility with admin cross-org access

### DIFF
--- a/backend/src/lambda/__tests__/backfill-project-org.test.ts
+++ b/backend/src/lambda/__tests__/backfill-project-org.test.ts
@@ -1,0 +1,132 @@
+/**
+ * Tests for the one-time backfill-project-org Lambda.
+ *
+ * Coverage:
+ *  - Scans the projects table and updates only items missing `organization`
+ *    (or where it is explicitly null) to 'Default'.
+ *  - Leaves items that already carry an organization untouched.
+ *  - Paginates through LastEvaluatedKey across multiple scan pages.
+ *  - Tolerates a concurrent write (ConditionalCheckFailedException) without
+ *    treating it as a failure.
+ *  - Surfaces genuine update errors in `failedIds` without throwing.
+ */
+import { DynamoDBDocumentClient, ScanCommand, UpdateCommand } from '@aws-sdk/lib-dynamodb';
+import { mockClient } from 'aws-sdk-client-mock';
+
+import { backfillProjectOrg, handler } from '../backfill-project-org';
+
+const dynamoMock = mockClient(DynamoDBDocumentClient);
+
+describe('backfill-project-org', () => {
+  beforeEach(() => {
+    dynamoMock.reset();
+    process.env.PROJECTS_TABLE = 'test-projects';
+  });
+
+  afterEach(() => {
+    delete process.env.PROJECTS_TABLE;
+  });
+
+  test('updates every item the Scan page returns to Default (server-side FilterExpression already excludes scoped rows)', async () => {
+    // Real DynamoDB applies FilterExpression server-side, so a Scan page
+    // only ever contains rows missing `organization` (or explicitly null).
+    // The handler itself does not re-filter client-side — it just updates
+    // whatever the page contains — so this fixture only includes rows that
+    // DynamoDB's filter would actually let through.
+    dynamoMock.on(ScanCommand).resolves({
+      Items: [
+        { id: 'proj-missing-org' }, // no organization attribute at all
+        { id: 'proj-null-org', organization: null }, // explicit null
+      ],
+    });
+    dynamoMock.on(UpdateCommand).resolves({});
+
+    const result = await backfillProjectOrg();
+
+    // Assert the FilterExpression sent to DynamoDB is the one that excludes
+    // already-scoped rows in the first place.
+    const scanCalls = dynamoMock.commandCalls(ScanCommand);
+    expect(scanCalls[0].args[0].input.FilterExpression).toBe(
+      'attribute_not_exists(organization) OR organization = :nullVal',
+    );
+
+    const updateCalls = dynamoMock.commandCalls(UpdateCommand);
+    const updatedIdsFromCalls = updateCalls.map((c) => (c.args[0].input.Key as { id: string }).id);
+
+    expect(result.scanned).toBe(2);
+    expect(result.updatedIds.sort()).toEqual(['proj-missing-org', 'proj-null-org']);
+    expect(updatedIdsFromCalls.sort()).toEqual(['proj-missing-org', 'proj-null-org']);
+    expect(result.failedIds).toHaveLength(0);
+
+    for (const call of updateCalls) {
+      const values = call.args[0].input.ExpressionAttributeValues as Record<string, unknown>;
+      expect(values[':org']).toBe('Default');
+      // Regression: the ConditionExpression references :nullVal — it must
+      // be bound in ExpressionAttributeValues or every UpdateCommand throws
+      // ValidationException at runtime (undefined attribute value token).
+      expect(values).toHaveProperty(':nullVal');
+      expect(values[':nullVal']).toBeNull();
+    }
+  });
+
+  test('paginates through multiple scan pages via LastEvaluatedKey', async () => {
+    dynamoMock
+      .on(ScanCommand)
+      .resolvesOnce({
+        Items: [{ id: 'proj-page-1' }],
+        LastEvaluatedKey: { id: 'proj-page-1' },
+      })
+      .resolvesOnce({
+        Items: [{ id: 'proj-page-2' }],
+      });
+    dynamoMock.on(UpdateCommand).resolves({});
+
+    const result = await backfillProjectOrg();
+
+    expect(dynamoMock.commandCalls(ScanCommand)).toHaveLength(2);
+    expect(result.scanned).toBe(2);
+    expect(result.updatedIds.sort()).toEqual(['proj-page-1', 'proj-page-2']);
+  });
+
+  test('a concurrent write (ConditionalCheckFailedException) is treated as already-scoped, not a failure', async () => {
+    dynamoMock.on(ScanCommand).resolves({ Items: [{ id: 'proj-race' }] });
+
+    const conflict = new Error('The conditional request failed');
+    conflict.name = 'ConditionalCheckFailedException';
+    dynamoMock.on(UpdateCommand).rejects(conflict);
+
+    const result = await backfillProjectOrg();
+
+    expect(result.updatedIds).toHaveLength(0);
+    expect(result.failedIds).toHaveLength(0);
+  });
+
+  test('a genuine update error is recorded in failedIds without throwing', async () => {
+    dynamoMock.on(ScanCommand).resolves({ Items: [{ id: 'proj-broken' }] });
+    dynamoMock.on(UpdateCommand).rejects(new Error('ProvisionedThroughputExceededException'));
+
+    const result = await backfillProjectOrg();
+
+    expect(result.updatedIds).toHaveLength(0);
+    expect(result.failedIds).toEqual(['proj-broken']);
+  });
+
+  test('items without an id are skipped entirely', async () => {
+    dynamoMock.on(ScanCommand).resolves({ Items: [{ notAnId: 'x' }] });
+
+    const result = await backfillProjectOrg();
+
+    expect(dynamoMock.commandCalls(UpdateCommand)).toHaveLength(0);
+    expect(result.updatedIds).toHaveLength(0);
+    expect(result.failedIds).toHaveLength(0);
+  });
+
+  test('handler wraps backfillProjectOrg and returns its result', async () => {
+    dynamoMock.on(ScanCommand).resolves({ Items: [{ id: 'proj-handler' }] });
+    dynamoMock.on(UpdateCommand).resolves({});
+
+    const result = await handler();
+
+    expect(result.updatedIds).toEqual(['proj-handler']);
+  });
+});

--- a/backend/src/lambda/__tests__/project-resolver.test.ts
+++ b/backend/src/lambda/__tests__/project-resolver.test.ts
@@ -14,6 +14,8 @@ import {
   GetCommand,
   PutCommand,
   UpdateCommand,
+  QueryCommand,
+  ScanCommand,
 } from '@aws-sdk/lib-dynamodb';
 import { EventBridgeClient, PutEventsCommand } from '@aws-sdk/client-eventbridge';
 import {
@@ -209,6 +211,261 @@ describe('project-resolver — archetype attributes', () => {
       expect(result.id).toBe('proj-claim');
       expect(cognitoMock.commandCalls(AdminGetUserCommand).length).toBe(0);
     });
+  });
+});
+
+describe('project-resolver — organization scoping', () => {
+  beforeEach(() => {
+    dynamoMock.reset();
+    eventBridgeMock.reset();
+    cognitoMock.reset();
+    process.env.PROJECTS_TABLE = 'test-projects';
+    process.env.EVENT_BUS_NAME = 'test-bus';
+    process.env.USER_POOL_ID = 'test-pool';
+
+    cognitoMock.on(AdminGetUserCommand).resolves({ UserAttributes: [] });
+    eventBridgeMock.on(PutEventsCommand).resolves({});
+  });
+
+  afterEach(() => {
+    delete process.env.PROJECTS_TABLE;
+    delete process.env.EVENT_BUS_NAME;
+    delete process.env.USER_POOL_ID;
+  });
+
+  const makeEventWithIdentity = (
+    fieldName: string,
+    args: Record<string, unknown>,
+    identity: Record<string, unknown>,
+  ) =>
+    ({
+      info: { fieldName },
+      arguments: args,
+      identity,
+    }) as unknown as HandlerEvent;
+
+  test('admin sees all projects across orgs via a full table scan', async () => {
+    const crossOrgItems = [
+      {
+        id: 'proj-org-a',
+        name: 'Org A project',
+        status: 'CREATED',
+        owner: 'user-a',
+        organization: 'org-a',
+        createdAt: '2025-01-01T00:00:00Z',
+        updatedAt: '2025-01-01T00:00:00Z',
+      },
+      {
+        id: 'proj-org-b',
+        name: 'Org B project',
+        status: 'CREATED',
+        owner: 'user-b',
+        organization: 'org-b',
+        createdAt: '2025-01-02T00:00:00Z',
+        updatedAt: '2025-01-02T00:00:00Z',
+      },
+    ];
+    dynamoMock.on(ScanCommand).resolves({ Items: crossOrgItems });
+
+    const result = await invokeHandler(
+      makeEventWithIdentity(
+        'listProjects',
+        {},
+        { sub: 'admin-1', 'custom:role': 'admin' },
+      ),
+    ) as unknown as { items: Array<{ id: string; archetypeStatus: string }> };
+
+    // Admin path must scan, never query the OrganizationIndex.
+    expect(dynamoMock.commandCalls(ScanCommand)).toHaveLength(1);
+    expect(dynamoMock.commandCalls(QueryCommand)).toHaveLength(0);
+
+    const ids = result.items.map((p) => p.id).sort();
+    expect(ids).toEqual(['proj-org-a', 'proj-org-b']);
+    // normaliseArchetype still applied on the admin path.
+    expect(result.items.every((p) => p.archetypeStatus === 'PENDING')).toBe(true);
+  });
+
+  test('user with no org claim gets Default org projects via OrganizationIndex', async () => {
+    const defaultOrgItems = [
+      {
+        id: 'proj-default-1',
+        name: 'Default org project',
+        status: 'CREATED',
+        owner: 'user-123',
+        organization: 'Default',
+        createdAt: '2025-01-01T00:00:00Z',
+        updatedAt: '2025-01-01T00:00:00Z',
+      },
+    ];
+    dynamoMock.on(QueryCommand).resolves({ Items: defaultOrgItems });
+
+    const result = await invokeHandler(
+      makeEventWithIdentity('listProjects', {}, { sub: 'user-123' }),
+    ) as unknown as { items: Array<{ id: string }> };
+
+    expect(dynamoMock.commandCalls(ScanCommand)).toHaveLength(0);
+    const queryCalls = dynamoMock.commandCalls(QueryCommand);
+    expect(queryCalls).toHaveLength(1);
+    const queryInput = queryCalls[0].args[0].input;
+    expect(queryInput.IndexName).toBe('OrganizationIndex');
+    expect((queryInput.ExpressionAttributeValues as Record<string, unknown>)[':org']).toBe(
+      'Default',
+    );
+
+    expect(result.items.map((p) => p.id)).toEqual(['proj-default-1']);
+  });
+
+  test('createProject always stamps organization (never undefined) when org claim is missing', async () => {
+    dynamoMock.on(PutCommand).resolves({});
+
+    const result = await invokeHandler(
+      makeEventWithIdentity(
+        'createProject',
+        { input: { name: 'No-org project' } },
+        { sub: 'user-123' },
+      ),
+    ) as unknown as { organization?: string };
+
+    expect(result.organization).toBe('Default');
+
+    const putCalls = dynamoMock.commandCalls(PutCommand);
+    expect(putCalls).toHaveLength(1);
+    const persisted = putCalls[0].args[0].input.Item as Record<string, unknown>;
+    expect(persisted.organization).toBe('Default');
+    expect(persisted.organization).not.toBeUndefined();
+  });
+
+  test('createProject stamps the claim organization when present (never undefined)', async () => {
+    dynamoMock.on(PutCommand).resolves({});
+
+    const result = await invokeHandler(
+      makeEventWithIdentity(
+        'createProject',
+        { input: { name: 'Org-claim project' } },
+        { sub: 'user-123', 'custom:organization': 'org-claim' },
+      ),
+    ) as unknown as { organization?: string };
+
+    expect(result.organization).toBe('org-claim');
+
+    const putCalls = dynamoMock.commandCalls(PutCommand);
+    const persisted = putCalls[0].args[0].input.Item as Record<string, unknown>;
+    expect(persisted.organization).toBe('org-claim');
+  });
+
+  test('admin can getProject on a project owned by, and scoped to, a different org', async () => {
+    dynamoMock.on(GetCommand).resolves({
+      Item: {
+        id: 'proj-org-b',
+        name: 'Org B project',
+        status: 'CREATED',
+        owner: 'user-b',
+        organization: 'org-b',
+        createdAt: '2025-01-02T00:00:00Z',
+        updatedAt: '2025-01-02T00:00:00Z',
+      },
+    });
+
+    const result = await invokeHandler(
+      makeEventWithIdentity(
+        'getProject',
+        { id: 'proj-org-b' },
+        { sub: 'admin-1', 'custom:role': 'admin' },
+      ),
+    ) as unknown as { id: string };
+
+    expect(result.id).toBe('proj-org-b');
+  });
+
+  test('non-admin still denied access to a project outside their org', async () => {
+    dynamoMock.on(GetCommand).resolves({
+      Item: {
+        id: 'proj-org-b',
+        name: 'Org B project',
+        status: 'CREATED',
+        owner: 'user-b',
+        organization: 'org-b',
+        createdAt: '2025-01-02T00:00:00Z',
+        updatedAt: '2025-01-02T00:00:00Z',
+      },
+    });
+
+    await expect(
+      invokeHandler(
+        makeEventWithIdentity(
+          'getProject',
+          { id: 'proj-org-b' },
+          { sub: 'user-123', 'custom:organization': 'org-a' },
+        ),
+      ),
+    ).rejects.toThrow(/Access denied/);
+  });
+
+  test('admin listProjects passes nextToken through as ExclusiveStartKey and returns LastEvaluatedKey', async () => {
+    const priorKey = { id: 'proj-page-boundary' };
+    dynamoMock.on(ScanCommand).resolves({
+      Items: [
+        {
+          id: 'proj-org-a',
+          name: 'Org A project',
+          status: 'CREATED',
+          owner: 'user-a',
+          organization: 'org-a',
+          createdAt: '2025-01-01T00:00:00Z',
+          updatedAt: '2025-01-01T00:00:00Z',
+        },
+      ],
+      LastEvaluatedKey: { id: 'proj-next-page' },
+    });
+
+    const result = await invokeHandler(
+      makeEventWithIdentity(
+        'listProjects',
+        { nextToken: JSON.stringify(priorKey) },
+        { sub: 'admin-1', 'custom:role': 'admin' },
+      ),
+    ) as unknown as { items: Array<{ id: string }>; nextToken?: string };
+
+    const scanCalls = dynamoMock.commandCalls(ScanCommand);
+    expect(scanCalls).toHaveLength(1);
+    expect(scanCalls[0].args[0].input.ExclusiveStartKey).toEqual(priorKey);
+
+    expect(result.nextToken).toBe(JSON.stringify({ id: 'proj-next-page' }));
+  });
+
+  test('non-admin listProjects passes nextToken through as ExclusiveStartKey on the OrganizationIndex query and returns LastEvaluatedKey', async () => {
+    const priorKey = { organization: 'Default', id: 'proj-page-boundary' };
+    dynamoMock.on(QueryCommand).resolves({
+      Items: [
+        {
+          id: 'proj-default-2',
+          name: 'Default org project 2',
+          status: 'CREATED',
+          owner: 'user-123',
+          organization: 'Default',
+          createdAt: '2025-01-03T00:00:00Z',
+          updatedAt: '2025-01-03T00:00:00Z',
+        },
+      ],
+      LastEvaluatedKey: { organization: 'Default', id: 'proj-next-page' },
+    });
+
+    const result = await invokeHandler(
+      makeEventWithIdentity(
+        'listProjects',
+        { nextToken: JSON.stringify(priorKey) },
+        { sub: 'user-123' },
+      ),
+    ) as unknown as { items: Array<{ id: string }>; nextToken?: string };
+
+    const queryCalls = dynamoMock.commandCalls(QueryCommand);
+    expect(queryCalls).toHaveLength(1);
+    expect(queryCalls[0].args[0].input.ExclusiveStartKey).toEqual(priorKey);
+
+    expect(result.nextToken).toBe(
+      JSON.stringify({ organization: 'Default', id: 'proj-next-page' }),
+    );
+    expect(result.items.map((p) => p.id)).toEqual(['proj-default-2']);
   });
 });
 

--- a/backend/src/lambda/backfill-project-org.ts
+++ b/backend/src/lambda/backfill-project-org.ts
@@ -1,0 +1,170 @@
+/**
+ * One-time backfill Lambda: stamps `organization: 'Default'` onto every
+ * projects-table row written before org scoping existed.
+ *
+ * Context: createProject used to persist `organization: userOrganization ||
+ * undefined` — rows created by a caller whose JWT lacked the
+ * `custom:organization` claim were written with NO organization attribute
+ * at all. Those rows never landed on the OrganizationIndex GSI, so
+ * listProjects's org-scoped query could never surface them and the same
+ * org's other members couldn't see them (see project-resolver.ts).
+ *
+ * This handler scans the full projects table, finds every item missing the
+ * `organization` attribute (or where it is explicitly undefined/null),
+ * and UpdateCommands it to `organization: 'Default'` — the same fallback
+ * createProject/listProjects now use going forward. Existing rows that
+ * already carry an organization are left untouched.
+ *
+ * Idempotent and safe to re-run: a project already backfilled (or created
+ * post-fix) simply won't match the FilterExpression on a subsequent run.
+ *
+ * ── How to run this (one-time migration, no permanent CDK resource) ──────
+ *
+ * This handler is intentionally NOT wired into any CDK stack — it is a
+ * single-shot backfill, not a piece of running infrastructure, so it does
+ * not need a permanent Lambda function, schedule, or IAM role in the stack
+ * definition. Pick ONE of the following to execute it:
+ *
+ * Option A — Deploy a temporary Lambda via the CDK CLI / AWS CLI, then invoke it:
+ *   1. Bundle this file the same way other resolvers are bundled:
+ *        npx esbuild src/lambda/backfill-project-org.ts --bundle \
+ *          --platform=node --target=node24 --outdir=dist/lambda \
+ *          --external:@aws-sdk/* --format=cjs
+ *   2. Create a throwaway Lambda function from dist/lambda/backfill-project-org.js
+ *      (handler: backfill-project-org.handler, runtime: nodejs24.x) with an
+ *      execution role scoped to Scan/UpdateItem on the projects table, and
+ *      set the PROJECTS_TABLE env var to the deployed table name, e.g.:
+ *        aws lambda create-function \
+ *          --function-name citadel-backfill-project-org-<env> \
+ *          --runtime nodejs24.x --handler backfill-project-org.handler \
+ *          --role <execution-role-arn> \
+ *          --zip-file fileb://dist/lambda/backfill-project-org.zip \
+ *          --environment "Variables={PROJECTS_TABLE=<projects-table-name>}"
+ *   3. Invoke it once and inspect the result:
+ *        aws lambda invoke --function-name citadel-backfill-project-org-<env> /dev/stdout
+ *   4. Delete the temporary function afterwards:
+ *        aws lambda delete-function --function-name citadel-backfill-project-org-<env>
+ *
+ * Option B — AWS Console:
+ *   1. Console → Lambda → Create function → paste the compiled JS (or upload
+ *      the zip from Option A step 1) with handler `backfill-project-org.handler`.
+ *   2. Attach an execution role/policy allowing Scan + UpdateItem on the
+ *      projects table only (least privilege — no other permissions needed).
+ *   3. Set the PROJECTS_TABLE environment variable to the deployed table name.
+ *   4. Use the "Test" tab with an empty `{}` event payload to invoke it, and
+ *      check the returned scanned/updated/failed counts in the response and
+ *      CloudWatch Logs.
+ *   5. Delete the function once the backfill result shows failedIds is empty
+ *      (or has been manually reconciled).
+ *
+ * This is a one-off migration: it does not need a permanent CDK Lambda
+ * resource, a schedule, or EventBridge wiring — just apply it once per
+ * environment, confirm the result, and tear the temporary function down.
+ */
+import { DynamoDBClient } from '@aws-sdk/client-dynamodb';
+import {
+  DynamoDBDocumentClient,
+  ScanCommand,
+  UpdateCommand,
+  type NativeAttributeValue,
+} from '@aws-sdk/lib-dynamodb';
+
+const docClient = DynamoDBDocumentClient.from(new DynamoDBClient({}));
+
+/** Same fallback tenant name used by project-resolver.ts. Kept as a local
+ * constant (rather than importing from project-resolver.ts) so this
+ * standalone migration Lambda has no runtime dependency on the resolver
+ * module — its only coupling to project-resolver is the value itself. */
+const DEFAULT_ORGANIZATION = 'Default';
+
+function projectsTable(): string {
+  return process.env.PROJECTS_TABLE ?? '';
+}
+
+export interface BackfillProjectOrgResult {
+  /** Total items scanned across all pages. */
+  scanned: number;
+  /** Ids updated to organization: 'Default'. */
+  updatedIds: string[];
+  /** Ids that failed to update (logged, not thrown). */
+  failedIds: string[];
+}
+
+/**
+ * Scans the entire projects table (paginating through LastEvaluatedKey) and
+ * backfills `organization: 'Default'` onto every item missing it.
+ */
+export async function backfillProjectOrg(): Promise<BackfillProjectOrgResult> {
+  const result: BackfillProjectOrgResult = { scanned: 0, updatedIds: [], failedIds: [] };
+  const tableName = projectsTable();
+
+  let exclusiveStartKey: Record<string, NativeAttributeValue> | undefined;
+
+  do {
+    const page = await docClient.send(
+      new ScanCommand({
+        TableName: tableName,
+        FilterExpression: 'attribute_not_exists(organization) OR organization = :nullVal',
+        ExpressionAttributeValues: { ':nullVal': null },
+        ExclusiveStartKey: exclusiveStartKey,
+      }),
+    );
+
+    const items = page.Items ?? [];
+    result.scanned += items.length;
+
+    for (const item of items) {
+      const id = item.id as string | undefined;
+      if (!id) {
+        continue;
+      }
+      try {
+        await docClient.send(
+          new UpdateCommand({
+            TableName: tableName,
+            Key: { id },
+            UpdateExpression: 'SET #organization = :org',
+            ExpressionAttributeNames: { '#organization': 'organization' },
+            ExpressionAttributeValues: { ':org': DEFAULT_ORGANIZATION, ':nullVal': null },
+            // Defensive re-check: only stamp rows still missing/null org at
+            // write time, so a concurrent createProject/updateProject that
+            // has since set a real organization is never clobbered.
+            ConditionExpression: 'attribute_not_exists(organization) OR organization = :nullVal',
+          }),
+        );
+        result.updatedIds.push(id);
+      } catch (err: unknown) {
+        if (err instanceof Error && err.name === 'ConditionalCheckFailedException') {
+          // Organization was set concurrently between scan and update — no
+          // action needed, the row is already correctly scoped.
+          continue;
+        }
+        console.error(`backfillProjectOrg: failed to update project "${id}":`, err);
+        result.failedIds.push(id);
+      }
+    }
+
+    exclusiveStartKey = page.LastEvaluatedKey as Record<string, NativeAttributeValue> | undefined;
+  } while (exclusiveStartKey);
+
+  console.log(
+    JSON.stringify({
+      handler: 'backfill-project-org',
+      scanned: result.scanned,
+      updated: result.updatedIds.length,
+      failed: result.failedIds.length,
+      failedIds: result.failedIds,
+    }),
+  );
+
+  return result;
+}
+
+export const handler = async (): Promise<BackfillProjectOrgResult> => {
+  console.log('backfill-project-org: starting scan of', projectsTable());
+  const result = await backfillProjectOrg();
+  console.log(
+    `backfill-project-org: complete — scanned ${result.scanned}, updated ${result.updatedIds.length}, failed ${result.failedIds.length}`,
+  );
+  return result;
+};

--- a/backend/src/lambda/project-resolver.ts
+++ b/backend/src/lambda/project-resolver.ts
@@ -4,7 +4,7 @@ import { DynamoDBDocumentClient, GetCommand, PutCommand, UpdateCommand, ScanComm
 import { EventBridgeClient, PutEventsCommand } from '@aws-sdk/client-eventbridge';
 import { v4 as uuidv4 } from 'uuid';
 import { getUserId } from '../utils/appsync';
-import { extractOrgFromEvent } from '../utils/auth-event';
+import { extractOrgFromEvent, isAdminFromEvent } from '../utils/auth-event';
 import { LifecycleManager, PROJECT_TRANSITIONS } from '../adapters/lifecycle';
 import { isGrandfathered, emitGrandfatheredBypass } from '../utils/is-grandfathered';
 import { listADRsForProject } from './adr-resolver';
@@ -17,6 +17,16 @@ const eventBridgeClient = new EventBridgeClient({});
 
 const PROJECTS_TABLE = process.env.PROJECTS_TABLE!;
 const EVENT_BUS_NAME = process.env.EVENT_BUS_NAME!;
+
+/**
+ * Fallback tenant for callers whose JWT is missing the `custom:organization`
+ * claim (and for whom the Cognito AdminGetUser fallback also comes up
+ * empty). Projects created under this org are still visible to every other
+ * caller who also falls back to it — the previous behaviour ("no org" -->
+ * `organization: undefined`) silently orphaned the row from the
+ * OrganizationIndex GSI and made it invisible to everyone but its owner.
+ */
+const DEFAULT_ORGANIZATION = 'Default';
 
 interface Project {
   id: string;
@@ -95,6 +105,7 @@ interface UploadDocumentFile {
 interface HandlerArgs {
   id: string;
   filter?: ProjectFilter;
+  nextToken?: string;
   input: CreateProjectInput & UpdateProjectInput;
   projectId: string;
   file: UploadDocumentFile;
@@ -131,7 +142,7 @@ export const handler: AppSyncResolverHandler<HandlerArgs, unknown> = async (even
       case 'getProject':
         return await getProject(args.id, userId, event);
       case 'listProjects':
-        return await listProjects(args.filter, userId, event);
+        return await listProjects(args.filter, userId, event, args.nextToken);
       case 'createProject':
         return await createProject(args.input, userId, event);
       case 'updateProject':
@@ -161,6 +172,13 @@ async function getProject(id: string, userId: string, event: ResolverEvent): Pro
 
   const project = result.Item as Project;
 
+  // Admins can open any project regardless of org — mirrors the listProjects
+  // admin bypass (full scan, no org filter). Without this, admins could see
+  // cross-org projects in listProjects but not open them individually.
+  if (isAdminFromEvent(event)) {
+    return normaliseArchetype(project) as Project;
+  }
+
   // Check if user has access to this project
   // Allow access if: user is owner OR user is in same organization
   const userOrganization = await extractOrgFromEvent(event);
@@ -176,31 +194,38 @@ async function getProject(id: string, userId: string, event: ResolverEvent): Pro
   return normaliseArchetype(project) as Project;
 }
 
-async function listProjects(filter: ProjectFilter | undefined, userId: string, event: ResolverEvent): Promise<{ items: Project[]; nextToken?: string }> {
-  // Get user's organization
-  const userOrganization = await extractOrgFromEvent(event);
-
-  if (!userOrganization) {
-    // If user has no organization, fall back to owner-based filtering
+async function listProjects(
+  filter: ProjectFilter | undefined,
+  _userId: string,
+  event: ResolverEvent,
+  nextToken?: string,
+): Promise<{ items: Project[]; nextToken?: string }> {
+  // Admins see every project across every org — full table scan, no
+  // organization filter, with the same status/createdAfter/createdBefore
+  // filters applied as the non-admin path and pagination support.
+  if (isAdminFromEvent(event)) {
     const command = new ScanCommand({
       TableName: PROJECTS_TABLE,
-      FilterExpression: '#owner = :userId',
-      ExpressionAttributeNames: {
-        '#owner': 'owner',
-      },
-      ExpressionAttributeValues: {
-        ':userId': userId,
-      },
+      ExclusiveStartKey: nextToken ? (JSON.parse(nextToken) as Record<string, NativeAttributeValue>) : undefined,
     });
 
     const result = await docClient.send(command);
+
+    let items = (result.Items || []) as Project[];
+    items = applyProjectFilters(items, filter);
+
     return {
-      items: ((result.Items || []) as Project[]).map((p) => normaliseArchetype(p)!),
-      nextToken: result.LastEvaluatedKey? JSON.stringify(result.LastEvaluatedKey): undefined,
+      items: items.map((p) => normaliseArchetype(p)!),
+      nextToken: result.LastEvaluatedKey ? JSON.stringify(result.LastEvaluatedKey) : undefined,
     };
   }
 
-  // Query by organization using GSI
+  // Non-admins are scoped to their own organization. Missing/empty org
+  // claims default to DEFAULT_ORGANIZATION so users without a
+  // custom:organization claim still see (and share) a common project pool
+  // instead of being siloed to only the projects they personally created.
+  const userOrganization = (await extractOrgFromEvent(event)) || DEFAULT_ORGANIZATION;
+
   const command = new QueryCommand({
     TableName: PROJECTS_TABLE,
     IndexName: 'OrganizationIndex',
@@ -209,34 +234,45 @@ async function listProjects(filter: ProjectFilter | undefined, userId: string, e
       ':org': userOrganization,
     },
     ScanIndexForward: false, // Sort by createdAt descending (newest first)
+    ExclusiveStartKey: nextToken ? (JSON.parse(nextToken) as Record<string, NativeAttributeValue>) : undefined,
   });
 
   const result = await docClient.send(command);
 
-  let items = result.Items as Project[] || [];
+  const items = applyProjectFilters((result.Items || []) as Project[], filter);
 
-  // Apply additional filters
-  if (filter) {
-    if (filter.status) {
-      items = items.filter(item => item.status === filter.status);
-    }
-    if (filter.createdAfter) {
-      items = items.filter(item => item.createdAt >= filter.createdAfter!);
-    }
-    if (filter.createdBefore) {
-      items = items.filter(item => item.createdAt <= filter.createdBefore!);
-    }
+  return {
+    items: items.map((p) => normaliseArchetype(p)!),
+    nextToken: result.LastEvaluatedKey ? JSON.stringify(result.LastEvaluatedKey) : undefined,
+  };
+}
+
+/** Applies the optional status/createdAfter/createdBefore filters shared by every listProjects path. */
+function applyProjectFilters(items: Project[], filter: ProjectFilter | undefined): Project[] {
+  if (!filter) return items;
+
+  let filtered = items;
+  if (filter.status) {
+    filtered = filtered.filter((item) => item.status === filter.status);
   }
-
-  return { items: items.map((p) => normaliseArchetype(p)!) };
+  if (filter.createdAfter) {
+    filtered = filtered.filter((item) => item.createdAt >= filter.createdAfter!);
+  }
+  if (filter.createdBefore) {
+    filtered = filtered.filter((item) => item.createdAt <= filter.createdBefore!);
+  }
+  return filtered;
 }
 
 async function createProject(input: CreateProjectInput, userId: string, event: ResolverEvent): Promise<Project> {
   const now = new Date().toISOString();
   const projectId = uuidv4();
 
-  // Get user's organization
-  const userOrganization = await extractOrgFromEvent(event);
+  // Get user's organization, defaulting to DEFAULT_ORGANIZATION when the
+  // claim is missing so the project always lands on a real GSI partition
+  // (organization: undefined would silently drop the row out of the
+  // OrganizationIndex and make it invisible to everyone but its owner).
+  const userOrganization = (await extractOrgFromEvent(event)) || DEFAULT_ORGANIZATION;
 
   const project: Project = {
     id: projectId,
@@ -262,7 +298,7 @@ async function createProject(input: CreateProjectInput, userId: string, event: R
     createdAt: now,
     updatedAt: now,
     owner: userId,
-    organization: userOrganization || undefined,
+    organization: userOrganization,
     // new projects start PENDING; archetype/archetypeConfidence
     // stay absent until an archetype classifier populates them.
     archetypeStatus: 'PENDING',

--- a/backend/src/schema/schema.graphql
+++ b/backend/src/schema/schema.graphql
@@ -1,6 +1,6 @@
 type Query {
   getProject(id: ID!): Project
-  listProjects(filter: ProjectFilter): ProjectConnection
+  listProjects(filter: ProjectFilter, nextToken: String): ProjectConnection
   # ADR governance queries.
   getADR(adrId: ID!): ADR
   listADRsForProject(projectId: ID!): [ADR!]!


### PR DESCRIPTION
## Summary

Fixes organization-scoped project visibility so that:

1. **Projects always get an `organization` attribute** — `createProject` now defaults to `'Default'` when the caller's JWT lacks a `custom:organization` claim, instead of persisting `undefined` (which silently dropped the row from the `OrganizationIndex` GSI).

2. **`listProjects` uses the GSI for non-admins** — queries the `OrganizationIndex` scoped to the caller's org (defaulting to `'Default'`), so members of the same org see each other's projects.

3. **Admins see all projects cross-org** — admin callers get a full table scan (no org filter), with the same status/date filters and pagination support.

4. **`getProject` respects admin bypass** — admins can open a project owned by a different org, matching the cross-org visibility they get in `listProjects`.

5. **Pagination support added** — `listProjects` now accepts a `nextToken` argument (GraphQL schema updated) and passes it through as `ExclusiveStartKey` on both the scan and query paths.

6. **Backfill migration Lambda** — a one-shot `backfill-project-org` handler scans existing projects and stamps `organization: 'Default'` onto rows written before this fix. Includes full instructions for temporary deployment/invocation/teardown.

## Changes

- `backend/src/lambda/project-resolver.ts` — org-scoped query, admin scan bypass, DEFAULT_ORGANIZATION fallback, extracted applyProjectFilters helper, pagination plumbing
- `backend/src/schema/schema.graphql` — added nextToken param to listProjects
- `backend/src/lambda/backfill-project-org.ts` — one-time migration Lambda (not wired into CDK)
- `backend/src/lambda/__tests__/project-resolver.test.ts` — 8 new org-scoping tests
- `backend/src/lambda/__tests__/backfill-project-org.test.ts` — 6 tests for the backfill handler

## Testing

All new and existing tests pass. The backfill Lambda is covered by unit tests including pagination, idempotency (ConditionalCheckFailedException tolerance), and error reporting.