### PR TITLE
Feat/runtime cost telemetry

### DIFF
--- a/.audit-ci.json
+++ b/.audit-ci.json
@@ -5,17 +5,9 @@
   "high": true,
   "critical": true,
   "allowlist": [
-    "GHSA-v2hh-gcrm-f6hx",
-    "GHSA-4c8g-83qw-93j6",
-    "GHSA-3jxr-9vmj-r5cp",
-    "GHSA-r67j-r569-jrwp",
-    "GHSA-526f-jxpj-jmg2",
-    "GHSA-w5hq-g745-h8pq",
-    "GHSA-j965-2qgj-vjmq",
-    "aws-lambda",
-    "@databricks/sql"
+    "GHSA-mh99-v99m-4gvg"
   ],
   "report": true,
   "skip-dev": false,
-  "_comment": "This file intentionally carries NO active allowlist entries. Every advisory this project cannot fully remediate must be documented with a written justification and a revisit date in audit-ci-allowlist-justifications.md, and its GHSA/advisory id added to the 'allowlist' array above ONLY after that write-up exists. Plain JSON cannot hold inline comments, hence the separate justification file."
+  "_comment": "Carries GHSA-mh99-v99m-4gvg (brace-expansion). See audit-ci-allowlist-justifications.md for details and remediation path."
 }

--- a/README.md
+++ b/README.md
@@ -96,7 +96,7 @@ Service (AgentCore Runtime · Gateway · Knowledge Base)
 Gateway (per-app API Gateway · authorizer · metrics)
 ```
 
-Deployed as focused CDK stacks: `backend`, `services`, `governance`, `arbiter`, `frontend`, and `gateway`.
+Deployed as focused CDK stacks: `backend`, `services`, `governance`, `arbiter`, `frontend`, `gateway`, and `telemetry`.
 
 ## Getting started
 

--- a/arbiter/common/__tests__/test_usage_properties.py
+++ b/arbiter/common/__tests__/test_usage_properties.py
@@ -1,0 +1,251 @@
+"""Property-based tests for arbiter/common/usage.py
+
+Exercises the pure usage-record schema and helpers shared by the worker
+subprocess capture and the supervisor's converse-call capture: record
+construction/validation, Bedrock Converse usage-block extraction, and the
+defensive boundary sanitizer used when parsing a usage array coming back
+from a subprocess or an event payload.
+
+All helpers here are pure (no I/O, no AWS clients) and must never raise on
+malformed input except where explicitly documented (bad ``source`` literal).
+"""
+from __future__ import annotations
+
+import math
+
+import pytest
+from hypothesis import given, settings
+from hypothesis import strategies as st
+
+from common.usage import (
+    build_usage_record,
+    extract_converse_usage,
+    parse_usage_array,
+)
+
+# --- Hypothesis strategies ---------------------------------------------------
+
+_valid_sources = st.sampled_from(["worker", "supervisor"])
+_invalid_sources = st.text(max_size=20).filter(
+    lambda s: s not in ("worker", "supervisor")
+)
+
+# Arbitrary token-count inputs: negative ints, floats, None, strings, bools.
+_token_ish = st.one_of(
+    st.integers(min_value=-1000, max_value=1000),
+    st.floats(allow_nan=True, allow_infinity=True, width=32),
+    st.none(),
+    st.text(max_size=10),
+    st.booleans(),
+)
+
+_model_ids = st.one_of(st.none(), st.text(max_size=50))
+
+
+# ---------------------------------------------------------------------------
+# build_usage_record
+# ---------------------------------------------------------------------------
+
+class TestBuildUsageRecord:
+    """Property tests for build_usage_record."""
+
+    @given(source=_valid_sources, call_index=st.integers(min_value=0, max_value=10_000))
+    @settings(max_examples=50)
+    def test_required_keys_present_with_valid_source(self, source, call_index):
+        """A record built with a valid source always carries every required key."""
+        record = build_usage_record(
+            model_id="some.model",
+            input_tokens=10,
+            output_tokens=20,
+            latency_ms=5,
+            call_index=call_index,
+            source=source,
+        )
+        for key in (
+            "modelId",
+            "inputTokens",
+            "outputTokens",
+            "latencyMs",
+            "callIndex",
+            "capturedAt",
+            "source",
+        ):
+            assert key in record, f"missing required key: {key}"
+        assert record["source"] == source
+        assert record["callIndex"] == call_index
+        assert record["callIndex"] >= 0
+
+    @given(
+        input_tokens=_token_ish,
+        output_tokens=_token_ish,
+    )
+    @settings(max_examples=100)
+    def test_token_counts_always_non_negative_ints(self, input_tokens, output_tokens):
+        """Token counts are always coerced/clamped to non-negative ints,
+        regardless of negative, float, None, string, or bool input."""
+        record = build_usage_record(
+            model_id="m",
+            input_tokens=input_tokens,
+            output_tokens=output_tokens,
+            latency_ms=0,
+            call_index=0,
+            source="worker",
+        )
+        assert isinstance(record["inputTokens"], int)
+        assert isinstance(record["outputTokens"], int)
+        assert record["inputTokens"] >= 0
+        assert record["outputTokens"] >= 0
+
+    @given(source=_invalid_sources)
+    @settings(max_examples=30)
+    def test_invalid_source_raises_value_error(self, source):
+        """A source outside {'worker','supervisor'} raises ValueError."""
+        with pytest.raises(ValueError):
+            build_usage_record(
+                model_id="m",
+                input_tokens=1,
+                output_tokens=1,
+                latency_ms=1,
+                call_index=0,
+                source=source,
+            )
+
+    def test_missing_model_id_defaults_to_empty_string(self):
+        """None/missing modelId becomes '' per schema, not None."""
+        record = build_usage_record(
+            model_id=None,
+            input_tokens=1,
+            output_tokens=1,
+            latency_ms=1,
+            call_index=0,
+            source="worker",
+        )
+        assert record["modelId"] == ""
+
+    def test_captured_at_defaults_to_iso8601_utc_string(self):
+        """capturedAt defaults to a non-empty ISO8601 string when not supplied."""
+        record = build_usage_record(
+            model_id="m",
+            input_tokens=1,
+            output_tokens=1,
+            latency_ms=1,
+            call_index=0,
+            source="worker",
+        )
+        assert isinstance(record["capturedAt"], str)
+        assert len(record["capturedAt"]) > 0
+        # Must be parseable as ISO8601.
+        from datetime import datetime
+        datetime.fromisoformat(record["capturedAt"].replace("Z", "+00:00"))
+
+    @given(call_index=st.integers(max_value=-1))
+    @settings(max_examples=20)
+    def test_negative_call_index_clamped_to_zero(self, call_index):
+        """callIndex is clamped to >= 0 even if a negative value is supplied."""
+        record = build_usage_record(
+            model_id="m",
+            input_tokens=1,
+            output_tokens=1,
+            latency_ms=1,
+            call_index=call_index,
+            source="worker",
+        )
+        assert record["callIndex"] >= 0
+
+
+# ---------------------------------------------------------------------------
+# extract_converse_usage
+# ---------------------------------------------------------------------------
+
+class TestExtractConverseUsage:
+    """Property tests for extract_converse_usage."""
+
+    @given(
+        input_tokens=st.integers(min_value=0, max_value=100_000),
+        output_tokens=st.integers(min_value=0, max_value=100_000),
+        total_tokens=st.integers(min_value=0, max_value=200_000),
+    )
+    @settings(max_examples=50)
+    def test_matching_usage_block_returns_matching_ints(
+        self, input_tokens, output_tokens, total_tokens
+    ):
+        """A well-formed Converse response usage block round-trips exactly."""
+        resp = {
+            "usage": {
+                "inputTokens": input_tokens,
+                "outputTokens": output_tokens,
+                "totalTokens": total_tokens,
+            }
+        }
+        got_in, got_out, got_total = extract_converse_usage(resp)
+        assert got_in == input_tokens
+        assert got_out == output_tokens
+        assert got_total == total_tokens
+
+    def test_missing_usage_block_returns_zeros_and_none(self):
+        """No usage key -> (0, 0, None), never raises."""
+        assert extract_converse_usage({}) == (0, 0, None)
+
+    def test_none_response_never_raises(self):
+        """None response is tolerated defensively."""
+        result = extract_converse_usage(None)
+        assert result == (0, 0, None)
+
+    @given(garbage=st.one_of(
+        st.text(max_size=20),
+        st.integers(),
+        st.lists(st.integers(), max_size=3),
+        st.dictionaries(st.text(max_size=5), st.text(max_size=5), max_size=3),
+    ))
+    @settings(max_examples=50)
+    def test_arbitrary_garbage_never_raises(self, garbage):
+        """Arbitrary non-conforming input never raises."""
+        result = extract_converse_usage(garbage)
+        assert isinstance(result, tuple) and len(result) == 3
+
+
+# ---------------------------------------------------------------------------
+# parse_usage_array
+# ---------------------------------------------------------------------------
+
+class TestParseUsageArray:
+    """Property tests for parse_usage_array — boundary sanitizer."""
+
+    @given(raw=st.one_of(
+        st.none(),
+        st.text(max_size=30),
+        st.integers(),
+        st.dictionaries(st.text(max_size=5), st.text(max_size=5), max_size=3),
+        st.lists(st.one_of(
+            st.dictionaries(st.text(max_size=10), st.text(max_size=10), max_size=5),
+            st.integers(),
+            st.text(max_size=10),
+            st.none(),
+        ), max_size=10),
+    ))
+    @settings(max_examples=100)
+    def test_never_raises_on_arbitrary_input(self, raw):
+        """parse_usage_array must never raise regardless of input shape."""
+        result = parse_usage_array(raw)
+        assert isinstance(result, list)
+
+    def test_non_list_input_returns_empty_list(self):
+        """A non-list top-level value returns an empty list rather than raising."""
+        assert parse_usage_array("not-a-list") == []
+        assert parse_usage_array(None) == []
+        assert parse_usage_array(42) == []
+
+    def test_list_of_dicts_passes_through(self):
+        """A list of well-formed dict records passes through as dicts."""
+        records = [
+            {"modelId": "m", "inputTokens": 1, "outputTokens": 2,
+             "latencyMs": 3, "callIndex": 0, "capturedAt": "2024-01-01T00:00:00Z",
+             "source": "worker"},
+        ]
+        result = parse_usage_array(records)
+        assert result == records
+
+    def test_non_dict_entries_are_dropped(self):
+        """Non-dict entries in the list are dropped, not raised on."""
+        result = parse_usage_array([{"a": 1}, "garbage", 42, None, {"b": 2}])
+        assert result == [{"a": 1}, {"b": 2}]

--- a/arbiter/common/__tests__/test_usage_properties.py
+++ b/arbiter/common/__tests__/test_usage_properties.py
@@ -18,6 +18,7 @@ from hypothesis import given, settings
 from hypothesis import strategies as st
 
 from common.usage import (
+    aggregate_usage,
     build_usage_record,
     extract_converse_usage,
     parse_usage_array,
@@ -249,3 +250,98 @@ class TestParseUsageArray:
         """Non-dict entries in the list are dropped, not raised on."""
         result = parse_usage_array([{"a": 1}, "garbage", 42, None, {"b": 2}])
         assert result == [{"a": 1}, {"b": 2}]
+
+
+# ---------------------------------------------------------------------------
+# aggregate_usage
+# ---------------------------------------------------------------------------
+
+class TestAggregateUsage:
+    """Property tests for aggregate_usage — pure per-node usage rollup."""
+
+    @given(raw=st.one_of(
+        st.none(),
+        st.text(max_size=30),
+        st.integers(),
+        st.dictionaries(st.text(max_size=5), st.text(max_size=5), max_size=3),
+        st.lists(st.one_of(
+            st.dictionaries(st.text(max_size=10), st.text(max_size=10), max_size=5),
+            st.integers(),
+            st.text(max_size=10),
+            st.none(),
+        ), max_size=10),
+    ))
+    @settings(max_examples=100)
+    def test_never_raises_on_arbitrary_input(self, raw):
+        """aggregate_usage must never raise regardless of input shape."""
+        result = aggregate_usage(raw)
+        assert isinstance(result, dict)
+        for key in ("inputTokens", "outputTokens", "totalTokens", "callCount"):
+            assert key in result
+
+    def test_empty_input_returns_all_zeros(self):
+        """No records -> every total is zero, never raises."""
+        assert aggregate_usage([]) == {
+            "inputTokens": 0,
+            "outputTokens": 0,
+            "totalTokens": 0,
+            "callCount": 0,
+        }
+        assert aggregate_usage(None) == {
+            "inputTokens": 0,
+            "outputTokens": 0,
+            "totalTokens": 0,
+            "callCount": 0,
+        }
+
+    @given(
+        records=st.lists(
+            st.fixed_dictionaries({
+                "inputTokens": st.integers(min_value=0, max_value=10_000),
+                "outputTokens": st.integers(min_value=0, max_value=10_000),
+            }),
+            max_size=10,
+        ),
+    )
+    @settings(max_examples=100)
+    def test_totals_equal_sum_of_inputs_and_outputs(self, records):
+        """totalTokens is always inputTokens + outputTokens; callCount == len(records)."""
+        result = aggregate_usage(records)
+        expected_in = sum(r["inputTokens"] for r in records)
+        expected_out = sum(r["outputTokens"] for r in records)
+        assert result["inputTokens"] == expected_in
+        assert result["outputTokens"] == expected_out
+        assert result["totalTokens"] == expected_in + expected_out
+        assert result["callCount"] == len(records)
+
+    def test_garbage_entries_dropped_before_summing(self):
+        """Non-dict entries in the raw list are dropped, not summed as zero."""
+        records = [
+            {"inputTokens": 5, "outputTokens": 10},
+            "garbage",
+            42,
+            None,
+            {"inputTokens": 3, "outputTokens": 2},
+        ]
+        result = aggregate_usage(records)
+        assert result == {
+            "inputTokens": 8,
+            "outputTokens": 12,
+            "totalTokens": 20,
+            "callCount": 2,
+        }
+
+    def test_missing_or_malformed_token_fields_coerce_to_zero(self):
+        """A record missing inputTokens/outputTokens (or with malformed values)
+        contributes 0 for that field rather than raising."""
+        records = [
+            {"inputTokens": "not-a-number", "outputTokens": None},
+            {"outputTokens": 7},
+        ]
+        result = aggregate_usage(records)
+        assert result == {
+            "inputTokens": 0,
+            "outputTokens": 7,
+            "totalTokens": 7,
+            "callCount": 2,
+        }

--- a/arbiter/common/__tests__/test_workflow_contract.py
+++ b/arbiter/common/__tests__/test_workflow_contract.py
@@ -298,6 +298,87 @@ def test_completed_result_requires_output():
         )
 
 
+# --- Node-result event: additive usage passthrough (rollup) -----------------
+
+
+def test_build_result_completed_with_usage_sets_top_level_usage():
+    """A completed result built with usage=[...] carries a top-level 'usage'
+    key, additive to (and separate from) any usage nested inside output."""
+    usage = [{'inputTokens': 5, 'outputTokens': 7}]
+    detail = build_node_result_detail(
+        execution_id='e', node_id='n', workflow_id='w', agent_id='a',
+        status=STATUS_COMPLETED, output={'response': 'ok'}, timestamp='t',
+        usage=usage,
+    )
+    assert detail['usage'] == usage
+    assert detail['output'] == {'response': 'ok'}
+
+
+def test_build_result_completed_without_usage_omits_usage_key():
+    """Omitting usage entirely keeps the detail byte-identical to before this
+    feature — no 'usage' key appears."""
+    detail = build_node_result_detail(
+        execution_id='e', node_id='n', workflow_id='w', agent_id='a',
+        status=STATUS_COMPLETED, output={'response': 'ok'}, timestamp='t',
+    )
+    assert 'usage' not in detail
+
+
+def test_build_result_failed_ignores_usage():
+    """A failed result never carries a top-level usage key, even if a caller
+    passes one — failed results have no output to attribute usage to."""
+    detail = build_node_result_detail(
+        execution_id='e', node_id='n', workflow_id='w', agent_id='a',
+        status=STATUS_FAILED, error='boom', timestamp='t',
+        usage=[{'inputTokens': 1, 'outputTokens': 1}],
+    )
+    assert 'usage' not in detail
+
+
+def test_build_result_malformed_usage_never_raises_and_is_sanitized():
+    """A non-list usage value is sanitized to [] rather than raising or
+    passing through garbage — build_node_result_detail must never raise on
+    malformed usage."""
+    detail = build_node_result_detail(
+        execution_id='e', node_id='n', workflow_id='w', agent_id='a',
+        status=STATUS_COMPLETED, output={'response': 'ok'}, timestamp='t',
+        usage='not-a-list',  # type: ignore[arg-type]
+    )
+    assert detail['usage'] == []
+
+
+def test_parse_result_detail_passes_through_top_level_usage():
+    usage = [{'inputTokens': 3, 'outputTokens': 4}]
+    detail = build_node_result_detail(
+        execution_id='e', node_id='n', workflow_id='w', agent_id='a',
+        status=STATUS_COMPLETED, output={'response': 'ok'}, timestamp='t',
+        usage=usage,
+    )
+    parsed = parse_node_result_detail(detail)
+    assert parsed.usage == usage
+
+
+def test_parse_result_detail_defaults_usage_to_empty_list_when_absent():
+    detail = build_node_result_detail(
+        execution_id='e', node_id='n', workflow_id='w', agent_id='a',
+        status=STATUS_COMPLETED, output={'response': 'ok'}, timestamp='t',
+    )
+    parsed = parse_node_result_detail(detail)
+    assert parsed.usage == []
+
+
+def test_parse_result_detail_sanitizes_malformed_usage_on_the_wire():
+    """A detail body that arrived over the wire with a malformed 'usage'
+    value (e.g. hand-crafted or corrupted) is sanitized, never raised on."""
+    detail = build_node_result_detail(
+        execution_id='e', node_id='n', workflow_id='w', agent_id='a',
+        status=STATUS_COMPLETED, output={'response': 'ok'}, timestamp='t',
+    )
+    detail['usage'] = 'garbage'
+    parsed = parse_node_result_detail(detail)
+    assert parsed.usage == []
+
+
 def test_failed_result_requires_error():
     with pytest.raises(ValueError):
         build_node_result_detail(

--- a/arbiter/common/usage.py
+++ b/arbiter/common/usage.py
@@ -1,0 +1,146 @@
+"""Shared model-invocation usage-record schema and helpers.
+
+A ``UsageRecord`` is a plain dict describing one model invocation's token
+counts and latency, captured either from the worker subprocess (wrapping a
+Strands ``BedrockModel`` call) or from the supervisor's own Bedrock Converse
+call. It is pure telemetry data — no I/O, no AWS clients, no global state —
+so it can be imported from any layer (worker, supervisor, and later the
+intake/workflow step-runner paths) without side effects.
+
+Schema (``UsageRecord``)::
+
+    {
+        "modelId": str,        # "" if unknown
+        "inputTokens": int,    # >= 0
+        "outputTokens": int,   # >= 0
+        "latencyMs": int,      # >= 0
+        "callIndex": int,      # >= 0, 0-based monotonic per process
+        "capturedAt": str,     # ISO8601 UTC
+        "source": "worker" | "supervisor",
+        # optional, additive:
+        "totalTokens": int,    # >= 0, only present when known
+    }
+
+Every helper here is defensive: malformed input is coerced/clamped rather
+than raising, EXCEPT ``build_usage_record`` validating the ``source``
+literal, which is an explicit programmer-error signal (a caller passing an
+unrecognized source is a bug at the call site, not untrusted external data).
+"""
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from typing import Any, Optional
+
+VALID_SOURCES = ("worker", "supervisor")
+
+
+def _coerce_non_negative_int(value: Any) -> int:
+    """Best-effort coercion of an arbitrary value to a non-negative int.
+
+    Accepts ints, floats (truncated), and numeric strings. Anything else
+    (None, non-numeric strings, NaN/inf floats, unexpected types) coerces to
+    0. Negative results are clamped to 0. Never raises.
+    """
+    try:
+        if isinstance(value, bool):
+            # bool is an int subclass; treat True/False as 1/0 explicitly
+            # rather than falling through to the generic int() path below
+            # (which would also work, but this is clearer intent).
+            return 1 if value else 0
+        if isinstance(value, (int, float)):
+            if isinstance(value, float) and (value != value or value in (float("inf"), float("-inf"))):
+                # NaN or +/-inf
+                return 0
+            coerced = int(value)
+        elif isinstance(value, str):
+            coerced = int(float(value.strip()))
+        else:
+            return 0
+    except (TypeError, ValueError, OverflowError):
+        return 0
+    return max(0, coerced)
+
+
+def build_usage_record(
+    *,
+    model_id: Optional[str],
+    input_tokens: Any,
+    output_tokens: Any,
+    latency_ms: Any,
+    call_index: Any,
+    source: str,
+    captured_at: Optional[str] = None,
+    total_tokens: Any = None,
+) -> dict:
+    """Build a validated ``UsageRecord`` dict.
+
+    ``source`` must be one of ``VALID_SOURCES`` — raises ``ValueError``
+    otherwise (a programmer error at the call site, not untrusted data).
+    All numeric fields are coerced/clamped to non-negative ints; ``model_id``
+    defaults to ``""`` when falsy/None; ``captured_at`` defaults to the
+    current UTC time in ISO8601 form when not supplied.
+
+    ``total_tokens`` is optional and additive: included only when a
+    non-None value is supplied (or successfully coerced), so callers that
+    don't have a total omit the key entirely rather than writing a
+    misleading ``0``.
+    """
+    if source not in VALID_SOURCES:
+        raise ValueError(
+            f"invalid usage record source {source!r}; expected one of {VALID_SOURCES}"
+        )
+
+    record: dict = {
+        "modelId": model_id if isinstance(model_id, str) and model_id else "",
+        "inputTokens": _coerce_non_negative_int(input_tokens),
+        "outputTokens": _coerce_non_negative_int(output_tokens),
+        "latencyMs": _coerce_non_negative_int(latency_ms),
+        "callIndex": _coerce_non_negative_int(call_index),
+        "capturedAt": captured_at or datetime.now(timezone.utc).isoformat(),
+        "source": source,
+    }
+
+    if total_tokens is not None:
+        record["totalTokens"] = _coerce_non_negative_int(total_tokens)
+
+    return record
+
+
+def extract_converse_usage(resp: Any) -> tuple[int, int, Optional[int]]:
+    """Extract ``(inputTokens, outputTokens, totalTokens)`` from a Bedrock
+    Converse-shaped response.
+
+    Defensive by contract: any non-conforming shape (None, wrong type,
+    missing/partial ``usage`` block) returns ``(0, 0, None)`` rather than
+    raising. ``totalTokens`` is ``None`` when absent so callers can tell
+    "known zero" apart from "not reported".
+    """
+    try:
+        if not isinstance(resp, dict):
+            return (0, 0, None)
+        usage = resp.get("usage")
+        if not isinstance(usage, dict):
+            return (0, 0, None)
+        input_tokens = _coerce_non_negative_int(usage.get("inputTokens"))
+        output_tokens = _coerce_non_negative_int(usage.get("outputTokens"))
+        raw_total = usage.get("totalTokens")
+        total_tokens = _coerce_non_negative_int(raw_total) if raw_total is not None else None
+        return (input_tokens, output_tokens, total_tokens)
+    except Exception:  # noqa: BLE001 — boundary extractor must never raise
+        return (0, 0, None)
+
+
+def parse_usage_array(raw: Any) -> list[dict]:
+    """Sanitize an arbitrary value into a list of dict usage records.
+
+    Boundary sanitizer used when parsing a usage array that crossed a
+    process or event boundary (subprocess stdout JSON, an SQS/EventBridge
+    payload). A non-list top-level value returns ``[]``. Non-dict entries
+    within a list are dropped. Never raises regardless of input shape.
+    """
+    try:
+        if not isinstance(raw, list):
+            return []
+        return [entry for entry in raw if isinstance(entry, dict)]
+    except Exception:  # noqa: BLE001 — boundary sanitizer must never raise
+        return []

--- a/arbiter/common/usage.py
+++ b/arbiter/common/usage.py
@@ -144,3 +144,33 @@ def parse_usage_array(raw: Any) -> list[dict]:
         return [entry for entry in raw if isinstance(entry, dict)]
     except Exception:  # noqa: BLE001 — boundary sanitizer must never raise
         return []
+
+
+def aggregate_usage(records: Any) -> dict:
+    """Sum a (possibly unsanitized) usage array into per-node totals.
+
+    Pure, defensive rollup used to derive per-node ``usageTotals`` from the
+    sanitized usage records a workflow node accumulated. ``records`` is
+    passed through ``parse_usage_array`` first, so any non-list input or
+    non-dict entries are dropped rather than raising. Missing/malformed
+    ``inputTokens``/``outputTokens`` fields within a surviving record
+    coerce to 0 via ``_coerce_non_negative_int``. Never raises.
+
+    Returns::
+
+        {
+            "inputTokens": int,   # sum across records, >= 0
+            "outputTokens": int,  # sum across records, >= 0
+            "totalTokens": int,   # inputTokens + outputTokens
+            "callCount": int,     # number of sanitized records
+        }
+    """
+    recs = parse_usage_array(records)
+    total_in = sum(_coerce_non_negative_int(r.get("inputTokens")) for r in recs)
+    total_out = sum(_coerce_non_negative_int(r.get("outputTokens")) for r in recs)
+    return {
+        "inputTokens": total_in,
+        "outputTokens": total_out,
+        "totalTokens": total_in + total_out,
+        "callCount": len(recs),
+    }

--- a/arbiter/common/workflow_contract.py
+++ b/arbiter/common/workflow_contract.py
@@ -36,6 +36,8 @@ from dataclasses import dataclass, field
 from datetime import datetime, timezone
 from typing import Any, Optional
 
+from common.usage import parse_usage_array
+
 # --- EventBridge identifiers (mirror the step runner's event helpers) --------
 
 # Event source stamped on every workflow lifecycle event. Matches ``SOURCE``
@@ -83,7 +85,9 @@ class NodeResultDetail:
     """The EventBridge detail body of a node-completed / node-failed event.
 
     A completed result carries ``output`` (and no ``error``); a failed result
-    carries ``error`` (and no ``output``).
+    carries ``error`` (and no ``output``). ``usage`` is additive: a sanitized
+    list of worker usage records lifted to the top level for a completed
+    result (``[]`` when absent or when the result is failed).
     """
 
     execution_id: str
@@ -94,6 +98,7 @@ class NodeResultDetail:
     timestamp: str
     output: Optional[dict[str, Any]] = None
     error: Optional[str] = None
+    usage: list[dict[str, Any]] = field(default_factory=list)
 
 
 # --- Internal validation helpers ---------------------------------------------
@@ -233,6 +238,7 @@ def build_node_result_detail(
     output: Optional[dict[str, Any]] = None,
     error: Optional[str] = None,
     timestamp: Optional[str] = None,
+    usage: Optional[list[dict[str, Any]]] = None,
 ) -> dict:
     """Build the EventBridge detail body for a node-result event.
 
@@ -240,6 +246,15 @@ def build_node_result_detail(
     an ``output`` object; a failed result requires a non-empty ``error``
     string. ``timestamp`` defaults to the current UTC time (ISO 8601) when not
     supplied; pass it explicitly for deterministic output.
+
+    ``usage`` is additive and optional: a list of worker usage records
+    promoted to a top-level ``detail['usage']`` key for a completed result
+    (additive to, and separate from, any ``usage`` nested inside ``output``).
+    Sanitized via ``parse_usage_array`` — a malformed value degrades to ``[]``
+    rather than raising. Only set when a completed result AND a non-None
+    ``usage`` was supplied, so omitting it keeps the detail byte-identical to
+    pre-feature callers. A failed result never carries a top-level ``usage``
+    key, even if one is passed, since there is no output to attribute it to.
     """
     _validate_identity(
         'node-result event',
@@ -271,6 +286,8 @@ def build_node_result_detail(
                 "node-result event: a 'completed' result requires an 'output' object"
             )
         detail['output'] = output
+        if usage is not None:
+            detail['usage'] = parse_usage_array(usage)
     else:  # STATUS_FAILED
         if not isinstance(error, str) or error == '':
             raise ValueError(
@@ -326,4 +343,5 @@ def parse_node_result_detail(detail: Any) -> NodeResultDetail:
         timestamp=timestamp,
         output=output,
         error=error,
+        usage=parse_usage_array(detail.get('usage')),
     )

--- a/arbiter/stepRunner/__tests__/test_events_properties.py
+++ b/arbiter/stepRunner/__tests__/test_events_properties.py
@@ -117,6 +117,30 @@ class TestPublishNodeCompletedEvent:
         assert detail['output'] == {'result': 'success'}
         assert detail['correlationId'] == 'exec-002'
         assert 'timestamp' in detail
+        # Additive: usage omitted by this call — no 'usage' key present,
+        # byte-identical to the pre-rollup-feature detail shape.
+        assert 'usage' not in detail
+
+    def test_publish_node_completed_with_usage_adds_top_level_usage_key(self, mock_eb_client):
+        """Usage rollup hop (additive): passing usage=[...] adds a top-level
+        'usage' key to the detail, mirroring the worker's producer shape."""
+        from events import publish_node_completed
+
+        usage = [{'inputTokens': 3, 'outputTokens': 4}]
+        publish_node_completed(
+            execution_id='exec-003',
+            workflow_id='wf-003',
+            node_id='node-B',
+            agent_id='agent-2',
+            completed_at='2025-01-01T00:06:00Z',
+            output={'result': 'success'},
+            usage=usage,
+        )
+
+        call_args = mock_eb_client.put_events.call_args
+        entries = call_args[1].get('Entries') or call_args.kwargs.get('Entries')
+        detail = json.loads(entries[0]['Detail'])
+        assert detail['usage'] == usage
 
 
 # ---------------------------------------------------------------------------

--- a/arbiter/stepRunner/__tests__/test_index_handler.py
+++ b/arbiter/stepRunner/__tests__/test_index_handler.py
@@ -1,0 +1,86 @@
+"""
+Unit tests for the step runner Lambda handler's EventBridge routing.
+
+Covers the usage-rollup hop's handler-side extraction: a
+``workflow.node.completed`` detail carries an additive top-level ``usage``
+key (promoted by the worker via ``workflow_contract.build_node_result_detail``).
+The handler extracts it and forwards it to
+``executor.handle_node_completion`` as a fourth positional/keyword argument,
+falling back to ``output.get('usage', [])`` when the top-level key is absent
+so an in-flight event emitted before this change still routes correctly.
+
+All AWS is mocked; no real network or credentials are touched.
+"""
+
+import sys
+import os
+from unittest.mock import patch
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..'))
+
+import index
+
+
+def _event(detail_type, detail):
+    return {'detail-type': detail_type, 'detail': detail}
+
+
+class TestNodeCompletedUsageExtraction:
+    def test_top_level_usage_is_forwarded_to_handle_node_completion(self):
+        usage = [{'inputTokens': 3, 'outputTokens': 4}]
+        detail = {
+            'executionId': 'exec-1',
+            'nodeId': 'n0',
+            'output': {'response': 'ok', 'usage': usage},
+            'usage': usage,
+        }
+        with patch.object(index, 'handle_node_completion') as mock_handle:
+            index.handler(_event('workflow.node.completed', detail), {})
+
+        mock_handle.assert_called_once_with('exec-1', 'n0', detail['output'], usage)
+
+    def test_missing_top_level_usage_falls_back_to_output_usage(self):
+        """An in-flight event emitted before this change carries no top-level
+        'usage' key — the handler falls back to output['usage']."""
+        usage = [{'inputTokens': 1, 'outputTokens': 2}]
+        detail = {
+            'executionId': 'exec-1',
+            'nodeId': 'n0',
+            'output': {'response': 'ok', 'usage': usage},
+        }
+        with patch.object(index, 'handle_node_completion') as mock_handle:
+            index.handler(_event('workflow.node.completed', detail), {})
+
+        mock_handle.assert_called_once_with('exec-1', 'n0', detail['output'], usage)
+
+    def test_missing_usage_everywhere_defaults_to_empty_list(self):
+        detail = {
+            'executionId': 'exec-1',
+            'nodeId': 'n0',
+            'output': {'response': 'ok'},
+        }
+        with patch.object(index, 'handle_node_completion') as mock_handle:
+            index.handler(_event('workflow.node.completed', detail), {})
+
+        mock_handle.assert_called_once_with('exec-1', 'n0', detail['output'], [])
+
+    def test_missing_output_key_defaults_output_and_usage(self):
+        detail = {'executionId': 'exec-1', 'nodeId': 'n0'}
+        with patch.object(index, 'handle_node_completion') as mock_handle:
+            index.handler(_event('workflow.node.completed', detail), {})
+
+        mock_handle.assert_called_once_with('exec-1', 'n0', {}, [])
+
+    def test_other_detail_types_are_unaffected(self):
+        with patch.object(index, 'handle_node_failure') as mock_fail:
+            index.handler(_event('workflow.node.failed', {
+                'executionId': 'exec-1', 'nodeId': 'n0', 'error': 'boom',
+            }), {})
+        mock_fail.assert_called_once_with('exec-1', 'n0', 'boom')
+
+    def test_handler_returns_status_code_200(self):
+        with patch.object(index, 'handle_node_completion'):
+            result = index.handler(_event('workflow.node.completed', {
+                'executionId': 'exec-1', 'nodeId': 'n0', 'output': {},
+            }), {})
+        assert result == {'statusCode': 200}

--- a/arbiter/stepRunner/__tests__/test_usage_rollup_persistence.py
+++ b/arbiter/stepRunner/__tests__/test_usage_rollup_persistence.py
@@ -1,0 +1,304 @@
+"""
+Unit + property tests for the usage rollup's persistence and idempotency.
+
+``handle_node_completion`` now accepts an additive ``usage`` argument (a list
+of worker usage records, defaulting to ``[]``). The SAME completed-node
+``update_item`` call persists the sanitized usage array and its per-node
+totals under ``nodeResults[nodeId].usage`` / ``.usageTotals`` via a per-node
+SET — never an ADD, so reprocessing writes byte-identical values.
+
+Covers (design test list #2/#3/#4/#7):
+  * the update writes usage + usageTotals in the SAME update_item call
+  * the UpdateExpression contains no ADD anywhere
+  * a duplicate delivery (guard intact) leaves totals unchanged
+  * a guard-bypass variant proves the SET itself is idempotent (last-write-wins)
+  * fallback: usage supplied only via output['usage'] (no top-level arg) still
+    persists totals
+  * concurrent completions of different nodes never collide on usage keys
+
+All AWS is mocked; no real network or credentials are touched.
+"""
+
+import sys
+import os
+import json
+import copy
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..'))
+
+import pytest
+from unittest.mock import patch, MagicMock
+from hypothesis import given, settings
+from hypothesis import strategies as st
+
+
+CHAIN_WORKFLOW = {
+    'workflowId': 'wf-chain',
+    'name': 'Chain',
+    'definition': json.dumps({
+        'nodes': [
+            {'id': 'n0', 'type': 'agent', 'agentId': 'agent-A', 'data': {}},
+            {'id': 'n1', 'type': 'agent', 'agentId': 'agent-B', 'data': {}},
+        ],
+        'edges': [{'id': 'e0', 'source': 'n0', 'target': 'n1'}],
+    }),
+    'configuration': json.dumps({}),
+}
+
+CHAIN_EXEC = {
+    'executionId': 'exec-chain',
+    'workflowId': 'wf-chain',
+    'appId': 'app-1',
+    'status': 'running',
+    'nodeResults': {
+        'n0': {'nodeId': 'n0', 'agentId': 'agent-A', 'status': 'running', 'retryCount': 0},
+        'n1': {'nodeId': 'n1', 'agentId': 'agent-B', 'status': 'pending', 'retryCount': 0},
+    },
+}
+
+DIAMOND_WORKFLOW = {
+    'workflowId': 'wf-diamond',
+    'name': 'Diamond',
+    'definition': json.dumps({
+        'nodes': [
+            {'id': 'n0', 'type': 'agent', 'agentId': 'agent-A', 'data': {}},
+            {'id': 'n1', 'type': 'agent', 'agentId': 'agent-B', 'data': {}},
+            {'id': 'n2', 'type': 'agent', 'agentId': 'agent-C', 'data': {}},
+            {'id': 'n3', 'type': 'agent', 'agentId': 'agent-D', 'data': {}},
+        ],
+        'edges': [
+            {'id': 'e0', 'source': 'n0', 'target': 'n1'},
+            {'id': 'e1', 'source': 'n0', 'target': 'n2'},
+            {'id': 'e2', 'source': 'n1', 'target': 'n3'},
+            {'id': 'e3', 'source': 'n2', 'target': 'n3'},
+        ],
+    }),
+    'configuration': json.dumps({}),
+}
+
+DIAMOND_EXEC = {
+    'executionId': 'exec-diamond',
+    'workflowId': 'wf-diamond',
+    'appId': 'app-1',
+    'status': 'running',
+    'nodeResults': {
+        'n0': {'nodeId': 'n0', 'agentId': 'agent-A', 'status': 'completed', 'retryCount': 0},
+        'n1': {'nodeId': 'n1', 'agentId': 'agent-B', 'status': 'running', 'retryCount': 0},
+        'n2': {'nodeId': 'n2', 'agentId': 'agent-C', 'status': 'running', 'retryCount': 0},
+        'n3': {'nodeId': 'n3', 'agentId': 'agent-D', 'status': 'pending', 'retryCount': 0},
+    },
+}
+
+
+@pytest.fixture
+def mock_exec():
+    """Patch the module-level tables, events, and SQS client on executor."""
+    import executor
+
+    tables = {
+        'workflows_table': MagicMock(),
+        'executions_table': MagicMock(),
+        'events': MagicMock(),
+        'sqs': MagicMock(),
+    }
+    with patch.object(executor, '_workflows_table', tables['workflows_table']), \
+         patch.object(executor, '_executions_table', tables['executions_table']), \
+         patch.object(executor, 'events', tables['events']), \
+         patch.object(executor, '_get_sqs_client', return_value=tables['sqs']):
+        yield tables
+
+
+def _completed_update_calls(executions_table):
+    """Return update_item calls whose UpdateExpression sets nodeResults status
+    to completed (the single call the usage rollup augments)."""
+    calls = []
+    for call in executions_table.update_item.call_args_list:
+        kwargs = call.kwargs
+        expr = kwargs.get('UpdateExpression', '')
+        values = kwargs.get('ExpressionAttributeValues', {})
+        if 'nodeResults.#nid.#status' in expr and values.get(':status') == 'completed':
+            calls.append(kwargs)
+    return calls
+
+
+class TestUsagePersistedInSameUpdateCall:
+    def test_completed_update_call_sets_usage_and_usage_totals(self, mock_exec, monkeypatch):
+        import executor
+
+        monkeypatch.delenv('WORKER_QUEUE_URL', raising=False)
+        mock_exec['workflows_table'].get_item.return_value = {'Item': copy.deepcopy(CHAIN_WORKFLOW)}
+        mock_exec['executions_table'].get_item.return_value = {'Item': copy.deepcopy(CHAIN_EXEC)}
+
+        usage = [{'inputTokens': 10, 'outputTokens': 5}]
+        executor.handle_node_completion('exec-chain', 'n0', {'result': 'done'}, usage)
+
+        calls = _completed_update_calls(mock_exec['executions_table'])
+        assert len(calls) == 1
+        kwargs = calls[0]
+        assert 'nodeResults.#nid.#usage' in kwargs['UpdateExpression']
+        assert 'nodeResults.#nid.#usageTotals' in kwargs['UpdateExpression']
+        assert kwargs['ExpressionAttributeValues'][':usage'] == usage
+        assert kwargs['ExpressionAttributeValues'][':usageTotals'] == {
+            'inputTokens': 10, 'outputTokens': 5, 'totalTokens': 15, 'callCount': 1,
+        }
+
+    def test_update_expression_never_contains_add(self, mock_exec, monkeypatch):
+        """Design constraint: the usage write is a per-node SET, never an ADD."""
+        import executor
+
+        monkeypatch.delenv('WORKER_QUEUE_URL', raising=False)
+        mock_exec['workflows_table'].get_item.return_value = {'Item': copy.deepcopy(CHAIN_WORKFLOW)}
+        mock_exec['executions_table'].get_item.return_value = {'Item': copy.deepcopy(CHAIN_EXEC)}
+
+        executor.handle_node_completion(
+            'exec-chain', 'n0', {'result': 'done'}, [{'inputTokens': 1, 'outputTokens': 1}],
+        )
+
+        for call in mock_exec['executions_table'].update_item.call_args_list:
+            expr = call.kwargs.get('UpdateExpression', '')
+            # 'ADD' as a distinct clause keyword, not a substring of e.g. an
+            # attribute name — every clause in this codebase starts with SET.
+            assert not expr.strip().upper().startswith('ADD ')
+            assert ' ADD ' not in f' {expr.upper()} '
+
+    def test_fallback_when_usage_only_in_output(self, mock_exec, monkeypatch):
+        """Back-compat: no top-level usage arg (defaults to None) — the
+        function falls back to output['usage'] itself so a direct caller
+        (or an old in-flight event) still gets usage persisted."""
+        import executor
+
+        monkeypatch.delenv('WORKER_QUEUE_URL', raising=False)
+        mock_exec['workflows_table'].get_item.return_value = {'Item': copy.deepcopy(CHAIN_WORKFLOW)}
+        mock_exec['executions_table'].get_item.return_value = {'Item': copy.deepcopy(CHAIN_EXEC)}
+
+        output = {'result': 'done', 'usage': [{'inputTokens': 2, 'outputTokens': 3}]}
+        # usage arg omitted entirely -> falls back to output['usage'].
+        executor.handle_node_completion('exec-chain', 'n0', output)
+
+        calls = _completed_update_calls(mock_exec['executions_table'])
+        assert calls[0]['ExpressionAttributeValues'][':usage'] == [{'inputTokens': 2, 'outputTokens': 3}]
+        assert calls[0]['ExpressionAttributeValues'][':usageTotals'] == {
+            'inputTokens': 2, 'outputTokens': 3, 'totalTokens': 5, 'callCount': 1,
+        }
+
+
+class TestDuplicateDeliveryUsageIdempotency:
+    def _exec_get_item_first_running_then(self, status_after, node_id, base_exec):
+        call_count = [0]
+
+        def side_effect(**kwargs):
+            call_count[0] += 1
+            e = copy.deepcopy(base_exec)
+            if call_count[0] == 1:
+                e['nodeResults'][node_id]['status'] = 'running'
+            else:
+                e['nodeResults'][node_id]['status'] = status_after
+            return {'Item': e}
+
+        return side_effect
+
+    def test_duplicate_completion_leaves_persisted_usage_totals_unchanged(self, mock_exec, monkeypatch):
+        """With the status guard intact, a redelivered node-completed event
+        (with usage) is a full no-op on the second call — the completed
+        update_item (and thus its usage write) fires exactly once."""
+        import executor
+
+        monkeypatch.delenv('WORKER_QUEUE_URL', raising=False)
+        mock_exec['workflows_table'].get_item.return_value = {'Item': copy.deepcopy(CHAIN_WORKFLOW)}
+        mock_exec['executions_table'].get_item.side_effect = \
+            self._exec_get_item_first_running_then('completed', 'n0', CHAIN_EXEC)
+
+        usage = [{'inputTokens': 10, 'outputTokens': 5}]
+        executor.handle_node_completion('exec-chain', 'n0', {'result': 'done'}, usage)
+        executor.handle_node_completion('exec-chain', 'n0', {'result': 'done'}, usage)  # duplicate
+
+        calls = _completed_update_calls(mock_exec['executions_table'])
+        assert len(calls) == 1  # guard short-circuits the second delivery entirely
+
+    def test_guard_bypass_write_is_still_idempotent_last_write_wins(self, mock_exec, monkeypatch):
+        """Even if the guard were bypassed (never returns early), calling the
+        completed-update path twice with identical usage writes byte-identical
+        SET values both times — last-write-wins, no drift."""
+        import executor
+
+        monkeypatch.delenv('WORKER_QUEUE_URL', raising=False)
+        mock_exec['workflows_table'].get_item.return_value = {'Item': copy.deepcopy(CHAIN_WORKFLOW)}
+        # Always return a FRESH deep copy of the node as 'running' so the
+        # guard never short-circuits on either call — this exercises the
+        # write's own idempotency, not the guard's, and avoids the executor's
+        # in-place node_results mutation leaking between calls (which would
+        # otherwise make the second call see 'completed' via the SAME dict
+        # object returned by a plain .return_value).
+        mock_exec['executions_table'].get_item.side_effect = \
+            lambda **kwargs: {'Item': copy.deepcopy(CHAIN_EXEC)}
+
+        usage = [{'inputTokens': 10, 'outputTokens': 5}]
+        executor.handle_node_completion('exec-chain', 'n0', {'result': 'done'}, usage)
+        executor.handle_node_completion('exec-chain', 'n0', {'result': 'done'}, usage)
+
+        calls = _completed_update_calls(mock_exec['executions_table'])
+        assert len(calls) == 2
+        assert calls[0]['ExpressionAttributeValues'][':usage'] == calls[1]['ExpressionAttributeValues'][':usage']
+        assert calls[0]['ExpressionAttributeValues'][':usageTotals'] == calls[1]['ExpressionAttributeValues'][':usageTotals']
+
+    @given(dup_count=st.integers(min_value=0, max_value=5))
+    @settings(max_examples=20, deadline=None)
+    def test_any_number_of_duplicates_leave_usage_totals_stable(self, dup_count):
+        """Property: 1 real completion + N duplicates ⇒ the persisted usage
+        totals are identical to the single-delivery case (guard intact)."""
+        import executor
+
+        wf_table = MagicMock()
+        exec_table = MagicMock()
+        ev = MagicMock()
+        wf_table.get_item.return_value = {'Item': copy.deepcopy(CHAIN_WORKFLOW)}
+        exec_table.get_item.side_effect = \
+            self._exec_get_item_first_running_then('completed', 'n0', CHAIN_EXEC)
+
+        usage = [{'inputTokens': 7, 'outputTokens': 2}]
+        with patch.object(executor, '_workflows_table', wf_table), \
+             patch.object(executor, '_executions_table', exec_table), \
+             patch.object(executor, 'events', ev), \
+             patch.object(executor, '_get_sqs_client', return_value=MagicMock()), \
+             patch.dict(os.environ, {}, clear=False):
+            os.environ.pop('WORKER_QUEUE_URL', None)
+            for _ in range(1 + dup_count):
+                executor.handle_node_completion('exec-chain', 'n0', {'result': 'done'}, usage)
+
+        calls = _completed_update_calls(exec_table)
+        assert len(calls) == 1
+        assert calls[0]['ExpressionAttributeValues'][':usageTotals'] == {
+            'inputTokens': 7, 'outputTokens': 2, 'totalTokens': 9, 'callCount': 1,
+        }
+
+
+class TestConcurrentNodesNoKeyCollision:
+    def test_diamond_two_predecessors_each_write_own_usage_keys(self, mock_exec, monkeypatch):
+        """Two different nodes (n1, n2) completing concurrently each write
+        their own nodeResults[nid].usage / .usageTotals — no key collision,
+        no clobbering of the other node's usage."""
+        import executor
+
+        monkeypatch.delenv('WORKER_QUEUE_URL', raising=False)
+        mock_exec['workflows_table'].get_item.return_value = {'Item': copy.deepcopy(DIAMOND_WORKFLOW)}
+
+        # n1 completes first (n2 still running in the persisted view).
+        exec_after_n1 = copy.deepcopy(DIAMOND_EXEC)
+        exec_after_n1['nodeResults']['n1']['status'] = 'completed'
+        mock_exec['executions_table'].get_item.side_effect = [
+            {'Item': copy.deepcopy(DIAMOND_EXEC)},
+            {'Item': exec_after_n1},
+        ]
+
+        usage_n1 = [{'inputTokens': 4, 'outputTokens': 1}]
+        usage_n2 = [{'inputTokens': 9, 'outputTokens': 6}]
+        executor.handle_node_completion('exec-diamond', 'n1', {'r': 1}, usage_n1)
+        executor.handle_node_completion('exec-diamond', 'n2', {'r': 2}, usage_n2)
+
+        calls = _completed_update_calls(mock_exec['executions_table'])
+        assert len(calls) == 2
+        by_node = {c['ExpressionAttributeNames']['#nid']: c for c in calls}
+        assert by_node['n1']['ExpressionAttributeValues'][':usage'] == usage_n1
+        assert by_node['n2']['ExpressionAttributeValues'][':usage'] == usage_n2
+        assert by_node['n1']['ExpressionAttributeValues'][':usageTotals']['totalTokens'] == 5
+        assert by_node['n2']['ExpressionAttributeValues'][':usageTotals']['totalTokens'] == 15

--- a/arbiter/stepRunner/events.py
+++ b/arbiter/stepRunner/events.py
@@ -60,9 +60,22 @@ def publish_node_started(execution_id: str, workflow_id: str, node_id: str, agen
     })
 
 
-def publish_node_completed(execution_id: str, workflow_id: str, node_id: str, agent_id: str, completed_at: str, output: dict) -> None:
-    """Publish workflow.node.completed event when a node completes successfully."""
-    publish_event('workflow.node.completed', {
+def publish_node_completed(
+    execution_id: str, workflow_id: str, node_id: str, agent_id: str, completed_at: str,
+    output: dict, usage: list | None = None,
+) -> None:
+    """Publish workflow.node.completed event when a node completes successfully.
+
+    ``usage`` is additive and optional (usage rollup hop): forwarded as a
+    top-level ``usage`` key on the detail, mirroring the shape
+    ``workflow_contract.build_node_result_detail`` produces on the worker's
+    hot-path producer. This helper is not the live producer today (the
+    worker's ``_emit_node_result`` is — see module docstring caveat below),
+    but keeping the same additive shape here avoids drift if a caller adopts
+    it later. Omitted (``None``) keeps the detail identical to pre-feature
+    callers — no ``usage`` key is added.
+    """
+    detail = {
         'executionId': execution_id,
         'workflowId': workflow_id,
         'nodeId': node_id,
@@ -70,7 +83,10 @@ def publish_node_completed(execution_id: str, workflow_id: str, node_id: str, ag
         'completedAt': completed_at,
         'output': output,
         'correlationId': execution_id,
-    })
+    }
+    if usage is not None:
+        detail['usage'] = usage
+    publish_event('workflow.node.completed', detail)
 
 
 def publish_node_failed(execution_id: str, workflow_id: str, node_id: str, agent_id: str, error: str, retry_count: int) -> None:

--- a/arbiter/stepRunner/executor.py
+++ b/arbiter/stepRunner/executor.py
@@ -24,6 +24,7 @@ from dag import (
 from condition import evaluate_condition
 from retry import calculate_backoff, should_retry
 from common import workflow_contract
+from common.usage import aggregate_usage, parse_usage_array
 
 # DynamoDB table names from environment
 WORKFLOWS_TABLE = os.environ.get('WORKFLOWS_TABLE', 'citadel-workflows-dev')
@@ -288,16 +289,28 @@ def invoke_node(execution_id: str, workflow_id: str, node: dict, input_data: dic
     )
 
 
-def handle_node_completion(execution_id: str, node_id: str, output: dict) -> None:
+def handle_node_completion(execution_id: str, node_id: str, output: dict, usage: list | None = None) -> None:
     """Handle a completed node and advance the workflow.
 
-    1. Update node status → completed in DynamoDB
+    1. Update node status → completed in DynamoDB (same call also persists
+       the sanitized usage array + per-node usage totals — usage rollup hop)
     2. Publish workflow.node.completed event
     3. Evaluate conditional edges on outgoing edges
     4. For conditional edges that evaluate to false → mark downstream as skipped
     5. For convergence nodes → check if all predecessors complete
     6. Invoke ready nodes
     7. If all nodes complete → mark execution completed
+
+    ``usage`` is additive and optional: a list of worker usage records for
+    this node (the caller — ``index.handler`` — extracts it from the
+    event's top-level ``usage`` key, falling back to ``output['usage']``).
+    When omitted, this function itself falls back to ``output.get('usage',
+    [])`` so a direct caller need not duplicate that fallback. Sanitized via
+    ``parse_usage_array``/``aggregate_usage`` — malformed usage degrades to
+    empty totals rather than raising. Persisted as a per-node SET (never an
+    ADD) in the SAME update_item call that marks the node completed, so a
+    duplicate delivery guarded by the status check below writes it at most
+    once, and even an unguarded re-write is byte-identical (last-write-wins).
     """
     execution = _load_execution(execution_id)
     if not execution:
@@ -326,17 +339,42 @@ def handle_node_completion(execution_id: str, node_id: str, output: dict) -> Non
 
     now = _now_iso()
 
-    # Update node to completed
+    # Usage rollup: sanitize the caller-supplied usage array (falling back to
+    # output['usage'] when the caller omitted it) and compute this node's
+    # totals. Both are defensive — malformed input degrades to [] / all-zero
+    # totals rather than raising, so usage processing can never fail the
+    # workflow.
+    sanitized_usage = parse_usage_array(usage if usage is not None else output.get('usage', []))
+    node_usage_totals = aggregate_usage(sanitized_usage)
+
+    # Update node to completed. The usage + usageTotals SET rides in the SAME
+    # update_item call as status/completedAt/output — never a second call,
+    # never an ADD — so reprocessing (if the guard above were ever bypassed)
+    # writes the identical bytes under the same nodeResults[node_id] key.
     _executions_table.update_item(
         Key={'executionId': execution_id},
-        UpdateExpression='SET nodeResults.#nid.#status = :status, nodeResults.#nid.#completedAt = :completedAt, nodeResults.#nid.#output = :output',
+        UpdateExpression=(
+            'SET nodeResults.#nid.#status = :status, '
+            'nodeResults.#nid.#completedAt = :completedAt, '
+            'nodeResults.#nid.#output = :output, '
+            'nodeResults.#nid.#usage = :usage, '
+            'nodeResults.#nid.#usageTotals = :usageTotals'
+        ),
         ExpressionAttributeNames={
             '#nid': node_id,
             '#status': 'status',
             '#completedAt': 'completedAt',
             '#output': 'output',
+            '#usage': 'usage',
+            '#usageTotals': 'usageTotals',
         },
-        ExpressionAttributeValues={':status': 'completed', ':completedAt': now, ':output': output},
+        ExpressionAttributeValues={
+            ':status': 'completed',
+            ':completedAt': now,
+            ':output': output,
+            ':usage': sanitized_usage,
+            ':usageTotals': node_usage_totals,
+        },
     )
 
     # Best-effort telemetry (WF-053). A metric or log failure must never break

--- a/arbiter/stepRunner/index.py
+++ b/arbiter/stepRunner/index.py
@@ -11,7 +11,15 @@ def handler(event, context):
     if detail_type == 'execution.start.requested':
         start_execution(detail['executionId'], detail['workflowId'])
     elif detail_type == 'workflow.node.completed':
-        handle_node_completion(detail['executionId'], detail['nodeId'], detail.get('output', {}))
+        output = detail.get('output', {})
+        # Usage rollup hop: prefer the additive top-level 'usage' key (the
+        # worker promotes it there via workflow_contract.build_node_result_detail);
+        # fall back to output['usage'] for an in-flight event emitted before
+        # this change, and finally to [] when neither is present.
+        usage = detail.get('usage')
+        if usage is None:
+            usage = output.get('usage', [])
+        handle_node_completion(detail['executionId'], detail['nodeId'], output, usage)
     elif detail_type == 'workflow.node.failed':
         handle_node_failure(detail['executionId'], detail['nodeId'], detail.get('error', ''))
     elif detail_type == 'execution.cancel.requested':

--- a/arbiter/supervisor/__tests__/test_supervisor_governed_dispatch.py
+++ b/arbiter/supervisor/__tests__/test_supervisor_governed_dispatch.py
@@ -200,8 +200,11 @@ class TestModeDrivenPermissiveShadow:
 
         assert mock_load.called
         mock_write.assert_called_once_with(finding)
+        # governed_process_agent_call forwards the additive supervisor_usage
+        # kwarg (default None when the caller doesn't supply one).
         mock_dispatch.assert_called_once_with(
             _AGENTS_CONFIG, _ORCH, "agent-a", {"x": 1}, "use-1",
+            supervisor_usage=None,
         )
         assert result == {"dispatched": True}
 

--- a/arbiter/supervisor/__tests__/test_supervisor_usage_capture.py
+++ b/arbiter/supervisor/__tests__/test_supervisor_usage_capture.py
@@ -1,0 +1,274 @@
+"""Supervisor Converse-call usage capture + dispatch-result attachment tests.
+
+Covers the design's supervisor-side additions:
+
+  - ``orchestrate()`` captures ``response['usage']`` from the Bedrock
+    Converse call, builds a ``source='supervisor'`` usage record, and
+    threads it through ``invoke_agents_from_conversation`` ->
+    ``governed_process_agent_call`` -> ``process_agent_call``.
+  - ``process_agent_call`` stamps ``payload['supervisorUsage']`` on the SQS
+    dispatch body when a supervisor usage record is supplied.
+  - All new parameters default to ``None`` so existing callers/tests are
+    unaffected (backward compatible); a missing/absent usage block degrades
+    to zeros + a WARN log rather than raising, and dispatch still proceeds.
+
+Follows the module-import and boto3-stubbing conventions of
+``test_supervisor_app_id.py`` / ``test_supervisor_governed_dispatch.py``.
+"""
+from __future__ import annotations
+
+import json
+import logging
+import os
+import sys
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+
+os.environ.setdefault("AGENT_CONFIG_TABLE", "fake-table")
+os.environ.setdefault("EVENT_BUS_NAME", "fake-bus")
+os.environ.setdefault("ORCHESTRATION_TABLE", "fake-orch-table")
+os.environ.setdefault("WORKER_STATE_TABLE", "fake-worker-table")
+
+_mock_dynamodb = MagicMock()
+_mock_sqs = MagicMock()
+_mock_bedrock = MagicMock()
+_mock_events = MagicMock()
+
+with patch.multiple(
+    "boto3",
+    resource=MagicMock(return_value=_mock_dynamodb),
+    client=MagicMock(side_effect=lambda svc, **kw: {
+        "sqs": _mock_sqs,
+        "bedrock-runtime": _mock_bedrock,
+        "events": _mock_events,
+    }.get(svc, MagicMock())),
+):
+    import index as supervisor_mod
+
+
+def _bedrock_response_with_tool_use(usage=None):
+    """A Converse response with a single toolUse content item, optionally
+    carrying a usage block."""
+    resp = {
+        "output": {
+            "message": {
+                "role": "assistant",
+                "content": [
+                    {"toolUse": {"name": "agent-a", "input": {"x": 1}, "toolUseId": "tu-1"}},
+                ],
+            }
+        }
+    }
+    if usage is not None:
+        resp["usage"] = usage
+    return resp
+
+
+def _bedrock_response_text_only(text="ok", usage=None):
+    resp = {
+        "output": {
+            "message": {
+                "role": "assistant",
+                "content": [{"text": text}],
+            }
+        }
+    }
+    if usage is not None:
+        resp["usage"] = usage
+    return resp
+
+
+_AGENTS_CONFIG = {
+    "agents": [{"name": "agent-a", "description": "test", "schema": {}, "action": {"type": "sqs", "target": "https://sqs.fake/q"}}]
+}
+
+
+class TestOrchestrateSupervisorUsageCapture:
+    """orchestrate() captures Converse usage and threads it downstream."""
+
+    @patch.object(supervisor_mod, "save_orchestration")
+    @patch.object(supervisor_mod, "create_workflow_tracking_record", return_value="req-1")
+    @patch.object(supervisor_mod, "governed_process_agent_call")
+    @patch.object(supervisor_mod, "bedrock_circuit_breaker")
+    @patch.object(supervisor_mod, "load_config_from_dynamodb")
+    def test_supervisor_usage_threaded_to_governed_dispatch(
+        self, mock_load, mock_breaker, mock_governed, mock_tracking, mock_save
+    ):
+        """A Converse response with a usage block results in
+        governed_process_agent_call being invoked with a supervisor_usage
+        kwarg carrying a source='supervisor' record."""
+        mock_load.return_value = {"agents": _AGENTS_CONFIG["agents"]}
+        mock_breaker.call.return_value = _bedrock_response_with_tool_use(
+            usage={"inputTokens": 11, "outputTokens": 22, "totalTokens": 33}
+        )
+        mock_governed.return_value = {"ok": True}
+
+        supervisor_mod.orchestrate(initial_message="hello")
+
+        assert mock_governed.called
+        _, kwargs = mock_governed.call_args
+        supervisor_usage = kwargs.get("supervisor_usage")
+        assert supervisor_usage is not None, \
+            "expected governed_process_agent_call to receive a supervisor_usage kwarg"
+        assert supervisor_usage["source"] == "supervisor"
+        assert supervisor_usage["inputTokens"] == 11
+        assert supervisor_usage["outputTokens"] == 22
+        assert supervisor_usage["modelId"] == supervisor_mod.MODEL_ID
+
+    @patch.object(supervisor_mod, "save_orchestration")
+    @patch.object(supervisor_mod, "events_client")
+    @patch.object(supervisor_mod, "bedrock_circuit_breaker")
+    @patch.object(supervisor_mod, "load_config_from_dynamodb")
+    def test_missing_usage_block_degrades_to_zeros_and_warn(
+        self, mock_load, mock_breaker, mock_events_client, mock_save, caplog
+    ):
+        """A Converse response with NO usage block still lets orchestrate()
+        proceed (text-only response path), degrading to a zeroed usage
+        record rather than raising, and logs a WARN."""
+        mock_load.return_value = {"agents": _AGENTS_CONFIG["agents"]}
+        mock_breaker.call.return_value = _bedrock_response_text_only("done")
+
+        with caplog.at_level(logging.WARNING, logger=supervisor_mod.logger.name):
+            supervisor_mod.orchestrate(initial_message="hello")
+
+        # Must not have raised; the text-only (no agents invoked, no
+        # callback) path still publishes supervisor feedback to EventBridge.
+        assert mock_events_client.put_events.called
+        assert any(
+            "no usage block" in r.message for r in caplog.records
+        )
+
+    @patch.object(supervisor_mod, "save_orchestration")
+    @patch.object(supervisor_mod, "create_workflow_tracking_record", return_value="req-1")
+    @patch.object(supervisor_mod, "governed_process_agent_call")
+    @patch.object(supervisor_mod, "bedrock_circuit_breaker")
+    @patch.object(supervisor_mod, "load_config_from_dynamodb")
+    def test_backward_compatible_without_new_kwarg_semantics(
+        self, mock_load, mock_breaker, mock_governed, mock_tracking, mock_save
+    ):
+        """orchestrate() still works end-to-end when the Converse response
+        carries no usage block at all — dispatch is unaffected."""
+        mock_load.return_value = {"agents": _AGENTS_CONFIG["agents"]}
+        mock_breaker.call.return_value = _bedrock_response_with_tool_use(usage=None)
+        mock_governed.return_value = {"ok": True}
+
+        # Must not raise.
+        supervisor_mod.orchestrate(initial_message="hello")
+        assert mock_governed.called
+
+
+class TestProcessAgentCallSupervisorUsageStamping:
+    """process_agent_call stamps payload['supervisorUsage'] on the SQS body."""
+
+    def _agent_config(self):
+        return {
+            "agents": [
+                {"name": "agent-a", "action": {"type": "sqs", "target": "https://sqs.fake/q"}},
+            ]
+        }
+
+    def test_supervisor_usage_stamped_on_sqs_payload(self):
+        """When supervisor_usage is supplied, the SQS MessageBody JSON
+        carries a 'supervisorUsage' key with the record."""
+        _mock_sqs.send_message.reset_mock()
+        usage_record = {
+            "modelId": "m", "inputTokens": 1, "outputTokens": 2,
+            "latencyMs": 3, "callIndex": 0,
+            "capturedAt": "2024-01-01T00:00:00Z", "source": "supervisor",
+        }
+
+        with patch.object(supervisor_mod, "EVENT_BUS_NAME", None):
+            result = supervisor_mod.process_agent_call(
+                self._agent_config(),
+                {"orchestrationId": "orch-1"},
+                "agent-a",
+                {"x": 1},
+                "use-1",
+                supervisor_usage=usage_record,
+            )
+
+        assert _mock_sqs.send_message.called
+        _, kwargs = _mock_sqs.send_message.call_args
+        body = json.loads(kwargs["MessageBody"])
+        assert body.get("supervisorUsage") == usage_record
+
+    def test_no_supervisor_usage_kwarg_is_backward_compatible(self):
+        """Calling process_agent_call without supervisor_usage at all
+        (the pre-existing call signature) still dispatches successfully,
+        with no 'supervisorUsage' key forced into the payload."""
+        _mock_sqs.send_message.reset_mock()
+
+        with patch.object(supervisor_mod, "EVENT_BUS_NAME", None):
+            result = supervisor_mod.process_agent_call(
+                self._agent_config(),
+                {"orchestrationId": "orch-1"},
+                "agent-a",
+                {"x": 1},
+                "use-1",
+            )
+
+        assert _mock_sqs.send_message.called
+        _, kwargs = _mock_sqs.send_message.call_args
+        body = json.loads(kwargs["MessageBody"])
+        assert "supervisorUsage" not in body
+
+    def test_none_supervisor_usage_omits_key_entirely(self):
+        """Explicit supervisor_usage=None must not add a null key to the
+        payload — it should behave identically to omitting the kwarg."""
+        _mock_sqs.send_message.reset_mock()
+
+        with patch.object(supervisor_mod, "EVENT_BUS_NAME", None):
+            supervisor_mod.process_agent_call(
+                self._agent_config(),
+                {"orchestrationId": "orch-1"},
+                "agent-a",
+                {"x": 1},
+                "use-1",
+                supervisor_usage=None,
+            )
+
+        _, kwargs = _mock_sqs.send_message.call_args
+        body = json.loads(kwargs["MessageBody"])
+        assert "supervisorUsage" not in body
+
+
+class TestGovernedProcessAgentCallForwardsSupervisorUsage:
+    """governed_process_agent_call's permit/shadow/permissive paths forward
+    supervisor_usage through to process_agent_call unchanged."""
+
+    def _state(self, enforcement_mode="shadow"):
+        state = MagicMock()
+        state.authority_units = []
+        state.composition_contracts = []
+        state.case_law = []
+        state.constitutional_layers = []
+        state.enforcement_mode = enforcement_mode
+        return state
+
+    def test_shadow_mode_forwards_supervisor_usage(self, monkeypatch):
+        monkeypatch.setattr(supervisor_mod, "_GOVERNANCE_AVAILABLE", True)
+        usage_record = {"source": "supervisor", "inputTokens": 5}
+
+        with patch.object(supervisor_mod, "load_governance_state", return_value=self._state("shadow")), \
+             patch.object(supervisor_mod, "GovernanceEngine") as mock_engine_cls, \
+             patch.object(supervisor_mod, "write_finding"), \
+             patch.object(supervisor_mod, "process_agent_call") as mock_dispatch:
+            mock_finding = MagicMock()
+            mock_finding.scope_evaluated = "supervisor-dispatch"
+            mock_engine_cls.return_value.evaluate.return_value = mock_finding
+
+            supervisor_mod.governed_process_agent_call(
+                {"agents": [{"name": "agent-a", "domain": "d"}]},
+                {"orchestrationId": "orch-1"},
+                "agent-a",
+                {"x": 1},
+                "use-1",
+                supervisor_usage=usage_record,
+            )
+
+        mock_dispatch.assert_called_once()
+        _, kwargs = mock_dispatch.call_args
+        assert kwargs.get("supervisor_usage") == usage_record

--- a/arbiter/supervisor/index.py
+++ b/arbiter/supervisor/index.py
@@ -71,6 +71,15 @@ if _arbiter_dir not in sys.path:
 from common.region import cross_region_prefix
 from model_config_loader import load_model_id
 
+# Shared usage-record schema/helpers (arbiter/common/usage.py). arbiter/ is
+# already on sys.path (inserted above for the governance package import), so
+# this resolves the same way as ``common.region``/``common.workflow_contract``
+# elsewhere in the codebase. Kept as a hard import (not defensively guarded)
+# because ``arbiter/common/`` ships alongside the supervisor Lambda asset
+# today — unlike workerWrapper's deferred-bundling situation for
+# ``tools_config``/``workflow_contract``.
+from common.usage import build_usage_record, extract_converse_usage
+
 
 def _load_governance_package():
     """Load ``arbiter/governance/`` as a package under a private name.
@@ -326,6 +335,7 @@ def governed_process_agent_call(
     agent_input: Any,
     agent_use_id: str,
     app_id: str | None = None,
+    supervisor_usage: dict | None = None,
 ) -> Any:
     """Control-surface wrapper around ``process_agent_call`` (US-ARB-008).
 
@@ -463,13 +473,15 @@ def governed_process_agent_call(
     #    strict: PERMIT -> call, DENY -> block, ESCALATE/HALT -> SNS + block.
     if bypass_override or enforcement_mode in ('permissive', 'shadow'):
         return process_agent_call(
-            agents_config, orchestration, agent_name, agent_input, agent_use_id
+            agents_config, orchestration, agent_name, agent_input, agent_use_id,
+            supervisor_usage=supervisor_usage,
         )
 
     decision = finding.decision
     if decision == ArbitrationDecision.PERMIT:
         return process_agent_call(
-            agents_config, orchestration, agent_name, agent_input, agent_use_id
+            agents_config, orchestration, agent_name, agent_input, agent_use_id,
+            supervisor_usage=supervisor_usage,
         )
     elif decision == ArbitrationDecision.DENY:
         return {
@@ -517,7 +529,7 @@ def _route_escalation(finding) -> None:
         )
 
 
-def process_agent_call(agents_config, orchestration, agent_name, agent_input, agent_use_id):
+def process_agent_call(agents_config, orchestration, agent_name, agent_input, agent_use_id, *, supervisor_usage=None):
     agent_config = next(
         (agent for agent in agents_config['agents'] if agent['name'] == agent_name), None)
 
@@ -534,6 +546,13 @@ def process_agent_call(agents_config, orchestration, agent_name, agent_input, ag
         "agent_use_id": agent_use_id,
         "node": agent_name
     }
+
+    # Additive: stamp the supervisor's own Converse-call usage record on the
+    # dispatch payload when one was captured. Omitted entirely (not a null
+    # key) when the caller didn't supply one — keeps the payload unchanged
+    # for existing callers/tests.
+    if supervisor_usage is not None:
+        payload['supervisorUsage'] = supervisor_usage
 
     # Activate the per-agent modelOverride binding: resolve the configured
     # model key to a concrete inference-profile id and forward it in the
@@ -593,7 +612,7 @@ def process_agent_call(agents_config, orchestration, agent_name, agent_input, ag
         return response
 
 
-def invoke_agents_from_conversation(orchestration, agents_config, app_id=None):
+def invoke_agents_from_conversation(orchestration, agents_config, app_id=None, supervisor_usage=None):
     agent_ids = []
     output_message = orchestration["conversation"][-1]
     text_response = None
@@ -614,6 +633,7 @@ def invoke_agents_from_conversation(orchestration, agents_config, app_id=None):
                 tool_use['input'],
                 tool_use['toolUseId'],
                 app_id=app_id if app_id is not None else orchestration.get('app_id'),
+                supervisor_usage=supervisor_usage,
             )
             print(f'Agent call result: {result}')
         elif 'text' in content:
@@ -707,6 +727,7 @@ def orchestrate(initial_message=None, orchestration=None, callback=None, app_id=
     print(f"Agent specs created: {json.dumps(agent_specs, default=str)}")
     print(f"Calling Bedrock with conversation: {json.dumps(orchestration['conversation'], default=str)}")
 
+    _converse_start = time.perf_counter()
     response = bedrock_circuit_breaker.call(
         bedrock.converse,
         modelId=MODEL_ID,
@@ -721,14 +742,36 @@ def orchestrate(initial_message=None, orchestration=None, callback=None, app_id=
             "toolChoice": {"auto": {}}
         }
     )
+    _converse_latency_ms = int((time.perf_counter() - _converse_start) * 1000)
 
     print(f"Bedrock response: {json.dumps(response, default=str)}")
     print(f"Response output message: {json.dumps(response['output']['message'], default=str)}")
 
     orchestration["conversation"].append(response['output']['message'])
 
+    # Capture this Converse call's usage as a source='supervisor' record.
+    # extract_converse_usage degrades to (0, 0, None) on a missing/malformed
+    # usage block rather than raising, so a provider response that omits
+    # usage still lets orchestration proceed — just logged as a WARN.
+    input_tokens, output_tokens, total_tokens = extract_converse_usage(response)
+    if 'usage' not in response:
+        logger.warning(
+            'Bedrock Converse response for orchestration %s carried no '
+            'usage block; recording a zeroed supervisor usage record.',
+            orchestration.get('orchestrationId', 'unknown'),
+        )
+    supervisor_usage = build_usage_record(
+        model_id=MODEL_ID,
+        input_tokens=input_tokens,
+        output_tokens=output_tokens,
+        latency_ms=_converse_latency_ms,
+        call_index=0,
+        source='supervisor',
+        total_tokens=total_tokens,
+    )
+
     invoke_agents_from_conversation(
-        orchestration, agent_configs, app_id=app_id
+        orchestration, agent_configs, app_id=app_id, supervisor_usage=supervisor_usage
     )
 
     save_orchestration(orchestration=orchestration)

--- a/arbiter/workerWrapper/__tests__/test_usage_capture_properties.py
+++ b/arbiter/workerWrapper/__tests__/test_usage_capture_properties.py
@@ -1,0 +1,288 @@
+"""Property-based tests for arbiter/workerWrapper/agent_runner.py usage capture.
+
+Exercises the third patch installer, ``_install_usage_capture``, which wraps
+``strands.models.BedrockModel``'s response-producing method to append
+``source='worker'`` usage records to a module-global list, and the
+``main()`` stdout envelope change from a bare ``{"response": ...}`` to
+``{"response": ..., "usage": [...]}``.
+
+Mirrors the conventions in ``test_agent_runner_properties.py`` (fake strands
+module injection via monkeypatch, temp-module handler execution, captured
+stdout parsing).
+"""
+
+import sys
+import os
+import json
+import tempfile
+import types
+from unittest.mock import patch
+
+import pytest
+from hypothesis import given, settings, HealthCheck
+from hypothesis import strategies as st
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+
+
+def _install_fake_strands_with_bedrock(monkeypatch, converse_impl=None):
+    """Install a fake ``strands`` module with a ``BedrockModel`` exposing a
+    ``converse`` method, so ``_install_usage_capture`` has a real seam to
+    patch. ``converse_impl`` lets the caller control the wrapped method's
+    behaviour (return value or raise).
+    """
+    fake_mod = types.ModuleType("strands")
+
+    class _FakeAgent:
+        def __init__(self, *args, tool_handler=None, tools=None, **kwargs):
+            self.tool_handler = tool_handler
+            self.tools = list(tools) if tools is not None else []
+
+    fake_mod.Agent = _FakeAgent
+    fake_models = types.ModuleType("strands.models")
+
+    class _BedrockModelStub:
+        def __init__(self, *args, **kwargs):
+            self.model_id = kwargs.get("model_id")
+            self.args = args
+            self.kwargs = kwargs
+
+        def converse(self, *args, **kwargs):
+            if converse_impl is not None:
+                return converse_impl(self, *args, **kwargs)
+            return {
+                "usage": {"inputTokens": 7, "outputTokens": 3, "totalTokens": 10}
+            }
+
+    fake_models.BedrockModel = _BedrockModelStub
+    fake_mod.models = fake_models
+    monkeypatch.setitem(sys.modules, "strands", fake_mod)
+    monkeypatch.setitem(sys.modules, "strands.models", fake_models)
+    return fake_mod
+
+
+def _run_runner_with_module(module_src, request, captured):
+    """Execute ``agent_runner.main()`` against a temp module, capturing stdout."""
+    with tempfile.NamedTemporaryFile(
+        mode="w", suffix=".py", delete=False
+    ) as f:
+        f.write(module_src)
+        module_path = f.name
+
+    try:
+        payload = json.dumps({"modulePath": module_path, "request": request})
+        with patch("sys.stdin") as mock_stdin, \
+             patch("builtins.print", side_effect=lambda s: captured.append(s)):
+            mock_stdin.read.return_value = payload
+            sys.modules.pop("agent_runner", None)
+            from agent_runner import main
+            main()
+    finally:
+        os.unlink(module_path)
+
+
+# ---------------------------------------------------------------------------
+# Envelope: {"response": ..., "usage": [...]}
+# ---------------------------------------------------------------------------
+
+class TestAgentRunnerUsageEnvelope:
+    """main() stdout envelope always carries a 'usage' key."""
+
+    @given(return_value=st.text(max_size=100))
+    @settings(max_examples=20, suppress_health_check=[HealthCheck.function_scoped_fixture])
+    def test_envelope_always_has_usage_key(self, monkeypatch, return_value):
+        """Regardless of strands availability, stdout envelope has 'usage'."""
+        monkeypatch.delenv("CITADEL_AGENT_ID", raising=False)
+        monkeypatch.delitem(sys.modules, "strands", raising=False)
+        module_src = (
+            f"def handler(**kwargs):\n"
+            f"    return {return_value!r}\n"
+        )
+        captured = []
+        _run_runner_with_module(module_src, {}, captured)
+        assert len(captured) == 1
+        parsed = json.loads(captured[0])
+        assert "response" in parsed
+        assert "usage" in parsed
+        assert isinstance(parsed["usage"], list)
+
+    def test_empty_usage_list_is_legal_when_no_bedrock_call_made(self, monkeypatch):
+        """A handler that never calls BedrockModel produces usage == []."""
+        _install_fake_strands_with_bedrock(monkeypatch)
+        module_src = (
+            "def handler(**kwargs):\n"
+            "    return 'no-model-call'\n"
+        )
+        captured = []
+        _run_runner_with_module(module_src, {}, captured)
+        parsed = json.loads(captured[0])
+        assert parsed["usage"] == []
+
+
+# ---------------------------------------------------------------------------
+# _install_usage_capture — happy path
+# ---------------------------------------------------------------------------
+
+class TestInstallUsageCaptureHappyPath:
+    def test_happy_path_capture_source_worker_call_index_zero(self, monkeypatch):
+        """A single converse() call is captured as source='worker', callIndex 0."""
+        _install_fake_strands_with_bedrock(monkeypatch)
+        module_src = (
+            "from strands.models import BedrockModel\n"
+            "def handler(**kwargs):\n"
+            "    m = BedrockModel(model_id='m.test')\n"
+            "    resp = m.converse()\n"
+            "    return 'ok'\n"
+        )
+        captured = []
+        _run_runner_with_module(module_src, {}, captured)
+        parsed = json.loads(captured[0])
+        usage = parsed["usage"]
+        assert len(usage) == 1
+        record = usage[0]
+        assert record["source"] == "worker"
+        assert record["callIndex"] == 0
+        assert record["latencyMs"] >= 0
+        assert record["modelId"] == "m.test"
+        assert record["inputTokens"] == 7
+        assert record["outputTokens"] == 3
+
+    def test_multiple_calls_increment_call_index_monotonically(self, monkeypatch):
+        """Multiple converse() calls within one process get monotonic callIndex."""
+        _install_fake_strands_with_bedrock(monkeypatch)
+        module_src = (
+            "from strands.models import BedrockModel\n"
+            "def handler(**kwargs):\n"
+            "    m = BedrockModel(model_id='m.test')\n"
+            "    m.converse()\n"
+            "    m.converse()\n"
+            "    m.converse()\n"
+            "    return 'ok'\n"
+        )
+        captured = []
+        _run_runner_with_module(module_src, {}, captured)
+        parsed = json.loads(captured[0])
+        usage = parsed["usage"]
+        assert len(usage) == 3
+        assert [r["callIndex"] for r in usage] == [0, 1, 2]
+
+    def test_model_override_env_wins_over_instance_attribute(self, monkeypatch):
+        """MODEL_OVERRIDE env var takes priority over the instance's model_id."""
+        monkeypatch.setenv("MODEL_OVERRIDE", "us.override.model")
+        _install_fake_strands_with_bedrock(monkeypatch)
+        module_src = (
+            "from strands.models import BedrockModel\n"
+            "def handler(**kwargs):\n"
+            "    m = BedrockModel(model_id='original.model')\n"
+            "    m.converse()\n"
+            "    return 'ok'\n"
+        )
+        captured = []
+        _run_runner_with_module(module_src, {}, captured)
+        parsed = json.loads(captured[0])
+        # _install_model_override also runs and forces the instance's
+        # model_id kwarg to the override, so the usage record should reflect
+        # the override either via env-read priority or the (already
+        # overridden) instance attribute — either way, override wins.
+        assert parsed["usage"][0]["modelId"] == "us.override.model"
+
+
+# ---------------------------------------------------------------------------
+# _install_usage_capture — graceful degradation
+# ---------------------------------------------------------------------------
+
+class TestInstallUsageCaptureDegradation:
+    def test_degrades_when_strands_unimportable(self, monkeypatch):
+        """Missing strands -> no crash, run completes, usage stays []."""
+        monkeypatch.delitem(sys.modules, "strands", raising=False)
+        monkeypatch.delitem(sys.modules, "strands.models", raising=False)
+
+        import builtins
+        real_import = builtins.__import__
+
+        def failing_import(name, *args, **kwargs):
+            if name == "strands" or name.startswith("strands."):
+                raise ImportError("strands unavailable (simulated)")
+            return real_import(name, *args, **kwargs)
+
+        monkeypatch.setattr(builtins, "__import__", failing_import)
+
+        module_src = (
+            "def handler(**kwargs):\n"
+            "    return 'ran-without-strands'\n"
+        )
+        captured = []
+        _run_runner_with_module(module_src, {}, captured)
+        parsed = json.loads(captured[0])
+        assert parsed["response"] == "ran-without-strands"
+        assert parsed["usage"] == []
+
+    def test_degrades_when_bedrock_model_absent(self, monkeypatch):
+        """strands present but no BedrockModel -> no crash, usage stays []."""
+        fake_mod = types.ModuleType("strands")
+        fake_mod.Agent = object
+        fake_models = types.ModuleType("strands.models")
+        # No BedrockModel attribute at all.
+        fake_mod.models = fake_models
+        monkeypatch.setitem(sys.modules, "strands", fake_mod)
+        monkeypatch.setitem(sys.modules, "strands.models", fake_models)
+
+        module_src = (
+            "def handler(**kwargs):\n"
+            "    return 'ran-without-bedrock-model'\n"
+        )
+        captured = []
+        _run_runner_with_module(module_src, {}, captured)
+        parsed = json.loads(captured[0])
+        assert parsed["response"] == "ran-without-bedrock-model"
+        assert parsed["usage"] == []
+
+    def test_capture_never_breaks_run_when_seam_raises(self, monkeypatch):
+        """If the wrapped converse() raises, the exception propagates to the
+        handler (unchanged behavior) but the capture machinery itself must
+        not introduce a NEW failure mode — no crash inside agent_runner's
+        capture bookkeeping.
+        """
+        def _raising_converse(self, *args, **kwargs):
+            raise RuntimeError("bedrock boom")
+
+        _install_fake_strands_with_bedrock(monkeypatch, converse_impl=_raising_converse)
+
+        module_src = (
+            "from strands.models import BedrockModel\n"
+            "def handler(**kwargs):\n"
+            "    m = BedrockModel(model_id='m.test')\n"
+            "    try:\n"
+            "        m.converse()\n"
+            "    except RuntimeError as e:\n"
+            "        return f'caught:{e}'\n"
+            "    return 'unreachable'\n"
+        )
+        captured = []
+        _run_runner_with_module(module_src, {}, captured)
+        parsed = json.loads(captured[0])
+        assert parsed["response"] == "caught:bedrock boom"
+        # The failed call must not have appended a bogus usage record.
+        assert parsed["usage"] == []
+
+    def test_returns_false_when_seam_method_not_found(self, monkeypatch):
+        """BedrockModel without converse/stream/structured_output -> installer
+        returns False and degrades without raising."""
+        fake_mod = types.ModuleType("strands")
+        fake_mod.Agent = object
+        fake_models = types.ModuleType("strands.models")
+
+        class _NoSeamBedrockModel:
+            def __init__(self, *args, **kwargs):
+                pass
+
+        fake_models.BedrockModel = _NoSeamBedrockModel
+        fake_mod.models = fake_models
+        monkeypatch.setitem(sys.modules, "strands", fake_mod)
+        monkeypatch.setitem(sys.modules, "strands.models", fake_models)
+
+        sys.modules.pop("agent_runner", None)
+        from agent_runner import _install_usage_capture
+
+        installed = _install_usage_capture()
+        assert installed is False

--- a/arbiter/workerWrapper/__tests__/test_worker_node_telemetry.py
+++ b/arbiter/workerWrapper/__tests__/test_worker_node_telemetry.py
@@ -99,3 +99,118 @@ class TestWorkerNodeCorrelationLogging:
             "expected a structured log carrying executionId/nodeId/workflowId on failure"
         # The failure log should reference the error.
         assert any('error' in log for log in matches)
+
+
+# ---------------------------------------------------------------------------
+# Usage capture is additive on both the supervisor-task and workflow-node
+# paths: task.completion Detail gains a 'usage' key without disturbing any
+# existing key, and workflow node completed output gains 'usage' alongside
+# the existing 'response' key. The failure path is unchanged (no usage key
+# expected there — a failed run never produced a response envelope either).
+# ---------------------------------------------------------------------------
+
+class TestUsageCaptureAdditive:
+    def test_task_completion_detail_carries_usage_additively(self):
+        """post_task_complete's EventBridge Detail gains 'usage' without
+        disturbing orchestration_id/data/agent_use_id/node."""
+        mock_events = MagicMock()
+        mock_events.put_events.return_value = {'FailedEntryCount': 0}
+
+        with patch.dict('os.environ', {
+            'AGENT_CONFIG_TABLE': 'test-table',
+            'COMPLETION_BUS_NAME': 'test-bus',
+        }):
+            with patch('boto3.resource'), patch('boto3.client', return_value=mock_events):
+                index = _fresh_index()
+                usage_records = [
+                    {'modelId': 'm', 'inputTokens': 1, 'outputTokens': 2,
+                     'latencyMs': 3, 'callIndex': 0,
+                     'capturedAt': '2024-01-01T00:00:00Z', 'source': 'worker'},
+                ]
+                index.post_task_complete(
+                    'a response', 'agent-use-1', 'agent-A', 'orch-1',
+                    usage=usage_records,
+                )
+
+        call_args = mock_events.put_events.call_args
+        entry = call_args[1]['Entries'][0] if 'Entries' in call_args[1] else call_args[0][0]['Entries'][0]
+        detail = json.loads(entry['Detail'])
+        assert detail['orchestration_id'] == 'orch-1'
+        assert detail['agent_use_id'] == 'agent-use-1'
+        assert detail['node'] == 'agent-A'
+        assert 'data' in detail
+        assert detail['usage'] == usage_records
+
+    def test_task_completion_detail_usage_defaults_to_empty_list(self):
+        """When no usage is captured, the Detail still carries 'usage': []
+        rather than omitting the key or passing None through."""
+        mock_events = MagicMock()
+        mock_events.put_events.return_value = {'FailedEntryCount': 0}
+
+        with patch.dict('os.environ', {
+            'AGENT_CONFIG_TABLE': 'test-table',
+            'COMPLETION_BUS_NAME': 'test-bus',
+        }):
+            with patch('boto3.resource'), patch('boto3.client', return_value=mock_events):
+                index = _fresh_index()
+                index.post_task_complete('a response', 'agent-use-1', 'agent-A', 'orch-1')
+
+        call_args = mock_events.put_events.call_args
+        entry = call_args[1]['Entries'][0] if 'Entries' in call_args[1] else call_args[0][0]['Entries'][0]
+        detail = json.loads(entry['Detail'])
+        assert detail['usage'] == []
+
+    def test_workflow_node_completed_output_carries_usage_additively(self, capsys):
+        """_process_workflow_node's success output gains 'usage' alongside
+        the existing 'response' key."""
+        mock_result = MagicMock(
+            returncode=0,
+            stdout=json.dumps({'response': 'done', 'usage': [
+                {'modelId': 'm', 'inputTokens': 5, 'outputTokens': 6,
+                 'latencyMs': 7, 'callIndex': 0,
+                 'capturedAt': '2024-01-01T00:00:00Z', 'source': 'worker'},
+            ]}),
+            stderr='',
+        )
+        mock_events = MagicMock()
+        mock_events.put_events.return_value = {'FailedEntryCount': 0}
+
+        with patch.dict('os.environ', _NODE_ENV):
+            with patch('boto3.resource'), patch('boto3.client', return_value=mock_events):
+                index = _fresh_index()
+                with patch.object(index, 'load_config_from_dynamodb',
+                                  return_value={'config': {'filename': 'agent.py'}}), \
+                     patch.object(index, 'get_scoped_credentials', return_value=None), \
+                     patch.object(index, 'load_file_from_s3_into_tmp'), \
+                     patch('subprocess.run', return_value=mock_result):
+                    index.process_event(dict(NODE_MESSAGE), {})
+
+        call_args = mock_events.put_events.call_args
+        entry = call_args[1]['Entries'][0] if 'Entries' in call_args[1] else call_args[0][0]['Entries'][0]
+        detail = json.loads(entry['Detail'])
+        output = detail.get('output', {})
+        assert output.get('response') == 'done'
+        assert len(output.get('usage', [])) == 1
+        assert output['usage'][0]['source'] == 'worker'
+
+    def test_workflow_node_failure_path_unchanged_no_usage_key_required(self, capsys):
+        """Failure path is unchanged: no 'output'/'usage' key is required
+        on a workflow.node.failed event."""
+        mock_result = MagicMock(returncode=1, stdout='', stderr='boom')
+        mock_events = MagicMock()
+        mock_events.put_events.return_value = {'FailedEntryCount': 0}
+
+        with patch.dict('os.environ', _NODE_ENV):
+            with patch('boto3.resource'), patch('boto3.client', return_value=mock_events):
+                index = _fresh_index()
+                with patch.object(index, 'load_config_from_dynamodb',
+                                  return_value={'config': {'filename': 'agent.py'}}), \
+                     patch.object(index, 'get_scoped_credentials', return_value=None), \
+                     patch.object(index, 'load_file_from_s3_into_tmp'), \
+                     patch('subprocess.run', return_value=mock_result):
+                    index.process_event(dict(NODE_MESSAGE), {})
+
+        call_args = mock_events.put_events.call_args
+        entry = call_args[1]['Entries'][0] if 'Entries' in call_args[1] else call_args[0][0]['Entries'][0]
+        detail = json.loads(entry['Detail'])
+        assert detail.get('status') == 'failed' or 'error' in detail

--- a/arbiter/workerWrapper/__tests__/test_worker_wrapper_properties.py
+++ b/arbiter/workerWrapper/__tests__/test_worker_wrapper_properties.py
@@ -186,6 +186,149 @@ class TestRunAgentSubprocessProperties:
 
 
 # ---------------------------------------------------------------------------
+# run_agent_in_subprocess — usage_sink envelope handling
+#
+# The child's stdout envelope is now {"response": str, "usage": [...]}.
+# run_agent_in_subprocess keeps returning a bare str (backward compatible)
+# and, when the caller passes usage_sink=[...], extends it in place with the
+# parsed usage records. Old {"response": ...}-only stdout and legacy
+# non-JSON stdout must continue to parse exactly as before, with usage_sink
+# staying empty.
+# ---------------------------------------------------------------------------
+
+class TestRunAgentUsageSinkEnvelope:
+    """Property tests for the additive usage_sink kwarg."""
+
+    def _fresh_index(self):
+        import sys
+        sys.modules.pop('index', None)
+        import index
+        return index
+
+    def test_usage_sink_extended_with_worker_usage_records(self):
+        """A well-formed {"response","usage":[...]}-shaped child envelope
+        extends the caller-supplied usage_sink in place."""
+        records = [
+            {'modelId': 'm', 'inputTokens': 1, 'outputTokens': 2,
+             'latencyMs': 3, 'callIndex': 0,
+             'capturedAt': '2024-01-01T00:00:00Z', 'source': 'worker'},
+        ]
+        mock_result = MagicMock()
+        mock_result.returncode = 0
+        mock_result.stdout = json.dumps({"response": "ok", "usage": records})
+        mock_result.stderr = ""
+
+        with patch.dict('os.environ', {
+            'AGENT_CONFIG_TABLE': 'test-table',
+            'CREDENTIAL_VENDER_FUNCTION': 'test-fn',
+        }):
+            with patch('boto3.resource'), patch('boto3.client'):
+                index = self._fresh_index()
+                with patch('subprocess.run', return_value=mock_result):
+                    sink = []
+                    result = index.run_agent_in_subprocess({}, None, usage_sink=sink)
+                    assert result == "ok"
+                    assert sink == records
+
+    def test_no_usage_sink_kwarg_is_backward_compatible(self):
+        """Callers that don't pass usage_sink see identical behavior to
+        before the envelope change — a bare str is returned."""
+        mock_result = MagicMock()
+        mock_result.returncode = 0
+        mock_result.stdout = json.dumps({"response": "ok", "usage": [{"a": 1}]})
+        mock_result.stderr = ""
+
+        with patch.dict('os.environ', {
+            'AGENT_CONFIG_TABLE': 'test-table',
+            'CREDENTIAL_VENDER_FUNCTION': 'test-fn',
+        }):
+            with patch('boto3.resource'), patch('boto3.client'):
+                index = self._fresh_index()
+                with patch('subprocess.run', return_value=mock_result):
+                    result = index.run_agent_in_subprocess({}, None)
+                    assert result == "ok"
+
+    def test_old_response_only_envelope_still_parses_usage_sink_stays_empty(self):
+        """Legacy {"response": ...}-only stdout (no 'usage' key) still parses
+        exactly as today; a supplied usage_sink stays empty rather than
+        raising on the missing key."""
+        mock_result = MagicMock()
+        mock_result.returncode = 0
+        mock_result.stdout = json.dumps({"response": "legacy-ok"})
+        mock_result.stderr = ""
+
+        with patch.dict('os.environ', {
+            'AGENT_CONFIG_TABLE': 'test-table',
+            'CREDENTIAL_VENDER_FUNCTION': 'test-fn',
+        }):
+            with patch('boto3.resource'), patch('boto3.client'):
+                index = self._fresh_index()
+                with patch('subprocess.run', return_value=mock_result):
+                    sink = []
+                    result = index.run_agent_in_subprocess({}, None, usage_sink=sink)
+                    assert result == "legacy-ok"
+                    assert sink == []
+
+    def test_legacy_non_json_stdout_still_returns_raw_and_sink_stays_empty(self):
+        """Non-JSON stdout (legacy handler behavior) still returns the raw
+        string; usage_sink stays empty rather than raising."""
+        mock_result = MagicMock()
+        mock_result.returncode = 0
+        mock_result.stdout = "plain text output"
+        mock_result.stderr = ""
+
+        with patch.dict('os.environ', {
+            'AGENT_CONFIG_TABLE': 'test-table',
+            'CREDENTIAL_VENDER_FUNCTION': 'test-fn',
+        }):
+            with patch('boto3.resource'), patch('boto3.client'):
+                index = self._fresh_index()
+                with patch('subprocess.run', return_value=mock_result):
+                    sink = []
+                    result = index.run_agent_in_subprocess({}, None, usage_sink=sink)
+                    assert result == "plain text output"
+                    assert sink == []
+
+    def test_malformed_usage_field_never_crashes_parent(self):
+        """A malformed 'usage' field (wrong type) in the child envelope must
+        never crash the parent — usage_sink stays empty via the defensive
+        parser."""
+        mock_result = MagicMock()
+        mock_result.returncode = 0
+        mock_result.stdout = json.dumps({"response": "ok", "usage": "not-a-list"})
+        mock_result.stderr = ""
+
+        with patch.dict('os.environ', {
+            'AGENT_CONFIG_TABLE': 'test-table',
+            'CREDENTIAL_VENDER_FUNCTION': 'test-fn',
+        }):
+            with patch('boto3.resource'), patch('boto3.client'):
+                index = self._fresh_index()
+                with patch('subprocess.run', return_value=mock_result):
+                    sink = []
+                    result = index.run_agent_in_subprocess({}, None, usage_sink=sink)
+                    assert result == "ok"
+                    assert sink == []
+
+    def test_usage_sink_none_default_never_raises(self):
+        """The default usage_sink=None must never attempt to extend anything."""
+        mock_result = MagicMock()
+        mock_result.returncode = 0
+        mock_result.stdout = json.dumps({"response": "ok", "usage": [{"a": 1}]})
+        mock_result.stderr = ""
+
+        with patch.dict('os.environ', {
+            'AGENT_CONFIG_TABLE': 'test-table',
+            'CREDENTIAL_VENDER_FUNCTION': 'test-fn',
+        }):
+            with patch('boto3.resource'), patch('boto3.client'):
+                index = self._fresh_index()
+                with patch('subprocess.run', return_value=mock_result):
+                    result = index.run_agent_in_subprocess({}, None, usage_sink=None)
+                    assert result == "ok"
+
+
+# ---------------------------------------------------------------------------
 # post_task_complete properties
 # ---------------------------------------------------------------------------
 

--- a/arbiter/workerWrapper/__tests__/test_workflow_node_dispatch.py
+++ b/arbiter/workerWrapper/__tests__/test_workflow_node_dispatch.py
@@ -81,6 +81,36 @@ class TestWorkflowNodeRouting:
         # subprocess stdout carries no usage array); 'response' is unchanged.
         assert detail['output']['response'] == 'done'
         assert detail['output']['usage'] == []
+        # The additive top-level 'usage' key mirrors output['usage'] — the
+        # usage rollup hop promotes it out of output for the step runner.
+        assert detail['usage'] == []
+
+    def test_node_message_with_usage_promotes_top_level_usage(self):
+        """When the subprocess stdout carries a usage array, the emitted
+        node-completed detail promotes it to a top-level 'usage' key in
+        addition to output['usage'] (unchanged, additive)."""
+        stdout = json.dumps({
+            'response': 'done',
+            'usage': [{'inputTokens': 5, 'outputTokens': 9}],
+        })
+        mock_result = MagicMock(returncode=0, stdout=stdout, stderr='')
+        mock_events = MagicMock()
+        mock_events.put_events.return_value = {'FailedEntryCount': 0}
+
+        with patch.dict('os.environ', _NODE_ENV):
+            with patch('boto3.resource'), patch('boto3.client', return_value=mock_events):
+                index = _fresh_index()
+                with patch.object(index, 'load_config_from_dynamodb',
+                                  return_value={'config': {'filename': 'agent.py'}}), \
+                     patch.object(index, 'get_scoped_credentials', return_value=None), \
+                     patch.object(index, 'load_file_from_s3_into_tmp'), \
+                     patch('subprocess.run', return_value=mock_result):
+                    index.process_event(dict(NODE_MESSAGE), {})
+
+        entry = mock_events.put_events.call_args.kwargs['Entries'][0]
+        detail = json.loads(entry['Detail'])
+        assert detail['output']['usage'] == [{'inputTokens': 5, 'outputTokens': 9}]
+        assert detail['usage'] == [{'inputTokens': 5, 'outputTokens': 9}]
 
     def test_node_message_subprocess_failure_emits_node_failed(self):
         # Non-zero exit → run_agent_in_subprocess(raise_on_error=True) raises →

--- a/arbiter/workerWrapper/__tests__/test_workflow_node_dispatch.py
+++ b/arbiter/workerWrapper/__tests__/test_workflow_node_dispatch.py
@@ -77,7 +77,10 @@ class TestWorkflowNodeRouting:
         assert detail['workflowId'] == 'wf-1'
         assert detail['agentId'] == 'agent-A'
         assert detail['status'] == 'completed'
-        assert detail['output'] == {'response': 'done'}
+        # output gained an additive 'usage' key (empty here since the mocked
+        # subprocess stdout carries no usage array); 'response' is unchanged.
+        assert detail['output']['response'] == 'done'
+        assert detail['output']['usage'] == []
 
     def test_node_message_subprocess_failure_emits_node_failed(self):
         # Non-zero exit → run_agent_in_subprocess(raise_on_error=True) raises →

--- a/arbiter/workerWrapper/agent_runner.py
+++ b/arbiter/workerWrapper/agent_runner.py
@@ -12,7 +12,257 @@ Writes the agent response as a JSON line to stdout.
 import json
 import sys
 import os
+import time
 import importlib.util
+
+# Module-global sink for usage records captured during this subprocess's
+# lifetime. Reset per-process (one agent_runner.main() invocation == one
+# subprocess), so callIndex is a simple monotonic counter starting at 0.
+_CAPTURED_USAGE: list = []
+
+# Ordered candidate method names probed on strands.models.BedrockModel to
+# find the response-producing seam to wrap. Multiple candidates survive a
+# strands rename of the primary method without requiring a code change here.
+_USAGE_CAPTURE_SEAM_CANDIDATES = ('converse', 'stream', 'structured_output')
+
+
+def _usage_builder():
+    """Return the canonical ``build_usage_record`` helper.
+
+    Imported defensively: the worker Lambda bundle currently ships only
+    ``arbiter/workerWrapper/`` (see the ``tools_config``/``workflow_contract``
+    deferred-bundling notes elsewhere in this package), so
+    ``arbiter/common/usage.py`` may not be present at runtime yet. We first
+    try adding the project root to ``sys.path`` and importing the canonical
+    module; if that fails we fall back to an inline mirror with the same
+    contract so capture still works pending the bundling follow-up.
+    """
+    _here = os.path.dirname(os.path.abspath(__file__))
+    _project_root = os.path.dirname(os.path.dirname(_here))
+    if _project_root not in sys.path:
+        sys.path.insert(0, _project_root)
+
+    try:
+        from common.usage import build_usage_record  # type: ignore[import-not-found]
+        return build_usage_record
+    except ImportError as exc:
+        sys.stderr.write(
+            f'[agent_runner] WARN canonical usage module unavailable, '
+            f'using inline mirror: {exc}\n'
+        )
+
+        def _inline_build_usage_record(
+            *, model_id, input_tokens, output_tokens, latency_ms,
+            call_index, source, captured_at=None, total_tokens=None,
+        ):
+            import datetime as _dt
+
+            def _nn_int(value):
+                try:
+                    if isinstance(value, bool):
+                        return 1 if value else 0
+                    if isinstance(value, (int, float)):
+                        if isinstance(value, float) and (value != value or value in (float('inf'), float('-inf'))):
+                            return 0
+                        coerced = int(value)
+                    elif isinstance(value, str):
+                        coerced = int(float(value.strip()))
+                    else:
+                        return 0
+                except (TypeError, ValueError, OverflowError):
+                    return 0
+                return max(0, coerced)
+
+            if source not in ('worker', 'supervisor'):
+                raise ValueError(f'invalid usage record source {source!r}')
+
+            record = {
+                'modelId': model_id if isinstance(model_id, str) and model_id else '',
+                'inputTokens': _nn_int(input_tokens),
+                'outputTokens': _nn_int(output_tokens),
+                'latencyMs': _nn_int(latency_ms),
+                'callIndex': _nn_int(call_index),
+                'capturedAt': captured_at or _dt.datetime.now(_dt.timezone.utc).isoformat(),
+                'source': source,
+            }
+            if total_tokens is not None:
+                record['totalTokens'] = _nn_int(total_tokens)
+            return record
+
+        return _inline_build_usage_record
+
+
+def _extract_usage_from_response(resp):
+    """Best-effort ``(inputTokens, outputTokens, totalTokens)`` extraction
+    from a non-streaming Converse-shaped dict result. Never raises —
+    returns ``(0, 0, None)`` on any non-conforming shape.
+    """
+    try:
+        if not isinstance(resp, dict):
+            return (0, 0, None)
+        usage = resp.get('usage')
+        if not isinstance(usage, dict):
+            return (0, 0, None)
+
+        def _nn_int(value):
+            try:
+                return max(0, int(value))
+            except (TypeError, ValueError):
+                return 0
+
+        input_tokens = _nn_int(usage.get('inputTokens'))
+        output_tokens = _nn_int(usage.get('outputTokens'))
+        raw_total = usage.get('totalTokens')
+        total_tokens = _nn_int(raw_total) if raw_total is not None else None
+        return (input_tokens, output_tokens, total_tokens)
+    except Exception as exc:  # noqa: BLE001 — extraction must never raise
+        sys.stderr.write(
+            f'[agent_runner] WARN usage extraction failed: {exc}\n'
+        )
+        return (0, 0, None)
+
+
+def _wrap_streaming_usage_capture(event_iterator, model_id, start_time, build_record):
+    """Passthrough generator wrapping a streaming response iterator.
+
+    Yields every event unchanged; inspects each event's ``metadata.usage``
+    (when present) to capture usage at stream completion. Any inspection
+    failure is swallowed with a WARN — the underlying stream is never
+    disrupted by capture bookkeeping.
+    """
+    last_usage = None
+    try:
+        for event in event_iterator:
+            try:
+                if isinstance(event, dict):
+                    metadata = event.get('metadata')
+                    if isinstance(metadata, dict) and isinstance(metadata.get('usage'), dict):
+                        last_usage = metadata['usage']
+            except Exception as exc:  # noqa: BLE001 — never break the stream
+                sys.stderr.write(
+                    f'[agent_runner] WARN streaming usage inspection failed: {exc}\n'
+                )
+            yield event
+    finally:
+        try:
+            input_tokens, output_tokens, total_tokens = _extract_usage_from_response(
+                {'usage': last_usage} if last_usage else {}
+            )
+            latency_ms = int((time.perf_counter() - start_time) * 1000)
+            record = build_record(
+                model_id=model_id,
+                input_tokens=input_tokens,
+                output_tokens=output_tokens,
+                latency_ms=latency_ms,
+                call_index=len(_CAPTURED_USAGE),
+                source='worker',
+                total_tokens=total_tokens,
+            )
+            _CAPTURED_USAGE.append(record)
+        except Exception as exc:  # noqa: BLE001 — capture must never raise
+            sys.stderr.write(
+                f'[agent_runner] WARN streaming usage capture failed: {exc}\n'
+            )
+
+
+def _install_usage_capture():
+    """Patch ``strands.models.BedrockModel``'s response-producing method to
+    append a ``source='worker'`` usage record to the module-global
+    ``_CAPTURED_USAGE`` list after every call.
+
+    Discovers the seam method by name from ``_USAGE_CAPTURE_SEAM_CANDIDATES``
+    to survive strands renames. Wraps both a non-streaming dict result and a
+    streaming event iterator (inspected via a passthrough generator).
+    Latency is timed with ``perf_counter``; ``model_id`` prefers the
+    ``MODEL_OVERRIDE`` env var (mirroring ``_install_model_override``'s
+    precedence) and falls back to the instance's ``model_id`` attribute.
+
+    Every capture step is wrapped in ``except Exception`` -> WARN-to-stderr
+    + continue. Capture must never raise into ``main()`` and must never
+    alter the response returned to the caller.
+
+    Graceful degrade when ``strands``/``BedrockModel`` cannot be imported,
+    or when none of the candidate seam methods exist on ``BedrockModel``:
+    WARN to stderr and return False.
+
+    Returns True when the patch was installed, False otherwise.
+    """
+    try:
+        import strands  # type: ignore[import-not-found]  # noqa: F401
+        from strands import models as _sm
+    except ImportError as exc:
+        sys.stderr.write(
+            f'[agent_runner] WARN usage capture skipped — '
+            f'strands unavailable: {exc}\n'
+        )
+        return False
+
+    Bedrock = getattr(_sm, 'BedrockModel', None)
+    if Bedrock is None:
+        sys.stderr.write(
+            '[agent_runner] WARN usage capture skipped — '
+            'strands.models.BedrockModel unavailable\n'
+        )
+        return False
+
+    seam_name = None
+    for candidate in _USAGE_CAPTURE_SEAM_CANDIDATES:
+        if hasattr(Bedrock, candidate):
+            seam_name = candidate
+            break
+
+    if seam_name is None:
+        sys.stderr.write(
+            '[agent_runner] WARN usage capture skipped — no known '
+            f'response-producing method found on BedrockModel '
+            f'(tried {_USAGE_CAPTURE_SEAM_CANDIDATES})\n'
+        )
+        return False
+
+    build_record = _usage_builder()
+    original_method = getattr(Bedrock, seam_name)
+
+    def _capturing_method(self, *args, **kwargs):
+        start_time = time.perf_counter()
+        result = original_method(self, *args, **kwargs)
+
+        try:
+            model_id = os.environ.get('MODEL_OVERRIDE') or getattr(self, 'model_id', None) or ''
+        except Exception as exc:  # noqa: BLE001 — never break the call
+            sys.stderr.write(
+                f'[agent_runner] WARN usage capture model_id lookup failed: {exc}\n'
+            )
+            model_id = ''
+
+        # Streaming case: result is a generator/iterator, not a dict. Wrap
+        # it in a passthrough generator that captures usage at completion
+        # without altering the yielded events.
+        if hasattr(result, '__next__') or (hasattr(result, '__iter__') and not isinstance(result, (dict, list, str, bytes))):
+            return _wrap_streaming_usage_capture(result, model_id, start_time, build_record)
+
+        try:
+            input_tokens, output_tokens, total_tokens = _extract_usage_from_response(result)
+            latency_ms = int((time.perf_counter() - start_time) * 1000)
+            record = build_record(
+                model_id=model_id,
+                input_tokens=input_tokens,
+                output_tokens=output_tokens,
+                latency_ms=latency_ms,
+                call_index=len(_CAPTURED_USAGE),
+                source='worker',
+                total_tokens=total_tokens,
+            )
+            _CAPTURED_USAGE.append(record)
+        except Exception as exc:  # noqa: BLE001 — capture must never raise
+            sys.stderr.write(
+                f'[agent_runner] WARN usage capture failed for non-streaming '
+                f'response: {exc}\n'
+            )
+
+        return result
+
+    setattr(Bedrock, seam_name, _capturing_method)
+    return True
 
 
 def _install_governed_tool_handler():
@@ -137,6 +387,13 @@ def main():
     module_path = payload['modulePath']
     request = payload.get('request', {})
 
+    # Reset the per-process usage sink. In the real Lambda subprocess each
+    # main() invocation IS the process lifetime (one exec per subprocess),
+    # so this is a no-op in production; it exists so tests that call main()
+    # repeatedly within one interpreter (or re-run this module) get a fresh
+    # 0-based callIndex sequence each time rather than accumulating state.
+    _CAPTURED_USAGE.clear()
+
     # Install governance patch BEFORE exec_module so every Agent(...)
     # construction in the loaded module picks it up. Safe no-op when the
     # subprocess env lacks CITADEL_AGENT_ID (backward compatible).
@@ -145,6 +402,12 @@ def main():
     # Overrides the model id for operator-selected per-agent overrides;
     # no-op unless MODEL_OVERRIDE is set in the subprocess environment.
     _install_model_override()
+
+    # Wraps BedrockModel's response-producing method to capture per-call
+    # token usage/latency into _CAPTURED_USAGE; degrades to a no-op (WARN
+    # to stderr) when strands/BedrockModel/the seam method are unavailable.
+    # Never alters the response and never raises into main().
+    _install_usage_capture()
 
     # Load and execute the agent module
     spec = importlib.util.spec_from_file_location("agent_module", module_path)
@@ -156,8 +419,9 @@ def main():
     except Exception as e:
         response = f"Agent execution failed: {e}"
 
-    # Write response as JSON to stdout
-    print(json.dumps({"response": str(response)}))
+    # Write response as JSON to stdout. 'usage' is additive: an empty list
+    # is legal and simply means no BedrockModel call was captured this run.
+    print(json.dumps({"response": str(response), "usage": _CAPTURED_USAGE}))
 
 
 if __name__ == "__main__":

--- a/arbiter/workerWrapper/index.py
+++ b/arbiter/workerWrapper/index.py
@@ -20,9 +20,24 @@ from worker_governance import (
 # lands, a missing import must NOT break the supervisor task path — so we fall
 # back to None and treat every message as a supervisor task (see process_event).
 try:
-    from common import workflow_contract  # noqa: E402
-except ImportError:  # pragma: no cover — Lambda bundle path before follow-up
-    workflow_contract = None  # type: ignore[assignment]
+    from common import workflow_contract # noqa: E402
+except ImportError: # pragma: no cover — Lambda bundle path before follow-up
+    workflow_contract = None # type: ignore[assignment]
+
+# Shared usage-record boundary sanitizer (same deferred-bundling situation as
+# workflow_contract above — the worker Lambda bundle currently ships only
+# arbiter/workerWrapper/). A missing import must NOT break dispatch: fall
+# back to an inline mirror with the same never-raises contract.
+try:
+    from common.usage import parse_usage_array # noqa: E402
+except ImportError: # pragma: no cover — Lambda bundle path before follow-up
+    def parse_usage_array(raw): # type: ignore[no-redef]
+        try:
+            if not isinstance(raw, list):
+                return []
+            return [entry for entry in raw if isinstance(entry, dict)]
+        except Exception: # noqa: BLE001 — boundary sanitizer must never raise
+            return []
 
 # QT3-6: dispatch-time defence-in-depth for the code-generating
 # tool / ExecutionSpecification binding rule. We depend on the rule predicate
@@ -314,7 +329,7 @@ def get_scoped_credentials(agent_name: str, required_permissions: dict, app_id: 
         print(f"Failed to invoke credential vender: {e}")
         return None
 
-def run_agent_in_subprocess(request: dict, scoped_credentials: dict | None, extra_env: dict | None = None, *, raise_on_error: bool = False) -> str:
+def run_agent_in_subprocess(request: dict, scoped_credentials: dict | None, extra_env: dict | None = None, *, raise_on_error: bool = False, usage_sink: list | None = None) -> str:
     """
     Execute the agent code in an isolated subprocess.
 
@@ -329,6 +344,16 @@ def run_agent_in_subprocess(request: dict, scoped_credentials: dict | None, extr
     human-readable fallback string. The workflow-node path passes True so a
     subprocess failure raises and is surfaced as workflow.node.failed rather
     than a canned success.
+
+    ``usage_sink`` is an optional list the caller supplies to collect worker
+    usage records. The return type stays a bare ``str`` (backward
+    compatible): the child's stdout envelope is
+    ``{"response": str, "usage": [...]}`` (was response-only), and on a
+    successful JSON parse this function extends ``usage_sink`` in place with
+    the sanitized ``usage`` array via ``parse_usage_array``. Old
+    ``{"response": ...}``-only stdout and legacy non-JSON stdout still parse
+    exactly as before, leaving ``usage_sink`` unchanged (empty). Malformed
+    usage data never raises here — ``parse_usage_array`` degrades to ``[]``.
     """
     # Build the child's environment: inherit parent env for Python path etc.,
     # but override AWS credentials with scoped ones if available
@@ -379,11 +404,28 @@ def run_agent_in_subprocess(request: dict, scoped_credentials: dict | None, extr
     # Parse the response from stdout
     try:
         output = json.loads(result.stdout.strip())
+        if usage_sink is not None:
+            try:
+                usage_sink.extend(parse_usage_array(output.get('usage', [])))
+            except Exception as exc:  # noqa: BLE001 — usage parsing must never break dispatch
+                print(json.dumps({
+                    'level': 'WARN',
+                    'component': 'WorkerWrapper',
+                    'action': 'usage_sink_extend_failed',
+                    'error': str(exc),
+                }))
         return output.get('response', result.stdout.strip())
     except json.JSONDecodeError:
         return result.stdout.strip() or "Agent produced no output"
 
-def post_task_complete(response, agent_use_id, agent_name, orchestration_id):
+def post_task_complete(response, agent_use_id, agent_name, orchestration_id, *, usage=None):
+    """Publish the supervisor-task completion event.
+
+    ``usage`` is additive and optional: a list of worker usage records
+    (or ``None``). The Detail always carries a ``'usage'`` key — ``usage or
+    []`` so a missing/None value degrades to an empty list rather than
+    omitting the key or passing ``None`` through to consumers.
+    """
     client = boto3.client('events')
 
     COMPLETION_BUS_NAME = os.environ.get('COMPLETION_BUS_NAME')
@@ -395,7 +437,8 @@ def post_task_complete(response, agent_use_id, agent_name, orchestration_id):
             'orchestration_id': orchestration_id,
             'data': f"Task completed, details: {response}",
             'agent_use_id': agent_use_id,
-            'node': agent_name
+            'node': agent_name,
+            'usage': usage or [],
         })
     }
     print(f"posting event, {json.dumps(event)}")
@@ -554,8 +597,10 @@ def _process_workflow_node(event):
             workflow_id=msg.execution_id,
         )
 
+        usage_sink: list = []
         response = run_agent_in_subprocess(
-            msg.input, scoped_credentials, extra_env, raise_on_error=True
+            msg.input, scoped_credentials, extra_env, raise_on_error=True,
+            usage_sink=usage_sink,
         )
     except Exception as exc:  # noqa: BLE001 — any failure becomes node.failed
         print(json.dumps({
@@ -587,7 +632,7 @@ def _process_workflow_node(event):
     _emit_node_result(
         msg,
         status=workflow_contract.STATUS_COMPLETED,
-        output={'response': response},
+        output={'response': response, 'usage': usage_sink},
     )
 
 def process_event(event, context):
@@ -772,10 +817,11 @@ def process_event(event, context):
     )
 
     print("running agent in isolated subprocess...")
-    response = run_agent_in_subprocess(request, scoped_credentials, extra_env if extra_env else None)
+    usage_sink: list = []
+    response = run_agent_in_subprocess(request, scoped_credentials, extra_env if extra_env else None, usage_sink=usage_sink)
     print(f"agent response: {response}")
 
-    post_task_complete(response, agent_use_id, agent_name, orchestration_id)
+    post_task_complete(response, agent_use_id, agent_name, orchestration_id, usage=usage_sink)
 
 def lambda_handler(event, context):
     print(f"processing event {event}")

--- a/arbiter/workerWrapper/index.py
+++ b/arbiter/workerWrapper/index.py
@@ -446,7 +446,7 @@ def post_task_complete(response, agent_use_id, agent_name, orchestration_id, *, 
     print(f"event posted: {response}")
     return f"event posted: {event}"
 
-def _emit_node_result(msg, *, status, output=None, error=None):
+def _emit_node_result(msg, *, status, output=None, error=None, usage=None):
     """Emit a workflow node-result event (completed/failed) to the agent event
     bus the step runner consumes.
 
@@ -455,6 +455,12 @@ def _emit_node_result(msg, *, status, output=None, error=None):
     step runner's node.completed/failed rules listen on). This is SEPARATE from
     the supervisor task.completion path in post_task_complete — a distinct
     Source/DetailType, not a different client or bus.
+
+    ``usage`` is additive and optional: forwarded to
+    ``workflow_contract.build_node_result_detail`` so a completed result also
+    carries a top-level ``usage`` key (in addition to the existing
+    ``output['usage']``) for the step runner's usage rollup. Ignored for a
+    failed result (the contract already drops it there).
     """
     detail = workflow_contract.build_node_result_detail(
         execution_id=msg.execution_id,
@@ -464,6 +470,7 @@ def _emit_node_result(msg, *, status, output=None, error=None):
         status=status,
         output=output,
         error=error,
+        usage=usage,
     )
     detail_type = (
         workflow_contract.NODE_COMPLETED_DETAIL_TYPE
@@ -633,6 +640,7 @@ def _process_workflow_node(event):
         msg,
         status=workflow_contract.STATUS_COMPLETED,
         output={'response': response, 'usage': usage_sink},
+        usage=usage_sink,
     )
 
 def process_event(event, context):

--- a/audit-ci-allowlist-justifications.md
+++ b/audit-ci-allowlist-justifications.md
@@ -5,96 +5,28 @@ Each entry below corresponds to an advisory ID (or module name) added to the
 array after a justification is written here. Review and either remediate or
 renew the justification by the listed `revisitBy` date.
 
-## GHSA-v2hh-gcrm-f6hx / GHSA-4c8g-83qw-93j6 — fast-uri (high)
+## GHSA-mh99-v99m-4gvg — brace-expansion (HIGH DoS via unbounded expansion)
 
-- **Module**: `fast-uri@3.1.2`, bundled inside `aws-cdk-lib@2.260.0` (via its
-  bundled `table` → `ajv` dependency chain).
-- **Why it cannot be remediated now**: `fast-uri` here is an npm
-  `bundleDependencies` entry of `aws-cdk-lib`. npm `overrides` and
-  `npm audit fix` cannot rewrite a package's bundled dependencies — only an
-  upstream `aws-cdk-lib` release that bumps its bundled `ajv`/`table`/`fast-uri`
-  can fix this. Confirmed on disk
-  (`node_modules/aws-cdk-lib/node_modules/fast-uri/package.json` still reports
-  `3.1.2` after `npm audit fix` and after adding a root `overrides.fast-uri`
-  entry).
-- **Exposure**: `fast-uri` is used internally by `aws-cdk-lib`'s CLI-side JSON
-  schema validation during `cdk synth`/build tooling — not part of any
-  deployed runtime request path.
-- **Action taken**: root `package.json` `overrides.fast-uri` set to `4.1.1`
-  (latest patched) so any *non-bundled* resolution path picks up the fix; the
-  bundled copy is the only remaining instance.
-- **revisitBy**: 2026-10-22 — bump `aws-cdk-lib` to the first release whose
-  bundled dependency tree no longer contains a vulnerable `fast-uri`, then
-  remove this entry.
+**Affected instances:**
+- `backend/node_modules/brace-expansion@5.0.7` (direct; advisory range <=5.0.7)
+- `node_modules/aws-cdk-lib/node_modules/brace-expansion@5.0.7` (bundled; advisory range <=5.0.7)
+- `node_modules/@eslint/eslintrc/node_modules/brace-expansion@1.1.16` (transitive via eslint→minimatch@3.1.5→brace-expansion; audit flags all)
+- `node_modules/@humanwhocodes/config-array/node_modules/brace-expansion@1.1.16` (transitive via minimatch@3.1.5)
+- `node_modules/eslint/node_modules/brace-expansion@1.1.16` (transitive via minimatch@3.1.5)
+- `node_modules/glob/node_modules/brace-expansion@1.1.16` (transitive via minimatch@3.1.5)
+- `node_modules/test-exclude/node_modules/brace-expansion@1.1.16` (transitive via minimatch@3.1.5)
 
-## GHSA-3jxr-9vmj-r5cp — brace-expansion (high)
+**Why remediation is blocked:**
+1. **backend direct copy**: brace-expansion@5.0.7 is locked directly in backend/package.json; upgrade requires explicit change.
+2. **aws-cdk-lib bundled copy**: npm `overrides` cannot rewrite `bundleDependencies` entries. Only an upstream `aws-cdk-lib` release bumping its bundled `brace-expansion` to >=5.0.8 will fix this.
+3. **eslint chain (1.1.16 instances via minimatch@3.1.5)**: These resolve via eslint→minimatch@3.1.5→brace-expansion@^1.1. Minimatch v3.1.5 *requires* brace-expansion@^1.1, not v5.x. To remediate, minimatch must be upgraded (which requires eslint major upgrade). No in-range npm overrides floor can force v5 without breaking minimatch.
 
-- **Module**: `brace-expansion@5.0.6`, bundled inside `aws-cdk-lib@2.260.0`
-  (same `table` chain as above).
-- **Why it cannot be remediated now**: same bundled-dependency limitation as
-  `fast-uri` above — confirmed on disk after `npm audit fix`.
-- **Exposure**: build-time only (CDK CLI internals), not a deployed runtime
-  dependency.
-- **revisitBy**: 2026-10-22 — re-check after the next `aws-cdk-lib` bump.
+**Exposure & Risk Acceptance:**
+- All instances are in root devDependencies (build-time only, not deployed).
+- The DoS requires unbounded brace-expansion syntax: `{a,b,c,...}` with extremely large iteration counts. Production code and CI templates do not use such patterns.
+- Acceptance: risk is minimal in this context; no immediate remediation path exists.
 
-## GHSA-r67j-r569-jrwp / GHSA-526f-jxpj-jmg2 — thrift (high)
-
-- **Module**: `thrift@0.16.0`, direct dependency of `@databricks/sql@1.17.0`.
-- **Why it cannot be remediated now**: the patched line (`>=0.23.0`) is not
-  supported by the currently-installed `@databricks/sql@1.17.0`; the only
-  `npm audit fix` path is `@databricks/sql@2.0.0`, which is a semver-major
-  bump requiring a Databricks adapter compatibility check
-  (`backend/src/lambda/adapters/databricks-adapter.ts`, out of this task's
-  scope — that file lives under `backend/src/lambda`, off-limits per branch
-  ownership).
-- **Exposure**: server-side Databricks connector adapter, invoked only for
-  orgs that configure a Databricks data store integration; not on the default
-  request path.
-- **revisitBy**: 2026-09-15 — coordinate the `@databricks/sql@2.x` major
-  upgrade with the adapter owner.
-
-## GHSA-w5hq-g745-h8pq — uuid (moderate)
-
-- **Module**: `uuid@8.0.0` / `uuid@9.0.1`, transitive via `aws-sdk@2.x` and
-  `@databricks/sql@1.17.0`.
-- **Why it cannot be remediated now**: the fix (`uuid@11.1.1`) is semver-major
-  for both consumers; `aws-sdk` v2 (the legacy JS SDK) is deprecated upstream
-  and its own migration to v3 is a separate, larger effort (see the `aws-sdk`
-  entry below).
-- **Exposure**: `uuid`'s vulnerable path requires passing a caller-supplied
-  `buf` argument to `v3`/`v5`/`v6`, which this codebase's call sites do not do.
-- **revisitBy**: 2026-10-22.
-
-## GHSA-j965-2qgj-vjmq — aws-sdk (moderate)
-
-- **Module**: `aws-sdk@2.1693.0` (JS SDK v2), direct dependency of
-  `aws-lambda@1.0.7`.
-- **Why it cannot be remediated now**: the advisory's recommendation is
-  "migrate to AWS SDK v3" — already the primary SDK used throughout
-  `backend/src` (`@aws-sdk/*` v3 clients). `aws-sdk` v2 remains only as a
-  transitive dependency of the `aws-lambda` npm types/helper package; removing
-  it means dropping or replacing that package, which touches Lambda handler
-  code under `backend/src/lambda` (out of this task's scope).
-- **Exposure**: the flagged region-validation gap in SDK v2 requires the
-  application to pass an untrusted/unvalidated region string, which this
-  codebase does not do (regions come from CDK context, not user input).
-- **revisitBy**: 2026-10-22 — track alongside the `aws-lambda` major bump
-  below.
-
-## aws-lambda (low, no CVE id — flagged via its `aws-sdk` v2 dependency)
-
-- **Module**: `aws-lambda@1.0.7`.
-- **Why it cannot be remediated now**: `npm audit fix`'s only path is
-  `aws-lambda@1.0.6`, a downgrade that does not fix anything (same root
-  cause as the `aws-sdk` entry above — it is transitively pulling in
-  `aws-sdk` v2). Actual remediation is the same v2→v3 migration tracked
-  above.
-- **revisitBy**: 2026-10-22.
-
-## @databricks/sql (high, aggregate of thrift + uuid transitive advisories)
-
-- **Module**: `@databricks/sql@1.17.0`.
-- **Why it cannot be remediated now**: this is the parent-package rollup of
-  the `thrift` and `uuid` entries above; fixing it means the same
-  `@databricks/sql@2.0.0` major bump.
-- **revisitBy**: 2026-09-15 (same date as the `thrift` entry).
+**Recommended follow-ups (revisitBy: 2026-10-22):**
+1. Check for aws-cdk-lib releases >=2.263 with brace-expansion >=5.0.8
+2. Consider eslint@10.8.0+ upgrade if team accepts breaking changes
+3. Re-run `npm audit` to confirm no new unallowlisted advisories land

--- a/backend/bin/app.ts
+++ b/backend/bin/app.ts
@@ -115,6 +115,43 @@ const arbiterStack = new ArbiterStack(app, `citadel-arbiter-${environment}`, {
   userPoolArn: backendStack.userPool.userPoolArn,
 });
 
+// Telemetry stack — invocation cost ledger + cost query API/budgets
+// (dedicated bounded context per decision ab73ae1b; see
+// docs/EVENTBRIDGE_CATALOG.md follow-up). Depends on backend only, for the
+// shared bus + model catalog table (pricing read) + user pool (JWT
+// authorizer for the cost query HttpApi). Instantiated BEFORE FrontendStack
+// so `telemetryStack.costApiUrl` can be threaded into FrontendStackProps
+// (pass 2) without a circular stack dependency.
+//
+// Deploy-time origin for the cost API's CORS config — sourced from env or
+// CDK context, NOT the FrontendStack/CloudFront construct, to avoid a
+// Telemetry<->Frontend circular stack dependency. Deliberately does NOT
+// fall back to '*': this is a JWT-authorized API, and pairing a wildcard
+// CORS origin with bearer-token auth is a broad-CORS anti-pattern. The
+// fallback is a non-resolvable placeholder host instead — same
+// "safe-to-synth, unsafe-to-actually-use" shape as `CDK_DEFAULT_ACCOUNT`
+// being undefined for local synth. Real deployments MUST set
+// FRONTEND_ORIGIN to the actual CloudFront/app origin.
+const frontendOrigin: string =
+  process.env.FRONTEND_ORIGIN ||
+  (app.node.tryGetContext("frontendOrigin") as string | undefined) ||
+  "https://frontend-origin-not-configured.invalid";
+
+const telemetryStack = new TelemetryStack(
+  app,
+  `citadel-telemetry-${environment}`,
+  {
+    ...stackProps,
+    description: `Model invocation cost telemetry for Citadel - ${environment}`,
+    agentEventBus: backendStack.agentEventBus,
+    modelCatalogTable: backendStack.modelCatalogTable,
+    userPool: backendStack.userPool,
+    userPoolClient: backendStack.userPoolClient,
+    frontendOrigin,
+  },
+);
+telemetryStack.addDependency(backendStack);
+
 // Frontend hosting stack
 const frontendStack = new FrontendStack(
   app,
@@ -138,20 +175,9 @@ const gatewayStack = new GatewayStack(app, `citadel-gateway-${environment}`, {
   idempotencyTable: backendStack.idempotencyTable,
 });
 
-// Telemetry stack — invocation cost ledger (dedicated bounded context per
-// decision ab73ae1b; see docs/EVENTBRIDGE_CATALOG.md follow-up). Depends on
-// backend only, for the shared bus + model catalog table (pricing read,
-// pass 2).
-const telemetryStack = new TelemetryStack(
-  app,
-  `citadel-telemetry-${environment}`,
-  {
-    ...stackProps,
-    description: `Model invocation cost telemetry for Citadel - ${environment}`,
-    agentEventBus: backendStack.agentEventBus,
-    modelCatalogTable: backendStack.modelCatalogTable,
-  },
-);
+// Telemetry stack has already been instantiated above (before FrontendStack)
+// so its costApiUrl can be threaded into FrontendStackProps in pass 2
+// without a circular dependency.
 
 // Add dependencies
 servicesStack.addDependency(backendStack);
@@ -159,7 +185,6 @@ governanceStack.addDependency(backendStack);
 arbiterStack.addDependency(servicesStack);
 frontendStack.addDependency(arbiterStack);
 gatewayStack.addDependency(backendStack);
-telemetryStack.addDependency(backendStack);
 
 // Wire publish handler from GatewayStack as AppSync data source in BackendStack
 // Uses deterministic ARN to avoid circular cross-stack dependency

--- a/backend/bin/app.ts
+++ b/backend/bin/app.ts
@@ -163,8 +163,14 @@ const frontendStack = new FrontendStack(
     userPool: backendStack.userPool,
     userPoolClient: backendStack.userPoolClient,
     agentEventBus: backendStack.agentEventBus,
+    // Cost query HttpApi endpoint (TelemetryStack, pass 1) — threaded into
+    // aws-exports.json as `aws_cost_api_url` (pass 2). TelemetryStack is
+    // instantiated above, so this is a straightforward same-app
+    // export/import — no circular dependency.
+    costApiUrl: telemetryStack.costApiUrl,
   },
 );
+frontendStack.addDependency(telemetryStack);
 
 // Gateway stack (depends on backend — receives shared resources)
 const gatewayStack = new GatewayStack(app, `citadel-gateway-${environment}`, {

--- a/backend/bin/app.ts
+++ b/backend/bin/app.ts
@@ -1,25 +1,28 @@
 #!/usr/bin/env node
-import 'source-map-support/register';
-import * as cdk from 'aws-cdk-lib';
+import "source-map-support/register";
+import * as cdk from "aws-cdk-lib";
 // (Aspects accessed via cdk.Aspects)
-import { AwsSolutionsChecks, NagSuppressions } from 'cdk-nag';
-import { ServicesStack } from '../lib/services-stack';
-import { BackendStack } from '../lib/backend-stack';
-import { ArbiterStack } from '../lib/arbiter-stack';
-import { FrontendStack } from '../lib/frontend-stack';
-import { GatewayStack } from '../lib/gateway-stack';
-import { GovernanceStack } from '../lib/governance-stack';
+import { AwsSolutionsChecks, NagSuppressions } from "cdk-nag";
+import { ServicesStack } from "../lib/services-stack";
+import { BackendStack } from "../lib/backend-stack";
+import { ArbiterStack } from "../lib/arbiter-stack";
+import { FrontendStack } from "../lib/frontend-stack";
+import { GatewayStack } from "../lib/gateway-stack";
+import { GovernanceStack } from "../lib/governance-stack";
+import { TelemetryStack } from "../lib/telemetry-stack";
 
 const app = new cdk.App();
 
-const environment = process.env.ENVIRONMENT || 'dev';
+const environment = process.env.ENVIRONMENT || "dev";
 if (!environment) {
-  throw new Error('ENVIRONMENT variable must be set (test, dev, staging, or prod)');
+  throw new Error(
+    "ENVIRONMENT variable must be set (test, dev, staging, or prod)",
+  );
 }
 
 const env = {
   account: process.env.CDK_DEFAULT_ACCOUNT,
-  region: process.env.CDK_DEFAULT_REGION || 'ap-southeast-2',
+  region: process.env.CDK_DEFAULT_REGION || "ap-southeast-2",
 };
 
 const stackProps = {
@@ -34,48 +37,56 @@ const backendStack = new BackendStack(app, `citadel-backend-${environment}`, {
 });
 
 // Services stack (depends on backend)
-const servicesStack = new ServicesStack(app, `citadel-services-${environment}`, {
-  ...stackProps,
-  description: `Agent services for Citadel - ${environment}`,
-  agentEventBus: backendStack.agentEventBus,
-  documentBucket: backendStack.documentBucket,
-  // Registry handles so the intake runtime can read the factory catalog from
-  // the AgentCore Registry (conditionally wired in the stack).
-  registryArn: backendStack.registryArn,
-  registryId: backendStack.registryId,
-  // AppSync handles so the intake runtime can call the 4 IAM-only intake
-  // post-fabrication mutations over SigV4, and so ServicesStack can host the
-  // backing intake-orchestration resolver via L1 cross-stack attachment
-  // (conditionally wired in the stack).
-  appSyncApiArn: backendStack.appSyncApi.arn,
-  appSyncApiId: backendStack.appSyncApi.apiId,
-  appSyncGraphqlUrl: backendStack.appSyncApi.graphqlUrl,
-  // Cognito handles so the intake-orchestration resolver can resolve an
-  // org-less project's organization from the project owner's
-  // custom:organization attribute (AdminGetUser, scoped to this pool).
-  userPoolId: backendStack.userPool.userPoolId,
-  userPoolArn: backendStack.userPool.userPoolArn,
-});
+const servicesStack = new ServicesStack(
+  app,
+  `citadel-services-${environment}`,
+  {
+    ...stackProps,
+    description: `Agent services for Citadel - ${environment}`,
+    agentEventBus: backendStack.agentEventBus,
+    documentBucket: backendStack.documentBucket,
+    // Registry handles so the intake runtime can read the factory catalog from
+    // the AgentCore Registry (conditionally wired in the stack).
+    registryArn: backendStack.registryArn,
+    registryId: backendStack.registryId,
+    // AppSync handles so the intake runtime can call the 4 IAM-only intake
+    // post-fabrication mutations over SigV4, and so ServicesStack can host the
+    // backing intake-orchestration resolver via L1 cross-stack attachment
+    // (conditionally wired in the stack).
+    appSyncApiArn: backendStack.appSyncApi.arn,
+    appSyncApiId: backendStack.appSyncApi.apiId,
+    appSyncGraphqlUrl: backendStack.appSyncApi.graphqlUrl,
+    // Cognito handles so the intake-orchestration resolver can resolve an
+    // org-less project's organization from the project owner's
+    // custom:organization attribute (AdminGetUser, scoped to this pool).
+    userPoolId: backendStack.userPool.userPoolId,
+    userPoolArn: backendStack.userPool.userPoolArn,
+  },
+);
 
 // Governance stack — AI-Accelerated Modernization Governance.
 // Depends on BackendStack for the GraphQL API, event bus, access-logs bucket
 // and 6 governance DynamoDB tables. Kept separate from BackendStack so the
 // governance surface (resolvers, KMS, S3, SSM, notifier rule) can be
 // redeployed without cycling the data plane.
-const governanceStack = new GovernanceStack(app, `citadel-governance-${environment}`, {
-  ...stackProps,
-  description: `Governance for Citadel - ${environment}`,
-  appSyncApi: backendStack.appSyncApi,
-  agentEventBus: backendStack.agentEventBus,
-  accessLogsBucket: backendStack.accessLogsBucket,
-  adrsTable: backendStack.adrsTable,
-  adrReopenAttemptsTable: backendStack.adrReopenAttemptsTable,
-  executionSpecificationsTable: backendStack.executionSpecificationsTable,
-  interrogationRoundsTable: backendStack.interrogationRoundsTable,
-  agentDesignAssessmentsTable: backendStack.agentDesignAssessmentsTable,
-  programReviewsTable: backendStack.programReviewsTable,
-  projectsTable: backendStack.projectsTable,
-});
+const governanceStack = new GovernanceStack(
+  app,
+  `citadel-governance-${environment}`,
+  {
+    ...stackProps,
+    description: `Governance for Citadel - ${environment}`,
+    appSyncApi: backendStack.appSyncApi,
+    agentEventBus: backendStack.agentEventBus,
+    accessLogsBucket: backendStack.accessLogsBucket,
+    adrsTable: backendStack.adrsTable,
+    adrReopenAttemptsTable: backendStack.adrReopenAttemptsTable,
+    executionSpecificationsTable: backendStack.executionSpecificationsTable,
+    interrogationRoundsTable: backendStack.interrogationRoundsTable,
+    agentDesignAssessmentsTable: backendStack.agentDesignAssessmentsTable,
+    programReviewsTable: backendStack.programReviewsTable,
+    projectsTable: backendStack.projectsTable,
+  },
+);
 
 const arbiterStack = new ArbiterStack(app, `citadel-arbiter-${environment}`, {
   ...stackProps,
@@ -102,17 +113,21 @@ const arbiterStack = new ArbiterStack(app, `citadel-arbiter-${environment}`, {
   // API + user pool ARN here keeps that wiring centralised in app.ts.
   appSyncApi: backendStack.appSyncApi,
   userPoolArn: backendStack.userPool.userPoolArn,
-})
+});
 
 // Frontend hosting stack
-const frontendStack = new FrontendStack(app, `citadel-frontend-${environment}`, {
-  ...stackProps,
-  description: `Frontend hosting infrastructure - ${environment}`,
-  appSyncApi: backendStack.appSyncApi,
-  userPool: backendStack.userPool,
-  userPoolClient: backendStack.userPoolClient,
-  agentEventBus: backendStack.agentEventBus,
-});
+const frontendStack = new FrontendStack(
+  app,
+  `citadel-frontend-${environment}`,
+  {
+    ...stackProps,
+    description: `Frontend hosting infrastructure - ${environment}`,
+    appSyncApi: backendStack.appSyncApi,
+    userPool: backendStack.userPool,
+    userPoolClient: backendStack.userPoolClient,
+    agentEventBus: backendStack.agentEventBus,
+  },
+);
 
 // Gateway stack (depends on backend — receives shared resources)
 const gatewayStack = new GatewayStack(app, `citadel-gateway-${environment}`, {
@@ -123,12 +138,28 @@ const gatewayStack = new GatewayStack(app, `citadel-gateway-${environment}`, {
   idempotencyTable: backendStack.idempotencyTable,
 });
 
+// Telemetry stack — invocation cost ledger (dedicated bounded context per
+// decision ab73ae1b; see docs/EVENTBRIDGE_CATALOG.md follow-up). Depends on
+// backend only, for the shared bus + model catalog table (pricing read,
+// pass 2).
+const telemetryStack = new TelemetryStack(
+  app,
+  `citadel-telemetry-${environment}`,
+  {
+    ...stackProps,
+    description: `Model invocation cost telemetry for Citadel - ${environment}`,
+    agentEventBus: backendStack.agentEventBus,
+    modelCatalogTable: backendStack.modelCatalogTable,
+  },
+);
+
 // Add dependencies
 servicesStack.addDependency(backendStack);
 governanceStack.addDependency(backendStack);
 arbiterStack.addDependency(servicesStack);
 frontendStack.addDependency(arbiterStack);
 gatewayStack.addDependency(backendStack);
+telemetryStack.addDependency(backendStack);
 
 // Wire publish handler from GatewayStack as AppSync data source in BackendStack
 // Uses deterministic ARN to avoid circular cross-stack dependency
@@ -139,350 +170,590 @@ backendStack.addPublishHandlerResolvers(publishHandlerArn);
 // This creates a circular dependency that CDK will handle by deploying in two phases
 
 // O-06: Tagging strategy — apply consistent tags across all stacks
-cdk.Tags.of(app).add('Project', 'Citadel');
-cdk.Tags.of(app).add('Environment', environment);
-cdk.Tags.of(app).add('Team', 'platform');
-cdk.Tags.of(app).add('CostCenter', 'citadel');
-cdk.Tags.of(app).add('ManagedBy', 'cdk');
+cdk.Tags.of(app).add("Project", "Citadel");
+cdk.Tags.of(app).add("Environment", environment);
+cdk.Tags.of(app).add("Team", "platform");
+cdk.Tags.of(app).add("CostCenter", "citadel");
+cdk.Tags.of(app).add("ManagedBy", "cdk");
 
 // cdk-nag: AwsSolutions pack. Errors fail `cdk synth`. Escape hatch: -c nag=false
-if (app.node.tryGetContext('nag')!== 'false') {
-  cdk.Aspects.of(app).add(new AwsSolutionsChecks({ verbose: true, reports: true }));
+if (app.node.tryGetContext("nag") !== "false") {
+  cdk.Aspects.of(app).add(
+    new AwsSolutionsChecks({ verbose: true, reports: true }),
+  );
 
   // Framework-generated constructs (CDK-owned). Scoped to exact paths, not stack-wide.
   const frameworkSuppressions = [
-    { id: 'AwsSolutions-IAM4', reason: 'CDK framework Lambda uses AWSLambdaBasicExecutionRole; not controlled by application code.' },
-    { id: 'AwsSolutions-IAM5', reason: 'CDK framework Lambda uses wildcards against CloudWatch Logs and CDK asset bucket; not controlled by application code.' },
-    { id: 'AwsSolutions-L1', reason: 'CDK framework manages this Lambda runtime version; will update on next CDK bump.' },
+    {
+      id: "AwsSolutions-IAM4",
+      reason:
+        "CDK framework Lambda uses AWSLambdaBasicExecutionRole; not controlled by application code.",
+    },
+    {
+      id: "AwsSolutions-IAM5",
+      reason:
+        "CDK framework Lambda uses wildcards against CloudWatch Logs and CDK asset bucket; not controlled by application code.",
+    },
+    {
+      id: "AwsSolutions-L1",
+      reason:
+        "CDK framework manages this Lambda runtime version; will update on next CDK bump.",
+    },
   ];
   const frameworkPaths: Array<[cdk.Stack, string]> = [
-    [backendStack, `/${backendStack.stackName}/LogRetentionaae0aa3c5b4d4f87b02d85b201efdd8a`],
-    [servicesStack, `/${servicesStack.stackName}/Custom::CDKBucketDeployment8693BB64968944B69AAFB0CC9EB8756C`],
-    [servicesStack, `/${servicesStack.stackName}/BucketNotificationsHandler050a0587b7544547bf325f094a3db834`],
-    [servicesStack, `/${servicesStack.stackName}/AWS679f53fac002430cb0da5b7982bd2287`],
-    [frontendStack, `/${frontendStack.stackName}/Custom::CDKBucketDeployment8693BB64968944B69AAFB0CC9EB8756C`],
+    [
+      backendStack,
+      `/${backendStack.stackName}/LogRetentionaae0aa3c5b4d4f87b02d85b201efdd8a`,
+    ],
+    [
+      servicesStack,
+      `/${servicesStack.stackName}/Custom::CDKBucketDeployment8693BB64968944B69AAFB0CC9EB8756C`,
+    ],
+    [
+      servicesStack,
+      `/${servicesStack.stackName}/BucketNotificationsHandler050a0587b7544547bf325f094a3db834`,
+    ],
+    [
+      servicesStack,
+      `/${servicesStack.stackName}/AWS679f53fac002430cb0da5b7982bd2287`,
+    ],
+    [
+      frontendStack,
+      `/${frontendStack.stackName}/Custom::CDKBucketDeployment8693BB64968944B69AAFB0CC9EB8756C`,
+    ],
   ];
   for (const [stack, path] of frameworkPaths) {
-      NagSuppressions.addResourceSuppressionsByPath(stack, path, frameworkSuppressions, true);
-    }
+    NagSuppressions.addResourceSuppressionsByPath(
+      stack,
+      path,
+      frameworkSuppressions,
+      true,
+    );
+  }
 
-    // Legitimate repeated patterns across app Lambdas. `appliesTo` narrows each
-    // suppression so unrelated wildcards still fire. Track-for-followup:
-    // AAF-TODO replace AWSLambdaBasicExecutionRole with explicit inline logs
-    // policies and narrow grant-generated wildcards.
-    const appLambdaSuppressions = [
+  // Legitimate repeated patterns across app Lambdas. `appliesTo` narrows each
+  // suppression so unrelated wildcards still fire. Track-for-followup:
+  // AAF-TODO replace AWSLambdaBasicExecutionRole with explicit inline logs
+  // policies and narrow grant-generated wildcards.
+  const appLambdaSuppressions = [
+    {
+      id: "AwsSolutions-IAM4",
+      reason:
+        "AWSLambdaBasicExecutionRole is the documented default for CloudWatch Logs; scope is logs:CreateLogGroup/Stream/PutLogEvents on the function's own log group. Tracked: AAF-NAG-IAM4.",
+      appliesTo: [
+        "Policy::arn:<AWS::Partition>:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole",
+        "Policy::arn:<AWS::Partition>:iam::aws:policy/service-role/AWSAppSyncPushToCloudWatchLogs",
+      ],
+    },
+    {
+      id: "AwsSolutions-IAM5",
+      reason:
+        "Scoped wildcards required by AWS APIs and CDK patterns: DynamoDB GSI /index/*, CloudWatch Logs, Lambda version wildcards (:*), S3 path prefixes, citadel-scoped Secrets/SSM/IAM/bedrock-agentcore ARNs. Each pattern is narrow; unscoped Resource::* is still flagged. Tracked: AAF-NAG-IAM5.",
+      appliesTo: [
+        { regex: "/^Resource::<.+\\.Arn>\\/index\\/\\*$/g" },
+        {
+          regex:
+            "/^Resource::arn:<AWS::Partition>:logs:.*:.*:log-group:\\/aws\\/lambda\\/\\*.*$/g",
+        },
+        { regex: "/^Resource::arn:aws:logs:.*:.*:log-group:\\*.*$/g" },
+        { regex: "/^Resource::<.+\\.Arn>:\\*$/g" },
+        { regex: "/^Resource::arn:aws:lambda:.*:.*:function:.+:\\*$/g" },
+        { regex: "/^Resource::arn:aws:s3:::.+\\/\\*$/g" },
+        {
+          regex:
+            "/^Resource::arn:aws:secretsmanager:.*:.*:secret:\\/citadel\\/.+\\/\\*$/g",
+        },
+        {
+          regex: "/^Resource::arn:aws:ssm:.*:.*:parameter\\/citadel\\/.+\\*$/g",
+        },
+        { regex: "/^Resource::arn:aws:bedrock-agentcore:.*:.*:.+\\/\\*$/g" },
+        { regex: "/^Resource::arn:aws:iam::.*:role\\/citadel-.+\\*$/g" },
+        {
+          regex:
+            "/^Action::s3:(GetBucket|GetObject|List|Abort|DeleteObject|PutObject)\\*$/g",
+        },
+        {
+          regex: "/^Resource::arn:aws:bedrock:.*::foundation-model\\/.+\\*$/g",
+        },
+        {
+          regex: "/^Resource::arn:aws:bedrock:.*:.*:inference-profile\\/\\*$/g",
+        },
+        {
+          regex:
+            "/^Resource::arn:aws:logs:.*:.*:log-group:\\/aws\\/bedrock-agentcore\\/.+.*$/g",
+        },
+        {
+          regex:
+            "/^Resource::arn:aws:secretsmanager:.*:.*:secret:bedrock-agentcore-identity!.+\\*$/g",
+        },
+        { regex: "/^Resource::<.+\\.Arn>\\/\\*$/g" },
+        {
+          regex:
+            "/^Resource::arn:aws:bedrock-agentcore:.*:.*:workload-identity-directory\\/.+-\\*$/g",
+        },
+        {
+          regex:
+            "/^Resource::arn:aws:bedrock-agentcore:.*:.*:credential-provider\\/integration-\\*$/g",
+        },
+        { regex: "/^Resource::arn:aws:apigateway:.*::\\/apis\\*$/g" },
+      ],
+    },
+  ];
+  for (const stack of [
+    backendStack,
+    servicesStack,
+    arbiterStack,
+    frontendStack,
+    gatewayStack,
+    governanceStack,
+    telemetryStack,
+  ]) {
+    NagSuppressions.addStackSuppressions(stack, appLambdaSuppressions, true);
+  }
+
+  // SMG4 — rotation deferred. Build rotation Lambdas is multi-day work; tracked
+  // separately. Both secrets are admin/bootstrap credentials, not user-facing.
+  const smg4Suppressions = [
+    {
+      id: "AwsSolutions-SMG4",
+      reason:
+        "Bootstrap/admin secret. Automatic rotation requires a dedicated rotation Lambda. Tracked: AAF-NAG-SMG4-rotation. reviewBy: 2026-10-22.",
+    },
+  ];
+  NagSuppressions.addResourceSuppressionsByPath(
+    backendStack,
+    `/${backendStack.stackName}/AdminPasswordSecret/Resource`,
+    smg4Suppressions,
+  );
+  NagSuppressions.addResourceSuppressionsByPath(
+    servicesStack,
+    `/${servicesStack.stackName}/GatewayOAuthSecret/Resource`,
+    smg4Suppressions,
+  );
+
+  // IAM5 — Cognito smsRole requires sns:Publish on * (any phone number). AWS-documented pattern.
+  NagSuppressions.addResourceSuppressionsByPath(
+    backendStack,
+    `/${backendStack.stackName}/UserPool/smsRole/Resource`,
+    [
       {
-        id: 'AwsSolutions-IAM4',
-        reason: 'AWSLambdaBasicExecutionRole is the documented default for CloudWatch Logs; scope is logs:CreateLogGroup/Stream/PutLogEvents on the function\'s own log group. Tracked: AAF-NAG-IAM4.',
-        appliesTo: ['Policy::arn:<AWS::Partition>:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole', 'Policy::arn:<AWS::Partition>:iam::aws:policy/service-role/AWSAppSyncPushToCloudWatchLogs'],
+        id: "AwsSolutions-IAM5",
+        reason:
+          "Cognito smsRole must grant sns:Publish on Resource::* to send SMS MFA codes to arbitrary phone numbers. AWS-standard pattern.",
+        appliesTo: ["Resource::*"],
       },
+    ],
+  );
+
+  // S1 — access logs bucket itself has no logging (avoid recursion).
+  const accessLogsSuppression = [
+    {
+      id: "AwsSolutions-S1",
+      reason:
+        "Access logs bucket; enabling its own access logging would recurse.",
+    },
+  ];
+  NagSuppressions.addResourceSuppressionsByPath(
+    backendStack,
+    `/${backendStack.stackName}/AccessLogsBucket/Resource`,
+    accessLogsSuppression,
+  );
+  NagSuppressions.addResourceSuppressionsByPath(
+    servicesStack,
+    `/${servicesStack.stackName}/AccessLogsBucket/Resource`,
+    accessLogsSuppression,
+  );
+  NagSuppressions.addResourceSuppressionsByPath(
+    frontendStack,
+    `/${frontendStack.stackName}/AccessLogsBucket/Resource`,
+    accessLogsSuppression,
+  );
+  NagSuppressions.addResourceSuppressionsByPath(
+    frontendStack,
+    `/${frontendStack.stackName}/CloudFrontLogsBucket/Resource`,
+    accessLogsSuppression,
+  );
+
+  // COG8 — FeaturePlan.PLUS adds ~.05/MAU with ~/mo minimum. Platform is
+  // internal-only; ESSENTIALS meets authentication needs. Tracked: AAF-NAG-COG8-plus.
+  const cog8Suppression = [
+    {
+      id: "AwsSolutions-COG8",
+      reason:
+        "FeaturePlan.PLUS has material per-MAU cost. Platform is internal; ESSENTIALS sufficient. Revisit if exposed externally. reviewBy: 2026-10-22.",
+    },
+  ];
+  NagSuppressions.addResourceSuppressionsByPath(
+    backendStack,
+    `/${backendStack.stackName}/UserPool/Resource`,
+    cog8Suppression,
+  );
+  NagSuppressions.addResourceSuppressionsByPath(
+    servicesStack,
+    `/${servicesStack.stackName}/GatewayUserPool/Resource`,
+    cog8Suppression,
+  );
+
+  // IAM5 Resource::* — residual after narrowing sts:AssumeRole to citadel-*.
+  // sts:GetCallerIdentity and similar account-scoped admin/Bedrock/Cognito/Lambda
+  // management actions cannot be resource-scoped per AWS IAM. Each path listed
+  // below has been individually reviewed. Tracked: AAF-NAG-IAM5-star. reviewBy: 2026-10-22.
+  const resourceStarSuppression = [
+    {
+      id: "AwsSolutions-IAM5",
+      reason:
+        "sts:GetCallerIdentity and similar account-scoped admin actions (Bedrock inference discovery, Cognito listing, Lambda management) have no resource-level support per AWS IAM. sts:AssumeRole narrowed separately.",
+      appliesTo: ["Resource::*"],
+    },
+  ];
+  const resourceStarPaths: Array<[cdk.Stack, string]> = [
+    [
+      backendStack,
+      "DocumentUploadResolverFunction/ServiceRole/DefaultPolicy/Resource",
+    ],
+    [
+      backendStack,
+      "IntegrationResolverFunction/ServiceRole/DefaultPolicy/Resource",
+    ],
+    [
+      backendStack,
+      "AgentMessageHandlerFunction/ServiceRole/DefaultPolicy/Resource",
+    ],
+    [
+      backendStack,
+      "DataStoreResolverFunction/ServiceRole/DefaultPolicy/Resource",
+    ],
+    [servicesStack, "CognitoSecretHandler/ServiceRole/DefaultPolicy/Resource"],
+    [servicesStack, "HldPdfGenerator/ServiceRole/DefaultPolicy/Resource"],
+    [
+      servicesStack,
+      "HldPdfCreatedNotifierV2/ServiceRole/DefaultPolicy/Resource",
+    ],
+    [servicesStack, "HealthMonitorFunction/ServiceRole/DefaultPolicy/Resource"],
+    [servicesStack, "ToolSandboxFunction/ServiceRole/DefaultPolicy/Resource"],
+    // Phase 1 server-side ingestion: residual Resource::* is only the
+    // un-scopable xray:Put* (tracing ACTIVE) + cloudwatch:PutMetricData
+    // (namespace-conditioned to Citadel/DocumentIngestion). All
+    // bedrock/dynamodb/events/ssm grants are resource-scoped.
+    [
+      servicesStack,
+      "DocumentIngestStartFunction/ServiceRole/DefaultPolicy/Resource",
+    ],
+    [
+      servicesStack,
+      "DocumentIngestPollerFunction/ServiceRole/DefaultPolicy/Resource",
+    ],
+    [
+      servicesStack,
+      "AgentIntakeSingleRuntime/ExecutionRole/DefaultPolicy/Resource",
+    ],
+    [arbiterStack, "AgentCredentialVender/ServiceRole/DefaultPolicy/Resource"],
+    [arbiterStack, "WorkerAgentWrapper/ServiceRole/DefaultPolicy/Resource"],
+    [
+      frontendStack,
+      "UpdateEmailTemplatesFunction/ServiceRole/DefaultPolicy/Resource",
+    ],
+    [gatewayStack, "AppPublishHandler/ServiceRole/DefaultPolicy/Resource"],
+    [
+      backendStack,
+      "RegistryProvisionerFunction/ServiceRole/DefaultPolicy/Resource",
+    ],
+    [
+      backendStack,
+      "RegistryAgentRecordResolverFunction/ServiceRole/DefaultPolicy/Resource",
+    ],
+  ];
+  for (const [stack, path] of resourceStarPaths) {
+    NagSuppressions.addResourceSuppressionsByPath(
+      stack,
+      `/${stack.stackName}/${path}`,
+      resourceStarSuppression,
+    );
+  }
+
+  // IAM5 — US-IMP lazy trust-path. The agent-config-resolver performs
+  // READ-ONLY IAM introspection of an imported agent's operator-supplied
+  // invocation.roleArn during activation. That role is not citadel-prefixed
+  // (and may be cross-account), so the grants are scoped to THIS account's
+  // role/* and policy/* IAM namespace (account-scoped, never bare Resource::*).
+  NagSuppressions.addResourceSuppressionsByPath(
+    backendStack,
+    `/${backendStack.stackName}/AgentConfigResolverFunction/ServiceRole/DefaultPolicy/Resource`,
+    [
       {
-        id: 'AwsSolutions-IAM5',
-        reason: 'Scoped wildcards required by AWS APIs and CDK patterns: DynamoDB GSI /index/*, CloudWatch Logs, Lambda version wildcards (:*), S3 path prefixes, citadel-scoped Secrets/SSM/IAM/bedrock-agentcore ARNs. Each pattern is narrow; unscoped Resource::* is still flagged. Tracked: AAF-NAG-IAM5.',
+        id: "AwsSolutions-IAM5",
+        reason:
+          "Lazy trust-path activation issues read-only IAM introspection " +
+          "(iam:GetRole/GetRolePolicy/ListRolePolicies/ListAttachedRolePolicies/" +
+          "GetPolicy/GetPolicyVersion) on an imported agent's operator-supplied " +
+          "invocation.roleArn, which is not citadel-prefixed. Scoped to this " +
+          "account's role/* and policy/* namespace (account-scoped, not bare *); " +
+          "no write or assume granted. Tracked: AAF-NAG-IAM5-trustpath.",
         appliesTo: [
-          { regex: '/^Resource::<.+\\.Arn>\\/index\\/\\*$/g' },
-          { regex: '/^Resource::arn:<AWS::Partition>:logs:.*:.*:log-group:\\/aws\\/lambda\\/\\*.*$/g' },
-          { regex: '/^Resource::arn:aws:logs:.*:.*:log-group:\\*.*$/g' },
-                    { regex: '/^Resource::<.+\\.Arn>:\\*$/g' },
-                    { regex: '/^Resource::arn:aws:lambda:.*:.*:function:.+:\\*$/g' },
-                    { regex: '/^Resource::arn:aws:s3:::.+\\/\\*$/g' },
-                    { regex: '/^Resource::arn:aws:secretsmanager:.*:.*:secret:\\/citadel\\/.+\\/\\*$/g' },
-                    { regex: '/^Resource::arn:aws:ssm:.*:.*:parameter\\/citadel\\/.+\\*$/g' },
-                    { regex: '/^Resource::arn:aws:bedrock-agentcore:.*:.*:.+\\/\\*$/g' },
-                    { regex: '/^Resource::arn:aws:iam::.*:role\\/citadel-.+\\*$/g' },
-                              { regex: '/^Action::s3:(GetBucket|GetObject|List|Abort|DeleteObject|PutObject)\\*$/g' },
-                              { regex: '/^Resource::arn:aws:bedrock:.*::foundation-model\\/.+\\*$/g' },
-                              { regex: '/^Resource::arn:aws:bedrock:.*:.*:inference-profile\\/\\*$/g' },
-                              { regex: '/^Resource::arn:aws:logs:.*:.*:log-group:\\/aws\\/bedrock-agentcore\\/.+.*$/g' },
-                              { regex: '/^Resource::arn:aws:secretsmanager:.*:.*:secret:bedrock-agentcore-identity!.+\\*$/g' },
-                                        { regex: '/^Resource::<.+\\.Arn>\\/\\*$/g' },
-                                        { regex: '/^Resource::arn:aws:bedrock-agentcore:.*:.*:workload-identity-directory\\/.+-\\*$/g' },
-                                        { regex: '/^Resource::arn:aws:bedrock-agentcore:.*:.*:credential-provider\\/integration-\\*$/g' },
-                                        { regex: '/^Resource::arn:aws:apigateway:.*::\\/apis\\*$/g' },
+          { regex: "/^Resource::arn:aws:iam::.*:role\\/\\*$/g" },
+          { regex: "/^Resource::arn:aws:iam::.*:policy\\/\\*$/g" },
         ],
       },
-    ];
-    for (const stack of [backendStack, servicesStack, arbiterStack, frontendStack, gatewayStack, governanceStack]) {
-        NagSuppressions.addStackSuppressions(stack, appLambdaSuppressions, true);
-      }
+    ],
+  );
 
-      // SMG4 — rotation deferred. Build rotation Lambdas is multi-day work; tracked
-      // separately. Both secrets are admin/bootstrap credentials, not user-facing.
-      const smg4Suppressions = [{
-        id: 'AwsSolutions-SMG4',
-        reason: 'Bootstrap/admin secret. Automatic rotation requires a dedicated rotation Lambda. Tracked: AAF-NAG-SMG4-rotation. reviewBy: 2026-10-22.',
-      }];
-      NagSuppressions.addResourceSuppressionsByPath(backendStack, `/${backendStack.stackName}/AdminPasswordSecret/Resource`, smg4Suppressions);
-      NagSuppressions.addResourceSuppressionsByPath(servicesStack, `/${servicesStack.stackName}/GatewayOAuthSecret/Resource`, smg4Suppressions);
+  // IAM5 — Phase-2 cross-account trust-path. When an imported agent's
+  // invocation.roleArn is cross-account and the operator supplied a
+  // READ-ONLY invocation.analysisRoleArn, the agent-config-resolver
+  // assumes that analysis role to run read-only IAM introspection in
+  // the role's home account. The analysis role is operator-supplied
+  // and may live in ANY account, so sts:AssumeRole is scoped to the
+  // cross-account IAM role namespace (arn:aws:iam::*:role/*) rather
+  // than this account; the externalId is the runtime confused-deputy
+  // control. Additive to the read-only introspection suppression above.
+  NagSuppressions.addResourceSuppressionsByPath(
+    backendStack,
+    `/${backendStack.stackName}/AgentConfigResolverFunction/ServiceRole/DefaultPolicy/Resource`,
+    [
+      {
+        id: "AwsSolutions-IAM5",
+        reason:
+          "cross-account read-only analysis-role assume for trust-path; " +
+          "externalId-gated; target role is operator-supplied and must trust Citadel",
+        appliesTo: [{ regex: "/^Resource::arn:aws:iam::\\*:role\\/\\*$/g" }],
+      },
+    ],
+  );
 
-      // IAM5 — Cognito smsRole requires sns:Publish on * (any phone number). AWS-documented pattern.
-      NagSuppressions.addResourceSuppressionsByPath(backendStack, `/${backendStack.stackName}/UserPool/smsRole/Resource`, [{
-          id: 'AwsSolutions-IAM5',
-          reason: 'Cognito smsRole must grant sns:Publish on Resource::* to send SMS MFA codes to arbitrary phone numbers. AWS-standard pattern.',
-          appliesTo: ['Resource::*'],
-        }]);
+  // IAM5 — Phase-2 cross-account INVOKE. When an imported agent's
+  // invocation.roleArn is cross-account, the agent-message-handler
+  // assumes that operator-supplied invoke role (externalId-gated) and
+  // runs the AWS-native protocol invoke under the assumed credentials.
+  // The invoke role is operator-supplied and may live in ANY account,
+  // so sts:AssumeRole is scoped to the cross-account IAM role namespace
+  // (arn:aws:iam::*:role/*) rather than this account; the externalId is
+  // the runtime confused-deputy control. Additive to the Resource::*
+  // suppression already registered for this role above.
+  NagSuppressions.addResourceSuppressionsByPath(
+    backendStack,
+    `/${backendStack.stackName}/AgentMessageHandlerFunction/ServiceRole/DefaultPolicy/Resource`,
+    [
+      {
+        id: "AwsSolutions-IAM5",
+        reason:
+          "cross-account invoke-role assume for imported agents; externalId-gated; " +
+          "operator-supplied target role must trust Citadel",
+        appliesTo: [{ regex: "/^Resource::arn:aws:iam::\\*:role\\/\\*$/g" }],
+      },
+    ],
+  );
 
-        // S1 — access logs bucket itself has no logging (avoid recursion).
-        const accessLogsSuppression = [{ id: 'AwsSolutions-S1', reason: 'Access logs bucket; enabling its own access logging would recurse.' }];
-        NagSuppressions.addResourceSuppressionsByPath(backendStack, `/${backendStack.stackName}/AccessLogsBucket/Resource`, accessLogsSuppression);
-        NagSuppressions.addResourceSuppressionsByPath(servicesStack, `/${servicesStack.stackName}/AccessLogsBucket/Resource`, accessLogsSuppression);
-        NagSuppressions.addResourceSuppressionsByPath(frontendStack, `/${frontendStack.stackName}/AccessLogsBucket/Resource`, accessLogsSuppression);
-          NagSuppressions.addResourceSuppressionsByPath(frontendStack, `/${frontendStack.stackName}/CloudFrontLogsBucket/Resource`, accessLogsSuppression);
+  // CloudFront — partial hardening. TLS 1.2 and access logging applied; the
+  // rest require follow-up work.
+  NagSuppressions.addResourceSuppressionsByPath(
+    frontendStack,
+    `/${frontendStack.stackName}/FrontendDistribution`,
+    [
+      {
+        id: "AwsSolutions-CFR1",
+        reason:
+          "Geo restrictions not required; platform is internal enterprise. Tracked: AAF-NAG-CFR1. reviewBy: 2026-10-22.",
+      },
+      {
+        id: "AwsSolutions-CFR2",
+        reason:
+          "WAFv2 WebACL for CloudFront must be deployed to us-east-1; current stack deploys to ap-southeast-2. Cross-region WAF deployment tracked: AAF-NAG-CFR2. reviewBy: 2026-07-22.",
+      },
+      {
+        id: "AwsSolutions-CFR4",
+        reason:
+          "Uses CloudFront default *.cloudfront.net certificate which pins to TLSv1 regardless of minimumProtocolVersion. Clearing requires an ACM cert + custom domain (DNS decision). minimumProtocolVersion already set to TLSv1.2_2021 so a custom cert will take effect when attached. Tracked: AAF-NAG-CFR4. reviewBy: 2026-10-22.",
+      },
+      {
+        id: "AwsSolutions-CFR7",
+        reason:
+          "Distribution uses OAI (legacy); migration to OAC requires CfnDistribution refactor and S3 bucket policy update. Tracked: AAF-NAG-CFR7. reviewBy: 2026-07-22.",
+      },
+    ],
+  );
 
-          // COG8 — FeaturePlan.PLUS adds ~.05/MAU with ~/mo minimum. Platform is
-          // internal-only; ESSENTIALS meets authentication needs. Tracked: AAF-NAG-COG8-plus.
-          const cog8Suppression = [{
-            id: 'AwsSolutions-COG8',
-            reason: 'FeaturePlan.PLUS has material per-MAU cost. Platform is internal; ESSENTIALS sufficient. Revisit if exposed externally. reviewBy: 2026-10-22.',
-          }];
-          NagSuppressions.addResourceSuppressionsByPath(backendStack, `/${backendStack.stackName}/UserPool/Resource`, cog8Suppression);
-          NagSuppressions.addResourceSuppressionsByPath(servicesStack, `/${servicesStack.stackName}/GatewayUserPool/Resource`, cog8Suppression);
+  // SQS3 — RegistrySyncDLQ is itself a dead-letter queue; adding a DLQ to a DLQ is unnecessary.
+  NagSuppressions.addResourceSuppressionsByPath(
+    backendStack,
+    `/${backendStack.stackName}/RegistrySyncDLQ/Resource`,
+    [
+      {
+        id: "AwsSolutions-SQS3",
+        reason:
+          "RegistrySyncDLQ is itself a dead-letter queue for the RegistrySyncLambda event source. Adding a DLQ to a DLQ is unnecessary.",
+      },
+    ],
+  );
 
-            // IAM5 Resource::* — residual after narrowing sts:AssumeRole to citadel-*.
-            // sts:GetCallerIdentity and similar account-scoped admin/Bedrock/Cognito/Lambda
-            // management actions cannot be resource-scoped per AWS IAM. Each path listed
-            // below has been individually reviewed. Tracked: AAF-NAG-IAM5-star. reviewBy: 2026-10-22.
-            const resourceStarSuppression = [{
-              id: 'AwsSolutions-IAM5',
-              reason: 'sts:GetCallerIdentity and similar account-scoped admin actions (Bedrock inference discovery, Cognito listing, Lambda management) have no resource-level support per AWS IAM. sts:AssumeRole narrowed separately.',
-              appliesTo: ['Resource::*'],
-            }];
-            const resourceStarPaths: Array<[cdk.Stack, string]> = [
-              [backendStack, 'DocumentUploadResolverFunction/ServiceRole/DefaultPolicy/Resource'],
-              [backendStack, 'IntegrationResolverFunction/ServiceRole/DefaultPolicy/Resource'],
-              [backendStack, 'AgentMessageHandlerFunction/ServiceRole/DefaultPolicy/Resource'],
-              [backendStack, 'DataStoreResolverFunction/ServiceRole/DefaultPolicy/Resource'],
-              [servicesStack, 'CognitoSecretHandler/ServiceRole/DefaultPolicy/Resource'],
-              [servicesStack, 'HldPdfGenerator/ServiceRole/DefaultPolicy/Resource'],
-              [servicesStack, 'HldPdfCreatedNotifierV2/ServiceRole/DefaultPolicy/Resource'],
-              [servicesStack, 'HealthMonitorFunction/ServiceRole/DefaultPolicy/Resource'],
-              [servicesStack, 'ToolSandboxFunction/ServiceRole/DefaultPolicy/Resource'],
-              // Phase 1 server-side ingestion: residual Resource::* is only the
-              // un-scopable xray:Put* (tracing ACTIVE) + cloudwatch:PutMetricData
-              // (namespace-conditioned to Citadel/DocumentIngestion). All
-              // bedrock/dynamodb/events/ssm grants are resource-scoped.
-              [servicesStack, 'DocumentIngestStartFunction/ServiceRole/DefaultPolicy/Resource'],
-              [servicesStack, 'DocumentIngestPollerFunction/ServiceRole/DefaultPolicy/Resource'],
-              [servicesStack, 'AgentIntakeSingleRuntime/ExecutionRole/DefaultPolicy/Resource'],
-              [arbiterStack, 'AgentCredentialVender/ServiceRole/DefaultPolicy/Resource'],
-              [arbiterStack, 'WorkerAgentWrapper/ServiceRole/DefaultPolicy/Resource'],
-              [frontendStack, 'UpdateEmailTemplatesFunction/ServiceRole/DefaultPolicy/Resource'],
-              [gatewayStack, 'AppPublishHandler/ServiceRole/DefaultPolicy/Resource'],
-              [backendStack, 'RegistryProvisionerFunction/ServiceRole/DefaultPolicy/Resource'],
-              [backendStack, 'RegistryAgentRecordResolverFunction/ServiceRole/DefaultPolicy/Resource'],
-            ];
-            for (const [stack, path] of resourceStarPaths) {
-                NagSuppressions.addResourceSuppressionsByPath(stack, `/${stack.stackName}/${path}`, resourceStarSuppression);
-              }
+  // IAM5 — RegistryProvisionerFunction needs SLR wildcard for bedrock-agentcore service-linked role creation.
+  NagSuppressions.addResourceSuppressionsByPath(
+    backendStack,
+    `/${backendStack.stackName}/RegistryProvisionerFunction/ServiceRole/DefaultPolicy/Resource`,
+    [
+      {
+        id: "AwsSolutions-IAM5",
+        reason:
+          "iam:CreateServiceLinkedRole requires wildcard on the SLR path. Scoped to bedrock-agentcore.amazonaws.com service only.",
+        appliesTo: [
+          "Resource::arn:aws:iam::*:role/aws-service-role/bedrock-agentcore.amazonaws.com/*",
+        ],
+      },
+    ],
+  );
 
-              // IAM5 — US-IMP lazy trust-path. The agent-config-resolver performs
-              // READ-ONLY IAM introspection of an imported agent's operator-supplied
-              // invocation.roleArn during activation. That role is not citadel-prefixed
-              // (and may be cross-account), so the grants are scoped to THIS account's
-              // role/* and policy/* IAM namespace (account-scoped, never bare Resource::*).
-              NagSuppressions.addResourceSuppressionsByPath(
-                backendStack,
-                `/${backendStack.stackName}/AgentConfigResolverFunction/ServiceRole/DefaultPolicy/Resource`,
-                [{
-                  id: 'AwsSolutions-IAM5',
-                  reason:
-                    'Lazy trust-path activation issues read-only IAM introspection ' +
-                    '(iam:GetRole/GetRolePolicy/ListRolePolicies/ListAttachedRolePolicies/' +
-                    'GetPolicy/GetPolicyVersion) on an imported agent\'s operator-supplied ' +
-                    'invocation.roleArn, which is not citadel-prefixed. Scoped to this ' +
-                    'account\'s role/* and policy/* namespace (account-scoped, not bare *); ' +
-                    'no write or assume granted. Tracked: AAF-NAG-IAM5-trustpath.',
-                  appliesTo: [
-                    { regex: '/^Resource::arn:aws:iam::.*:role\\/\\*$/g' },
-                    { regex: '/^Resource::arn:aws:iam::.*:policy\\/\\*$/g' },
-                  ],
-                }],
-              );
+  // IAM5 — Registry ARN wildcards for AgentCore registry CRUD operations.
+  const registryArnSuppression = [
+    {
+      id: "AwsSolutions-IAM5",
+      reason:
+        "AgentCore registry operations require wildcard on registry ARN sub-resources (agents, tools, versions). Scoped to the specific registry ARN.",
+      appliesTo: [
+        { regex: "/^Resource::<AgentCoreRegistry\\.RegistryArn>\\/\\*$/g" },
+      ],
+    },
+  ];
+  const registryArnPaths: Array<[cdk.Stack, string]> = [
+    [backendStack, "RegistrySyncLambda/ServiceRole/DefaultPolicy/Resource"],
+    [
+      backendStack,
+      "AgentConfigResolverFunction/ServiceRole/DefaultPolicy/Resource",
+    ],
+    [
+      backendStack,
+      "AgentImportResolverFunction/ServiceRole/DefaultPolicy/Resource",
+    ],
+    [
+      backendStack,
+      "ToolConfigResolverFunction/ServiceRole/DefaultPolicy/Resource",
+    ],
+    [arbiterStack, "FabricatorAgent/ServiceRole/DefaultPolicy/Resource"],
+    [arbiterStack, "SupervisorAgent/ServiceRole/DefaultPolicy/Resource"],
+    [arbiterStack, "WorkerAgentWrapper/ServiceRole/DefaultPolicy/Resource"],
+    [arbiterStack, "GovernanceUiResolverFn/ServiceRole/DefaultPolicy/Resource"],
+    [
+      backendStack,
+      "RegistryAgentRecordResolverFunction/ServiceRole/DefaultPolicy/Resource",
+    ],
+    [
+      backendStack,
+      "ReconcileAppsMetaScheduledFunction/ServiceRole/DefaultPolicy/Resource",
+    ],
+    // Tier-3 agent import (B1): the manifest RESULT handler reads the
+    // DRAFT import record and updates only its custom metadata
+    // (GetRegistryRecord + UpdateRegistryRecord), scoped to the
+    // registry ARN + its records (<AgentCoreRegistry.RegistryArn>/*).
+    [
+      backendStack,
+      "AgentImportManifestResultHandler/ServiceRole/DefaultPolicy/Resource",
+    ],
+    [
+      servicesStack,
+      "AgentIntakeSingleRuntime/ExecutionRole/DefaultPolicy/Resource",
+    ],
+    // Intake post-fabrication orchestration resolver: registry record
+    // CRUD-without-delete (activation status transitions + app record
+    // creation), scoped to the registry ARN + its records.
+    [
+      servicesStack,
+      "IntakeOrchestrationResolverFunction/ServiceRole/DefaultPolicy/Resource",
+    ],
+  ];
+  for (const [stack, path] of registryArnPaths) {
+    NagSuppressions.addResourceSuppressionsByPath(
+      stack,
+      `/${stack.stackName}/${path}`,
+      registryArnSuppression,
+    );
+  }
 
-              // IAM5 — Phase-2 cross-account trust-path. When an imported agent's
-              // invocation.roleArn is cross-account and the operator supplied a
-              // READ-ONLY invocation.analysisRoleArn, the agent-config-resolver
-              // assumes that analysis role to run read-only IAM introspection in
-              // the role's home account. The analysis role is operator-supplied
-              // and may live in ANY account, so sts:AssumeRole is scoped to the
-              // cross-account IAM role namespace (arn:aws:iam::*:role/*) rather
-              // than this account; the externalId is the runtime confused-deputy
-              // control. Additive to the read-only introspection suppression above.
-              NagSuppressions.addResourceSuppressionsByPath(
-                backendStack,
-                `/${backendStack.stackName}/AgentConfigResolverFunction/ServiceRole/DefaultPolicy/Resource`,
-                [{
-                  id: 'AwsSolutions-IAM5',
-                  reason:
-                    'cross-account read-only analysis-role assume for trust-path; ' +
-                    'externalId-gated; target role is operator-supplied and must trust Citadel',
-                  appliesTo: [
-                    { regex: '/^Resource::arn:aws:iam::\\*:role\\/\\*$/g' },
-                  ],
-                }],
-              );
+  // IAM5 — AgentImportResolverFunction discovery policy
+  // (buildImportDiscoveryPolicy) grants read-only List/Describe/Get
+  // across the phase-1 substrates with Resource '*', which those
+  // List/Describe APIs do not support resource-level scoping for.
+  // Additive to the registry-ARN suppression already registered for
+  // this role above.
+  NagSuppressions.addResourceSuppressionsByPath(
+    backendStack,
+    `/${backendStack.stackName}/AgentImportResolverFunction/ServiceRole/DefaultPolicy/Resource`,
+    [
+      {
+        id: "AwsSolutions-IAM5",
+        reason: "read-only discovery list/describe requires * resource",
+        appliesTo: ["Resource::*"],
+      },
+    ],
+  );
 
-              // IAM5 — Phase-2 cross-account INVOKE. When an imported agent's
-              // invocation.roleArn is cross-account, the agent-message-handler
-              // assumes that operator-supplied invoke role (externalId-gated) and
-              // runs the AWS-native protocol invoke under the assumed credentials.
-              // The invoke role is operator-supplied and may live in ANY account,
-              // so sts:AssumeRole is scoped to the cross-account IAM role namespace
-              // (arn:aws:iam::*:role/*) rather than this account; the externalId is
-              // the runtime confused-deputy control. Additive to the Resource::*
-              // suppression already registered for this role above.
-              NagSuppressions.addResourceSuppressionsByPath(
-                backendStack,
-                `/${backendStack.stackName}/AgentMessageHandlerFunction/ServiceRole/DefaultPolicy/Resource`,
-                [{
-                  id: 'AwsSolutions-IAM5',
-                  reason:
-                    'cross-account invoke-role assume for imported agents; externalId-gated; ' +
-                    'operator-supplied target role must trust Citadel',
-                  appliesTo: [
-                    { regex: '/^Resource::arn:aws:iam::\\*:role\\/\\*$/g' },
-                  ],
-                }],
-              );
+  // IAM5 — US-IMP-018 ECS source adapter endpoint resolution. The ECS
+  // discovery substrate resolves a service's HTTP endpoint via
+  // read-only ecs:ListClusters/ListServices/DescribeServices/
+  // DescribeTaskDefinition (granted by buildImportDiscoveryPolicy) plus
+  // read-only elasticloadbalancing:DescribeTargetGroups/
+  // DescribeLoadBalancers. These List/Describe APIs have no
+  // resource-level scoping, so they require Resource '*'. Additive to
+  // the discovery suppression registered just above; read-only only.
+  NagSuppressions.addResourceSuppressionsByPath(
+    backendStack,
+    `/${backendStack.stackName}/AgentImportResolverFunction/ServiceRole/DefaultPolicy/Resource`,
+    [
+      {
+        id: "AwsSolutions-IAM5",
+        reason: "read-only ECS/ELB discovery requires * resource",
+        appliesTo: ["Resource::*"],
+      },
+    ],
+  );
 
-              // CloudFront — partial hardening. TLS 1.2 and access logging applied; the
-              // rest require follow-up work.
-              NagSuppressions.addResourceSuppressionsByPath(frontendStack, `/${frontendStack.stackName}/FrontendDistribution`, [
-                              { id: 'AwsSolutions-CFR1', reason: 'Geo restrictions not required; platform is internal enterprise. Tracked: AAF-NAG-CFR1. reviewBy: 2026-10-22.' },
-                              { id: 'AwsSolutions-CFR2', reason: 'WAFv2 WebACL for CloudFront must be deployed to us-east-1; current stack deploys to ap-southeast-2. Cross-region WAF deployment tracked: AAF-NAG-CFR2. reviewBy: 2026-07-22.' },
-                              { id: 'AwsSolutions-CFR4', reason: 'Uses CloudFront default *.cloudfront.net certificate which pins to TLSv1 regardless of minimumProtocolVersion. Clearing requires an ACM cert + custom domain (DNS decision). minimumProtocolVersion already set to TLSv1.2_2021 so a custom cert will take effect when attached. Tracked: AAF-NAG-CFR4. reviewBy: 2026-10-22.' },
-                              { id: 'AwsSolutions-CFR7', reason: 'Distribution uses OAI (legacy); migration to OAC requires CfnDistribution refactor and S3 bucket policy update. Tracked: AAF-NAG-CFR7. reviewBy: 2026-07-22.' },
-                            ]);
+  // IAM5 — AgentImportResolverFunction pre-activation TEST-INVOKE
+  // (testImportedAgent). The admin/architect-gated dry-run invokes an
+  // operator-supplied import candidate; the target is arbitrary, so
+  // the invoke actions are scoped to THIS ACCOUNT (lambda function:*,
+  // bedrock agent-alias/*, execute-api) rather than bare Resource::*.
+  // The bedrock-agentcore runtime/* and /citadel/agents/* (GetSecretValue)
+  // wildcards are already covered by the stack-level IAM5 suppression.
+  // Additive to the discovery suppression registered just above.
+  NagSuppressions.addResourceSuppressionsByPath(
+    backendStack,
+    `/${backendStack.stackName}/AgentImportResolverFunction/ServiceRole/DefaultPolicy/Resource`,
+    [
+      {
+        id: "AwsSolutions-IAM5",
+        reason:
+          "admin/architect-gated pre-activation test-invoke against " +
+          "operator-supplied targets; account-scoped (lambda function:*, " +
+          "bedrock agent-alias/*, execute-api), never bare Resource::*. " +
+          "Tracked: AAF-NAG-IAM5-testinvoke.",
+        appliesTo: [
+          { regex: "/^Resource::arn:aws:lambda:\\*:.*:function:\\*$/g" },
+          { regex: "/^Resource::arn:aws:bedrock:\\*:.*:agent-alias\\/\\*$/g" },
+          { regex: "/^Resource::arn:aws:execute-api:\\*:.*:\\*$/g" },
+        ],
+      },
+    ],
+  );
 
-              // SQS3 — RegistrySyncDLQ is itself a dead-letter queue; adding a DLQ to a DLQ is unnecessary.
-              NagSuppressions.addResourceSuppressionsByPath(backendStack, `/${backendStack.stackName}/RegistrySyncDLQ/Resource`, [{
-                id: 'AwsSolutions-SQS3',
-                reason: 'RegistrySyncDLQ is itself a dead-letter queue for the RegistrySyncLambda event source. Adding a DLQ to a DLQ is unnecessary.',
-              }]);
-
-              // IAM5 — RegistryProvisionerFunction needs SLR wildcard for bedrock-agentcore service-linked role creation.
-              NagSuppressions.addResourceSuppressionsByPath(backendStack, `/${backendStack.stackName}/RegistryProvisionerFunction/ServiceRole/DefaultPolicy/Resource`, [{
-                id: 'AwsSolutions-IAM5',
-                reason: 'iam:CreateServiceLinkedRole requires wildcard on the SLR path. Scoped to bedrock-agentcore.amazonaws.com service only.',
-                appliesTo: ['Resource::arn:aws:iam::*:role/aws-service-role/bedrock-agentcore.amazonaws.com/*'],
-              }]);
-
-              // IAM5 — Registry ARN wildcards for AgentCore registry CRUD operations.
-              const registryArnSuppression = [{
-                id: 'AwsSolutions-IAM5',
-                reason: 'AgentCore registry operations require wildcard on registry ARN sub-resources (agents, tools, versions). Scoped to the specific registry ARN.',
-                appliesTo: [
-                  { regex: '/^Resource::<AgentCoreRegistry\\.RegistryArn>\\/\\*$/g' },
-                ],
-              }];
-              const registryArnPaths: Array<[cdk.Stack, string]> = [
-                [backendStack, 'RegistrySyncLambda/ServiceRole/DefaultPolicy/Resource'],
-                [backendStack, 'AgentConfigResolverFunction/ServiceRole/DefaultPolicy/Resource'],
-                [backendStack, 'AgentImportResolverFunction/ServiceRole/DefaultPolicy/Resource'],
-                [backendStack, 'ToolConfigResolverFunction/ServiceRole/DefaultPolicy/Resource'],
-                [arbiterStack, 'FabricatorAgent/ServiceRole/DefaultPolicy/Resource'],
-                [arbiterStack, 'SupervisorAgent/ServiceRole/DefaultPolicy/Resource'],
-                [arbiterStack, 'WorkerAgentWrapper/ServiceRole/DefaultPolicy/Resource'],
-                [arbiterStack, 'GovernanceUiResolverFn/ServiceRole/DefaultPolicy/Resource'],
-                [backendStack, 'RegistryAgentRecordResolverFunction/ServiceRole/DefaultPolicy/Resource'],
-                [backendStack, 'ReconcileAppsMetaScheduledFunction/ServiceRole/DefaultPolicy/Resource'],
-                // Tier-3 agent import (B1): the manifest RESULT handler reads the
-                // DRAFT import record and updates only its custom metadata
-                // (GetRegistryRecord + UpdateRegistryRecord), scoped to the
-                // registry ARN + its records (<AgentCoreRegistry.RegistryArn>/*).
-                [backendStack, 'AgentImportManifestResultHandler/ServiceRole/DefaultPolicy/Resource'],
-                [servicesStack, 'AgentIntakeSingleRuntime/ExecutionRole/DefaultPolicy/Resource'],
-                // Intake post-fabrication orchestration resolver: registry record
-                // CRUD-without-delete (activation status transitions + app record
-                // creation), scoped to the registry ARN + its records.
-                [servicesStack, 'IntakeOrchestrationResolverFunction/ServiceRole/DefaultPolicy/Resource'],
-              ];
-              for (const [stack, path] of registryArnPaths) {
-                NagSuppressions.addResourceSuppressionsByPath(stack, `/${stack.stackName}/${path}`, registryArnSuppression);
-              }
-
-              // IAM5 — AgentImportResolverFunction discovery policy
-              // (buildImportDiscoveryPolicy) grants read-only List/Describe/Get
-              // across the phase-1 substrates with Resource '*', which those
-              // List/Describe APIs do not support resource-level scoping for.
-              // Additive to the registry-ARN suppression already registered for
-              // this role above.
-              NagSuppressions.addResourceSuppressionsByPath(
-                backendStack,
-                `/${backendStack.stackName}/AgentImportResolverFunction/ServiceRole/DefaultPolicy/Resource`,
-                [{
-                  id: 'AwsSolutions-IAM5',
-                  reason: 'read-only discovery list/describe requires * resource',
-                  appliesTo: ['Resource::*'],
-                }],
-              );
-
-              // IAM5 — US-IMP-018 ECS source adapter endpoint resolution. The ECS
-              // discovery substrate resolves a service's HTTP endpoint via
-              // read-only ecs:ListClusters/ListServices/DescribeServices/
-              // DescribeTaskDefinition (granted by buildImportDiscoveryPolicy) plus
-              // read-only elasticloadbalancing:DescribeTargetGroups/
-              // DescribeLoadBalancers. These List/Describe APIs have no
-              // resource-level scoping, so they require Resource '*'. Additive to
-              // the discovery suppression registered just above; read-only only.
-              NagSuppressions.addResourceSuppressionsByPath(
-                backendStack,
-                `/${backendStack.stackName}/AgentImportResolverFunction/ServiceRole/DefaultPolicy/Resource`,
-                [{
-                  id: 'AwsSolutions-IAM5',
-                  reason: 'read-only ECS/ELB discovery requires * resource',
-                  appliesTo: ['Resource::*'],
-                }],
-              );
-
-              // IAM5 — AgentImportResolverFunction pre-activation TEST-INVOKE
-              // (testImportedAgent). The admin/architect-gated dry-run invokes an
-              // operator-supplied import candidate; the target is arbitrary, so
-              // the invoke actions are scoped to THIS ACCOUNT (lambda function:*,
-              // bedrock agent-alias/*, execute-api) rather than bare Resource::*.
-              // The bedrock-agentcore runtime/* and /citadel/agents/* (GetSecretValue)
-              // wildcards are already covered by the stack-level IAM5 suppression.
-              // Additive to the discovery suppression registered just above.
-              NagSuppressions.addResourceSuppressionsByPath(
-                backendStack,
-                `/${backendStack.stackName}/AgentImportResolverFunction/ServiceRole/DefaultPolicy/Resource`,
-                [{
-                  id: 'AwsSolutions-IAM5',
-                  reason:
-                    'admin/architect-gated pre-activation test-invoke against ' +
-                    'operator-supplied targets; account-scoped (lambda function:*, ' +
-                    'bedrock agent-alias/*, execute-api), never bare Resource::*. ' +
-                    'Tracked: AAF-NAG-IAM5-testinvoke.',
-                  appliesTo: [
-                    { regex: '/^Resource::arn:aws:lambda:\\*:.*:function:\\*$/g' },
-                    { regex: '/^Resource::arn:aws:bedrock:\\*:.*:agent-alias\\/\\*$/g' },
-                    { regex: '/^Resource::arn:aws:execute-api:\\*:.*:\\*$/g' },
-                  ],
-                }],
-              );
-
-              // IAM5 — Phase-2 cross-account INVOKE for the import resolver. When
-              // an import candidate's invocation.roleArn is cross-account, the
-              // admin/architect-gated testImportedAgent / probeAgentCandidate
-              // dry-run assumes that operator-supplied invoke role (externalId-
-              // gated) and runs the AWS-native protocol invoke under the assumed
-              // credentials. The invoke role is operator-supplied and may live in
-              // ANY account, so sts:AssumeRole is scoped to the cross-account IAM
-              // role namespace (arn:aws:iam::*:role/*) rather than this account;
-              // the externalId is the runtime confused-deputy control. Additive to
-              // the discovery + test-invoke suppressions already registered for
-              // this role above.
-              NagSuppressions.addResourceSuppressionsByPath(
-                backendStack,
-                `/${backendStack.stackName}/AgentImportResolverFunction/ServiceRole/DefaultPolicy/Resource`,
-                [{
-                  id: 'AwsSolutions-IAM5',
-                  reason:
-                    'cross-account invoke-role assume for imported-agent test/probe; ' +
-                    'externalId-gated; operator-supplied target role must trust Citadel',
-                  appliesTo: [
-                    { regex: '/^Resource::arn:aws:iam::\\*:role\\/\\*$/g' },
-                  ],
-                }],
-              );
+  // IAM5 — Phase-2 cross-account INVOKE for the import resolver. When
+  // an import candidate's invocation.roleArn is cross-account, the
+  // admin/architect-gated testImportedAgent / probeAgentCandidate
+  // dry-run assumes that operator-supplied invoke role (externalId-
+  // gated) and runs the AWS-native protocol invoke under the assumed
+  // credentials. The invoke role is operator-supplied and may live in
+  // ANY account, so sts:AssumeRole is scoped to the cross-account IAM
+  // role namespace (arn:aws:iam::*:role/*) rather than this account;
+  // the externalId is the runtime confused-deputy control. Additive to
+  // the discovery + test-invoke suppressions already registered for
+  // this role above.
+  NagSuppressions.addResourceSuppressionsByPath(
+    backendStack,
+    `/${backendStack.stackName}/AgentImportResolverFunction/ServiceRole/DefaultPolicy/Resource`,
+    [
+      {
+        id: "AwsSolutions-IAM5",
+        reason:
+          "cross-account invoke-role assume for imported-agent test/probe; " +
+          "externalId-gated; operator-supplied target role must trust Citadel",
+        appliesTo: [{ regex: "/^Resource::arn:aws:iam::\\*:role\\/\\*$/g" }],
+      },
+    ],
+  );
 }

--- a/backend/lib/backend-stack.ts
+++ b/backend/lib/backend-stack.ts
@@ -49,6 +49,9 @@ export class BackendStack extends cdk.Stack {
   public readonly adrReopenAttemptsTable: dynamodb.Table;
   public readonly registryArn: string;
   public readonly registryId: string;
+  // Exposed for TelemetryStack (pass-1 cost ledger): the writer Lambda needs
+  // read access to model pricing metadata (pass-2 cost computation).
+  public readonly modelCatalogTable: dynamodb.Table;
 
   constructor(scope: Construct, id: string, props: BackendStackProps) {
     super(scope, id, props);
@@ -187,13 +190,17 @@ export class BackendStack extends cdk.Stack {
 
     // Model Catalog Table — inventory of invokable foundation models. Additive and
     // not yet wired into any runtime/Lambda env; operators curate rows over time.
-    const modelCatalogTable = new dynamodb.Table(this, "ModelCatalogTable", {
-      tableName: `citadel-model-catalog-${props.environment}`,
-      partitionKey: { name: "modelKey", type: dynamodb.AttributeType.STRING },
-      billingMode: dynamodb.BillingMode.PAY_PER_REQUEST,
-      removalPolicy: cdk.RemovalPolicy.DESTROY,
-      pointInTimeRecoverySpecification: { pointInTimeRecoveryEnabled: true },
-    });
+    const modelCatalogTable = (this.modelCatalogTable = new dynamodb.Table(
+      this,
+      "ModelCatalogTable",
+      {
+        tableName: `citadel-model-catalog-${props.environment}`,
+        partitionKey: { name: "modelKey", type: dynamodb.AttributeType.STRING },
+        billingMode: dynamodb.BillingMode.PAY_PER_REQUEST,
+        removalPolicy: cdk.RemovalPolicy.DESTROY,
+        pointInTimeRecoverySpecification: { pointInTimeRecoveryEnabled: true },
+      },
+    ));
 
     // Model Config Table — resolved model-selection defaults/overrides. Additive and
     // not yet wired into any runtime/Lambda env.

--- a/backend/lib/frontend-stack.ts
+++ b/backend/lib/frontend-stack.ts
@@ -1,17 +1,17 @@
-import * as cdk from 'aws-cdk-lib';
-import * as s3 from 'aws-cdk-lib/aws-s3';
-import * as cloudfront from 'aws-cdk-lib/aws-cloudfront';
-import * as origins from 'aws-cdk-lib/aws-cloudfront-origins';
-import * as s3deploy from 'aws-cdk-lib/aws-s3-deployment';
-import * as appsync from '@aws-cdk/aws-appsync-alpha';
-import * as cognito from 'aws-cdk-lib/aws-cognito';
+import * as cdk from "aws-cdk-lib";
+import * as s3 from "aws-cdk-lib/aws-s3";
+import * as cloudfront from "aws-cdk-lib/aws-cloudfront";
+import * as origins from "aws-cdk-lib/aws-cloudfront-origins";
+import * as s3deploy from "aws-cdk-lib/aws-s3-deployment";
+import * as appsync from "@aws-cdk/aws-appsync-alpha";
+import * as cognito from "aws-cdk-lib/aws-cognito";
 import * as events from "aws-cdk-lib/aws-events";
-import * as iam from 'aws-cdk-lib/aws-iam';
-import * as logs from 'aws-cdk-lib/aws-logs';
-import * as wafv2 from 'aws-cdk-lib/aws-wafv2';
-import * as fs from 'fs';
-import * as path from 'path';
-import { Construct } from 'constructs';
+import * as iam from "aws-cdk-lib/aws-iam";
+import * as logs from "aws-cdk-lib/aws-logs";
+import * as wafv2 from "aws-cdk-lib/aws-wafv2";
+import * as fs from "fs";
+import * as path from "path";
+import { Construct } from "constructs";
 
 interface FrontendStackProps extends cdk.StackProps {
   appSyncApi: appsync.GraphqlApi;
@@ -19,6 +19,8 @@ interface FrontendStackProps extends cdk.StackProps {
   userPoolClient: cognito.UserPoolClient;
   agentEventBus: events.EventBus;
   environment: string;
+  /** Cost query HttpApi endpoint from TelemetryStack (pass 2) — rides the existing aws-exports.json deployment as `aws_cost_api_url`. */
+  costApiUrl: string;
 }
 
 export class FrontendStack extends cdk.Stack {
@@ -27,76 +29,76 @@ export class FrontendStack extends cdk.Stack {
 
   constructor(scope: Construct, id: string, props: FrontendStackProps) {
     super(scope, id, props);
-    
+
     // S3 bucket for frontend hosting
-    const accessLogsBucket = new s3.Bucket(this, 'AccessLogsBucket', {
-          bucketName: `citadel-frontend-s3-logs-${props.environment}-${this.account}-${this.region}`,
-          encryption: s3.BucketEncryption.S3_MANAGED,
-          blockPublicAccess: s3.BlockPublicAccess.BLOCK_ALL,
-          enforceSSL: true,
-          removalPolicy: cdk.RemovalPolicy.DESTROY,
-          autoDeleteObjects: true,
-          lifecycleRules: [{ expiration: cdk.Duration.days(90) }],
-        });
-    
-        this.bucket = new s3.Bucket(this, 'FrontendBucket', {
-              bucketName: `citadel-frontend-${props.environment}-${this.account}-${this.region}`,
-              removalPolicy: cdk.RemovalPolicy.DESTROY,
-              autoDeleteObjects: true,
-              versioned: true,
-              publicReadAccess: false,
-              blockPublicAccess: s3.BlockPublicAccess.BLOCK_ALL,
-              enforceSSL: true,
-              serverAccessLogsBucket: accessLogsBucket,
-              serverAccessLogsPrefix: 'frontend/',
-            });
+    const accessLogsBucket = new s3.Bucket(this, "AccessLogsBucket", {
+      bucketName: `citadel-frontend-s3-logs-${props.environment}-${this.account}-${this.region}`,
+      encryption: s3.BucketEncryption.S3_MANAGED,
+      blockPublicAccess: s3.BlockPublicAccess.BLOCK_ALL,
+      enforceSSL: true,
+      removalPolicy: cdk.RemovalPolicy.DESTROY,
+      autoDeleteObjects: true,
+      lifecycleRules: [{ expiration: cdk.Duration.days(90) }],
+    });
+
+    this.bucket = new s3.Bucket(this, "FrontendBucket", {
+      bucketName: `citadel-frontend-${props.environment}-${this.account}-${this.region}`,
+      removalPolicy: cdk.RemovalPolicy.DESTROY,
+      autoDeleteObjects: true,
+      versioned: true,
+      publicReadAccess: false,
+      blockPublicAccess: s3.BlockPublicAccess.BLOCK_ALL,
+      enforceSSL: true,
+      serverAccessLogsBucket: accessLogsBucket,
+      serverAccessLogsPrefix: "frontend/",
+    });
 
     // Create OAI
-    const oai = new cloudfront.OriginAccessIdentity(this, 'OAI');
+    const oai = new cloudfront.OriginAccessIdentity(this, "OAI");
     this.bucket.grantRead(oai);
 
     // WAF WebACL for CloudFront (S-16 fix)
     // CloudFront-scoped WAF WebACLs can only be created in us-east-1
     let webAclArn: string | undefined;
-    if (this.region === 'us-east-1') {
-      const webAcl = new wafv2.CfnWebACL(this, 'CloudFrontWebAcl', {
+    if (this.region === "us-east-1") {
+      const webAcl = new wafv2.CfnWebACL(this, "CloudFrontWebAcl", {
         defaultAction: { allow: {} },
-        scope: 'CLOUDFRONT',
+        scope: "CLOUDFRONT",
         visibilityConfig: {
           cloudWatchMetricsEnabled: true,
-          metricName: 'CitadelWebAcl',
+          metricName: "CitadelWebAcl",
           sampledRequestsEnabled: true,
         },
         rules: [
           {
-            name: 'AWSManagedRulesCommonRuleSet',
+            name: "AWSManagedRulesCommonRuleSet",
             priority: 1,
             overrideAction: { none: {} },
             statement: {
               managedRuleGroupStatement: {
-                vendorName: 'AWS',
-                name: 'AWSManagedRulesCommonRuleSet',
+                vendorName: "AWS",
+                name: "AWSManagedRulesCommonRuleSet",
               },
             },
             visibilityConfig: {
               cloudWatchMetricsEnabled: true,
-              metricName: 'CommonRuleSet',
+              metricName: "CommonRuleSet",
               sampledRequestsEnabled: true,
             },
           },
           {
-            name: 'RateLimitRule',
+            name: "RateLimitRule",
             priority: 2,
             action: { block: {} },
             statement: {
               rateBasedStatement: {
                 limit: 2000,
-                aggregateKeyType: 'IP',
+                aggregateKeyType: "IP",
               },
             },
             visibilityConfig: {
               cloudWatchMetricsEnabled: true,
-              metricName: 'RateLimitRule',
+              metricName: "RateLimitRule",
               sampledRequestsEnabled: true,
             },
           },
@@ -106,148 +108,205 @@ export class FrontendStack extends cdk.Stack {
     }
 
     // CloudFront distribution using L1 construct
-    const cloudFrontLogsBucket = new s3.Bucket(this, 'CloudFrontLogsBucket', {
-          bucketName: `citadel-cf-logs-${props.environment}-${this.account}-${this.region}`,
-          encryption: s3.BucketEncryption.S3_MANAGED,
-          blockPublicAccess: s3.BlockPublicAccess.BLOCK_ALL,
-          enforceSSL: true,
-          // CloudFront log delivery requires BucketOwnerPreferred ACL (it writes as awslogsdelivery canonical ID).
-          objectOwnership: s3.ObjectOwnership.BUCKET_OWNER_PREFERRED,
-          removalPolicy: cdk.RemovalPolicy.DESTROY,
-          autoDeleteObjects: true,
-          lifecycleRules: [{ expiration: cdk.Duration.days(90) }],
-        });
-    
-        const cfnDistribution = new cloudfront.CfnDistribution(this, 'FrontendDistribution', {
-          distributionConfig: {
-            enabled: true,
-            defaultRootObject: 'index.html',
-            priceClass: 'PriceClass_100',
-            comment: 'Citadel Frontend Distribution', logging: { bucket: cloudFrontLogsBucket.bucketRegionalDomainName, prefix: 'cloudfront/', includeCookies: false }, viewerCertificate: { cloudFrontDefaultCertificate: true, minimumProtocolVersion: 'TLSv1.2_2021' },
-            webAclId: webAclArn,
-            origins: [
-              {
-                id: 's3-origin',
-                domainName: this.bucket.bucketRegionalDomainName,
-                s3OriginConfig: {
-                  originAccessIdentity: `origin-access-identity/cloudfront/${oai.originAccessIdentityId}`,
-                },
-              },
-              {
-                id: 'appsync-origin',
-                domainName: cdk.Fn.select(2, cdk.Fn.split('/', props.appSyncApi.graphqlUrl)),
-                customOriginConfig: {
-                  httpPort: 80,
-                  httpsPort: 443,
-                  originProtocolPolicy: 'https-only',
-                  originSslProtocols: ['TLSv1.2'],
-                },
-              },
-            ],
-            defaultCacheBehavior: {
-              targetOriginId: 's3-origin',
-              viewerProtocolPolicy: 'redirect-to-https',
-              allowedMethods: ['GET', 'HEAD', 'OPTIONS'],
-              cachedMethods: ['GET', 'HEAD', 'OPTIONS'],
-              compress: true,
-              cachePolicyId: '658327ea-f89d-4fab-a63d-7e88639e58f6', // CachingOptimized
-            },
-            cacheBehaviors: [
-              {
-                pathPattern: '/api/*',
-                targetOriginId: 'appsync-origin',
-                viewerProtocolPolicy: 'https-only',
-                allowedMethods: ['GET', 'HEAD', 'OPTIONS', 'PUT', 'POST', 'PATCH', 'DELETE'],
-                cachedMethods: ['GET', 'HEAD'],
-                cachePolicyId: '4135ea2d-6df8-44a3-9df3-4b5a84be39ad', // CachingDisabled
-                originRequestPolicyId: '88a5eaf4-2fd4-4709-b370-b4c650ea3fcf', // CORS-S3Origin
-              },
-            ],
-            customErrorResponses: [
-              {
-                errorCode: 404,
-                responseCode: 200,
-                responsePagePath: '/index.html',
-                errorCachingMinTtl: 1800,
-              },
-              {
-                errorCode: 403,
-                responseCode: 200,
-                responsePagePath: '/index.html',
-                errorCachingMinTtl: 1800,
-              },
-            ],
-          },
-        });
+    const cloudFrontLogsBucket = new s3.Bucket(this, "CloudFrontLogsBucket", {
+      bucketName: `citadel-cf-logs-${props.environment}-${this.account}-${this.region}`,
+      encryption: s3.BucketEncryption.S3_MANAGED,
+      blockPublicAccess: s3.BlockPublicAccess.BLOCK_ALL,
+      enforceSSL: true,
+      // CloudFront log delivery requires BucketOwnerPreferred ACL (it writes as awslogsdelivery canonical ID).
+      objectOwnership: s3.ObjectOwnership.BUCKET_OWNER_PREFERRED,
+      removalPolicy: cdk.RemovalPolicy.DESTROY,
+      autoDeleteObjects: true,
+      lifecycleRules: [{ expiration: cdk.Duration.days(90) }],
+    });
 
-    this.distribution = cloudfront.Distribution.fromDistributionAttributes(this, 'Distribution', {
-      distributionId: cfnDistribution.ref,
-      domainName: cfnDistribution.attrDomainName,
-    }) as cloudfront.Distribution;
+    const cfnDistribution = new cloudfront.CfnDistribution(
+      this,
+      "FrontendDistribution",
+      {
+        distributionConfig: {
+          enabled: true,
+          defaultRootObject: "index.html",
+          priceClass: "PriceClass_100",
+          comment: "Citadel Frontend Distribution",
+          logging: {
+            bucket: cloudFrontLogsBucket.bucketRegionalDomainName,
+            prefix: "cloudfront/",
+            includeCookies: false,
+          },
+          viewerCertificate: {
+            cloudFrontDefaultCertificate: true,
+            minimumProtocolVersion: "TLSv1.2_2021",
+          },
+          webAclId: webAclArn,
+          origins: [
+            {
+              id: "s3-origin",
+              domainName: this.bucket.bucketRegionalDomainName,
+              s3OriginConfig: {
+                originAccessIdentity: `origin-access-identity/cloudfront/${oai.originAccessIdentityId}`,
+              },
+            },
+            {
+              id: "appsync-origin",
+              domainName: cdk.Fn.select(
+                2,
+                cdk.Fn.split("/", props.appSyncApi.graphqlUrl),
+              ),
+              customOriginConfig: {
+                httpPort: 80,
+                httpsPort: 443,
+                originProtocolPolicy: "https-only",
+                originSslProtocols: ["TLSv1.2"],
+              },
+            },
+          ],
+          defaultCacheBehavior: {
+            targetOriginId: "s3-origin",
+            viewerProtocolPolicy: "redirect-to-https",
+            allowedMethods: ["GET", "HEAD", "OPTIONS"],
+            cachedMethods: ["GET", "HEAD", "OPTIONS"],
+            compress: true,
+            cachePolicyId: "658327ea-f89d-4fab-a63d-7e88639e58f6", // CachingOptimized
+          },
+          cacheBehaviors: [
+            {
+              pathPattern: "/api/*",
+              targetOriginId: "appsync-origin",
+              viewerProtocolPolicy: "https-only",
+              allowedMethods: [
+                "GET",
+                "HEAD",
+                "OPTIONS",
+                "PUT",
+                "POST",
+                "PATCH",
+                "DELETE",
+              ],
+              cachedMethods: ["GET", "HEAD"],
+              cachePolicyId: "4135ea2d-6df8-44a3-9df3-4b5a84be39ad", // CachingDisabled
+              originRequestPolicyId: "88a5eaf4-2fd4-4709-b370-b4c650ea3fcf", // CORS-S3Origin
+            },
+          ],
+          customErrorResponses: [
+            {
+              errorCode: 404,
+              responseCode: 200,
+              responsePagePath: "/index.html",
+              errorCachingMinTtl: 1800,
+            },
+            {
+              errorCode: 403,
+              responseCode: 200,
+              responsePagePath: "/index.html",
+              errorCachingMinTtl: 1800,
+            },
+          ],
+        },
+      },
+    );
+
+    this.distribution = cloudfront.Distribution.fromDistributionAttributes(
+      this,
+      "Distribution",
+      {
+        distributionId: cfnDistribution.ref,
+        domainName: cfnDistribution.attrDomainName,
+      },
+    ) as cloudfront.Distribution;
 
     // Configure Cognito email templates with CloudFront URL using Custom Resource
-    const hostUrl = process.env.HOST_URL || `https://${cfnDistribution.attrDomainName}`;
-    
-    const verificationEmailTemplate = fs.readFileSync(
-      path.join(__dirname, '../src/cognito-email-templates/verification-email.html'),
-      'utf-8'
-    ).replace(/https:\/\/your-domain\.com/g, hostUrl);
-    
-    const invitationEmailTemplate = fs.readFileSync(
-      path.join(__dirname, '../src/cognito-email-templates/invitation-email.html'),
-      'utf-8'
-    ).replace(/https:\/\/your-domain\.com/g, hostUrl);
+    const hostUrl =
+      process.env.HOST_URL || `https://${cfnDistribution.attrDomainName}`;
 
-    const passwordResetEmailTemplate = fs.readFileSync(
-      path.join(__dirname, '../src/cognito-email-templates/password-reset-email.html'),
-      'utf-8'
-    ).replace(/https:\/\/your-domain\.com/g, hostUrl);
+    const verificationEmailTemplate = fs
+      .readFileSync(
+        path.join(
+          __dirname,
+          "../src/cognito-email-templates/verification-email.html",
+        ),
+        "utf-8",
+      )
+      .replace(/https:\/\/your-domain\.com/g, hostUrl);
+
+    const invitationEmailTemplate = fs
+      .readFileSync(
+        path.join(
+          __dirname,
+          "../src/cognito-email-templates/invitation-email.html",
+        ),
+        "utf-8",
+      )
+      .replace(/https:\/\/your-domain\.com/g, hostUrl);
+
+    const passwordResetEmailTemplate = fs
+      .readFileSync(
+        path.join(
+          __dirname,
+          "../src/cognito-email-templates/password-reset-email.html",
+        ),
+        "utf-8",
+      )
+      .replace(/https:\/\/your-domain\.com/g, hostUrl);
 
     // Create a Lambda function to update Cognito email templates
-    const updateEmailTemplatesFunction = new cdk.aws_lambda.Function(this, 'UpdateEmailTemplatesFunction', {
-      runtime: cdk.aws_lambda.Runtime.PYTHON_3_14,
-      handler: 'index.handler',
-      code: cdk.aws_lambda.Code.fromAsset(path.join(__dirname, '../../src/lambda/update-email-templates')),
-      timeout: cdk.Duration.seconds(30),
-      logGroup: new logs.LogGroup(this, 'UpdateEmailTemplatesFunctionLogs', { retention: logs.RetentionDays.ONE_WEEK, removalPolicy: cdk.RemovalPolicy.DESTROY }),
-      tracing: cdk.aws_lambda.Tracing.ACTIVE, // O-03
-      environment: {
-        POWERTOOLS_SERVICE_NAME: 'citadel', // O-02
-        POWERTOOLS_LOG_LEVEL: 'INFO',
+    const updateEmailTemplatesFunction = new cdk.aws_lambda.Function(
+      this,
+      "UpdateEmailTemplatesFunction",
+      {
+        runtime: cdk.aws_lambda.Runtime.PYTHON_3_14,
+        handler: "index.handler",
+        code: cdk.aws_lambda.Code.fromAsset(
+          path.join(__dirname, "../../src/lambda/update-email-templates"),
+        ),
+        timeout: cdk.Duration.seconds(30),
+        logGroup: new logs.LogGroup(this, "UpdateEmailTemplatesFunctionLogs", {
+          retention: logs.RetentionDays.ONE_WEEK,
+          removalPolicy: cdk.RemovalPolicy.DESTROY,
+        }),
+        tracing: cdk.aws_lambda.Tracing.ACTIVE, // O-03
+        environment: {
+          POWERTOOLS_SERVICE_NAME: "citadel", // O-02
+          POWERTOOLS_LOG_LEVEL: "INFO",
+        },
       },
-    });
+    );
 
     // Grant permissions to update Cognito User Pool
     updateEmailTemplatesFunction.addToRolePolicy(
       new iam.PolicyStatement({
         effect: iam.Effect.ALLOW,
-        actions: ['cognito-idp:UpdateUserPool', 'cognito-idp:DescribeUserPool'],
+        actions: ["cognito-idp:UpdateUserPool", "cognito-idp:DescribeUserPool"],
         resources: [props.userPool.userPoolArn],
-      })
+      }),
     );
 
     // Create Custom Resource to trigger the Lambda
-    const emailTemplatesCustomResource = new cdk.CustomResource(this, 'EmailTemplatesCustomResource', {
-      serviceToken: updateEmailTemplatesFunction.functionArn,
-      properties: {
-        UserPoolId: props.userPool.userPoolId,
-        VerificationTemplate: verificationEmailTemplate,
-        InvitationTemplate: invitationEmailTemplate,
-        PasswordResetTemplate: passwordResetEmailTemplate,
-        // Trigger update when CloudFront URL changes
-        CloudFrontUrl: hostUrl,
-        // O-05: Use version string instead of Date.now() to avoid unnecessary re-runs
-        Version: 'v1.1.0',
+    const emailTemplatesCustomResource = new cdk.CustomResource(
+      this,
+      "EmailTemplatesCustomResource",
+      {
+        serviceToken: updateEmailTemplatesFunction.functionArn,
+        properties: {
+          UserPoolId: props.userPool.userPoolId,
+          VerificationTemplate: verificationEmailTemplate,
+          InvitationTemplate: invitationEmailTemplate,
+          PasswordResetTemplate: passwordResetEmailTemplate,
+          // Trigger update when CloudFront URL changes
+          CloudFrontUrl: hostUrl,
+          // O-05: Use version string instead of Date.now() to avoid unnecessary re-runs
+          Version: "v1.1.0",
+        },
       },
-    });
+    );
 
     // Ensure this runs after the distribution is created
     emailTemplatesCustomResource.node.addDependency(cfnDistribution);
 
     // Output CloudFront URL for reference
-    new cdk.CfnOutput(this, 'CloudFrontUrl', {
+    new cdk.CfnOutput(this, "CloudFrontUrl", {
       value: hostUrl,
-      description: 'CloudFront Distribution URL used in email templates',
+      description: "CloudFront Distribution URL used in email templates",
     });
 
     // Create a configuration file for the frontend
@@ -255,48 +314,58 @@ export class FrontendStack extends cdk.Stack {
       aws_project_region: this.region,
       aws_appsync_graphqlEndpoint: props.appSyncApi.graphqlUrl,
       aws_appsync_region: this.region,
-      aws_appsync_authenticationType: 'AMAZON_COGNITO_USER_POOLS',
+      aws_appsync_authenticationType: "AMAZON_COGNITO_USER_POOLS",
       aws_cognito_region: this.region,
       aws_user_pools_id: props.userPool.userPoolId,
-      aws_user_pools_web_client_id: props.userPoolClient.userPoolClientId, 
-      aws_cognito_identity_pool_id: '', // Optional: Add if using Identity Pool
-      aws_mandatory_sign_in: 'enable',
-      aws_cognito_username_attributes: ['EMAIL'],
+      aws_user_pools_web_client_id: props.userPoolClient.userPoolClientId,
+      aws_cognito_identity_pool_id: "", // Optional: Add if using Identity Pool
+      aws_mandatory_sign_in: "enable",
+      aws_cognito_username_attributes: ["EMAIL"],
       aws_cognito_social_providers: [],
-      aws_cognito_signup_attributes: ['EMAIL', 'GIVEN_NAME', 'FAMILY_NAME'],
-      aws_cognito_mfa_configuration: 'OPTIONAL',
-      aws_cognito_mfa_types: ['SMS', 'TOTP'],
+      aws_cognito_signup_attributes: ["EMAIL", "GIVEN_NAME", "FAMILY_NAME"],
+      aws_cognito_mfa_configuration: "OPTIONAL",
+      aws_cognito_mfa_types: ["SMS", "TOTP"],
       aws_cognito_password_protection_settings: {
         passwordPolicyMinLength: 8,
-        passwordPolicyCharacters: ['REQUIRES_LOWERCASE', 'REQUIRES_UPPERCASE', 'REQUIRES_NUMBERS', 'REQUIRES_SYMBOLS'],
+        passwordPolicyCharacters: [
+          "REQUIRES_LOWERCASE",
+          "REQUIRES_UPPERCASE",
+          "REQUIRES_NUMBERS",
+          "REQUIRES_SYMBOLS",
+        ],
       },
-      aws_cognito_verification_mechanisms: ['EMAIL'],
+      aws_cognito_verification_mechanisms: ["EMAIL"],
       aws_event_bus_url: props.agentEventBus.eventBusArn,
+      aws_cost_api_url: props.costApiUrl,
     };
 
     // Deploy frontend build files to S3
-    const frontendBuildPath = process.env.FRONTEND_BUILD_PATH || '../frontend/build';
-    new s3deploy.BucketDeployment(this, 'FrontendBuildDeployment', {
-      sources: [s3deploy.Source.asset(frontendBuildPath), s3deploy.Source.jsonData('aws-exports.json', frontendConfig)],
+    const frontendBuildPath =
+      process.env.FRONTEND_BUILD_PATH || "../frontend/build";
+    new s3deploy.BucketDeployment(this, "FrontendBuildDeployment", {
+      sources: [
+        s3deploy.Source.asset(frontendBuildPath),
+        s3deploy.Source.jsonData("aws-exports.json", frontendConfig),
+      ],
       destinationBucket: this.bucket,
       distribution: this.distribution,
-      distributionPaths:["/*"]
+      distributionPaths: ["/*"],
     });
 
     // Outputs
-    new cdk.CfnOutput(this, 'FrontendUrl', {
+    new cdk.CfnOutput(this, "FrontendUrl", {
       value: `https://${this.distribution.distributionDomainName}`,
-      description: 'Frontend URL',
+      description: "Frontend URL",
     });
 
-    new cdk.CfnOutput(this, 'FrontendBucketName', {
+    new cdk.CfnOutput(this, "FrontendBucketName", {
       value: this.bucket.bucketName,
-      description: 'Frontend S3 Bucket Name',
+      description: "Frontend S3 Bucket Name",
     });
 
-    new cdk.CfnOutput(this, 'CloudFrontDistributionId', {
+    new cdk.CfnOutput(this, "CloudFrontDistributionId", {
       value: this.distribution.distributionId,
-      description: 'CloudFront Distribution ID',
+      description: "CloudFront Distribution ID",
     });
   }
 }

--- a/backend/lib/telemetry-stack.ts
+++ b/backend/lib/telemetry-stack.ts
@@ -1,0 +1,153 @@
+import * as cdk from "aws-cdk-lib";
+import * as dynamodb from "aws-cdk-lib/aws-dynamodb";
+import * as events from "aws-cdk-lib/aws-events";
+import * as targets from "aws-cdk-lib/aws-events-targets";
+import * as lambda from "aws-cdk-lib/aws-lambda";
+import * as logs from "aws-cdk-lib/aws-logs";
+import { Construct } from "constructs";
+
+export interface TelemetryStackProps extends cdk.StackProps {
+  environment: string;
+  /** Shared EventBridge bus (from BackendStack) — telemetry only consumes, never publishes this pass. */
+  agentEventBus: events.IEventBus;
+  /** Model catalog table (from BackendStack) — read access for pass-2 pricing lookup. */
+  modelCatalogTable: dynamodb.ITable;
+}
+
+/**
+ * TelemetryStack — Invocation cost ledger (pass 1: usage-only, no pricing math).
+ *
+ * Deliberate convention deviation: the cost-ledger table uses
+ * `removalPolicy: RETAIN` (not the project-wide DESTROY default) because it
+ * is a financial/audit record a later reconciler compares against; losing
+ * it on `cdk destroy` is unacceptable. PITR remains enabled regardless.
+ */
+export class TelemetryStack extends cdk.Stack {
+  public readonly costLedgerTable: dynamodb.Table;
+  public readonly costLedgerWriterFunction: lambda.Function;
+
+  constructor(scope: Construct, id: string, props: TelemetryStackProps) {
+    super(scope, id, props);
+
+    // --- Cost ledger table -------------------------------------------------
+    // PK = ORG#<orgId> (unknown -> ORG#UNKNOWN), SK = <capturedAt>#<eventId>:<callIndex>.
+    // Time-prefixed SK on the base table AND every GSI means org/project/app/
+    // agent/workflow time-range rollups are all plain `Query`s — no separate
+    // global time-bucket GSI (that would create a hot partition).
+    this.costLedgerTable = new dynamodb.Table(this, "CostLedgerTable", {
+      tableName: `citadel-cost-ledger-${props.environment}`,
+      partitionKey: { name: "PK", type: dynamodb.AttributeType.STRING },
+      sortKey: { name: "SK", type: dynamodb.AttributeType.STRING },
+      billingMode: dynamodb.BillingMode.PAY_PER_REQUEST,
+      pointInTimeRecoverySpecification: { pointInTimeRecoveryEnabled: true },
+      removalPolicy: cdk.RemovalPolicy.RETAIN,
+    });
+
+    // 4 sparse GSIs — key attrs are only written on rows that have that
+    // dimension (writer's responsibility), so e.g. a non-workflow invocation
+    // never appears in WorkflowIndex. Projection ALL: report queries need
+    // cost + tokens + modelKey without a base-table hydrate.
+    this.costLedgerTable.addGlobalSecondaryIndex({
+      indexName: "ProjectIndex",
+      partitionKey: { name: "GSI1PK", type: dynamodb.AttributeType.STRING },
+      sortKey: { name: "GSI1SK", type: dynamodb.AttributeType.STRING },
+      projectionType: dynamodb.ProjectionType.ALL,
+    });
+    this.costLedgerTable.addGlobalSecondaryIndex({
+      indexName: "AppIndex",
+      partitionKey: { name: "GSI2PK", type: dynamodb.AttributeType.STRING },
+      sortKey: { name: "GSI2SK", type: dynamodb.AttributeType.STRING },
+      projectionType: dynamodb.ProjectionType.ALL,
+    });
+    this.costLedgerTable.addGlobalSecondaryIndex({
+      indexName: "AgentIndex",
+      partitionKey: { name: "GSI3PK", type: dynamodb.AttributeType.STRING },
+      sortKey: { name: "GSI3SK", type: dynamodb.AttributeType.STRING },
+      projectionType: dynamodb.ProjectionType.ALL,
+    });
+    this.costLedgerTable.addGlobalSecondaryIndex({
+      indexName: "WorkflowIndex",
+      partitionKey: { name: "GSI4PK", type: dynamodb.AttributeType.STRING },
+      sortKey: { name: "GSI4SK", type: dynamodb.AttributeType.STRING },
+      projectionType: dynamodb.ProjectionType.ALL,
+    });
+
+    // --- Writer Lambda -------------------------------------------------
+    // Reuses the shared `dist/lambda` asset root every other TS Lambda in
+    // this codebase compiles into (backend/src/lambda convention) — no new
+    // telemetry-specific src dir / bundling config.
+    this.costLedgerWriterFunction = new lambda.Function(
+      this,
+      "CostLedgerWriter",
+      {
+        functionName: `citadel-cost-ledger-writer-${props.environment}`,
+        runtime: lambda.Runtime.NODEJS_24_X,
+        handler: "cost-ledger-writer.handler",
+        code: lambda.Code.fromAsset("dist/lambda"),
+        timeout: cdk.Duration.seconds(30),
+        environment: {
+          COST_LEDGER_TABLE: this.costLedgerTable.tableName,
+          MODEL_CATALOG_TABLE: props.modelCatalogTable.tableName,
+          ENVIRONMENT: props.environment,
+        },
+        logGroup: new logs.LogGroup(this, "CostLedgerWriterLogs", {
+          retention: logs.RetentionDays.ONE_WEEK,
+          removalPolicy: cdk.RemovalPolicy.DESTROY,
+        }),
+      },
+    );
+
+    // Least-privilege: writer may write the ledger table and read pricing
+    // from the model catalog. Nothing else.
+    this.costLedgerTable.grantWriteData(this.costLedgerWriterFunction);
+    props.modelCatalogTable.grantReadData(this.costLedgerWriterFunction);
+
+    // --- EventBridge rules (3, all targeting the same writer) -------------
+    // Writer branches on `source`/`detail-type` internally; patterns can't
+    // correlate across sources, so the dedupe rule is enforced in the writer.
+    const retryProps = { retryAttempts: 2, maxEventAge: cdk.Duration.hours(2) };
+
+    const taskCompletionRule = new events.Rule(this, "TaskCompletionRule", {
+      eventBus: props.agentEventBus,
+      description:
+        "Routes worker task-completion usage events to the cost-ledger writer",
+      eventPattern: {
+        source: ["task.completion"],
+        detailType: ["task.completion"],
+      },
+    });
+    taskCompletionRule.addTarget(
+      new targets.LambdaFunction(this.costLedgerWriterFunction, retryProps),
+    );
+
+    const intakeUsageRule = new events.Rule(this, "IntakeUsageRule", {
+      eventBus: props.agentEventBus,
+      description:
+        "Routes intake-runtime usage events to the cost-ledger writer",
+      eventPattern: {
+        source: ["agent_intake.usage"],
+        detailType: ["intake.usage.captured"],
+      },
+    });
+    intakeUsageRule.addTarget(
+      new targets.LambdaFunction(this.costLedgerWriterFunction, retryProps),
+    );
+
+    const workflowNodeCompletedRule = new events.Rule(
+      this,
+      "WorkflowNodeCompletedRule",
+      {
+        eventBus: props.agentEventBus,
+        description:
+          "Routes workflow-node-completed usage events to the cost-ledger writer",
+        eventPattern: {
+          source: ["citadel.workflows"],
+          detailType: ["workflow.node.completed"],
+        },
+      },
+    );
+    workflowNodeCompletedRule.addTarget(
+      new targets.LambdaFunction(this.costLedgerWriterFunction, retryProps),
+    );
+  }
+}

--- a/backend/lib/telemetry-stack.ts
+++ b/backend/lib/telemetry-stack.ts
@@ -2,9 +2,11 @@ import * as cdk from "aws-cdk-lib";
 import * as dynamodb from "aws-cdk-lib/aws-dynamodb";
 import * as events from "aws-cdk-lib/aws-events";
 import * as targets from "aws-cdk-lib/aws-events-targets";
+import * as iam from "aws-cdk-lib/aws-iam";
 import * as lambda from "aws-cdk-lib/aws-lambda";
 import * as logs from "aws-cdk-lib/aws-logs";
 import { Construct } from "constructs";
+import { NagSuppressions } from "cdk-nag";
 
 export interface TelemetryStackProps extends cdk.StackProps {
   environment: string;
@@ -25,6 +27,7 @@ export interface TelemetryStackProps extends cdk.StackProps {
 export class TelemetryStack extends cdk.Stack {
   public readonly costLedgerTable: dynamodb.Table;
   public readonly costLedgerWriterFunction: lambda.Function;
+  public readonly costLedgerReconcilerFunction: lambda.Function;
 
   constructor(scope: Construct, id: string, props: TelemetryStackProps) {
     super(scope, id, props);
@@ -148,6 +151,110 @@ export class TelemetryStack extends cdk.Stack {
     );
     workflowNodeCompletedRule.addTarget(
       new targets.LambdaFunction(this.costLedgerWriterFunction, retryProps),
+    );
+
+    // --- Cost ledger reconciler (Tier A aggregate drift, Tier B skeleton) --
+    // Scheduled hourly: compares aggregate ledger token totals against
+    // AWS/Bedrock CloudWatch token metrics per model per hour-aligned
+    // window and emits a drift metric. Never flips a ledger row's
+    // `estimate:true` — an aggregate comparison cannot honestly produce a
+    // per-row actual (Tier B, which would, is a feature-flagged-off
+    // skeleton this story).
+    this.costLedgerReconcilerFunction = new lambda.Function(
+      this,
+      "CostLedgerReconciler",
+      {
+        functionName: `citadel-cost-ledger-reconciler-${props.environment}`,
+        runtime: lambda.Runtime.NODEJS_24_X,
+        handler: "cost-ledger-reconciler.handler",
+        code: lambda.Code.fromAsset("dist/lambda"),
+        timeout: cdk.Duration.minutes(5),
+        environment: {
+          COST_LEDGER_TABLE: this.costLedgerTable.tableName,
+          ENVIRONMENT: props.environment,
+          SETTLE_LAG_MINUTES: "15",
+          MAX_WINDOWS_PER_RUN: "6",
+          METRIC_NAMESPACE: "Citadel/CostReconciler",
+          COST_RECONCILER_TIER_B_ENABLED: "false",
+        },
+        logGroup: new logs.LogGroup(this, "CostLedgerReconcilerLogs", {
+          retention: logs.RetentionDays.ONE_WEEK,
+          removalPolicy: cdk.RemovalPolicy.DESTROY,
+        }),
+      },
+    );
+
+    // Least-privilege inline policy — deliberately NOT
+    // `grantReadWriteData`, which would also grant Delete/BatchWrite the
+    // reconciler never needs. Read-modify-write only, via conditional
+    // Put/Update, so a reconciler failure can never corrupt a ledger row.
+    this.costLedgerReconcilerFunction.addToRolePolicy(
+      new iam.PolicyStatement({
+        effect: iam.Effect.ALLOW,
+        actions: [
+          "dynamodb:Query",
+          "dynamodb:Scan",
+          "dynamodb:PutItem",
+          "dynamodb:UpdateItem",
+        ],
+        resources: [
+          this.costLedgerTable.tableArn,
+          `${this.costLedgerTable.tableArn}/index/*`,
+        ],
+      }),
+    );
+    this.costLedgerReconcilerFunction.addToRolePolicy(
+      new iam.PolicyStatement({
+        effect: iam.Effect.ALLOW,
+        actions: ["cloudwatch:GetMetricData"],
+        // GetMetricData has no resource-level permission support.
+        resources: ["*"],
+      }),
+    );
+    this.costLedgerReconcilerFunction.addToRolePolicy(
+      new iam.PolicyStatement({
+        effect: iam.Effect.ALLOW,
+        actions: ["cloudwatch:PutMetricData"],
+        resources: ["*"],
+        conditions: {
+          StringEquals: { "cloudwatch:namespace": "Citadel/CostReconciler" },
+        },
+      }),
+    );
+
+    // cdk-nag: GetMetricData has no resource-level permission support (AWS
+    // requires '*'); PutMetricData is narrowed via a namespace condition
+    // instead of a resource ARN (CloudWatch metric APIs are not ARN-
+    // addressable). Both statements are already scoped as tightly as the
+    // service allows.
+    NagSuppressions.addResourceSuppressions(
+      this.costLedgerReconcilerFunction.role!,
+      [
+        {
+          id: "AwsSolutions-IAM5",
+          reason:
+            "cloudwatch:GetMetricData has no resource-level scoping (AWS " +
+            "requires Resource:* for this action); cloudwatch:PutMetricData " +
+            "is narrowed via a StringEquals cloudwatch:namespace condition " +
+            "instead of a resource ARN, since CloudWatch metrics are not " +
+            "ARN-addressable.",
+          appliesTo: ["Resource::*"],
+        },
+      ],
+      true,
+    );
+
+    const costReconcilerScheduleRule = new events.Rule(
+      this,
+      "CostReconcilerScheduleRule",
+      {
+        description:
+          "Hourly trigger for the cost-ledger reconciler (Tier A aggregate drift)",
+        schedule: events.Schedule.rate(cdk.Duration.hours(1)),
+      },
+    );
+    costReconcilerScheduleRule.addTarget(
+      new targets.LambdaFunction(this.costLedgerReconcilerFunction),
     );
   }
 }

--- a/backend/lib/telemetry-stack.ts
+++ b/backend/lib/telemetry-stack.ts
@@ -1,4 +1,8 @@
 import * as cdk from "aws-cdk-lib";
+import * as apigatewayv2 from "aws-cdk-lib/aws-apigatewayv2";
+import * as apigatewayv2Authorizers from "aws-cdk-lib/aws-apigatewayv2-authorizers";
+import * as apigatewayv2Integrations from "aws-cdk-lib/aws-apigatewayv2-integrations";
+import * as cognito from "aws-cdk-lib/aws-cognito";
 import * as dynamodb from "aws-cdk-lib/aws-dynamodb";
 import * as events from "aws-cdk-lib/aws-events";
 import * as targets from "aws-cdk-lib/aws-events-targets";
@@ -10,10 +14,20 @@ import { NagSuppressions } from "cdk-nag";
 
 export interface TelemetryStackProps extends cdk.StackProps {
   environment: string;
-  /** Shared EventBridge bus (from BackendStack) — telemetry only consumes, never publishes this pass. */
+  /** Shared EventBridge bus (from BackendStack) — telemetry now PUBLISHES cost.budget.* here too (pass 1), in addition to consuming usage events. */
   agentEventBus: events.IEventBus;
   /** Model catalog table (from BackendStack) — read access for pass-2 pricing lookup. */
   modelCatalogTable: dynamodb.ITable;
+  /** Cognito user pool backing the cost-query HttpApi's JWT authorizer. */
+  userPool: cognito.IUserPool;
+  /** Cognito user pool client — becomes the authorizer's audience. */
+  userPoolClient: cognito.IUserPoolClient;
+  /**
+   * Deploy-time frontend origin for CORS (e.g. the CloudFront domain).
+   * Sourced from env/CDK context, NOT the FrontendStack construct, to
+   * avoid a Telemetry<->Frontend circular stack dependency.
+   */
+  frontendOrigin: string;
 }
 
 /**
@@ -28,6 +42,11 @@ export class TelemetryStack extends cdk.Stack {
   public readonly costLedgerTable: dynamodb.Table;
   public readonly costLedgerWriterFunction: lambda.Function;
   public readonly costLedgerReconcilerFunction: lambda.Function;
+  public readonly costQueryHandlerFunction: lambda.Function;
+  public readonly costBudgetEvaluatorFunction: lambda.Function;
+  public readonly costHttpApi: apigatewayv2.HttpApi;
+  /** HttpApi endpoint URL — threaded into FrontendStack (pass 2) as `aws_cost_api_url`. */
+  public readonly costApiUrl: string;
 
   constructor(scope: Construct, id: string, props: TelemetryStackProps) {
     super(scope, id, props);
@@ -72,6 +91,18 @@ export class TelemetryStack extends cdk.Stack {
       indexName: "WorkflowIndex",
       partitionKey: { name: "GSI4PK", type: dynamodb.AttributeType.STRING },
       sortKey: { name: "GSI4SK", type: dynamodb.AttributeType.STRING },
+      projectionType: dynamodb.ProjectionType.ALL,
+    });
+
+    // Sparse BudgetIndex GSI — written ONLY on budget rows (GSI5PK/GSI5SK
+    // set exclusively by the PUT /budgets/{scope} handler). Lets the
+    // scheduled evaluator enumerate every budget across every org via a
+    // single `Query GSI5PK='BUDGET'` instead of a table Scan, keeping
+    // "never Scan on any cost-surface access path" true as the ledger grows.
+    this.costLedgerTable.addGlobalSecondaryIndex({
+      indexName: "BudgetIndex",
+      partitionKey: { name: "GSI5PK", type: dynamodb.AttributeType.STRING },
+      sortKey: { name: "GSI5SK", type: dynamodb.AttributeType.STRING },
       projectionType: dynamodb.ProjectionType.ALL,
     });
 
@@ -255,6 +286,214 @@ export class TelemetryStack extends cdk.Stack {
     );
     costReconcilerScheduleRule.addTarget(
       new targets.LambdaFunction(this.costLedgerReconcilerFunction),
+    );
+
+    // --- Cost query API (org-scoped summary/series + budgets) --------------
+    // HttpApi + HttpUserPoolAuthorizer are stable (graduated) L2 constructs
+    // at aws-cdk-lib ^2.260 — no alpha package needed.
+    this.costQueryHandlerFunction = new lambda.Function(
+      this,
+      "CostQueryHandler",
+      {
+        functionName: `citadel-cost-query-handler-${props.environment}`,
+        runtime: lambda.Runtime.NODEJS_24_X,
+        handler: "cost-query-handler.handler",
+        code: lambda.Code.fromAsset("dist/lambda"),
+        timeout: cdk.Duration.seconds(30),
+        environment: {
+          COST_LEDGER_TABLE: this.costLedgerTable.tableName,
+          ENVIRONMENT: props.environment,
+        },
+        logGroup: new logs.LogGroup(this, "CostQueryHandlerLogs", {
+          retention: logs.RetentionDays.ONE_WEEK,
+          removalPolicy: cdk.RemovalPolicy.DESTROY,
+        }),
+      },
+    );
+
+    // Least-privilege, with a documented tradeoff: this Lambda serves all 4
+    // cost-query-surface routes (GET summary/series/budgets, PUT
+    // /budgets/{scope}), so its role necessarily carries both
+    // `dynamodb:Query` (reads) and `dynamodb:UpdateItem` (the PUT budget
+    // write) on the SAME table ARN — IAM has no condition key to scope
+    // UpdateItem to `SK begins_with BUDGET#` the way the app-level code
+    // does, so this grant is table-wide, not read-only. It is still
+    // materially narrower than `grantReadWriteData` (never Delete, never
+    // BatchWrite, never Scan) and the app-level SK validation in
+    // `handlePutBudget` is the only thing standing between this grant and
+    // an accidental overwrite of a rollup row — mitigated by
+    // `validatePutBudgetBody` + `parseBudgetScope` rejecting anything that
+    // doesn't resolve to a `BUDGET#` SK before an UpdateCommand is ever
+    // built. If a future pass wants a hard IAM-level read/write split,
+    // splitting the GET routes into a second, Query-only Lambda is the
+    // fix — flagged for architect follow-up, not done in this pass since
+    // it changes the "1 Lambda / 4 routes" shape the design specified.
+    this.costQueryHandlerFunction.addToRolePolicy(
+      new iam.PolicyStatement({
+        effect: iam.Effect.ALLOW,
+        actions: ["dynamodb:Query", "dynamodb:UpdateItem"],
+        resources: [this.costLedgerTable.tableArn],
+      }),
+    );
+
+    // AwsSolutions-APIG1: the default (auto-created) HttpApi stage needs its
+    // own access-log destination — reuses the same
+    // ONE_WEEK-retention/DESTROY-on-delete LogGroup convention as every other
+    // Lambda log group in this stack, scoped to just this API.
+    const costHttpApiAccessLogs = new logs.LogGroup(
+      this,
+      "CostHttpApiAccessLogs",
+      {
+        retention: logs.RetentionDays.ONE_WEEK,
+        removalPolicy: cdk.RemovalPolicy.DESTROY,
+      },
+    );
+
+    this.costHttpApi = new apigatewayv2.HttpApi(this, "CostHttpApi", {
+      apiName: `citadel-cost-api-${props.environment}`,
+      corsPreflight: {
+        // Wildcard origin is refused outright — this is a JWT-authorized
+        // API, and pairing `Access-Control-Allow-Origin: *` with bearer
+        // tokens is a broad-CORS anti-pattern regardless of token
+        // validation happening server-side. `frontendOrigin` must be a
+        // concrete origin (enforced in bin/app.ts, which fails fast rather
+        // than silently defaulting to '*').
+        allowOrigins: [props.frontendOrigin],
+        allowMethods: [
+          apigatewayv2.CorsHttpMethod.GET,
+          apigatewayv2.CorsHttpMethod.PUT,
+          apigatewayv2.CorsHttpMethod.OPTIONS,
+        ],
+        allowHeaders: ["Authorization", "Content-Type"],
+        maxAge: cdk.Duration.hours(1),
+      },
+    });
+
+    // AwsSolutions-APIG1 requires access logging on every stage. HttpApi's
+    // default stage is created implicitly by the L2 construct with no
+    // logging hook exposed on `HttpApiProps`, so it's reached via the L1
+    // escape hatch on the default stage's CfnStage.
+    const cfnDefaultStage = this.costHttpApi.defaultStage!.node
+      .defaultChild as apigatewayv2.CfnStage;
+    cfnDefaultStage.accessLogSettings = {
+      destinationArn: costHttpApiAccessLogs.logGroupArn,
+      format: JSON.stringify({
+        requestId: "$context.requestId",
+        ip: "$context.identity.sourceIp",
+        requestTime: "$context.requestTime",
+        httpMethod: "$context.httpMethod",
+        routeKey: "$context.routeKey",
+        status: "$context.status",
+        integrationErrorMessage: "$context.integrationErrorMessage",
+        authorizerError: "$context.authorizer.error",
+      }),
+    };
+    costHttpApiAccessLogs.grantWrite(
+      new iam.ServicePrincipal("apigateway.amazonaws.com"),
+    );
+
+    const costJwtAuthorizer =
+      new apigatewayv2Authorizers.HttpUserPoolAuthorizer(
+        "CostJwtAuthorizer",
+        props.userPool,
+        { userPoolClients: [props.userPoolClient] },
+      );
+
+    const costQueryIntegration =
+      new apigatewayv2Integrations.HttpLambdaIntegration(
+        "CostQueryIntegration",
+        this.costQueryHandlerFunction,
+      );
+
+    // All 4 routes carry the JWT authorizer — org-scoping inside the
+    // handler relies on every request having already been through it.
+    this.costHttpApi.addRoutes({
+      path: "/cost/summary",
+      methods: [apigatewayv2.HttpMethod.GET],
+      integration: costQueryIntegration,
+      authorizer: costJwtAuthorizer,
+    });
+    this.costHttpApi.addRoutes({
+      path: "/cost/series",
+      methods: [apigatewayv2.HttpMethod.GET],
+      integration: costQueryIntegration,
+      authorizer: costJwtAuthorizer,
+    });
+    this.costHttpApi.addRoutes({
+      path: "/budgets",
+      methods: [apigatewayv2.HttpMethod.GET],
+      integration: costQueryIntegration,
+      authorizer: costJwtAuthorizer,
+    });
+    this.costHttpApi.addRoutes({
+      path: "/budgets/{scope}",
+      methods: [apigatewayv2.HttpMethod.PUT],
+      integration: costQueryIntegration,
+      authorizer: costJwtAuthorizer,
+    });
+
+    this.costApiUrl = this.costHttpApi.apiEndpoint;
+    new cdk.CfnOutput(this, "CostApiUrl", {
+      value: this.costApiUrl,
+      description:
+        "Cost query HttpApi endpoint (consumed by FrontendStack pass 2)",
+    });
+
+    // --- Cost budget evaluator (separate Lambda + separate hourly rule) ---
+    // Distinct from the reconciler: different purpose (budget breach vs
+    // token drift), independent failure isolation, and needs
+    // events:PutEvents (reconciler is metric-only, never publishes).
+    this.costBudgetEvaluatorFunction = new lambda.Function(
+      this,
+      "CostBudgetEvaluator",
+      {
+        functionName: `citadel-cost-budget-evaluator-${props.environment}`,
+        runtime: lambda.Runtime.NODEJS_24_X,
+        handler: "cost-budget-evaluator.handler",
+        code: lambda.Code.fromAsset("dist/lambda"),
+        timeout: cdk.Duration.minutes(5),
+        environment: {
+          COST_LEDGER_TABLE: this.costLedgerTable.tableName,
+          ENVIRONMENT: props.environment,
+          EVENT_BUS_NAME: props.agentEventBus.eventBusName,
+        },
+        logGroup: new logs.LogGroup(this, "CostBudgetEvaluatorLogs", {
+          retention: logs.RetentionDays.ONE_WEEK,
+          removalPolicy: cdk.RemovalPolicy.DESTROY,
+        }),
+      },
+    );
+
+    // Least-privilege: enumerate budgets via the sparse BudgetIndex GSI,
+    // read period-to-date spend via the base table, and conditionally
+    // UpdateItem the dedupe/notified map on the budget row itself. Never
+    // Scan, never Delete, never write a ledger usage row.
+    this.costBudgetEvaluatorFunction.addToRolePolicy(
+      new iam.PolicyStatement({
+        effect: iam.Effect.ALLOW,
+        actions: ["dynamodb:Query", "dynamodb:UpdateItem"],
+        resources: [
+          this.costLedgerTable.tableArn,
+          `${this.costLedgerTable.tableArn}/index/BudgetIndex`,
+        ],
+      }),
+    );
+
+    // Telemetry becomes an EventBridge *publisher* for the first time
+    // (previously consume-only) — scoped to the shared bus only.
+    props.agentEventBus.grantPutEventsTo(this.costBudgetEvaluatorFunction);
+
+    const costBudgetEvaluatorScheduleRule = new events.Rule(
+      this,
+      "CostBudgetEvaluatorScheduleRule",
+      {
+        description:
+          "Hourly trigger for the cost budget evaluator (breach/threshold detection)",
+        schedule: events.Schedule.rate(cdk.Duration.hours(1)),
+      },
+    );
+    costBudgetEvaluatorScheduleRule.addTarget(
+      new targets.LambdaFunction(this.costBudgetEvaluatorFunction),
     );
   }
 }

--- a/backend/package.json
+++ b/backend/package.json
@@ -101,5 +101,8 @@
   },
   "engines": {
     "node": ">=24.0.0"
+  },
+  "overrides": {
+    "brace-expansion": ">=5.0.8"
   }
 }

--- a/backend/src/lambda/__tests__/cost-budget-evaluator.test.ts
+++ b/backend/src/lambda/__tests__/cost-budget-evaluator.test.ts
@@ -1,0 +1,201 @@
+/**
+ * Tests for cost-budget-evaluator.ts (scheduled Lambda):
+ *  - BudgetIndex enumeration (GSI5PK='BUDGET' Query, never Scan).
+ *  - Period-to-date spend sums only priced rows (costMicros); unpriced
+ *    rows are tracked, never summed (never fabricate a price).
+ *  - Dedupe: two runs, same period+threshold -> exactly one publish
+ *    (the second run's conditional UpdateItem fails and is swallowed).
+ *  - Escalation: 0.8 -> 1.0 within the same period publishes again.
+ *  - Evaluator failures (a single budget's processing throwing) are
+ *    logged and never corrupt other budget rows — no empty catches.
+ */
+import {
+  DynamoDBDocumentClient,
+  QueryCommand,
+  UpdateCommand,
+} from "@aws-sdk/lib-dynamodb";
+import { mockClient } from "aws-sdk-client-mock";
+
+import { evaluateBudgets } from "../cost-budget-evaluator";
+import * as costNotifier from "../cost-notifier";
+
+const ddbMock = mockClient(DynamoDBDocumentClient);
+
+function budgetIndexRow(overrides: Record<string, unknown> = {}) {
+  return {
+    PK: "ORG#org-1",
+    SK: "BUDGET#ORG",
+    GSI5PK: "BUDGET",
+    GSI5SK: "ORG#org-1#BUDGET#ORG",
+    periodType: "monthly",
+    limitMicros: 1_000_000,
+    thresholds: [0.8, 1.0],
+    currency: "USD",
+    notified: {},
+    ...overrides,
+  };
+}
+
+beforeEach(() => {
+  ddbMock.reset();
+  jest.restoreAllMocks();
+  process.env.COST_LEDGER_TABLE = "test-ledger";
+});
+
+afterEach(() => {
+  delete process.env.COST_LEDGER_TABLE;
+});
+
+describe("evaluateBudgets", () => {
+  test("enumerates budgets via GSI5PK=BUDGET Query, never a Scan", async () => {
+    ddbMock
+      .on(QueryCommand, { IndexName: "BudgetIndex" })
+      .resolves({ Items: [budgetIndexRow()] });
+    ddbMock.on(QueryCommand).callsFake((input) => {
+      if (input.IndexName === "BudgetIndex") {
+        return { Items: [budgetIndexRow()] };
+      }
+      return { Items: [] }; // period-to-date spend query
+    });
+    ddbMock.on(UpdateCommand).resolves({});
+    jest.spyOn(costNotifier, "emitBudgetEvent").mockResolvedValue();
+
+    await evaluateBudgets();
+
+    const budgetIndexCalls = ddbMock
+      .commandCalls(QueryCommand)
+      .filter((c) => c.args[0].input.IndexName === "BudgetIndex");
+    expect(budgetIndexCalls).toHaveLength(1);
+    expect(budgetIndexCalls[0].args[0].input.ExpressionAttributeValues).toEqual(
+      expect.objectContaining({ ":gsi5pk": "BUDGET" }),
+    );
+  });
+
+  test("sums only priced rows for period-to-date spend, tracks unpriced separately", async () => {
+    ddbMock.on(QueryCommand).callsFake((input) => {
+      if (input.IndexName === "BudgetIndex") {
+        return { Items: [budgetIndexRow({ thresholds: [0.5] })] };
+      }
+      return {
+        Items: [
+          { costMicros: 400_000, priced: true },
+          { costMicros: 100_000, priced: true },
+          { costMicros: null, priced: false },
+        ],
+      };
+    });
+    ddbMock.on(UpdateCommand).resolves({});
+    const emitSpy = jest
+      .spyOn(costNotifier, "emitBudgetEvent")
+      .mockResolvedValue();
+
+    await evaluateBudgets();
+
+    // 500_000 / 1_000_000 = 0.5 -> crosses the 0.5 threshold -> notifies.
+    expect(emitSpy).toHaveBeenCalledWith(
+      "cost.budget.threshold.crossed",
+      expect.objectContaining({ spentMicros: 500_000, threshold: 0.5 }),
+    );
+  });
+
+  test("dedupe: a threshold already notified this period is not re-notified", async () => {
+    ddbMock.on(QueryCommand).callsFake((input) => {
+      if (input.IndexName === "BudgetIndex") {
+        return {
+          Items: [
+            budgetIndexRow({
+              thresholds: [0.8],
+              notified: { "2026-07": 0.8 },
+            }),
+          ],
+        };
+      }
+      return { Items: [{ costMicros: 900_000, priced: true }] };
+    });
+    ddbMock.on(UpdateCommand).resolves({});
+    const emitSpy = jest
+      .spyOn(costNotifier, "emitBudgetEvent")
+      .mockResolvedValue();
+
+    await evaluateBudgets({ now: new Date("2026-07-15T00:00:00.000Z") });
+
+    expect(emitSpy).not.toHaveBeenCalled();
+  });
+
+  test("escalation: 0.8 already notified, now crossing 1.0 in the same period publishes again", async () => {
+    ddbMock.on(QueryCommand).callsFake((input) => {
+      if (input.IndexName === "BudgetIndex") {
+        return {
+          Items: [
+            budgetIndexRow({
+              thresholds: [0.8, 1.0],
+              notified: { "2026-07": 0.8 },
+            }),
+          ],
+        };
+      }
+      return { Items: [{ costMicros: 1_200_000, priced: true }] };
+    });
+    ddbMock.on(UpdateCommand).resolves({});
+    const emitSpy = jest
+      .spyOn(costNotifier, "emitBudgetEvent")
+      .mockResolvedValue();
+
+    await evaluateBudgets({ now: new Date("2026-07-15T00:00:00.000Z") });
+
+    expect(emitSpy).toHaveBeenCalledWith(
+      "cost.budget.breached",
+      expect.objectContaining({ threshold: 1.0 }),
+    );
+  });
+
+  test("conditional UpdateItem dedupe: the second concurrent run's conditional check failure is swallowed, not thrown", async () => {
+    ddbMock.on(QueryCommand).callsFake((input) => {
+      if (input.IndexName === "BudgetIndex") {
+        return { Items: [budgetIndexRow({ thresholds: [0.8] })] };
+      }
+      return { Items: [{ costMicros: 900_000, priced: true }] };
+    });
+    const err = Object.assign(new Error("conditional check failed"), {
+      name: "ConditionalCheckFailedException",
+    });
+    ddbMock.on(UpdateCommand).rejects(err);
+    const emitSpy = jest
+      .spyOn(costNotifier, "emitBudgetEvent")
+      .mockResolvedValue();
+
+    await expect(evaluateBudgets()).resolves.not.toThrow();
+    // Conditional update failed -> notification must NOT have been sent,
+    // because the dedupe write is what gates the publish.
+    expect(emitSpy).not.toHaveBeenCalled();
+  });
+
+  test("one budget's processing failure is logged and does not prevent other budgets from being evaluated", async () => {
+    const consoleErrorSpy = jest.spyOn(console, "error").mockImplementation();
+    ddbMock.on(QueryCommand).callsFake((input) => {
+      if (input.IndexName === "BudgetIndex") {
+        return {
+          Items: [
+            budgetIndexRow({ PK: "ORG#org-bad", thresholds: [0.8] }),
+            budgetIndexRow({ PK: "ORG#org-good", thresholds: [0.8] }),
+          ],
+        };
+      }
+      // Fail the spend-lookup Query for the "bad" org only.
+      if (input.ExpressionAttributeValues?.[":org"] === "ORG#org-bad") {
+        throw new Error("transient DDB error");
+      }
+      return { Items: [{ costMicros: 900_000, priced: true }] };
+    });
+    ddbMock.on(UpdateCommand).resolves({});
+    const emitSpy = jest
+      .spyOn(costNotifier, "emitBudgetEvent")
+      .mockResolvedValue();
+
+    await evaluateBudgets();
+
+    expect(consoleErrorSpy).toHaveBeenCalled();
+    expect(emitSpy).toHaveBeenCalledTimes(1);
+    consoleErrorSpy.mockRestore();
+  });
+});

--- a/backend/src/lambda/__tests__/cost-ledger-reconciler.test.ts
+++ b/backend/src/lambda/__tests__/cost-ledger-reconciler.test.ts
@@ -1,0 +1,344 @@
+/**
+ * Handler tests for the cost-ledger reconciler (Tier A aggregate drift +
+ * Tier B inactive-by-default gate).
+ *
+ * Mocks DynamoDBDocumentClient (aws-sdk-client-mock, same convention as
+ * cost-ledger-writer.test.ts) and CloudWatchClient. No real AWS calls.
+ */
+
+import { DynamoDBDocumentClient } from "@aws-sdk/lib-dynamodb";
+import { CloudWatchClient } from "@aws-sdk/client-cloudwatch";
+import { mockClient } from "aws-sdk-client-mock";
+
+process.env.COST_LEDGER_TABLE = "citadel-cost-ledger-test";
+process.env.ENVIRONMENT = "test";
+process.env.SETTLE_LAG_MINUTES = "15";
+process.env.MAX_WINDOWS_PER_RUN = "6";
+process.env.METRIC_NAMESPACE = "Citadel/CostReconciler";
+process.env.COST_RECONCILER_TIER_B_ENABLED = "false";
+
+import {
+  ScanCommand,
+  PutCommand,
+  UpdateCommand,
+  GetCommand,
+} from "@aws-sdk/lib-dynamodb";
+import type {
+  PutCommandInput,
+  UpdateCommandInput,
+} from "@aws-sdk/lib-dynamodb";
+import {
+  GetMetricDataCommand,
+  PutMetricDataCommand,
+} from "@aws-sdk/client-cloudwatch";
+import { handler, tierBReconcile } from "../cost-ledger-reconciler";
+import type { LedgerWindowMarkerRow } from "../utils/cost-reconciler-types";
+
+const ddbMock = mockClient(DynamoDBDocumentClient);
+const cwMock = mockClient(CloudWatchClient);
+
+/**
+ * Builds a fixed "now" so windows are deterministic across test runs.
+ * Intentionally NOT hour-aligned: with SETTLE_LAG_MINUTES=15,
+ * targetEnd = alignToHour(14:20 - 15min) = alignToHour(14:05) = 14:00,
+ * and the cold-start default watermark = alignToHour(14:20) - 1h = 13:00,
+ * so exactly one window [13:00, 14:00) is pending on cold start.
+ */
+function fixedNowMs(): number {
+  return Date.parse("2026-07-25T14:20:00.000Z");
+}
+
+function ledgerRow(overrides: Record<string, unknown> = {}) {
+  return {
+    PK: "ORG#org-1",
+    SK: "2026-07-25T12:30:00.000Z#evt:0",
+    modelKey: "claude-sonnet",
+    modelId: "anthropic.claude-sonnet-5",
+    inputTokens: 100,
+    outputTokens: 50,
+    ...overrides,
+  };
+}
+
+describe("cost-ledger-reconciler handler", () => {
+  let nowSpy: jest.SpyInstance;
+
+  beforeEach(() => {
+    ddbMock.reset();
+    cwMock.reset();
+    nowSpy = jest.spyOn(Date, "now").mockReturnValue(fixedNowMs());
+    // Default: no watermark row (cold start) unless a test overrides it.
+    ddbMock.on(GetCommand).resolves({ Item: undefined });
+    cwMock.on(PutMetricDataCommand).resolves({});
+  });
+
+  afterEach(() => {
+    nowSpy.mockRestore();
+  });
+
+  test("cold start: no watermark row reconciles exactly the single most-recent closed window", async () => {
+    ddbMock.on(ScanCommand).resolves({ Items: [] });
+    ddbMock.on(PutCommand).resolves({});
+    ddbMock.on(UpdateCommand).resolves({});
+    cwMock.on(GetMetricDataCommand).resolves({ MetricDataResults: [] });
+
+    await handler();
+
+    const putCalls = ddbMock.commandCalls(PutCommand);
+    // Exactly one window marker written on cold start.
+    const markerPuts = putCalls.filter((c) =>
+      String(c.args[0].input.Item?.SK).startsWith("WINDOW#"),
+    );
+    expect(markerPuts).toHaveLength(1);
+  });
+
+  test("happy path: one window, matched model => marker, drift metric emitted, rows annotated, watermark advanced", async () => {
+    const rows = [ledgerRow()];
+    ddbMock.on(ScanCommand).resolves({ Items: rows });
+    ddbMock.on(PutCommand).resolves({});
+    ddbMock.on(UpdateCommand).resolves({});
+    cwMock.on(GetMetricDataCommand).resolves({
+      MetricDataResults: [
+        { Id: "input_0", Values: [90] },
+        { Id: "output_0", Values: [45] },
+      ],
+    });
+
+    await handler();
+
+    const putCalls = ddbMock.commandCalls(PutCommand);
+    const markerPut = putCalls.find((c) =>
+      String(c.args[0].input.Item?.SK).startsWith("WINDOW#"),
+    );
+    expect(markerPut).toBeDefined();
+    const marker = markerPut!.args[0].input.Item as LedgerWindowMarkerRow;
+    expect(marker.tier).toBe("A");
+    expect(marker.models[0].match).toBe("matched");
+    expect(marker.models[0].driftPct).not.toBeNull();
+
+    const emittedMetrics = cwMock.commandCalls(PutMetricDataCommand);
+    expect(emittedMetrics.length).toBeGreaterThan(0);
+    const driftDatum = emittedMetrics
+      .flatMap((c) => c.args[0].input.MetricData ?? [])
+      .find((d) => d.MetricName === "EstimateDriftPct");
+    expect(driftDatum).toBeDefined();
+
+    const updateCalls = ddbMock.commandCalls(UpdateCommand);
+    const annotation = updateCalls.find(
+      (c) => c.args[0].input.Key?.SK === rows[0].SK,
+    );
+    expect(annotation).toBeDefined();
+    expect(String(annotation!.args[0].input.UpdateExpression)).toContain(
+      "driftCheckedAt",
+    );
+    // annotateRows must touch ONLY driftCheckedAt — never flip/write `estimate`.
+    expect(String(annotation!.args[0].input.UpdateExpression)).not.toContain(
+      "estimate",
+    );
+
+    const watermarkUpdate = updateCalls.find(
+      (c) => c.args[0].input.Key?.SK === "WATERMARK",
+    );
+    expect(watermarkUpdate).toBeDefined();
+  });
+
+  test("IDEMPOTENCY: second run of the same window is a strict no-op (marker PutItem CCF)", async () => {
+    ddbMock.on(ScanCommand).resolves({ Items: [ledgerRow()] });
+    ddbMock.on(PutCommand).callsFake((input: PutCommandInput) => {
+      if (String(input.Item?.SK).startsWith("WINDOW#")) {
+        const err = new Error("ConditionalCheckFailedException");
+        err.name = "ConditionalCheckFailedException";
+        throw err;
+      }
+      return {};
+    });
+    ddbMock.on(UpdateCommand).resolves({});
+    cwMock.on(GetMetricDataCommand).resolves({
+      MetricDataResults: [
+        { Id: "input_0", Values: [90] },
+        { Id: "output_0", Values: [45] },
+      ],
+    });
+
+    await handler();
+
+    // No metric emit, no row annotation, no watermark advance — CCF means
+    // this exact window was already reconciled.
+    expect(cwMock.commandCalls(PutMetricDataCommand)).toHaveLength(0);
+    const updateCalls = ddbMock.commandCalls(UpdateCommand);
+    expect(updateCalls).toHaveLength(0);
+  });
+
+  test("unmatched model (no CloudWatch datapoints): marker records metricsMissing/null, no fabricated drift, no EstimateDriftPct datum", async () => {
+    ddbMock.on(ScanCommand).resolves({ Items: [ledgerRow()] });
+    ddbMock.on(PutCommand).resolves({});
+    ddbMock.on(UpdateCommand).resolves({});
+    cwMock.on(GetMetricDataCommand).resolves({
+      MetricDataResults: [
+        { Id: "input_0", Values: [] },
+        { Id: "output_0", Values: [] },
+      ],
+    });
+
+    await handler();
+
+    const putCalls = ddbMock.commandCalls(PutCommand);
+    const markerPut = putCalls.find((c) =>
+      String(c.args[0].input.Item?.SK).startsWith("WINDOW#"),
+    );
+    const marker = markerPut!.args[0].input.Item as LedgerWindowMarkerRow;
+    expect(marker.models[0].match).toBe("metricsMissing");
+    expect(marker.models[0].driftPct).toBeNull();
+    expect(marker.unmatchedModelCount).toBe(1);
+
+    const driftDatum = cwMock
+      .commandCalls(PutMetricDataCommand)
+      .flatMap((c) => c.args[0].input.MetricData ?? [])
+      .find((d) => d.MetricName === "EstimateDriftPct");
+    expect(driftDatum).toBeUndefined();
+  });
+
+  test("empty window (no ledger rows): marker still created, watermark still advances", async () => {
+    ddbMock.on(ScanCommand).resolves({ Items: [] });
+    ddbMock.on(PutCommand).resolves({});
+    ddbMock.on(UpdateCommand).resolves({});
+
+    await handler();
+
+    const putCalls = ddbMock.commandCalls(PutCommand);
+    const markerPut = putCalls.find((c) =>
+      String(c.args[0].input.Item?.SK).startsWith("WINDOW#"),
+    );
+    expect(markerPut).toBeDefined();
+    expect(
+      (markerPut!.args[0].input.Item as LedgerWindowMarkerRow).ledgerRowCount,
+    ).toBe(0);
+
+    const watermarkUpdate = ddbMock
+      .commandCalls(UpdateCommand)
+      .find((c) => c.args[0].input.Key?.SK === "WATERMARK");
+    expect(watermarkUpdate).toBeDefined();
+  });
+
+  test("MAX_WINDOWS_PER_RUN cap is honored on cold-start catch-up, windows processed ascending", async () => {
+    process.env.MAX_WINDOWS_PER_RUN = "2";
+    ddbMock.on(GetCommand).resolves({
+      // Watermark far in the past to force multi-window catch-up.
+      Item: { PK: "RECON#COST", SK: "WATERMARK", watermarkEpochSec: 0 },
+    });
+    ddbMock.on(ScanCommand).resolves({ Items: [] });
+    ddbMock.on(PutCommand).resolves({});
+    ddbMock.on(UpdateCommand).resolves({});
+
+    await handler();
+
+    const markerPuts = ddbMock
+      .commandCalls(PutCommand)
+      .filter((c) => String(c.args[0].input.Item?.SK).startsWith("WINDOW#"));
+    expect(markerPuts).toHaveLength(2);
+    const starts = markerPuts.map(
+      (c) =>
+        (c.args[0].input.Item as LedgerWindowMarkerRow).windowStartEpochSec,
+    );
+    expect(starts[0]).toBeLessThan(starts[1]);
+
+    process.env.MAX_WINDOWS_PER_RUN = "6";
+  });
+
+  test("annotation resilience: UpdateItem on a vanished row is swallowed as a logged no-op, sweep continues", async () => {
+    ddbMock.on(ScanCommand).resolves({ Items: [ledgerRow()] });
+    ddbMock.on(PutCommand).resolves({});
+    ddbMock.on(UpdateCommand).callsFake((input: UpdateCommandInput) => {
+      if (input.Key?.SK === "WATERMARK") return {};
+      const err = new Error("ConditionalCheckFailedException");
+      err.name = "ConditionalCheckFailedException";
+      throw err;
+    });
+    cwMock.on(GetMetricDataCommand).resolves({
+      MetricDataResults: [
+        { Id: "input_0", Values: [90] },
+        { Id: "output_0", Values: [45] },
+      ],
+    });
+
+    await expect(handler()).resolves.not.toThrow();
+    const watermarkUpdate = ddbMock
+      .commandCalls(UpdateCommand)
+      .find((c) => c.args[0].input.Key?.SK === "WATERMARK");
+    expect(watermarkUpdate).toBeDefined();
+  });
+
+  test("PutMetricData failure is logged and does not throw — window still counts as reconciled", async () => {
+    ddbMock.on(ScanCommand).resolves({ Items: [ledgerRow()] });
+    ddbMock.on(PutCommand).resolves({});
+    ddbMock.on(UpdateCommand).resolves({});
+    cwMock.on(GetMetricDataCommand).resolves({
+      MetricDataResults: [
+        { Id: "input_0", Values: [90] },
+        { Id: "output_0", Values: [45] },
+      ],
+    });
+    cwMock.on(PutMetricDataCommand).rejects(new Error("throttled"));
+
+    await expect(handler()).resolves.not.toThrow();
+    const watermarkUpdate = ddbMock
+      .commandCalls(UpdateCommand)
+      .find((c) => c.args[0].input.Key?.SK === "WATERMARK");
+    expect(watermarkUpdate).toBeDefined();
+  });
+
+  test("per-window error isolation: a Scan failure on one window does not abort the sweep", async () => {
+    process.env.MAX_WINDOWS_PER_RUN = "2";
+    ddbMock.on(GetCommand).resolves({
+      Item: { PK: "RECON#COST", SK: "WATERMARK", watermarkEpochSec: 0 },
+    });
+    let call = 0;
+    ddbMock.on(ScanCommand).callsFake(() => {
+      call += 1;
+      if (call === 1) throw new Error("transient scan failure");
+      return { Items: [] };
+    });
+    ddbMock.on(PutCommand).resolves({});
+    ddbMock.on(UpdateCommand).resolves({});
+
+    await expect(handler()).resolves.not.toThrow();
+    const markerPuts = ddbMock
+      .commandCalls(PutCommand)
+      .filter((c) => String(c.args[0].input.Item?.SK).startsWith("WINDOW#"));
+    // Second window still got its marker despite the first window's failure.
+    expect(markerPuts).toHaveLength(1);
+
+    process.env.MAX_WINDOWS_PER_RUN = "6";
+  });
+});
+
+describe("tierBReconcile — feature gate (skeleton only)", () => {
+  test("returns inactive/disabled when COST_RECONCILER_TIER_B_ENABLED is unset/false, mutates no ledger row", async () => {
+    process.env.COST_RECONCILER_TIER_B_ENABLED = "false";
+    const result = await tierBReconcile(
+      { startSec: 0, endSec: 3600 },
+      new Map(),
+    );
+    expect(result).toEqual({ active: false, reason: "disabled" });
+  });
+
+  test("returns inactive/missing_requestId when flag is true but ledger rows lack bedrockRequestId", async () => {
+    process.env.COST_RECONCILER_TIER_B_ENABLED = "true";
+    const result = await tierBReconcile(
+      { startSec: 0, endSec: 3600 },
+      new Map([
+        [
+          "claude-sonnet",
+          {
+            modelId: "anthropic.claude-sonnet-5",
+            inputTokens: 10,
+            outputTokens: 5,
+            rowKeys: [{ PK: "ORG#a", SK: "s1" }],
+          },
+        ],
+      ]),
+    );
+    expect(result).toEqual({ active: false, reason: "missing_requestId" });
+    process.env.COST_RECONCILER_TIER_B_ENABLED = "false";
+  });
+});

--- a/backend/src/lambda/__tests__/cost-ledger-writer.test.ts
+++ b/backend/src/lambda/__tests__/cost-ledger-writer.test.ts
@@ -204,3 +204,162 @@ describe("cost-ledger-writer (pass 1 — usage-only rows)", () => {
 // keep the exported error class referenced so an unused-import lint rule
 // doesn't flag it if a future test needs to construct one directly.
 void ConditionalCheckFailedError;
+
+describe("cost-ledger-writer (pass 2 — pricing + decomposition)", () => {
+  beforeEach(() => {
+    ddbMock.reset();
+    ddbMock.onAnyCommand().resolves({});
+  });
+
+  test("priced row: GetItem resolves catalog pricing, cost is computed and populated", async () => {
+    const { GetCommand } = await import("@aws-sdk/lib-dynamodb");
+    ddbMock.on(GetCommand).resolves({
+      Item: {
+        modelKey: "anthropic-claude-sonnet-5",
+        inputPer1kTokens: 3,
+        outputPer1kTokens: 15,
+        currency: "USD",
+      },
+    });
+
+    await handler(intakeUsageEvent());
+
+    const putCalls = ddbMock.commandCalls(
+      (await import("@aws-sdk/lib-dynamodb")).PutCommand,
+    );
+    const item = putCalls[0].args[0].input.Item as Record<string, unknown>;
+    expect(item.priced).toBe(true);
+    // intakeUsageEvent: inputTokens 10, outputTokens 5 @ $3/$15 per 1k
+    // = 10/1000*3 + 5/1000*15 = 0.03 + 0.075 = 0.105
+    expect(item.tokenCost).toBeCloseTo(0.105, 8);
+    expect(item.costMicros).toBe(105000);
+    expect(item.currency).toBe("USD");
+    expect(item.estimate).toBe(true);
+  });
+
+  test("priced row: decomposition shape has tokenCost populated, compute/idle/memory null, runtimeComponentsPending true", async () => {
+    const { GetCommand } = await import("@aws-sdk/lib-dynamodb");
+    ddbMock.on(GetCommand).resolves({
+      Item: {
+        modelKey: "anthropic-claude-sonnet-5",
+        inputPer1kTokens: 3,
+        outputPer1kTokens: 15,
+        currency: "USD",
+      },
+    });
+
+    await handler(intakeUsageEvent());
+
+    const putCalls = ddbMock.commandCalls(
+      (await import("@aws-sdk/lib-dynamodb")).PutCommand,
+    );
+    const item = putCalls[0].args[0].input.Item as Record<string, unknown>;
+    const decomp = item.decomposition as Record<string, unknown>;
+    expect(decomp.currency).toBe("USD");
+    expect(decomp.tokenCost).toBeCloseTo(0.105, 8);
+    expect(decomp.compute).toBeNull();
+    expect(decomp.idle).toBeNull();
+    expect(decomp.memory).toBeNull();
+    expect(decomp.runtimeComponentsPending).toBe(true);
+  });
+
+  test("unpriced row: model not in catalog (GetItem returns no Item) → still written, priced:false, unpricedReason set", async () => {
+    const { GetCommand } = await import("@aws-sdk/lib-dynamodb");
+    ddbMock.on(GetCommand).resolves({});
+    const warnSpy = jest.spyOn(console, "warn").mockImplementation(() => {});
+
+    await handler(intakeUsageEvent());
+
+    const putCalls = ddbMock.commandCalls(
+      (await import("@aws-sdk/lib-dynamodb")).PutCommand,
+    );
+    expect(putCalls).toHaveLength(1); // never dropped
+    const item = putCalls[0].args[0].input.Item as Record<string, unknown>;
+    expect(item.priced).toBe(false);
+    expect(item.tokenCost).toBeNull();
+    expect(item.costMicros).toBeNull();
+    expect(item.unpricedReason).toBe("model_not_in_catalog");
+    expect(warnSpy).toHaveBeenCalled();
+    warnSpy.mockRestore();
+  });
+
+  test("unpriced row: catalog row exists but lacks pricing fields → still written, priced:false, reason pricing_absent", async () => {
+    const { GetCommand } = await import("@aws-sdk/lib-dynamodb");
+    ddbMock.on(GetCommand).resolves({
+      Item: { modelKey: "anthropic-claude-sonnet-5", status: "enabled" },
+    });
+    const warnSpy = jest.spyOn(console, "warn").mockImplementation(() => {});
+
+    await handler(intakeUsageEvent());
+
+    const putCalls = ddbMock.commandCalls(
+      (await import("@aws-sdk/lib-dynamodb")).PutCommand,
+    );
+    expect(putCalls).toHaveLength(1);
+    const item = putCalls[0].args[0].input.Item as Record<string, unknown>;
+    expect(item.priced).toBe(false);
+    expect(item.unpricedReason).toBe("pricing_absent");
+    warnSpy.mockRestore();
+  });
+
+  test("catalog-read failure: GetItem throws → row STILL written unpriced and logged, never dropped", async () => {
+    const { GetCommand } = await import("@aws-sdk/lib-dynamodb");
+    ddbMock
+      .on(GetCommand)
+      .rejects(new Error("ProvisionedThroughputExceededException"));
+    const errorSpy = jest.spyOn(console, "error").mockImplementation(() => {});
+
+    await expect(handler(intakeUsageEvent())).resolves.not.toThrow();
+
+    const putCalls = ddbMock.commandCalls(
+      (await import("@aws-sdk/lib-dynamodb")).PutCommand,
+    );
+    expect(putCalls).toHaveLength(1); // never dropped despite catalog-read failure
+    const item = putCalls[0].args[0].input.Item as Record<string, unknown>;
+    expect(item.priced).toBe(false);
+    expect(item.tokenCost).toBeNull();
+    expect(item.unpricedReason).toBe("pricing_absent");
+    expect(errorSpy).toHaveBeenCalled();
+    errorSpy.mockRestore();
+  });
+
+  test("modelKey is resolved from the raw modelId using the same slug logic as catalog sync", async () => {
+    const { GetCommand } = await import("@aws-sdk/lib-dynamodb");
+    ddbMock.on(GetCommand).resolves({
+      Item: {
+        modelKey: "anthropic-claude-sonnet-5",
+        inputPer1kTokens: 1,
+        outputPer1kTokens: 2,
+        currency: "USD",
+      },
+    });
+
+    await handler(intakeUsageEvent()); // modelId: "anthropic.claude-sonnet-5"
+
+    const getCalls = ddbMock.commandCalls(GetCommand);
+    expect(getCalls[0].args[0].input.Key).toEqual({
+      modelKey: "anthropic-claude-sonnet-5",
+    });
+  });
+
+  test("multiple usage records in one event each resolve pricing independently", async () => {
+    const { GetCommand } = await import("@aws-sdk/lib-dynamodb");
+    ddbMock.on(GetCommand).resolves({
+      Item: {
+        modelKey: "anthropic-claude-sonnet-5",
+        inputPer1kTokens: 1,
+        outputPer1kTokens: 1,
+        currency: "USD",
+      },
+    });
+
+    await handler(workflowNodeCompletedEvent());
+
+    const putCalls = ddbMock.commandCalls(
+      (await import("@aws-sdk/lib-dynamodb")).PutCommand,
+    );
+    expect(putCalls).toHaveLength(1);
+    const item = putCalls[0].args[0].input.Item as Record<string, unknown>;
+    expect(item.priced).toBe(true);
+  });
+});

--- a/backend/src/lambda/__tests__/cost-ledger-writer.test.ts
+++ b/backend/src/lambda/__tests__/cost-ledger-writer.test.ts
@@ -1,0 +1,206 @@
+import { DynamoDBDocumentClient } from "@aws-sdk/lib-dynamodb";
+import { mockClient } from "aws-sdk-client-mock";
+import type { EventBridgeEvent } from "aws-lambda";
+
+process.env.COST_LEDGER_TABLE = "citadel-cost-ledger-test";
+process.env.MODEL_CATALOG_TABLE = "citadel-model-catalog-test";
+
+import {
+  handler,
+  ConditionalCheckFailedError,
+  IncomingDetail,
+} from "../cost-ledger-writer";
+
+type IncomingEvent = EventBridgeEvent<string, IncomingDetail>;
+
+const ddbMock = mockClient(DynamoDBDocumentClient);
+
+function taskCompletionEvent(overrides: Record<string, unknown> = {}) {
+  return {
+    id: "evt-1",
+    source: "task.completion",
+    "detail-type": "task.completion",
+    detail: {
+      taskId: "task-1",
+      orgId: "org-1",
+      projectId: "proj-1",
+      usage: [
+        {
+          modelId: "anthropic.claude-sonnet-5",
+          inputTokens: 100,
+          outputTokens: 50,
+          latencyMs: 250,
+          callIndex: 0,
+          capturedAt: "2026-07-25T00:00:00.000Z",
+          source: "worker",
+        },
+      ],
+      ...overrides,
+    },
+  } as unknown as IncomingEvent;
+}
+
+function intakeUsageEvent() {
+  return {
+    id: "evt-2",
+    source: "agent_intake.usage",
+    "detail-type": "intake.usage.captured",
+    detail: {
+      orgId: "org-2",
+      appId: "app-2",
+      usage: {
+        modelId: "anthropic.claude-sonnet-5",
+        inputTokens: 10,
+        outputTokens: 5,
+        latencyMs: 100,
+        callIndex: 0,
+        capturedAt: "2026-07-25T00:00:01.000Z",
+        source: "worker",
+      },
+    },
+  } as unknown as IncomingEvent;
+}
+
+function workflowNodeCompletedEvent() {
+  return {
+    id: "evt-3",
+    source: "citadel.workflows",
+    "detail-type": "workflow.node.completed",
+    detail: {
+      orgId: "org-3",
+      projectId: "proj-3",
+      appId: "app-3",
+      workflowExecutionId: "exec-3",
+      nodeId: "node-3",
+      agentId: "agent-3",
+      usage: [
+        {
+          modelId: "anthropic.claude-sonnet-5",
+          inputTokens: 20,
+          outputTokens: 8,
+          latencyMs: 80,
+          callIndex: 0,
+          capturedAt: "2026-07-25T00:00:02.000Z",
+          source: "worker",
+        },
+      ],
+    },
+  } as unknown as IncomingEvent;
+}
+
+describe("cost-ledger-writer (pass 1 — usage-only rows)", () => {
+  beforeEach(() => {
+    ddbMock.reset();
+    ddbMock.onAnyCommand().resolves({});
+  });
+
+  test("task.completion WITHOUT workflow correlation writes N usage rows", async () => {
+    await handler(taskCompletionEvent());
+    const putCalls = ddbMock.commandCalls(
+      (await import("@aws-sdk/lib-dynamodb")).PutCommand,
+    );
+    expect(putCalls).toHaveLength(1);
+    const item = putCalls[0].args[0].input.Item as Record<string, unknown>;
+    expect(item.PK).toBe("ORG#org-1");
+    expect(item.orgId).toBe("org-1");
+  });
+
+  test("intake.usage.captured writes exactly 1 row", async () => {
+    await handler(intakeUsageEvent());
+    const putCalls = ddbMock.commandCalls(
+      (await import("@aws-sdk/lib-dynamodb")).PutCommand,
+    );
+    expect(putCalls).toHaveLength(1);
+    const item = putCalls[0].args[0].input.Item as Record<string, unknown>;
+    expect(item.PK).toBe("ORG#org-2");
+    expect(item.GSI2PK).toBe("APP#app-2");
+  });
+
+  test("workflow.node.completed writes per-node usage rows with WorkflowIndex GSI keys", async () => {
+    await handler(workflowNodeCompletedEvent());
+    const putCalls = ddbMock.commandCalls(
+      (await import("@aws-sdk/lib-dynamodb")).PutCommand,
+    );
+    expect(putCalls).toHaveLength(1);
+    const item = putCalls[0].args[0].input.Item as Record<string, unknown>;
+    expect(item.GSI4PK).toBe("WORKFLOW#exec-3");
+    expect(String(item.GSI4SK)).toContain("#node-3#");
+    expect(item.GSI3PK).toBe("AGENT#agent-3");
+  });
+
+  test("DEDUPE: task.completion WITH workflowExecutionId/nodeId is dropped (0 rows)", async () => {
+    await handler(
+      taskCompletionEvent({ workflowExecutionId: "exec-9", nodeId: "node-9" }),
+    );
+    const putCalls = ddbMock.commandCalls(
+      (await import("@aws-sdk/lib-dynamodb")).PutCommand,
+    );
+    expect(putCalls).toHaveLength(0);
+  });
+
+  test("DEDUPE: task.completion WITHOUT workflow correlation is written", async () => {
+    await handler(taskCompletionEvent());
+    const putCalls = ddbMock.commandCalls(
+      (await import("@aws-sdk/lib-dynamodb")).PutCommand,
+    );
+    expect(putCalls).toHaveLength(1);
+  });
+
+  test("IDEMPOTENCY: redelivery of same event is swallowed via attribute_not_exists(PK) conditional check", async () => {
+    const { PutCommand } = await import("@aws-sdk/lib-dynamodb");
+    ddbMock.on(PutCommand).rejects(
+      Object.assign(new Error("The conditional request failed"), {
+        name: "ConditionalCheckFailedException",
+      }),
+    );
+
+    await expect(handler(intakeUsageEvent())).resolves.not.toThrow();
+  });
+
+  test("non-conditional-check errors are logged and rethrown for retry/DLQ semantics", async () => {
+    const { PutCommand } = await import("@aws-sdk/lib-dynamodb");
+    ddbMock
+      .on(PutCommand)
+      .rejects(new Error("ProvisionedThroughputExceededException"));
+
+    await expect(handler(intakeUsageEvent())).rejects.toThrow(
+      "ProvisionedThroughputExceededException",
+    );
+  });
+
+  test("sparse GSI attrs: missing appId/workflow correlation omits AppIndex/WorkflowIndex keys", async () => {
+    await handler(taskCompletionEvent());
+    const putCalls = ddbMock.commandCalls(
+      (await import("@aws-sdk/lib-dynamodb")).PutCommand,
+    );
+    const item = putCalls[0].args[0].input.Item as Record<string, unknown>;
+    expect(item.GSI2PK).toBeUndefined();
+    expect(item.GSI4PK).toBeUndefined();
+    // Project dimension IS present on this event -> ProjectIndex keys written
+    expect(item.GSI1PK).toBe("PROJECT#proj-1");
+  });
+
+  test("missing org resolves to ORG#UNKNOWN fallback", async () => {
+    await handler(taskCompletionEvent({ orgId: undefined }));
+    const putCalls = ddbMock.commandCalls(
+      (await import("@aws-sdk/lib-dynamodb")).PutCommand,
+    );
+    const item = putCalls[0].args[0].input.Item as Record<string, unknown>;
+    expect(item.PK).toBe("ORG#UNKNOWN");
+  });
+
+  test("usage-only rows carry no pricing fields (priced:false, tokenCost:null)", async () => {
+    await handler(intakeUsageEvent());
+    const putCalls = ddbMock.commandCalls(
+      (await import("@aws-sdk/lib-dynamodb")).PutCommand,
+    );
+    const item = putCalls[0].args[0].input.Item as Record<string, unknown>;
+    expect(item.priced).toBe(false);
+    expect(item.tokenCost).toBeNull();
+    expect(item.estimate).toBe(true);
+  });
+});
+
+// keep the exported error class referenced so an unused-import lint rule
+// doesn't flag it if a future test needs to construct one directly.
+void ConditionalCheckFailedError;

--- a/backend/src/lambda/__tests__/cost-notifier.test.ts
+++ b/backend/src/lambda/__tests__/cost-notifier.test.ts
@@ -1,0 +1,104 @@
+/**
+ * Tests for cost-notifier.ts — sanitize + PutEvents for cost.budget.*
+ * events on the shared agentEventBus, source citadel.telemetry.
+ */
+import {
+  EventBridgeClient,
+  PutEventsCommand,
+} from "@aws-sdk/client-eventbridge";
+import { mockClient } from "aws-sdk-client-mock";
+
+import { emitBudgetEvent, __resetCostNotifierForTest } from "../cost-notifier";
+
+const ebMock = mockClient(EventBridgeClient);
+
+beforeEach(() => {
+  ebMock.reset();
+  __resetCostNotifierForTest();
+  process.env.EVENT_BUS_NAME = "test-bus";
+});
+
+afterEach(() => {
+  delete process.env.EVENT_BUS_NAME;
+});
+
+describe("emitBudgetEvent", () => {
+  test("publishes cost.budget.threshold.crossed with source citadel.telemetry", async () => {
+    ebMock.on(PutEventsCommand).resolves({ FailedEntryCount: 0, Entries: [] });
+
+    await emitBudgetEvent("cost.budget.threshold.crossed", {
+      orgId: "org-1",
+      scope: "org",
+      periodKey: "2026-07",
+      threshold: 0.8,
+      spentMicros: 800_000,
+      limitMicros: 1_000_000,
+      currency: "USD",
+    });
+
+    const calls = ebMock.commandCalls(PutEventsCommand);
+    expect(calls).toHaveLength(1);
+    const entry = calls[0].args[0].input.Entries![0];
+    expect(entry.Source).toBe("citadel.telemetry");
+    expect(entry.DetailType).toBe("cost.budget.threshold.crossed");
+    expect(entry.EventBusName).toBe("test-bus");
+    const detail = JSON.parse(entry.Detail!);
+    expect(detail.orgId).toBe("org-1");
+    expect(detail.threshold).toBe(0.8);
+    expect(typeof detail.timestamp).toBe("string");
+  });
+
+  test("publishes cost.budget.breached for the hard threshold", async () => {
+    ebMock.on(PutEventsCommand).resolves({ FailedEntryCount: 0, Entries: [] });
+
+    await emitBudgetEvent("cost.budget.breached", {
+      orgId: "org-1",
+      scope: "app:app-1",
+      periodKey: "2026-07",
+      threshold: 1.0,
+      spentMicros: 1_200_000,
+      limitMicros: 1_000_000,
+      currency: "USD",
+    });
+
+    const entry =
+      ebMock.commandCalls(PutEventsCommand)[0].args[0].input.Entries![0];
+    expect(entry.DetailType).toBe("cost.budget.breached");
+  });
+
+  test("sanitizes dangerous tag content out of string fields before publish", async () => {
+    ebMock.on(PutEventsCommand).resolves({ FailedEntryCount: 0, Entries: [] });
+
+    await emitBudgetEvent("cost.budget.threshold.crossed", {
+      orgId: "org-1<script>alert(1)</script>",
+      scope: "org",
+      periodKey: "2026-07",
+      threshold: 0.8,
+      spentMicros: 1,
+      limitMicros: 1,
+      currency: "USD",
+    });
+
+    const entry =
+      ebMock.commandCalls(PutEventsCommand)[0].args[0].input.Entries![0];
+    const detail = JSON.parse(entry.Detail!);
+    expect(detail.orgId).toBe("org-1");
+    expect(detail.orgId).not.toContain("<script>");
+  });
+
+  test("propagates a PutEvents failure to the caller (evaluator must handle it without corrupting budget rows)", async () => {
+    ebMock.on(PutEventsCommand).rejects(new Error("EventBridge unavailable"));
+
+    await expect(
+      emitBudgetEvent("cost.budget.threshold.crossed", {
+        orgId: "org-1",
+        scope: "org",
+        periodKey: "2026-07",
+        threshold: 0.8,
+        spentMicros: 1,
+        limitMicros: 1,
+        currency: "USD",
+      }),
+    ).rejects.toThrow("EventBridge unavailable");
+  });
+});

--- a/backend/src/lambda/__tests__/cost-query-handler.property.test.ts
+++ b/backend/src/lambda/__tests__/cost-query-handler.property.test.ts
@@ -1,0 +1,159 @@
+/**
+ * BINDING property test (per architect design §7): for arbitrary org
+ * pairs, a non-admin request ALWAYS issues a Query with KeyCondition
+ * PK=ORG#<claimOrg> — asserted on the mocked DDB command itself, never by
+ * post-filtering results — and NEVER a Scan. A non-admin supplying a
+ * different orgId query/path param is rejected with 403 before any DDB
+ * call carrying that other org's key is ever made.
+ *
+ * Admin requests may honor an explicit ?orgId= (including cross-org).
+ */
+import fc from "fast-check";
+import {
+  DynamoDBDocumentClient,
+  QueryCommand,
+  ScanCommand,
+} from "@aws-sdk/lib-dynamodb";
+import { mockClient } from "aws-sdk-client-mock";
+import type { APIGatewayProxyEventV2WithJWTAuthorizer } from "aws-lambda";
+
+import { handler } from "../cost-query-handler";
+
+const ddbMock = mockClient(DynamoDBDocumentClient);
+
+const orgIdArb = fc
+  .stringMatching(/^[a-zA-Z0-9-]{1,20}$/)
+  .filter((s) => s.length > 0);
+
+function makeSummaryEvent(
+  claimOrg: string,
+  queryOrgId: string | undefined,
+  isAdmin: boolean,
+): APIGatewayProxyEventV2WithJWTAuthorizer {
+  const claims: Record<string, unknown> = {
+    "custom:organization": claimOrg,
+  };
+  if (isAdmin) claims["custom:role"] = "admin";
+
+  const qsp: Record<string, string> = { groupBy: "app" };
+  if (queryOrgId !== undefined) qsp.orgId = queryOrgId;
+
+  return {
+    version: "2.0",
+    routeKey: "GET /cost/summary",
+    rawPath: "/cost/summary",
+    rawQueryString: "",
+    headers: {},
+    queryStringParameters: qsp,
+    requestContext: {
+      authorizer: { jwt: { claims, scopes: null } },
+      http: { method: "GET", path: "/cost/summary" },
+    },
+    body: undefined,
+    isBase64Encoded: false,
+  } as unknown as APIGatewayProxyEventV2WithJWTAuthorizer;
+}
+
+beforeEach(() => {
+  ddbMock.reset();
+  ddbMock.on(QueryCommand).resolves({ Items: [] });
+  ddbMock.on(ScanCommand).resolves({ Items: [] });
+  process.env.COST_LEDGER_TABLE = "test-ledger";
+});
+
+afterEach(() => {
+  delete process.env.COST_LEDGER_TABLE;
+});
+
+describe("cost-query-handler org-scoping property (binding)", () => {
+  test("non-admin: every DDB command issued is a Query pinned to PK=ORG#<claimOrg>; never a Scan; never ORG#<otherOrg>", async () => {
+    await fc.assert(
+      fc.asyncProperty(orgIdArb, orgIdArb, async (orgA, orgB) => {
+        fc.pre(orgA !== orgB);
+        ddbMock.resetHistory();
+
+        const event = makeSummaryEvent(orgA, undefined, false);
+        await handler(event);
+
+        const scanCalls = ddbMock.commandCalls(ScanCommand);
+        expect(scanCalls).toHaveLength(0);
+
+        const queryCalls = ddbMock.commandCalls(QueryCommand);
+        expect(queryCalls.length).toBeGreaterThan(0);
+
+        for (const call of queryCalls) {
+          const input = call.args[0].input;
+          const values = input.ExpressionAttributeValues as Record<
+            string,
+            unknown
+          >;
+          // The key condition must pin exactly ORG#<orgA> — never orgB,
+          // and asserted on the command sent to DDB, not on results.
+          expect(Object.values(values)).toContain(`ORG#${orgA}`);
+          expect(Object.values(values)).not.toContain(`ORG#${orgB}`);
+        }
+      }),
+      { numRuns: 50 },
+    );
+  });
+
+  test("admin: ?orgId=<orgB> is honored — key condition pins ORG#<orgB>", async () => {
+    await fc.assert(
+      fc.asyncProperty(orgIdArb, orgIdArb, async (orgA, orgB) => {
+        ddbMock.resetHistory();
+
+        const event = makeSummaryEvent(orgA, orgB, true);
+        const res = await handler(event);
+        expect(res.statusCode).toBe(200);
+
+        const queryCalls = ddbMock.commandCalls(QueryCommand);
+        expect(queryCalls.length).toBeGreaterThan(0);
+        for (const call of queryCalls) {
+          const values = call.args[0].input.ExpressionAttributeValues as Record<
+            string,
+            unknown
+          >;
+          expect(Object.values(values)).toContain(`ORG#${orgB}`);
+        }
+      }),
+      { numRuns: 50 },
+    );
+  });
+
+  test("non-admin passing a different ?orgId= is rejected 403 before any DDB call carries that org", async () => {
+    await fc.assert(
+      fc.asyncProperty(orgIdArb, orgIdArb, async (orgA, orgB) => {
+        fc.pre(orgA !== orgB);
+        ddbMock.resetHistory();
+
+        const event = makeSummaryEvent(orgA, orgB, false);
+        const res = await handler(event);
+        expect(res.statusCode).toBe(403);
+
+        const queryCalls = ddbMock.commandCalls(QueryCommand);
+        for (const call of queryCalls) {
+          const values = call.args[0].input.ExpressionAttributeValues as Record<
+            string,
+            unknown
+          >;
+          expect(Object.values(values)).not.toContain(`ORG#${orgB}`);
+        }
+        const scanCalls = ddbMock.commandCalls(ScanCommand);
+        expect(scanCalls).toHaveLength(0);
+      }),
+      { numRuns: 50 },
+    );
+  });
+
+  test("non-admin passing ?orgId= equal to their own claim org is allowed (no-op parity)", async () => {
+    await fc.assert(
+      fc.asyncProperty(orgIdArb, async (orgA) => {
+        ddbMock.resetHistory();
+        const event = makeSummaryEvent(orgA, orgA, false);
+        const res = await handler(event);
+        expect(res.statusCode).toBe(200);
+      }),
+      { numRuns: 20 },
+    );
+  });
+});

--- a/backend/src/lambda/__tests__/cost-query-handler.test.ts
+++ b/backend/src/lambda/__tests__/cost-query-handler.test.ts
@@ -1,0 +1,197 @@
+/**
+ * Unit tests for cost-query-handler.ts: routing, base-table key condition
+ * discipline (PK=ORG#<claimOrg>), PUT /budgets validation, pagination
+ * cap/truncated flag, and response shapes.
+ *
+ * Cross-org leak / admin-bypass / never-Scan invariants live in the
+ * companion property test (cost-query-handler.property.test.ts) — this
+ * file covers example-based routing and shape correctness.
+ */
+import {
+  DynamoDBDocumentClient,
+  QueryCommand,
+  UpdateCommand,
+} from "@aws-sdk/lib-dynamodb";
+import { mockClient } from "aws-sdk-client-mock";
+import type { APIGatewayProxyEventV2WithJWTAuthorizer } from "aws-lambda";
+
+import { handler } from "../cost-query-handler";
+
+const ddbMock = mockClient(DynamoDBDocumentClient);
+
+function makeEvent(
+  overrides: Partial<APIGatewayProxyEventV2WithJWTAuthorizer> = {},
+  claims: Record<string, unknown> = { "custom:organization": "org-1" },
+): APIGatewayProxyEventV2WithJWTAuthorizer {
+  return {
+    version: "2.0",
+    routeKey: "GET /cost/summary",
+    rawPath: "/cost/summary",
+    rawQueryString: "",
+    headers: {},
+    queryStringParameters: null,
+    requestContext: {
+      authorizer: { jwt: { claims, scopes: null } },
+      http: { method: "GET", path: "/cost/summary" },
+    },
+    body: undefined,
+    isBase64Encoded: false,
+    ...overrides,
+  } as unknown as APIGatewayProxyEventV2WithJWTAuthorizer;
+}
+
+function ledgerRow(overrides: Record<string, unknown> = {}) {
+  return {
+    PK: "ORG#org-1",
+    SK: "2026-07-01T00:00:00.000Z#evt:0",
+    orgId: "org-1",
+    appId: "app-1",
+    modelKey: "model-x",
+    capturedAt: "2026-07-01T00:00:00.000Z",
+    totalTokens: 10,
+    costMicros: 1_000_000,
+    tokenCost: 1,
+    currency: "USD",
+    priced: true,
+    ...overrides,
+  };
+}
+
+beforeEach(() => {
+  ddbMock.reset();
+  process.env.COST_LEDGER_TABLE = "test-ledger";
+});
+
+afterEach(() => {
+  delete process.env.COST_LEDGER_TABLE;
+});
+
+describe("cost-query-handler routing", () => {
+  test("GET /cost/summary?groupBy=app returns a 200 with bucketed totals", async () => {
+    ddbMock.on(QueryCommand).resolves({ Items: [ledgerRow()] });
+
+    const event = makeEvent({
+      routeKey: "GET /cost/summary",
+      rawPath: "/cost/summary",
+      queryStringParameters: { groupBy: "app" },
+    } as Partial<APIGatewayProxyEventV2WithJWTAuthorizer>);
+
+    const res = await handler(event);
+    expect(res.statusCode).toBe(200);
+    const body = JSON.parse(res.body!);
+    expect(body.groupBy).toBe("app");
+    expect(body.estimate).toBe(true);
+    expect(body.buckets).toHaveLength(1);
+    expect(body.buckets[0].key).toBe("app-1");
+  });
+
+  test("GET /cost/summary rejects an invalid groupBy with 400", async () => {
+    const event = makeEvent({
+      routeKey: "GET /cost/summary",
+      rawPath: "/cost/summary",
+      queryStringParameters: { groupBy: "not-a-dimension" },
+    } as Partial<APIGatewayProxyEventV2WithJWTAuthorizer>);
+
+    const res = await handler(event);
+    expect(res.statusCode).toBe(400);
+  });
+
+  test("GET /cost/series?dimension=org&bucket=day returns points", async () => {
+    ddbMock.on(QueryCommand).resolves({ Items: [ledgerRow()] });
+
+    const event = makeEvent({
+      routeKey: "GET /cost/series",
+      rawPath: "/cost/series",
+      queryStringParameters: { dimension: "org", bucket: "day" },
+    } as Partial<APIGatewayProxyEventV2WithJWTAuthorizer>);
+
+    const res = await handler(event);
+    expect(res.statusCode).toBe(200);
+    const body = JSON.parse(res.body!);
+    expect(body.bucket).toBe("day");
+    expect(body.points).toHaveLength(1);
+  });
+
+  test("PUT /budgets/{scope} validates and upserts a budget row", async () => {
+    ddbMock.on(UpdateCommand).resolves({});
+
+    const event = makeEvent({
+      routeKey: "PUT /budgets/{scope}",
+      rawPath: "/budgets/org",
+      pathParameters: { scope: "org" },
+      body: JSON.stringify({
+        periodType: "monthly",
+        limitMicros: 1_000_000_000,
+        thresholds: [0.8, 1.0],
+        currency: "USD",
+      }),
+    } as Partial<APIGatewayProxyEventV2WithJWTAuthorizer>);
+
+    const res = await handler(event);
+    expect(res.statusCode).toBe(200);
+    const calls = ddbMock.commandCalls(UpdateCommand);
+    expect(calls).toHaveLength(1);
+    const input = calls[0].args[0].input;
+    expect(input.Key).toEqual({ PK: "ORG#org-1", SK: "BUDGET#ORG" });
+  });
+
+  test("PUT /budgets/{scope} rejects a malformed body with 400", async () => {
+    const event = makeEvent({
+      routeKey: "PUT /budgets/{scope}",
+      rawPath: "/budgets/org",
+      pathParameters: { scope: "org" },
+      body: JSON.stringify({ periodType: "yearly" }),
+    } as Partial<APIGatewayProxyEventV2WithJWTAuthorizer>);
+
+    const res = await handler(event);
+    expect(res.statusCode).toBe(400);
+  });
+
+  test("GET /budgets lists budgets for the caller org via base-table Query", async () => {
+    ddbMock.on(QueryCommand).resolves({
+      Items: [
+        {
+          PK: "ORG#org-1",
+          SK: "BUDGET#ORG",
+          periodType: "monthly",
+          limitMicros: 1_000_000_000,
+          thresholds: [0.8],
+          currency: "USD",
+          updatedAt: "2026-07-01T00:00:00.000Z",
+        },
+      ],
+    });
+
+    const event = makeEvent({
+      routeKey: "GET /budgets",
+      rawPath: "/budgets",
+    } as Partial<APIGatewayProxyEventV2WithJWTAuthorizer>);
+
+    const res = await handler(event);
+    expect(res.statusCode).toBe(200);
+    const body = JSON.parse(res.body!);
+    expect(body.budgets).toHaveLength(1);
+    expect(body.budgets[0].scope).toBe("org");
+  });
+
+  test("missing org claim returns 403 on every route", async () => {
+    const event = makeEvent(
+      {
+        routeKey: "GET /cost/summary",
+        rawPath: "/cost/summary",
+      } as Partial<APIGatewayProxyEventV2WithJWTAuthorizer>,
+      {},
+    );
+    const res = await handler(event);
+    expect(res.statusCode).toBe(403);
+  });
+
+  test("unrecognized route returns 404", async () => {
+    const event = makeEvent({
+      routeKey: "GET /unknown",
+      rawPath: "/unknown",
+    } as Partial<APIGatewayProxyEventV2WithJWTAuthorizer>);
+    const res = await handler(event);
+    expect(res.statusCode).toBe(404);
+  });
+});

--- a/backend/src/lambda/__tests__/execution-resolver.test.ts
+++ b/backend/src/lambda/__tests__/execution-resolver.test.ts
@@ -2,24 +2,40 @@
  * Unit tests for execution-resolver Lambda
  * Uses aws-sdk-client-mock for DynamoDB, EventBridge, Cognito
  */
-import { DynamoDBDocumentClient, GetCommand, PutCommand, UpdateCommand, QueryCommand } from '@aws-sdk/lib-dynamodb';
-import { EventBridgeClient, PutEventsCommand } from '@aws-sdk/client-eventbridge';
-import { CognitoIdentityProviderClient, AdminGetUserCommand } from '@aws-sdk/client-cognito-identity-provider';
-import { mockClient } from 'aws-sdk-client-mock';
+import {
+  DynamoDBDocumentClient,
+  GetCommand,
+  PutCommand,
+  UpdateCommand,
+  QueryCommand,
+} from "@aws-sdk/lib-dynamodb";
+import {
+  EventBridgeClient,
+  PutEventsCommand,
+} from "@aws-sdk/client-eventbridge";
+import {
+  CognitoIdentityProviderClient,
+  AdminGetUserCommand,
+} from "@aws-sdk/client-cognito-identity-provider";
+import { mockClient } from "aws-sdk-client-mock";
 
 const ddbMock = mockClient(DynamoDBDocumentClient);
 const ebMock = mockClient(EventBridgeClient);
 const cognitoMock = mockClient(CognitoIdentityProviderClient);
 
-jest.mock('../../utils/appsync', () => ({
-  getUserId: jest.fn().mockReturnValue('user-123'),
+jest.mock("../../utils/appsync", () => ({
+  getUserId: jest.fn().mockReturnValue("user-123"),
 }));
 
-import { handler } from '../execution-resolver';
+import { handler } from "../execution-resolver";
 
 type HandlerEvent = Parameters<typeof handler>[0];
 
-function makeEvent(fieldName: string, args: Record<string, unknown>, sub = 'user-123'): HandlerEvent {
+function makeEvent(
+  fieldName: string,
+  args: Record<string, unknown>,
+  sub = "user-123",
+): HandlerEvent {
   return {
     info: { fieldName },
     arguments: args,
@@ -34,32 +50,34 @@ function makeEvent(fieldName: string, args: Record<string, unknown>, sub = 'user
 const invokeHandler = handler as (event: HandlerEvent) => Promise<unknown>;
 
 /** Invokes the handler and casts the result. */
-async function invoke<T = Record<string, unknown>>(event: HandlerEvent): Promise<T> {
+async function invoke<T = Record<string, unknown>>(
+  event: HandlerEvent,
+): Promise<T> {
   return (await invokeHandler(event)) as T;
 }
 
 function mockCognitoOrg(orgId: string) {
   cognitoMock.on(AdminGetUserCommand).resolves({
     UserAttributes: [
-      { Name: 'sub', Value: 'user-123' },
-      { Name: 'custom:organization', Value: orgId },
+      { Name: "sub", Value: "user-123" },
+      { Name: "custom:organization", Value: orgId },
     ],
   });
 }
 
-describe('execution-resolver', () => {
+describe("execution-resolver", () => {
   beforeAll(() => {
-    process.env.EXECUTIONS_TABLE = 'citadel-executions-test';
-    process.env.WORKFLOWS_TABLE = 'citadel-workflows-test';
-    process.env.EVENT_BUS_NAME = 'citadel-agents-test';
-    process.env.USER_POOL_ID = 'us-east-1_test';
+    process.env.EXECUTIONS_TABLE = "citadel-executions-test";
+    process.env.WORKFLOWS_TABLE = "citadel-workflows-test";
+    process.env.EVENT_BUS_NAME = "citadel-agents-test";
+    process.env.USER_POOL_ID = "us-east-1_test";
   });
 
   beforeEach(() => {
     ddbMock.reset();
     ebMock.reset();
     cognitoMock.reset();
-    mockCognitoOrg('org-1');
+    mockCognitoOrg("org-1");
     ebMock.on(PutEventsCommand).resolves({});
   });
 
@@ -72,129 +90,294 @@ describe('execution-resolver', () => {
 
   // ─── getExecution ──────────────────────────────────────────────
 
-  describe('getExecution', () => {
-    test('returns item and verifies org access', async () => {
+  describe("getExecution", () => {
+    test("returns item and verifies org access", async () => {
       const execution = {
-        executionId: 'exec-1',
-        workflowId: 'wf-1',
-        orgId: 'org-1',
-        status: 'pending',
+        executionId: "exec-1",
+        workflowId: "wf-1",
+        orgId: "org-1",
+        status: "pending",
         nodeResults: {},
-        startedAt: '2024-01-01T00:00:00Z',
-        triggeredBy: 'user-123',
+        startedAt: "2024-01-01T00:00:00Z",
+        triggeredBy: "user-123",
       };
-      ddbMock.on(GetCommand).resolves({ Item: execution });
+      ddbMock.on(GetCommand).resolves({ Item: { ...execution } });
 
-      const result = await invoke(
-        makeEvent('getExecution', { executionId: 'exec-1' }),
+      const result = await invoke<Record<string, unknown>>(
+        makeEvent("getExecution", { executionId: "exec-1" }),
       );
 
-      expect(result).toEqual(execution);
+      // Additive: usageTotals is added (null here — no usage on this
+      // execution) but every pre-existing field is unchanged.
+      expect(result).toEqual({ ...execution, usageTotals: null });
     });
 
-    test('throws Access denied on org mismatch', async () => {
+    test("throws Access denied on org mismatch", async () => {
       ddbMock.on(GetCommand).resolves({
         Item: {
-          executionId: 'exec-1',
-          workflowId: 'wf-1',
-          orgId: 'org-other',
-          status: 'pending',
+          executionId: "exec-1",
+          workflowId: "wf-1",
+          orgId: "org-other",
+          status: "pending",
         },
       });
 
       await expect(
-        invoke(makeEvent('getExecution', { executionId: 'exec-1' }),),
-      ).rejects.toThrow('Access denied');
+        invoke(makeEvent("getExecution", { executionId: "exec-1" })),
+      ).rejects.toThrow("Access denied");
     });
 
-    test('claim-first path: reads custom:organization from identity and skips Cognito', async () => {
+    test("claim-first path: reads custom:organization from identity and skips Cognito", async () => {
       const execution = {
-        executionId: 'exec-claim',
-        workflowId: 'wf-claim',
-        orgId: 'org-claim',
-        status: 'pending',
+        executionId: "exec-claim",
+        workflowId: "wf-claim",
+        orgId: "org-claim",
+        status: "pending",
         nodeResults: {},
-        startedAt: '2024-01-01T00:00:00Z',
-        triggeredBy: 'user-123',
+        startedAt: "2024-01-01T00:00:00Z",
+        triggeredBy: "user-123",
       };
-      ddbMock.on(GetCommand).resolves({ Item: execution });
+      ddbMock.on(GetCommand).resolves({ Item: { ...execution } });
 
       const claimEvent = {
-        info: { fieldName: 'getExecution' },
-        arguments: { executionId: 'exec-claim' },
-        identity: { sub: 'user-123', 'custom:organization': 'org-claim' },
+        info: { fieldName: "getExecution" },
+        arguments: { executionId: "exec-claim" },
+        identity: { sub: "user-123", "custom:organization": "org-claim" },
       } as unknown as HandlerEvent;
 
       const result = await invoke(claimEvent);
 
-      expect(result).toEqual(execution);
+      expect(result).toEqual({ ...execution, usageTotals: null });
       expect(cognitoMock.commandCalls(AdminGetUserCommand).length).toBe(0);
+    });
+
+    test("returns additive usageTotals folded from per-node usageTotals", async () => {
+      const execution = {
+        executionId: "exec-usage",
+        workflowId: "wf-1",
+        orgId: "org-1",
+        status: "completed",
+        nodeResults: {
+          n0: {
+            nodeId: "n0",
+            status: "completed",
+            usageTotals: {
+              inputTokens: 10,
+              outputTokens: 5,
+              totalTokens: 15,
+              callCount: 1,
+            },
+          },
+          n1: {
+            nodeId: "n1",
+            status: "completed",
+            usageTotals: {
+              inputTokens: 3,
+              outputTokens: 7,
+              totalTokens: 10,
+              callCount: 2,
+            },
+          },
+        },
+        startedAt: "2024-01-01T00:00:00Z",
+        triggeredBy: "user-123",
+      };
+      ddbMock.on(GetCommand).resolves({ Item: execution });
+
+      const result = await invoke<Record<string, unknown>>(
+        makeEvent("getExecution", { executionId: "exec-usage" }),
+      );
+
+      expect(result.usageTotals).toEqual({
+        inputTokens: 13,
+        outputTokens: 12,
+        totalTokens: 25,
+        callCount: 3,
+      });
+      // Additive: existing fields and access checks are untouched.
+      expect(result.executionId).toBe("exec-usage");
+    });
+
+    test("falls back to node usage/output.usage when usageTotals absent", async () => {
+      const execution = {
+        executionId: "exec-usage-fallback",
+        workflowId: "wf-1",
+        orgId: "org-1",
+        status: "completed",
+        nodeResults: {
+          n0: {
+            nodeId: "n0",
+            status: "completed",
+            usage: [{ inputTokens: 4, outputTokens: 6 }],
+          },
+          n1: {
+            nodeId: "n1",
+            status: "completed",
+            output: {
+              response: "ok",
+              usage: [{ inputTokens: 1, outputTokens: 1 }],
+            },
+          },
+        },
+        startedAt: "2024-01-01T00:00:00Z",
+        triggeredBy: "user-123",
+      };
+      ddbMock.on(GetCommand).resolves({ Item: execution });
+
+      const result = await invoke<Record<string, unknown>>(
+        makeEvent("getExecution", { executionId: "exec-usage-fallback" }),
+      );
+
+      expect(result.usageTotals).toEqual({
+        inputTokens: 5,
+        outputTokens: 7,
+        totalTokens: 12,
+        callCount: 2,
+      });
+    });
+
+    test("returns null usageTotals when no node carries usage (legacy run)", async () => {
+      const execution = {
+        executionId: "exec-legacy",
+        workflowId: "wf-1",
+        orgId: "org-1",
+        status: "completed",
+        nodeResults: {
+          n0: {
+            nodeId: "n0",
+            status: "completed",
+            output: JSON.stringify({ response: "ok" }),
+          },
+        },
+        startedAt: "2024-01-01T00:00:00Z",
+        triggeredBy: "user-123",
+      };
+      ddbMock.on(GetCommand).resolves({ Item: execution });
+
+      const result = await invoke<Record<string, unknown>>(
+        makeEvent("getExecution", { executionId: "exec-legacy" }),
+      );
+
+      expect(result.usageTotals).toBeNull();
+    });
+
+    test("org access check still enforced when usage is present", async () => {
+      ddbMock.on(GetCommand).resolves({
+        Item: {
+          executionId: "exec-usage-denied",
+          workflowId: "wf-1",
+          orgId: "org-other",
+          status: "completed",
+          nodeResults: {
+            n0: {
+              nodeId: "n0",
+              status: "completed",
+              usageTotals: {
+                inputTokens: 1,
+                outputTokens: 1,
+                totalTokens: 2,
+                callCount: 1,
+              },
+            },
+          },
+        },
+      });
+
+      await expect(
+        invoke(makeEvent("getExecution", { executionId: "exec-usage-denied" })),
+      ).rejects.toThrow("Access denied");
     });
   });
 
   // ─── listExecutions ────────────────────────────────────────────
 
-  describe('listExecutions', () => {
-    test('queries WorkflowIndex GSI by workflowId', async () => {
+  describe("listExecutions", () => {
+    test("queries WorkflowIndex GSI by workflowId", async () => {
       const items = [
-        { executionId: 'exec-1', workflowId: 'wf-1', status: 'completed', startedAt: '2024-01-01T00:00:00Z' },
-        { executionId: 'exec-2', workflowId: 'wf-1', status: 'pending', startedAt: '2024-01-02T00:00:00Z' },
+        {
+          executionId: "exec-1",
+          workflowId: "wf-1",
+          status: "completed",
+          startedAt: "2024-01-01T00:00:00Z",
+        },
+        {
+          executionId: "exec-2",
+          workflowId: "wf-1",
+          status: "pending",
+          startedAt: "2024-01-02T00:00:00Z",
+        },
       ];
       ddbMock.on(QueryCommand).resolves({ Items: items });
 
       const result = await invoke(
-        makeEvent('listExecutions', { workflowId: 'wf-1' }),
+        makeEvent("listExecutions", { workflowId: "wf-1" }),
       );
 
       expect(result).toEqual({ items, nextToken: undefined });
 
       const queryCall = ddbMock.commandCalls(QueryCommand)[0];
-      expect(queryCall.args[0].input.IndexName).toBe('WorkflowIndex');
-      expect(queryCall.args[0].input.KeyConditionExpression).toContain('workflowId');
+      expect(queryCall.args[0].input.IndexName).toBe("WorkflowIndex");
+      expect(queryCall.args[0].input.KeyConditionExpression).toContain(
+        "workflowId",
+      );
     });
   });
 
   // ─── startExecution ────────────────────────────────────────────
 
-  describe('startExecution', () => {
+  describe("startExecution", () => {
     const publishedWorkflow = {
-      workflowId: 'wf-1',
-      orgId: 'org-1',
-      name: 'Published Workflow',
-      status: 'PUBLISHED',
+      workflowId: "wf-1",
+      orgId: "org-1",
+      name: "Published Workflow",
+      status: "PUBLISHED",
       version: 3,
       definition: JSON.stringify({
         nodes: [
-          { id: 'n1', agentId: 'agent-1', type: 'agent' },
-          { id: 'n2', agentId: 'agent-2', type: 'agent' },
+          { id: "n1", agentId: "agent-1", type: "agent" },
+          { id: "n2", agentId: "agent-2", type: "agent" },
         ],
-        edges: [{ id: 'e1', source: 'n1', target: 'n2' }],
+        edges: [{ id: "e1", source: "n1", target: "n2" }],
       }),
     };
 
-    test('verifies workflow is PUBLISHED, initializes all nodeResults as pending, publishes execution.start.requested event', async () => {
+    test("verifies workflow is PUBLISHED, initializes all nodeResults as pending, publishes execution.start.requested event", async () => {
       // First GetCommand: workflow lookup
       ddbMock.on(GetCommand).resolves({ Item: publishedWorkflow });
       ddbMock.on(PutCommand).resolves({});
 
       const result = await invoke(
-        makeEvent('startExecution', { workflowId: 'wf-1', input: JSON.stringify({ key: 'value' }) }),
+        makeEvent("startExecution", {
+          workflowId: "wf-1",
+          input: JSON.stringify({ key: "value" }),
+        }),
       );
 
       // Execution created with correct fields
       expect(result.executionId).toBeDefined();
-      expect(result.workflowId).toBe('wf-1');
-      expect(result.status).toBe('pending');
+      expect(result.workflowId).toBe("wf-1");
+      expect(result.status).toBe("pending");
       expect(result.workflowVersion).toBe(3);
-      expect(result.orgId).toBe('org-1');
-      expect(result.triggeredBy).toBe('user-123');
+      expect(result.orgId).toBe("org-1");
+      expect(result.triggeredBy).toBe("user-123");
       expect(result.startedAt).toBeDefined();
 
       // All nodeResults initialized as pending
-      const nodeResults = result.nodeResults as Record<string, { nodeId: string; agentId: string; status: string }>;
+      const nodeResults = result.nodeResults as Record<
+        string,
+        { nodeId: string; agentId: string; status: string }
+      >;
       expect(nodeResults).toBeDefined();
-      expect(nodeResults['n1']).toMatchObject({ nodeId: 'n1', agentId: 'agent-1', status: 'pending' });
-      expect(nodeResults['n2']).toMatchObject({ nodeId: 'n2', agentId: 'agent-2', status: 'pending' });
+      expect(nodeResults["n1"]).toMatchObject({
+        nodeId: "n1",
+        agentId: "agent-1",
+        status: "pending",
+      });
+      expect(nodeResults["n2"]).toMatchObject({
+        nodeId: "n2",
+        agentId: "agent-2",
+        status: "pending",
+      });
 
       // PutCommand for execution
       expect(ddbMock.commandCalls(PutCommand)).toHaveLength(1);
@@ -203,57 +386,57 @@ describe('execution-resolver', () => {
       const ebCalls = ebMock.commandCalls(PutEventsCommand);
       expect(ebCalls).toHaveLength(1);
       const entry = ebCalls[0].args[0].input.Entries![0];
-      expect(entry.Source).toBe('citadel.workflows');
-      expect(entry.DetailType).toBe('execution.start.requested');
+      expect(entry.Source).toBe("citadel.workflows");
+      expect(entry.DetailType).toBe("execution.start.requested");
       const detail = JSON.parse(entry.Detail!);
       expect(detail.executionId).toBe(result.executionId);
-      expect(detail.workflowId).toBe('wf-1');
+      expect(detail.workflowId).toBe("wf-1");
     });
 
-    test('rejects DRAFT workflows', async () => {
+    test("rejects DRAFT workflows", async () => {
       ddbMock.on(GetCommand).resolves({
         Item: {
-          workflowId: 'wf-draft',
-          orgId: 'org-1',
-          name: 'Draft Workflow',
-          status: 'DRAFT',
+          workflowId: "wf-draft",
+          orgId: "org-1",
+          name: "Draft Workflow",
+          status: "DRAFT",
           version: 1,
           definition: JSON.stringify({ nodes: [], edges: [] }),
         },
       });
 
       await expect(
-        invoke(makeEvent('startExecution', { workflowId: 'wf-draft' }),),
+        invoke(makeEvent("startExecution", { workflowId: "wf-draft" })),
       ).rejects.toThrow(/published/i);
     });
   });
 
   // ─── cancelExecution ───────────────────────────────────────────
 
-  describe('cancelExecution', () => {
-    test('updates status to cancelled and publishes execution.cancel.requested event', async () => {
+  describe("cancelExecution", () => {
+    test("updates status to cancelled and publishes execution.cancel.requested event", async () => {
       ddbMock.on(GetCommand).resolves({
         Item: {
-          executionId: 'exec-1',
-          workflowId: 'wf-1',
-          orgId: 'org-1',
-          status: 'running',
+          executionId: "exec-1",
+          workflowId: "wf-1",
+          orgId: "org-1",
+          status: "running",
         },
       });
       ddbMock.on(UpdateCommand).resolves({
         Attributes: {
-          executionId: 'exec-1',
-          workflowId: 'wf-1',
-          orgId: 'org-1',
-          status: 'cancelled',
+          executionId: "exec-1",
+          workflowId: "wf-1",
+          orgId: "org-1",
+          status: "cancelled",
         },
       });
 
       const result = await invoke(
-        makeEvent('cancelExecution', { executionId: 'exec-1' }),
+        makeEvent("cancelExecution", { executionId: "exec-1" }),
       );
 
-      expect(result.status).toBe('cancelled');
+      expect(result.status).toBe("cancelled");
 
       // UpdateCommand called
       const updateCalls = ddbMock.commandCalls(UpdateCommand);
@@ -263,37 +446,189 @@ describe('execution-resolver', () => {
       const ebCalls = ebMock.commandCalls(PutEventsCommand);
       expect(ebCalls).toHaveLength(1);
       const entry = ebCalls[0].args[0].input.Entries![0];
-      expect(entry.Source).toBe('citadel.workflows');
-      expect(entry.DetailType).toBe('execution.cancel.requested');
+      expect(entry.Source).toBe("citadel.workflows");
+      expect(entry.DetailType).toBe("execution.cancel.requested");
     });
   });
 
   // ─── publishWorkflowProgress ───────────────────────────────────
 
-  describe('publishWorkflowProgress', () => {
+  describe("publishWorkflowProgress", () => {
     const progressInput = {
-      executionId: 'exec-1',
-      workflowId: 'wf-1',
-      eventType: 'node.completed',
-      nodeId: 'n1',
-      status: 'completed',
+      executionId: "exec-1",
+      workflowId: "wf-1",
+      eventType: "node.completed",
+      nodeId: "n1",
+      status: "completed",
       output: '{"result":"ok"}',
       error: null,
-      timestamp: '2024-01-01T00:00:00Z',
+      timestamp: "2024-01-01T00:00:00Z",
     };
 
-    test('echoes args.input so AppSync fans out to onWorkflowProgress subscribers', async () => {
+    test("echoes args.input so AppSync fans out to onWorkflowProgress subscribers", async () => {
       const result = await invoke(
-        makeEvent('publishWorkflowProgress', { input: progressInput }),
+        makeEvent("publishWorkflowProgress", { input: progressInput }),
       );
 
       expect(result).toEqual(progressInput);
     });
 
-    test('does not throw Unknown field', async () => {
+    test("does not throw Unknown field", async () => {
       await expect(
-        invoke(makeEvent('publishWorkflowProgress', { input: progressInput }),),
+        invoke(makeEvent("publishWorkflowProgress", { input: progressInput })),
       ).resolves.toBeDefined();
     });
+  });
+});
+
+// ─── computeExecutionUsageTotals (pure reduction, usage rollup) ────
+
+import { computeExecutionUsageTotals } from "../execution-resolver";
+
+describe("computeExecutionUsageTotals", () => {
+  test("sums usageTotals across nodes", () => {
+    const result = computeExecutionUsageTotals({
+      n0: {
+        nodeId: "n0",
+        status: "completed",
+        usageTotals: {
+          inputTokens: 10,
+          outputTokens: 5,
+          totalTokens: 15,
+          callCount: 1,
+        },
+      },
+      n1: {
+        nodeId: "n1",
+        status: "completed",
+        usageTotals: {
+          inputTokens: 3,
+          outputTokens: 7,
+          totalTokens: 10,
+          callCount: 2,
+        },
+      },
+    });
+    expect(result).toEqual({
+      inputTokens: 13,
+      outputTokens: 12,
+      totalTokens: 25,
+      callCount: 3,
+    });
+  });
+
+  test("falls back to node usage array when usageTotals absent", () => {
+    const result = computeExecutionUsageTotals({
+      n0: {
+        nodeId: "n0",
+        status: "completed",
+        usage: [{ inputTokens: 4, outputTokens: 6 }],
+      },
+    });
+    expect(result).toEqual({
+      inputTokens: 4,
+      outputTokens: 6,
+      totalTokens: 10,
+      callCount: 1,
+    });
+  });
+
+  test("falls back to output.usage when neither usageTotals nor usage present", () => {
+    const result = computeExecutionUsageTotals({
+      n0: {
+        nodeId: "n0",
+        status: "completed",
+        output: {
+          response: "ok",
+          usage: [{ inputTokens: 1, outputTokens: 1 }],
+        },
+      },
+    });
+    expect(result).toEqual({
+      inputTokens: 1,
+      outputTokens: 1,
+      totalTokens: 2,
+      callCount: 1,
+    });
+  });
+
+  test("handles a JSON-string output field defensively", () => {
+    const result = computeExecutionUsageTotals({
+      n0: {
+        nodeId: "n0",
+        status: "completed",
+        output: JSON.stringify({
+          response: "ok",
+          usage: [{ inputTokens: 2, outputTokens: 2 }],
+        }),
+      },
+    });
+    expect(result).toEqual({
+      inputTokens: 2,
+      outputTokens: 2,
+      totalTokens: 4,
+      callCount: 1,
+    });
+  });
+
+  test("returns null for empty/undefined nodeResults", () => {
+    expect(computeExecutionUsageTotals(undefined)).toBeNull();
+    expect(computeExecutionUsageTotals({})).toBeNull();
+  });
+
+  test("returns null when no node carries any usage source", () => {
+    const result = computeExecutionUsageTotals({
+      n0: {
+        nodeId: "n0",
+        status: "completed",
+        output: JSON.stringify({ response: "ok" }),
+      },
+    });
+    expect(result).toBeNull();
+  });
+
+  test("malformed node entries never throw and are skipped", () => {
+    const result = computeExecutionUsageTotals({
+      n0: {
+        nodeId: "n0",
+        status: "completed",
+        usageTotals: {
+          inputTokens: 5,
+          outputTokens: 5,
+          totalTokens: 10,
+          callCount: 1,
+        },
+      },
+      n1: null as unknown as Record<string, unknown>,
+      n2: {
+        nodeId: "n2",
+        status: "completed",
+        usage: "not-an-array" as unknown as unknown[],
+      },
+    });
+    expect(result).toEqual({
+      inputTokens: 5,
+      outputTokens: 5,
+      totalTokens: 10,
+      callCount: 1,
+    });
+  });
+
+  test("is pure and idempotent: reducing the same input twice yields equal totals", () => {
+    const nodeResults = {
+      n0: {
+        nodeId: "n0",
+        status: "completed",
+        usageTotals: {
+          inputTokens: 6,
+          outputTokens: 4,
+          totalTokens: 10,
+          callCount: 1,
+        },
+      },
+    };
+    const first = computeExecutionUsageTotals(nodeResults);
+    const second = computeExecutionUsageTotals(nodeResults);
+    expect(first).toEqual(second);
   });
 });

--- a/backend/src/lambda/__tests__/model-catalog-sync.test.ts
+++ b/backend/src/lambda/__tests__/model-catalog-sync.test.ts
@@ -10,88 +10,94 @@
  * provider overlay is driven off the separate providerName field.
  */
 
-import { mockClient } from 'aws-sdk-client-mock';
+import { mockClient } from "aws-sdk-client-mock";
 import {
   BedrockClient,
   ListFoundationModelsCommand,
   ListInferenceProfilesCommand,
-} from '@aws-sdk/client-bedrock';
+} from "@aws-sdk/client-bedrock";
 import {
   DynamoDBDocumentClient,
   ScanCommand,
   PutCommand,
-} from '@aws-sdk/lib-dynamodb';
+} from "@aws-sdk/lib-dynamodb";
 
 // Stub only publishEvent; keep createProjectEvent + EventTypes real.
-jest.mock('../../utils/events', () => {
-  const actual = jest.requireActual('../../utils/events');
+jest.mock("../../utils/events", () => {
+  const actual = jest.requireActual("../../utils/events");
   return { ...actual, publishEvent: jest.fn().mockResolvedValue(undefined) };
 });
 
-import { publishEvent, EventTypes } from '../../utils/events';
+import { publishEvent, EventTypes } from "../../utils/events";
 
 const bedrockMock = mockClient(BedrockClient);
 const ddbMock = mockClient(DynamoDBDocumentClient);
 
 // SUT reads MODEL_CATALOG_TABLE at module load — import lazily after env is set.
-let syncModelCatalog: typeof import('../model-catalog-sync').syncModelCatalog;
+let syncModelCatalog: typeof import("../model-catalog-sync").syncModelCatalog;
 
 const FOUNDATION_MODELS = [
   // New (not in catalog) + anthropic overlay + region profile target.
   {
-    modelId: 'prov.model-a',
-    providerName: 'Anthropic',
-    outputModalities: ['TEXT'],
+    modelId: "prov.model-a",
+    providerName: "Anthropic",
+    outputModalities: ["TEXT"],
     responseStreamingSupported: true,
   },
   // Existing + cohere overlay; has stale metadata to prove a refresh.
   {
-    modelId: 'prov.model-b',
-    providerName: 'Cohere',
-    outputModalities: ['TEXT'],
+    modelId: "prov.model-b",
+    providerName: "Cohere",
+    outputModalities: ["TEXT"],
     responseStreamingSupported: true,
   },
   // New + stability overlay (tools disabled) + image modality.
   {
-    modelId: 'prov.model-c',
-    providerName: 'Stability',
-    outputModalities: ['IMAGE'],
+    modelId: "prov.model-c",
+    providerName: "Stability",
+    outputModalities: ["IMAGE"],
     responseStreamingSupported: false,
   },
 ];
 
 const INFERENCE_PROFILES = [
   {
-    inferenceProfileId: 'us.prov.model-a',
+    inferenceProfileId: "us.prov.model-a",
     models: [
-      { modelArn: 'arn:aws:bedrock:us-east-1::foundation-model/prov.model-a' },
+      { modelArn: "arn:aws:bedrock:us-east-1::foundation-model/prov.model-a" },
     ],
   },
 ];
 
 const EXISTING_ITEMS = [
   {
-    modelKey: 'prov-model-b',
-    provider: 'cohere',
-    baseModelId: 'prov.model-b',
-    modality: 'other', // stale — should refresh to 'text'
-    status: 'enabled', // operator-owned — must be preserved
-    discoveredAt: '2020-01-01T00:00:00.000Z',
+    modelKey: "prov-model-b",
+    provider: "cohere",
+    baseModelId: "prov.model-b",
+    modality: "other", // stale — should refresh to 'text'
+    status: "enabled", // operator-owned — must be preserved
+    discoveredAt: "2020-01-01T00:00:00.000Z",
     supportsStreaming: false, // stale — should refresh to true
+    // Operator-set pricing — must be preserved verbatim on sync (like status).
+    inputPer1kTokens: 9.99,
+    outputPer1kTokens: 19.99,
+    currency: "EUR",
+    pricingSource: "operator",
+    pricingUpdatedAt: "2021-06-01T00:00:00.000Z",
   },
   {
-    modelKey: 'prov-model-old',
-    provider: 'prov',
-    baseModelId: 'prov.model-old',
-    modality: 'text',
-    status: 'enabled', // present in catalog but absent from API → deprecate
-    discoveredAt: '2019-01-01T00:00:00.000Z',
+    modelKey: "prov-model-old",
+    provider: "prov",
+    baseModelId: "prov.model-old",
+    modality: "text",
+    status: "enabled", // present in catalog but absent from API → deprecate
+    discoveredAt: "2019-01-01T00:00:00.000Z",
   },
 ];
 
 beforeAll(async () => {
-  process.env.MODEL_CATALOG_TABLE = 'citadel-model-catalog-test';
-  ({ syncModelCatalog } = await import('../model-catalog-sync'));
+  process.env.MODEL_CATALOG_TABLE = "citadel-model-catalog-test";
+  ({ syncModelCatalog } = await import("../model-catalog-sync"));
 });
 
 beforeEach(() => {
@@ -119,49 +125,49 @@ function putFor(modelKey: string): Record<string, unknown> {
   return putItems().find((i) => i.modelKey === modelKey)!;
 }
 
-describe('model-catalog-sync', () => {
+describe("model-catalog-sync", () => {
   test('writes a new model with status "discovered"', async () => {
     await syncModelCatalog();
-    const item = putFor('prov-model-a');
+    const item = putFor("prov-model-a");
     expect(item).toBeDefined();
-    expect(item.status).toBe('discovered');
-    expect(item.baseModelId).toBe('prov.model-a');
+    expect(item.status).toBe("discovered");
+    expect(item.baseModelId).toBe("prov.model-a");
     expect(item.discoveredAt).toEqual(expect.any(String));
   });
 
   test('preserves operator status "enabled" while refreshing metadata', async () => {
     await syncModelCatalog();
-    const item = putFor('prov-model-b');
+    const item = putFor("prov-model-b");
     expect(item).toBeDefined();
-    expect(item.status).toBe('enabled'); // preserved, not overwritten
-    expect(item.discoveredAt).toBe('2020-01-01T00:00:00.000Z'); // preserved
-    expect(item.modality).toBe('text'); // refreshed from stale 'other'
+    expect(item.status).toBe("enabled"); // preserved, not overwritten
+    expect(item.discoveredAt).toBe("2020-01-01T00:00:00.000Z"); // preserved
+    expect(item.modality).toBe("text"); // refreshed from stale 'other'
     expect(item.supportsStreaming).toBe(true); // refreshed from stale false
   });
 
   test('marks a catalog entry absent from the API as "deprecated"', async () => {
     await syncModelCatalog();
-    const item = putFor('prov-model-old');
+    const item = putFor("prov-model-old");
     expect(item).toBeDefined();
-    expect(item.status).toBe('deprecated');
+    expect(item.status).toBe("deprecated");
   });
 
   test('maps an "us.<modelId>" inference profile to regionProfiles.us', async () => {
     await syncModelCatalog();
-    const item = putFor('prov-model-a');
-    expect(item.regionProfiles).toEqual({ us: 'us.prov.model-a' });
+    const item = putFor("prov-model-a");
+    expect(item.regionProfiles).toEqual({ us: "us.prov.model-a" });
   });
 
-  test('applies the provider overlay: anthropic tools=true, stability tools=false', async () => {
+  test("applies the provider overlay: anthropic tools=true, stability tools=false", async () => {
     await syncModelCatalog();
-    expect(putFor('prov-model-a').supportsTools).toBe(true);
-    expect(putFor('prov-model-c').supportsTools).toBe(false);
+    expect(putFor("prov-model-a").supportsTools).toBe(true);
+    expect(putFor("prov-model-c").supportsTools).toBe(false);
     // Non-text modality drives invoke_model rather than converse.
-    expect(putFor('prov-model-c').modality).toBe('image');
-    expect(putFor('prov-model-c').invocationMode).toBe('invoke_model');
+    expect(putFor("prov-model-c").modality).toBe("image");
+    expect(putFor("prov-model-c").invocationMode).toBe("invoke_model");
   });
 
-  test('publishes MODEL_CATALOG_SYNCED once with the summary', async () => {
+  test("publishes MODEL_CATALOG_SYNCED once with the summary", async () => {
     const result = await syncModelCatalog();
     expect(result).toEqual({
       discovered: 2,
@@ -174,5 +180,35 @@ describe('model-catalog-sync', () => {
     const arg = (publishEvent as jest.Mock).mock.calls[0][0];
     expect(arg.eventType).toBe(EventTypes.MODEL_CATALOG_SYNCED);
     expect(arg.payload).toEqual(result);
+  });
+});
+
+describe("model-catalog-sync — pricing overlay (pass 2)", () => {
+  test("applies the PROVIDER_PRICING default to a brand-new discovered row (no prior pricing)", async () => {
+    await syncModelCatalog();
+    const item = putFor("prov-model-a"); // provider: anthropic
+    expect(item.inputPer1kTokens).toEqual(expect.any(Number));
+    expect(item.outputPer1kTokens).toEqual(expect.any(Number));
+    expect(item.currency).toEqual(expect.any(String));
+    expect(item.pricingSource).toBe("synced_default");
+    expect(item.pricingUpdatedAt).toEqual(expect.any(String));
+  });
+
+  test("preserves operator-set pricing on an existing row exactly, like status", async () => {
+    await syncModelCatalog();
+    const item = putFor("prov-model-b"); // has operator pricing in EXISTING_ITEMS
+    expect(item.inputPer1kTokens).toBe(9.99);
+    expect(item.outputPer1kTokens).toBe(19.99);
+    expect(item.currency).toBe("EUR");
+    expect(item.pricingSource).toBe("operator");
+    expect(item.pricingUpdatedAt).toBe("2021-06-01T00:00:00.000Z");
+  });
+
+  test("unrecognized provider still gets a pricing default (fallback overlay), never left unpriced", async () => {
+    await syncModelCatalog();
+    const item = putFor("prov-model-c"); // provider: stability
+    expect(item.inputPer1kTokens).toEqual(expect.any(Number));
+    expect(item.outputPer1kTokens).toEqual(expect.any(Number));
+    expect(item.pricingSource).toBe("synced_default");
   });
 });

--- a/backend/src/lambda/__tests__/model-config-resolver.test.ts
+++ b/backend/src/lambda/__tests__/model-config-resolver.test.ts
@@ -1,8 +1,13 @@
 /**
  * Tests for model-config-resolver Lambda
  */
-import { DynamoDBDocumentClient, GetCommand, PutCommand, ScanCommand } from '@aws-sdk/lib-dynamodb';
-import { mockClient } from 'aws-sdk-client-mock';
+import {
+  DynamoDBDocumentClient,
+  GetCommand,
+  PutCommand,
+  ScanCommand,
+} from "@aws-sdk/lib-dynamodb";
+import { mockClient } from "aws-sdk-client-mock";
 
 const dynamoMock = mockClient(DynamoDBDocumentClient);
 
@@ -10,7 +15,7 @@ const dynamoMock = mockClient(DynamoDBDocumentClient);
 // createProjectEvent/EventTypes keep faithful (pure) behaviour so the resolver
 // builds a real event object without touching EventBridge.
 const mockPublishEvent = jest.fn();
-jest.mock('../../utils/events', () => ({
+jest.mock("../../utils/events", () => ({
   publishEvent: mockPublishEvent,
   createProjectEvent: (
     eventType: string,
@@ -19,19 +24,19 @@ jest.mock('../../utils/events', () => ({
     correlationId?: string,
   ) => ({ eventType, projectId, payload, correlationId }),
   EventTypes: {
-    MODEL_CONFIG_CHANGED: 'model.config.changed',
-    MODEL_CATALOG_SYNC_REQUESTED: 'model.catalog.sync_requested',
+    MODEL_CONFIG_CHANGED: "model.config.changed",
+    MODEL_CATALOG_SYNC_REQUESTED: "model.catalog.sync_requested",
   },
 }));
 
-import { handler } from '../model-config-resolver';
+import { handler } from "../model-config-resolver";
 
-describe('model-config-resolver', () => {
+describe("model-config-resolver", () => {
   beforeEach(() => {
     dynamoMock.reset();
     mockPublishEvent.mockReset().mockResolvedValue(undefined);
-    process.env.MODEL_CONFIG_TABLE = 'test-model-config';
-    process.env.MODEL_CATALOG_TABLE = 'test-model-catalog';
+    process.env.MODEL_CONFIG_TABLE = "test-model-config";
+    process.env.MODEL_CATALOG_TABLE = "test-model-catalog";
   });
 
   afterEach(() => {
@@ -41,8 +46,11 @@ describe('model-config-resolver', () => {
 
   // isAdminFromEvent is the REAL implementation (not mocked): admin via the
   // cognito:groups claim, and once via custom:role, prove both shapes work.
-  const adminIdentity = { username: 'admin-user', 'cognito:groups': ['admin'] };
-  const nonAdminIdentity = { username: 'dev-user', 'cognito:groups': ['developer'] };
+  const adminIdentity = { username: "admin-user", "cognito:groups": ["admin"] };
+  const nonAdminIdentity = {
+    username: "dev-user",
+    "cognito:groups": ["developer"],
+  };
 
   const makeEvent = (fieldName: string, args: unknown, identity?: unknown) => ({
     info: { fieldName },
@@ -51,88 +59,132 @@ describe('model-config-resolver', () => {
   });
 
   // Generic placeholder catalog entries — NO real model ids.
-  const catalogEntry = (modelKey: string, status: string): Record<string, unknown> => ({
+  const catalogEntry = (
+    modelKey: string,
+    status: string,
+  ): Record<string, unknown> => ({
     modelKey,
-    provider: 'vendor',
+    provider: "vendor",
     baseModelId: `${modelKey}-base`,
     status,
-    modality: 'text',
-    invocationMode: 'on_demand',
+    modality: "text",
+    invocationMode: "on_demand",
     supportsTools: true,
     supportsSystemPrompt: true,
     supportsStreaming: true,
-    regionProfiles: { 'us-east-1': { available: true } },
+    regionProfiles: { "us-east-1": { available: true } },
   });
 
-  describe('listModelCatalog', () => {
-    test('returns the scanned catalog items with regionProfiles as-is', async () => {
+  describe("listModelCatalog", () => {
+    test("returns the scanned catalog items with regionProfiles as-is", async () => {
       dynamoMock.on(ScanCommand).resolves({
         Items: [
-          catalogEntry('vendor.model-standard', 'enabled'),
-          catalogEntry('vendor.model-lite', 'disabled'),
+          catalogEntry("vendor.model-standard", "enabled"),
+          catalogEntry("vendor.model-lite", "disabled"),
         ],
       });
 
-      const result = await handler(makeEvent('listModelCatalog', {}));
+      const result = await handler(makeEvent("listModelCatalog", {}));
 
       expect(result).toHaveLength(2);
-      expect(result[0].modelKey).toBe('vendor.model-standard');
-      expect(result[0].regionProfiles).toEqual({ 'us-east-1': { available: true } });
+      expect(result[0].modelKey).toBe("vendor.model-standard");
+      expect(result[0].regionProfiles).toEqual({
+        "us-east-1": { available: true },
+      });
     });
 
-    test('returns an empty array when the catalog is empty', async () => {
+    test("returns an empty array when the catalog is empty", async () => {
       dynamoMock.on(ScanCommand).resolves({ Items: [] });
-      const result = await handler(makeEvent('listModelCatalog', {}));
+      const result = await handler(makeEvent("listModelCatalog", {}));
       expect(result).toEqual([]);
+    });
+
+    test("passes pricing fields through verbatim (interface passthrough only)", async () => {
+      const priced = {
+        ...catalogEntry("vendor.model-priced", "enabled"),
+        inputPer1kTokens: 3,
+        outputPer1kTokens: 15,
+        currency: "USD",
+        pricingSource: "operator",
+        pricingUpdatedAt: "2026-01-01T00:00:00.000Z",
+      };
+      dynamoMock.on(ScanCommand).resolves({ Items: [priced] });
+
+      const result = await handler(makeEvent("listModelCatalog", {}));
+
+      expect(result[0].inputPer1kTokens).toBe(3);
+      expect(result[0].outputPer1kTokens).toBe(15);
+      expect(result[0].currency).toBe("USD");
+      expect(result[0].pricingSource).toBe("operator");
+      expect(result[0].pricingUpdatedAt).toBe("2026-01-01T00:00:00.000Z");
+    });
+
+    test("rows with no pricing yet omit pricing fields rather than fabricating them", async () => {
+      dynamoMock.on(ScanCommand).resolves({
+        Items: [catalogEntry("vendor.model-unpriced", "enabled")],
+      });
+
+      const result = await handler(makeEvent("listModelCatalog", {}));
+
+      expect(result[0].inputPer1kTokens).toBeUndefined();
+      expect(result[0].outputPer1kTokens).toBeUndefined();
+      expect(result[0].currency).toBeUndefined();
     });
   });
 
-  describe('getModelConfig', () => {
-    test('returns the stored config item', async () => {
+  describe("getModelConfig", () => {
+    test("returns the stored config item", async () => {
       dynamoMock.on(GetCommand).resolves({
         Item: {
-          scope: 'platform',
-          globalDefaultKey: 'vendor.model-standard',
+          scope: "platform",
+          globalDefaultKey: "vendor.model-standard",
           slotDefaults: {},
           orgDefaults: {},
           agentOverrides: {},
-          localityMode: 'regional_preferred',
+          localityMode: "regional_preferred",
         },
       });
 
-      const result = await handler(makeEvent('getModelConfig', { scope: 'platform' }));
+      const result = await handler(
+        makeEvent("getModelConfig", { scope: "platform" }),
+      );
 
-      expect(result.scope).toBe('platform');
-      expect(result.globalDefaultKey).toBe('vendor.model-standard');
-      expect(result.localityMode).toBe('regional_preferred');
+      expect(result.scope).toBe("platform");
+      expect(result.globalDefaultKey).toBe("vendor.model-standard");
+      expect(result.localityMode).toBe("regional_preferred");
     });
 
-    test('returns a default skeleton when absent', async () => {
+    test("returns a default skeleton when absent", async () => {
       dynamoMock.on(GetCommand).resolves({});
-      const result = await handler(makeEvent('getModelConfig', {}));
+      const result = await handler(makeEvent("getModelConfig", {}));
       expect(result).toEqual({
-        scope: 'platform',
+        scope: "platform",
         globalDefaultKey: null,
         slotDefaults: {},
         orgDefaults: {},
         agentOverrides: {},
-        localityMode: 'off',
+        localityMode: "off",
       });
     });
   });
 
-  describe('updateModelConfig', () => {
-    test('admin + enabled globalDefaultKey → puts, publishes, returns merged', async () => {
+  describe("updateModelConfig", () => {
+    test("admin + enabled globalDefaultKey → puts, publishes, returns merged", async () => {
       dynamoMock.on(ScanCommand).resolves({
-        Items: [catalogEntry('vendor.model-standard', 'enabled')],
+        Items: [catalogEntry("vendor.model-standard", "enabled")],
       });
       dynamoMock.on(GetCommand).resolves({}); // no existing config → skeleton
       dynamoMock.on(PutCommand).resolves({});
 
       const result = await handler(
         makeEvent(
-          'updateModelConfig',
-          { input: { globalDefaultKey: 'vendor.model-standard', localityMode: 'strict' } },
+          "updateModelConfig",
+          {
+            input: {
+              globalDefaultKey: "vendor.model-standard",
+              localityMode: "strict",
+            },
+          },
           adminIdentity,
         ),
       );
@@ -140,20 +192,20 @@ describe('model-config-resolver', () => {
       expect(dynamoMock.commandCalls(PutCommand)).toHaveLength(1);
       expect(mockPublishEvent).toHaveBeenCalledTimes(1);
       expect(mockPublishEvent.mock.calls[0][0]).toMatchObject({
-        eventType: 'model.config.changed',
-        projectId: 'platform',
+        eventType: "model.config.changed",
+        projectId: "platform",
       });
-      expect(result.globalDefaultKey).toBe('vendor.model-standard');
-      expect(result.localityMode).toBe('strict');
-      expect(result.updatedBy).toBe('admin-user');
+      expect(result.globalDefaultKey).toBe("vendor.model-standard");
+      expect(result.localityMode).toBe("strict");
+      expect(result.updatedBy).toBe("admin-user");
       expect(result.updatedAt).toBeDefined();
     });
 
-    test('validates every slotDefaults value against the catalog', async () => {
+    test("validates every slotDefaults value against the catalog", async () => {
       dynamoMock.on(ScanCommand).resolves({
         Items: [
-          catalogEntry('vendor.model-standard', 'enabled'),
-          catalogEntry('vendor.model-fast', 'enabled'),
+          catalogEntry("vendor.model-standard", "enabled"),
+          catalogEntry("vendor.model-fast", "enabled"),
         ],
       });
       dynamoMock.on(GetCommand).resolves({});
@@ -161,74 +213,93 @@ describe('model-config-resolver', () => {
 
       const result = await handler(
         makeEvent(
-          'updateModelConfig',
-          { input: { slotDefaults: { chat: 'vendor.model-standard', code: 'vendor.model-fast' } } },
+          "updateModelConfig",
+          {
+            input: {
+              slotDefaults: {
+                chat: "vendor.model-standard",
+                code: "vendor.model-fast",
+              },
+            },
+          },
           adminIdentity,
         ),
       );
 
       expect(result.slotDefaults).toEqual({
-        chat: 'vendor.model-standard',
-        code: 'vendor.model-fast',
+        chat: "vendor.model-standard",
+        code: "vendor.model-fast",
       });
       expect(dynamoMock.commandCalls(PutCommand)).toHaveLength(1);
     });
 
-    test('non-admin → throws Only administrators (no write)', async () => {
+    test("non-admin → throws Only administrators (no write)", async () => {
       await expect(
         handler(
           makeEvent(
-            'updateModelConfig',
-            { input: { globalDefaultKey: 'vendor.model-standard' } },
+            "updateModelConfig",
+            { input: { globalDefaultKey: "vendor.model-standard" } },
             nonAdminIdentity,
           ),
         ),
-      ).rejects.toThrow('Only administrators');
+      ).rejects.toThrow("Only administrators");
       expect(dynamoMock.commandCalls(PutCommand)).toHaveLength(0);
     });
 
-    test('globalDefaultKey not in catalog → throws Unknown model', async () => {
+    test("globalDefaultKey not in catalog → throws Unknown model", async () => {
       dynamoMock.on(ScanCommand).resolves({
-        Items: [catalogEntry('vendor.model-standard', 'enabled')],
-      });
-      await expect(
-        handler(
-          makeEvent('updateModelConfig', { input: { globalDefaultKey: 'vendor.missing' } }, adminIdentity),
-        ),
-      ).rejects.toThrow('Unknown model: vendor.missing');
-    });
-
-    test('disabled model → throws Model not enabled', async () => {
-      dynamoMock.on(ScanCommand).resolves({
-        Items: [catalogEntry('vendor.model-standard', 'disabled')],
+        Items: [catalogEntry("vendor.model-standard", "enabled")],
       });
       await expect(
         handler(
           makeEvent(
-            'updateModelConfig',
-            { input: { globalDefaultKey: 'vendor.model-standard' } },
+            "updateModelConfig",
+            { input: { globalDefaultKey: "vendor.missing" } },
             adminIdentity,
           ),
         ),
-      ).rejects.toThrow('Model not enabled: vendor.model-standard');
+      ).rejects.toThrow("Unknown model: vendor.missing");
     });
 
-    test('invalid localityMode → throws', async () => {
+    test("disabled model → throws Model not enabled", async () => {
+      dynamoMock.on(ScanCommand).resolves({
+        Items: [catalogEntry("vendor.model-standard", "disabled")],
+      });
       await expect(
-        handler(makeEvent('updateModelConfig', { input: { localityMode: 'bogus' } }, adminIdentity)),
-      ).rejects.toThrow('Invalid localityMode');
+        handler(
+          makeEvent(
+            "updateModelConfig",
+            { input: { globalDefaultKey: "vendor.model-standard" } },
+            adminIdentity,
+          ),
+        ),
+      ).rejects.toThrow("Model not enabled: vendor.model-standard");
+    });
+
+    test("invalid localityMode → throws", async () => {
+      await expect(
+        handler(
+          makeEvent(
+            "updateModelConfig",
+            { input: { localityMode: "bogus" } },
+            adminIdentity,
+          ),
+        ),
+      ).rejects.toThrow("Invalid localityMode");
     });
   });
 
-  describe('setModelCatalogEntryStatus', () => {
-    test('admin + valid status → puts, publishes, returns updated', async () => {
-      dynamoMock.on(GetCommand).resolves({ Item: catalogEntry('vendor.model-standard', 'enabled') });
+  describe("setModelCatalogEntryStatus", () => {
+    test("admin + valid status → puts, publishes, returns updated", async () => {
+      dynamoMock
+        .on(GetCommand)
+        .resolves({ Item: catalogEntry("vendor.model-standard", "enabled") });
       dynamoMock.on(PutCommand).resolves({});
 
       const result = await handler(
         makeEvent(
-          'setModelCatalogEntryStatus',
-          { modelKey: 'vendor.model-standard', status: 'disabled' },
+          "setModelCatalogEntryStatus",
+          { modelKey: "vendor.model-standard", status: "disabled" },
           adminIdentity,
         ),
       );
@@ -236,92 +307,98 @@ describe('model-config-resolver', () => {
       expect(dynamoMock.commandCalls(PutCommand)).toHaveLength(1);
       expect(mockPublishEvent).toHaveBeenCalledTimes(1);
       expect(mockPublishEvent.mock.calls[0][0]).toMatchObject({
-        eventType: 'model.config.changed',
-        projectId: 'catalog',
+        eventType: "model.config.changed",
+        projectId: "catalog",
       });
-      expect(result.status).toBe('disabled');
-      expect(result.modelKey).toBe('vendor.model-standard');
+      expect(result.status).toBe("disabled");
+      expect(result.modelKey).toBe("vendor.model-standard");
     });
 
-    test('admin via custom:role is also authorised', async () => {
-      dynamoMock.on(GetCommand).resolves({ Item: catalogEntry('vendor.model-standard', 'enabled') });
+    test("admin via custom:role is also authorised", async () => {
+      dynamoMock
+        .on(GetCommand)
+        .resolves({ Item: catalogEntry("vendor.model-standard", "enabled") });
       dynamoMock.on(PutCommand).resolves({});
 
       const result = await handler(
         makeEvent(
-          'setModelCatalogEntryStatus',
-          { modelKey: 'vendor.model-standard', status: 'deprecated' },
-          { username: 'role-admin', 'custom:role': 'admin' },
+          "setModelCatalogEntryStatus",
+          { modelKey: "vendor.model-standard", status: "deprecated" },
+          { username: "role-admin", "custom:role": "admin" },
         ),
       );
 
-      expect(result.status).toBe('deprecated');
+      expect(result.status).toBe("deprecated");
     });
 
-    test('invalid status → throws', async () => {
+    test("invalid status → throws", async () => {
       await expect(
         handler(
           makeEvent(
-            'setModelCatalogEntryStatus',
-            { modelKey: 'vendor.model-standard', status: 'bogus' },
+            "setModelCatalogEntryStatus",
+            { modelKey: "vendor.model-standard", status: "bogus" },
             adminIdentity,
           ),
         ),
-      ).rejects.toThrow('Invalid status');
+      ).rejects.toThrow("Invalid status");
     });
 
-    test('unknown modelKey → throws Unknown model', async () => {
+    test("unknown modelKey → throws Unknown model", async () => {
       dynamoMock.on(GetCommand).resolves({});
       await expect(
         handler(
           makeEvent(
-            'setModelCatalogEntryStatus',
-            { modelKey: 'vendor.missing', status: 'enabled' },
+            "setModelCatalogEntryStatus",
+            { modelKey: "vendor.missing", status: "enabled" },
             adminIdentity,
           ),
         ),
-      ).rejects.toThrow('Unknown model: vendor.missing');
+      ).rejects.toThrow("Unknown model: vendor.missing");
     });
 
-    test('non-admin → throws Only administrators (no write)', async () => {
+    test("non-admin → throws Only administrators (no write)", async () => {
       await expect(
         handler(
           makeEvent(
-            'setModelCatalogEntryStatus',
-            { modelKey: 'vendor.model-standard', status: 'enabled' },
+            "setModelCatalogEntryStatus",
+            { modelKey: "vendor.model-standard", status: "enabled" },
             nonAdminIdentity,
           ),
         ),
-      ).rejects.toThrow('Only administrators');
+      ).rejects.toThrow("Only administrators");
       expect(dynamoMock.commandCalls(PutCommand)).toHaveLength(0);
     });
   });
 
-  describe('syncModelCatalog', () => {
-    test('admin → publishes sync_requested and returns triggered', async () => {
-      const result = await handler(makeEvent('syncModelCatalog', {}, adminIdentity));
+  describe("syncModelCatalog", () => {
+    test("admin → publishes sync_requested and returns triggered", async () => {
+      const result = await handler(
+        makeEvent("syncModelCatalog", {}, adminIdentity),
+      );
 
       expect(mockPublishEvent).toHaveBeenCalledTimes(1);
       expect(mockPublishEvent.mock.calls[0][0]).toMatchObject({
-        eventType: 'model.catalog.sync_requested',
-        projectId: 'catalog',
-        payload: { requestedBy: 'admin-user' },
+        eventType: "model.catalog.sync_requested",
+        projectId: "catalog",
+        payload: { requestedBy: "admin-user" },
       });
       expect(result).toEqual({
         triggered: true,
-        message: 'Model catalog sync started',
+        message: "Model catalog sync started",
       });
     });
 
-    test('non-admin → throws and does not publish', async () => {
+    test("non-admin → throws and does not publish", async () => {
       await expect(
-        handler(makeEvent('syncModelCatalog', {}, nonAdminIdentity)),
-      ).rejects.toThrow('Only administrators can trigger a model catalog sync');
+        handler(makeEvent("syncModelCatalog", {}, nonAdminIdentity)),
+      ).rejects.toThrow("Only administrators can trigger a model catalog sync");
       expect(mockPublishEvent).not.toHaveBeenCalled();
     });
   });
 
-  test('throws on unknown field', async () => {
-    await expect(handler(makeEvent('unknownField', {}))).rejects.toThrow('Unknown field');
+  test("throws on unknown field", async () => {
+    await expect(handler(makeEvent("unknownField", {}))).rejects.toThrow(
+      "Unknown field",
+    );
   });
 });

--- a/backend/src/lambda/cost-budget-evaluator.ts
+++ b/backend/src/lambda/cost-budget-evaluator.ts
@@ -1,0 +1,270 @@
+/**
+ * Cost Budget Evaluator — scheduled Lambda (separate from
+ * cost-ledger-reconciler.ts: different purpose — budget breach vs token
+ * drift — and independent failure isolation; needs `events:PutEvents`,
+ * which the reconciler does not).
+ *
+ * Flow per run:
+ *  1. Enumerate every budget row across every org via a single
+ *     `Query GSI5PK='BUDGET'` on the sparse `BudgetIndex` — sparse because
+ *     GSI5PK/GSI5SK are written ONLY on budget rows, so this stays cheap
+ *     and never becomes a Scan as the ledger grows (binding: never Scan).
+ *  2. For each budget, compute period-to-date spend via a base-table Query
+ *     `PK=ORG#<org> AND SK BETWEEN :periodStartIso AND :nowIso`, summing
+ *     `costMicros` only where `priced===true` (unpriced rows are counted,
+ *     never summed — never fabricate a price).
+ *  3. Determine which thresholds are newly crossed relative to the
+ *     budget's `notified` map for the current periodKey.
+ *  4. Dedupe via an atomic conditional `UpdateItem`
+ *     (`notified.#pk` absent OR less than the new threshold). Only a
+ *     successful conditional write is followed by a publish — this is
+ *     what makes the notification exactly-once per (period, threshold)
+ *     even under concurrent/retried evaluator runs.
+ *
+ * FAILURE ISOLATION (binding): one budget's processing failure (a read
+ * error, a malformed row) is logged via `console.error` and the loop
+ * continues to the next budget — it never throws out of `evaluateBudgets`
+ * and never leaves a partial/corrupt write on the budget row it failed on
+ * (the conditional UpdateItem is all-or-nothing).
+ */
+
+import { DynamoDBClient } from "@aws-sdk/client-dynamodb";
+import {
+  DynamoDBDocumentClient,
+  QueryCommand,
+  UpdateCommand,
+} from "@aws-sdk/lib-dynamodb";
+
+import {
+  periodKeyFor,
+  periodStartIso,
+  crossedThresholds,
+  highestNotifiedThreshold,
+  shouldNotify,
+  type BudgetPeriodType,
+} from "./utils/cost-budget";
+import { emitBudgetEvent, type BudgetDetailType } from "./cost-notifier";
+
+const dynamoClient = new DynamoDBClient({});
+const docClient = DynamoDBDocumentClient.from(dynamoClient);
+
+const COST_LEDGER_TABLE = process.env.COST_LEDGER_TABLE!;
+
+interface BudgetIndexRow {
+  PK: string; // ORG#<orgId>
+  SK: string; // BUDGET#ORG | BUDGET#APP#<appId>
+  periodType: BudgetPeriodType;
+  limitMicros: number;
+  thresholds: number[];
+  currency: string;
+  notified?: Record<string, number>;
+}
+
+interface EvaluateOptions {
+  now?: Date;
+}
+
+function orgIdFromPk(pk: string): string {
+  return pk.replace(/^ORG#/, "");
+}
+
+function scopeFromSk(sk: string): string {
+  return sk === "BUDGET#ORG" ? "org" : `app:${sk.replace("BUDGET#APP#", "")}`;
+}
+
+/** Enumerates every budget row via the sparse BudgetIndex GSI. Never a Scan. */
+async function listAllBudgets(): Promise<BudgetIndexRow[]> {
+  const rows: BudgetIndexRow[] = [];
+  let exclusiveStartKey: Record<string, unknown> | undefined;
+
+  do {
+    const result = await docClient.send(
+      new QueryCommand({
+        TableName: COST_LEDGER_TABLE,
+        IndexName: "BudgetIndex",
+        KeyConditionExpression: "GSI5PK = :gsi5pk",
+        ExpressionAttributeValues: { ":gsi5pk": "BUDGET" },
+        ExclusiveStartKey: exclusiveStartKey,
+      }),
+    );
+    rows.push(...((result.Items ?? []) as BudgetIndexRow[]));
+    exclusiveStartKey = result.LastEvaluatedKey as
+      | Record<string, unknown>
+      | undefined;
+  } while (exclusiveStartKey);
+
+  return rows;
+}
+
+/** Period-to-date spend for one org, summing only priced rows. */
+async function periodToDateSpend(
+  orgId: string,
+  periodStart: string,
+  nowIso: string,
+): Promise<{ spentMicros: number; unpricedCount: number }> {
+  let spentMicros = 0;
+  let unpricedCount = 0;
+  let exclusiveStartKey: Record<string, unknown> | undefined;
+
+  do {
+    const result = await docClient.send(
+      new QueryCommand({
+        TableName: COST_LEDGER_TABLE,
+        KeyConditionExpression: "PK = :org AND SK BETWEEN :from AND :to",
+        ExpressionAttributeValues: {
+          ":org": `ORG#${orgId}`,
+          ":from": periodStart,
+          ":to": nowIso,
+        },
+        ExclusiveStartKey: exclusiveStartKey,
+      }),
+    );
+
+    for (const item of result.Items ?? []) {
+      const row = item as { costMicros?: number | null; priced?: boolean };
+      if (row.priced && typeof row.costMicros === "number") {
+        spentMicros += row.costMicros;
+      } else {
+        unpricedCount += 1;
+      }
+    }
+
+    exclusiveStartKey = result.LastEvaluatedKey as
+      | Record<string, unknown>
+      | undefined;
+  } while (exclusiveStartKey);
+
+  return { spentMicros, unpricedCount };
+}
+
+/**
+ * Atomic dedupe write: succeeds only if nothing has been notified for this
+ * period yet, or the previously notified threshold is lower than the new
+ * one. Returns true when the write succeeded (caller should publish);
+ * false when a concurrent/prior run already claimed this
+ * (period, threshold) — the ConditionalCheckFailedException is swallowed
+ * here, intentionally: it is the expected "someone else already notified"
+ * outcome, not an error.
+ */
+async function tryClaimNotification(
+  pk: string,
+  sk: string,
+  periodKey: string,
+  threshold: number,
+): Promise<boolean> {
+  try {
+    await docClient.send(
+      new UpdateCommand({
+        TableName: COST_LEDGER_TABLE,
+        Key: { PK: pk, SK: sk },
+        UpdateExpression: "SET notified.#pk = :t",
+        ExpressionAttributeNames: { "#pk": periodKey },
+        ExpressionAttributeValues: { ":t": threshold },
+        ConditionExpression:
+          "attribute_not_exists(notified) OR attribute_not_exists(notified.#pk) OR notified.#pk < :t",
+      }),
+    );
+    return true;
+  } catch (err: unknown) {
+    if (
+      err instanceof Error &&
+      err.name === "ConditionalCheckFailedException"
+    ) {
+      // intentional-empty-catch: expected outcome when a concurrent/prior
+      // run already claimed this (period, threshold) — not an error.
+      return false;
+    }
+    console.error("cost-budget-evaluator: dedupe UpdateItem failed", {
+      pk,
+      sk,
+      periodKey,
+      threshold,
+      error: err instanceof Error ? err.message : String(err),
+    });
+    return false;
+  }
+}
+
+async function evaluateOneBudget(
+  budget: BudgetIndexRow,
+  now: Date,
+): Promise<void> {
+  const orgId = orgIdFromPk(budget.PK);
+  const scope = scopeFromSk(budget.SK);
+  const periodKey = periodKeyFor(budget.periodType, now);
+  const periodStart = periodStartIso(budget.periodType, periodKey);
+
+  const { spentMicros } = await periodToDateSpend(
+    orgId,
+    periodStart,
+    now.toISOString(),
+  );
+
+  const crossed = crossedThresholds(
+    spentMicros,
+    budget.limitMicros,
+    budget.thresholds,
+  );
+  if (crossed.length === 0) return;
+
+  const highestCrossed = crossed[crossed.length - 1];
+  const lastNotified = highestNotifiedThreshold(
+    budget.notified ?? {},
+    periodKey,
+  );
+  if (!shouldNotify(lastNotified, highestCrossed)) return;
+
+  const claimed = await tryClaimNotification(
+    budget.PK,
+    budget.SK,
+    periodKey,
+    highestCrossed,
+  );
+  if (!claimed) return;
+
+  const detailType: BudgetDetailType =
+    highestCrossed >= 1.0
+      ? "cost.budget.breached"
+      : "cost.budget.threshold.crossed";
+
+  await emitBudgetEvent(detailType, {
+    orgId,
+    scope,
+    periodKey,
+    threshold: highestCrossed,
+    spentMicros,
+    limitMicros: budget.limitMicros,
+    currency: budget.currency,
+  });
+}
+
+/**
+ * Evaluates every budget across every org. Never throws out of this
+ * function — a single budget's failure is logged and the remaining
+ * budgets are still evaluated (failure isolation, per binding rules).
+ */
+export async function evaluateBudgets(
+  options: EvaluateOptions = {},
+): Promise<void> {
+  const now = options.now ?? new Date();
+  const budgets = await listAllBudgets();
+
+  for (const budget of budgets) {
+    try {
+      await evaluateOneBudget(budget, now);
+    } catch (err: unknown) {
+      console.error(
+        "cost-budget-evaluator: failed to evaluate budget, continuing with remaining budgets",
+        {
+          pk: budget.PK,
+          sk: budget.SK,
+          error: err instanceof Error ? err.message : String(err),
+        },
+      );
+    }
+  }
+}
+
+export const handler = async (): Promise<void> => {
+  await evaluateBudgets();
+};

--- a/backend/src/lambda/cost-ledger-reconciler.ts
+++ b/backend/src/lambda/cost-ledger-reconciler.ts
@@ -1,0 +1,588 @@
+/**
+ * Cost Ledger Reconciler — Lambda (Tier A aggregate drift, Tier B skeleton).
+ *
+ * Scheduled `rate(1 hour)` handler that compares aggregate ledger token
+ * totals against AWS/Bedrock CloudWatch token metrics, per model per
+ * hour-aligned window, and emits a drift metric. Per-row `estimate:true`
+ * is NEVER flipped by Tier A — an aggregate comparison cannot honestly
+ * produce a per-row actual. See `utils/cost-drift.ts` for the pure math
+ * and `utils/cost-reconciler-types.ts` for the row shapes.
+ *
+ * WATERMARK / IDEMPOTENCY (binding, per architect design):
+ *   State lives in the cost-ledger table itself as reserved meta rows under
+ *   `PK="RECON#COST"` (never colliding with `ORG#...` data rows):
+ *     - `SK="WATERMARK"` — single global monotonic watermark (scan-avoidance
+ *       optimization only).
+ *     - `SK="WINDOW#<startSec>"` — per-window marker. Its `PutItem` with
+ *       `ConditionExpression: attribute_not_exists(PK)` IS the idempotency
+ *       gate (writer's exact pattern) — a re-run of an already-marked
+ *       window is a strict no-op: no metric emit, no row annotation, no
+ *       watermark regression. The marker is written BEFORE emit/annotate so
+ *       a mid-window crash leaves the marker present and a re-run skips
+ *       cleanly (at-most-once emit; the marker already holds the durable
+ *       drift truth, so a missed CloudWatch emit on crash is acceptable and
+ *       back-fillable).
+ *
+ * ERROR ISOLATION: each window is processed in its own try/catch so one bad
+ * window (e.g. a transient Scan failure) never aborts the sweep. A failed
+ * `PutMetricData` call is logged and swallowed — never thrown — because the
+ * marker row (already durable) is the source of truth; the metric is a
+ * best-effort projection of it.
+ *
+ * A reconciler failure must never corrupt ledger rows: every mutation is a
+ * conditional `PutItem`/`UpdateItem` (read-modify-write via
+ * `attribute_not_exists`), never a blind overwrite.
+ */
+
+import { DynamoDBClient } from "@aws-sdk/client-dynamodb";
+import {
+  DynamoDBDocumentClient,
+  GetCommand,
+  PutCommand,
+  ScanCommand,
+  UpdateCommand,
+} from "@aws-sdk/lib-dynamodb";
+import {
+  CloudWatchClient,
+  GetMetricDataCommand,
+  PutMetricDataCommand,
+  StandardUnit,
+  type MetricDataQuery,
+  type MetricDataResult,
+  type MetricDatum,
+} from "@aws-sdk/client-cloudwatch";
+import {
+  alignToHour,
+  aggregateLedgerWindow,
+  computeDriftPct,
+  enumerateWindows,
+} from "./utils/cost-drift";
+import {
+  RECON_PK,
+  WATERMARK_SK,
+  windowSk,
+  type LedgerModelAggregate,
+  type LedgerRowProjection,
+  type LedgerWindowMarkerRow,
+  type ModelDriftEntry,
+  type ReconcilerWindow,
+  type TierBGateResult,
+  type WatermarkRow,
+} from "./utils/cost-reconciler-types";
+
+const dynamoClient = new DynamoDBClient({});
+const docClient = DynamoDBDocumentClient.from(dynamoClient);
+const cloudwatch = new CloudWatchClient({});
+
+const DEFAULT_SETTLE_LAG_MINUTES = 15;
+const DEFAULT_MAX_WINDOWS_PER_RUN = 6;
+const DEFAULT_METRIC_NAMESPACE = "Citadel/CostReconciler";
+const HOUR_SEC = 3600;
+
+function costLedgerTable(): string {
+  return process.env.COST_LEDGER_TABLE!;
+}
+
+function environment(): string {
+  return process.env.ENVIRONMENT ?? "dev";
+}
+
+function settleLagSec(): number {
+  const raw = Number(process.env.SETTLE_LAG_MINUTES);
+  const minutes =
+    Number.isFinite(raw) && raw >= 0 ? raw : DEFAULT_SETTLE_LAG_MINUTES;
+  return minutes * 60;
+}
+
+function maxWindowsPerRun(): number {
+  const raw = Number(process.env.MAX_WINDOWS_PER_RUN);
+  return Number.isFinite(raw) && raw > 0
+    ? Math.trunc(raw)
+    : DEFAULT_MAX_WINDOWS_PER_RUN;
+}
+
+function metricNamespace(): string {
+  return process.env.METRIC_NAMESPACE || DEFAULT_METRIC_NAMESPACE;
+}
+
+function tierBEnabled(): boolean {
+  return process.env.COST_RECONCILER_TIER_B_ENABLED === "true";
+}
+
+function isConditionalCheckFailed(err: unknown): boolean {
+  return err instanceof Error && err.name === "ConditionalCheckFailedException";
+}
+
+/** Reads the single global watermark row. Absent row => cold start (caller picks the default). */
+async function readWatermark(): Promise<number | undefined> {
+  try {
+    const result = await docClient.send(
+      new GetCommand({
+        TableName: costLedgerTable(),
+        Key: { PK: RECON_PK, SK: WATERMARK_SK },
+      }),
+    );
+    const item = result.Item as WatermarkRow | undefined;
+    return item && Number.isFinite(item.watermarkEpochSec)
+      ? item.watermarkEpochSec
+      : undefined;
+  } catch (err: unknown) {
+    console.error(
+      "cost-ledger-reconciler: watermark read failed, treating as cold start",
+      { error: err instanceof Error ? err.message : String(err) },
+    );
+    return undefined;
+  }
+}
+
+/** Scan+filter the ledger table for rows captured within `[startSec, endSec)`. Paginated. */
+async function scanLedgerWindow(
+  window: ReconcilerWindow,
+): Promise<LedgerRowProjection[]> {
+  const startIso = new Date(window.startSec * 1000).toISOString();
+  const endIso = new Date(window.endSec * 1000).toISOString();
+
+  const rows: LedgerRowProjection[] = [];
+  let exclusiveStartKey: Record<string, unknown> | undefined;
+
+  do {
+    const resp = await docClient.send(
+      new ScanCommand({
+        TableName: costLedgerTable(),
+        FilterExpression: "capturedAt >= :s AND capturedAt < :e",
+        ExpressionAttributeValues: { ":s": startIso, ":e": endIso },
+        ProjectionExpression:
+          "PK, SK, modelKey, modelId, inputTokens, outputTokens, capturedAt, bedrockRequestId, estimate",
+        ExclusiveStartKey: exclusiveStartKey,
+      }),
+    );
+    for (const item of (resp.Items ?? []) as LedgerRowProjection[]) {
+      rows.push(item);
+    }
+    exclusiveStartKey = resp.LastEvaluatedKey;
+  } while (exclusiveStartKey);
+
+  return rows;
+}
+
+/** Batches one GetMetricData call for all in-window models' Input/OutputTokenCount Sum. */
+async function fetchMetricAggregates(
+  models: Map<string, LedgerModelAggregate>,
+  window: ReconcilerWindow,
+): Promise<
+  Map<string, { inputTokens: number | null; outputTokens: number | null }>
+> {
+  const modelKeys = [...models.keys()];
+  const result = new Map<
+    string,
+    { inputTokens: number | null; outputTokens: number | null }
+  >();
+  if (modelKeys.length === 0) return result;
+
+  const startTime = new Date(window.startSec * 1000);
+  const endTime = new Date(window.endSec * 1000);
+
+  const queries: MetricDataQuery[] = [];
+  modelKeys.forEach((modelKey, idx) => {
+    const modelId = models.get(modelKey)!.modelId;
+    queries.push({
+      Id: `input_${idx}`,
+      MetricStat: {
+        Metric: {
+          Namespace: "AWS/Bedrock",
+          MetricName: "InputTokenCount",
+          Dimensions: [{ Name: "ModelId", Value: modelId }],
+        },
+        Period: HOUR_SEC,
+        Stat: "Sum",
+      },
+      ReturnData: true,
+    });
+    queries.push({
+      Id: `output_${idx}`,
+      MetricStat: {
+        Metric: {
+          Namespace: "AWS/Bedrock",
+          MetricName: "OutputTokenCount",
+          Dimensions: [{ Name: "ModelId", Value: modelId }],
+        },
+        Period: HOUR_SEC,
+        Stat: "Sum",
+      },
+      ReturnData: true,
+    });
+  });
+
+  let metricResults: MetricDataResult[] = [];
+  try {
+    const resp = await cloudwatch.send(
+      new GetMetricDataCommand({
+        MetricDataQueries: queries,
+        StartTime: startTime,
+        EndTime: endTime,
+      }),
+    );
+    metricResults = resp.MetricDataResults ?? [];
+  } catch (err: unknown) {
+    console.error(
+      "cost-ledger-reconciler: GetMetricData failed, treating all models as unmatched this window",
+      { error: err instanceof Error ? err.message : String(err) },
+    );
+    modelKeys.forEach((modelKey) =>
+      result.set(modelKey, { inputTokens: null, outputTokens: null }),
+    );
+    return result;
+  }
+
+  const byId = new Map(metricResults.map((r) => [r.Id, r]));
+
+  modelKeys.forEach((modelKey, idx) => {
+    const inputResult = byId.get(`input_${idx}`);
+    const outputResult = byId.get(`output_${idx}`);
+    const inputSum =
+      inputResult?.Values && inputResult.Values.length > 0
+        ? inputResult.Values.reduce((sum, v) => sum + v, 0)
+        : null;
+    const outputSum =
+      outputResult?.Values && outputResult.Values.length > 0
+        ? outputResult.Values.reduce((sum, v) => sum + v, 0)
+        : null;
+    result.set(modelKey, { inputTokens: inputSum, outputTokens: outputSum });
+  });
+
+  return result;
+}
+
+/** Builds the per-model drift entries. Never fabricates a match when metrics are absent. */
+function buildDriftEntries(
+  ledgerAgg: Map<string, LedgerModelAggregate>,
+  metricAgg: Map<
+    string,
+    { inputTokens: number | null; outputTokens: number | null }
+  >,
+): { entries: ModelDriftEntry[]; unmatchedCount: number } {
+  const entries: ModelDriftEntry[] = [];
+  let unmatchedCount = 0;
+
+  for (const [modelKey, ledger] of ledgerAgg) {
+    const metric = metricAgg.get(modelKey);
+    const metricInputTokens = metric?.inputTokens ?? null;
+    const metricOutputTokens = metric?.outputTokens ?? null;
+
+    const ledgerTotal = ledger.inputTokens + ledger.outputTokens;
+    const metricTotal =
+      metricInputTokens !== null && metricOutputTokens !== null
+        ? metricInputTokens + metricOutputTokens
+        : null;
+
+    const matched = metricTotal !== null;
+    if (!matched) unmatchedCount += 1;
+
+    entries.push({
+      modelKey,
+      modelId: ledger.modelId,
+      ledgerInputTokens: ledger.inputTokens,
+      ledgerOutputTokens: ledger.outputTokens,
+      metricInputTokens,
+      metricOutputTokens,
+      driftPct: matched
+        ? computeDriftPct(ledgerTotal, metricTotal as number)
+        : null,
+      match: matched ? "matched" : "metricsMissing",
+    });
+  }
+
+  return { entries, unmatchedCount };
+}
+
+/** Best-effort metric emission — logs and swallows any failure (marker is already durable). */
+async function emitMetrics(
+  entries: ModelDriftEntry[],
+  ledgerRowCount: number,
+  unmatchedModelCount: number,
+): Promise<void> {
+  const env = environment();
+  const namespace = metricNamespace();
+  const timestamp = new Date();
+
+  const metricData: MetricDatum[] = [];
+
+  for (const entry of entries) {
+    if (entry.match === "matched" && entry.driftPct !== null) {
+      metricData.push({
+        MetricName: "EstimateDriftPct",
+        Value: entry.driftPct,
+        Unit: StandardUnit.Percent,
+        Timestamp: timestamp,
+        Dimensions: [
+          { Name: "Environment", Value: env },
+          { Name: "ModelKey", Value: entry.modelKey },
+        ],
+      });
+    }
+    metricData.push({
+      MetricName: "LedgerTokens",
+      Value: entry.ledgerInputTokens + entry.ledgerOutputTokens,
+      Unit: StandardUnit.Count,
+      Timestamp: timestamp,
+      Dimensions: [
+        { Name: "Environment", Value: env },
+        { Name: "ModelKey", Value: entry.modelKey },
+      ],
+    });
+    if (entry.metricInputTokens !== null && entry.metricOutputTokens !== null) {
+      metricData.push({
+        MetricName: "MetricTokens",
+        Value: entry.metricInputTokens + entry.metricOutputTokens,
+        Unit: StandardUnit.Count,
+        Timestamp: timestamp,
+        Dimensions: [
+          { Name: "Environment", Value: env },
+          { Name: "ModelKey", Value: entry.modelKey },
+        ],
+      });
+    }
+  }
+
+  metricData.push({
+    MetricName: "UnmatchedLedgerModels",
+    Value: unmatchedModelCount,
+    Unit: StandardUnit.Count,
+    Timestamp: timestamp,
+    Dimensions: [{ Name: "Environment", Value: env }],
+  });
+  metricData.push({
+    MetricName: "WindowsReconciled",
+    Value: 1,
+    Unit: StandardUnit.Count,
+    Timestamp: timestamp,
+    Dimensions: [{ Name: "Environment", Value: env }],
+  });
+
+  const matchedDrifts = entries
+    .filter((e) => e.driftPct !== null)
+    .map((e) => Math.abs(e.driftPct as number));
+  if (matchedDrifts.length > 0) {
+    metricData.push({
+      MetricName: "AbsEstimateDriftPct",
+      Value: Math.max(...matchedDrifts),
+      Unit: StandardUnit.Percent,
+      Timestamp: timestamp,
+      Dimensions: [{ Name: "Environment", Value: env }],
+    });
+  }
+
+  void ledgerRowCount; // reserved for future cardinality metric; not emitted yet.
+
+  // PutMetricData batches are capped at 1000 data points; our per-window
+  // cardinality is bounded by distinct models, well under that.
+  try {
+    await cloudwatch.send(
+      new PutMetricDataCommand({
+        Namespace: namespace,
+        MetricData: metricData,
+      }),
+    );
+  } catch (err: unknown) {
+    console.error(
+      "cost-ledger-reconciler: PutMetricData failed, window marker already durable — continuing",
+      { error: err instanceof Error ? err.message : String(err) },
+    );
+  }
+}
+
+/** Annotates every ledger row in the window with driftCheckedAt. A vanished row is a logged no-op. */
+async function annotateRows(
+  rowKeys: Array<{ PK: string; SK: string }>,
+  checkedAt: string,
+): Promise<void> {
+  for (const key of rowKeys) {
+    try {
+      await docClient.send(
+        new UpdateCommand({
+          TableName: costLedgerTable(),
+          Key: key,
+          UpdateExpression: "SET driftCheckedAt = :checkedAt",
+          ConditionExpression: "attribute_exists(PK)",
+          ExpressionAttributeValues: { ":checkedAt": checkedAt },
+        }),
+      );
+    } catch (err: unknown) {
+      if (isConditionalCheckFailed(err)) {
+        console.log(
+          "cost-ledger-reconciler: row vanished before annotation, skipping",
+          { key },
+        );
+        continue;
+      }
+      console.error("cost-ledger-reconciler: row annotation failed, skipping", {
+        key,
+        error: err instanceof Error ? err.message : String(err),
+      });
+    }
+  }
+}
+
+/** Monotonic, only-forward watermark advance. Never regresses. */
+async function advanceWatermark(newWatermarkSec: number): Promise<void> {
+  try {
+    await docClient.send(
+      new UpdateCommand({
+        TableName: costLedgerTable(),
+        Key: { PK: RECON_PK, SK: WATERMARK_SK },
+        UpdateExpression: "SET watermarkEpochSec = :next, updatedAt = :now",
+        ConditionExpression:
+          "attribute_not_exists(watermarkEpochSec) OR watermarkEpochSec < :next",
+        ExpressionAttributeValues: {
+          ":next": newWatermarkSec,
+          ":now": new Date().toISOString(),
+        },
+      }),
+    );
+  } catch (err: unknown) {
+    if (isConditionalCheckFailed(err)) {
+      console.log(
+        "cost-ledger-reconciler: watermark already at or past this window's end, no-op",
+        { newWatermarkSec },
+      );
+      return;
+    }
+    console.error("cost-ledger-reconciler: watermark advance failed", {
+      newWatermarkSec,
+      error: err instanceof Error ? err.message : String(err),
+    });
+  }
+}
+
+/**
+ * Processes exactly one window: read-only aggregate compute, then a
+ * conditional marker write that gates everything downstream. Returns
+ * without throwing on any sub-step failure other than the initial Scan
+ * (whose failure propagates so the per-window try/catch in `handler` can
+ * isolate it from sibling windows).
+ */
+async function reconcileWindow(window: ReconcilerWindow): Promise<void> {
+  const ledgerRows = await scanLedgerWindow(window);
+  const ledgerAgg = aggregateLedgerWindow(ledgerRows);
+  const metricAgg = await fetchMetricAggregates(ledgerAgg, window);
+  const { entries, unmatchedCount } = buildDriftEntries(ledgerAgg, metricAgg);
+
+  const computedAt = new Date().toISOString();
+  const marker: LedgerWindowMarkerRow = {
+    PK: RECON_PK,
+    SK: windowSk(window.startSec),
+    windowStartEpochSec: window.startSec,
+    windowEndEpochSec: window.endSec,
+    computedAt,
+    tier: "A",
+    models: entries,
+    ledgerRowCount: ledgerRows.length,
+    unmatchedModelCount: unmatchedCount,
+  };
+
+  try {
+    await docClient.send(
+      new PutCommand({
+        TableName: costLedgerTable(),
+        Item: marker,
+        ConditionExpression: "attribute_not_exists(PK)",
+      }),
+    );
+  } catch (err: unknown) {
+    if (isConditionalCheckFailed(err)) {
+      console.log(
+        "cost-ledger-reconciler: window already reconciled, strict no-op",
+        { windowStartEpochSec: window.startSec },
+      );
+      return;
+    }
+    console.error("cost-ledger-reconciler: window marker write failed", {
+      windowStartEpochSec: window.startSec,
+      error: err instanceof Error ? err.message : String(err),
+    });
+    return;
+  }
+
+  // Marker created — safe to emit/annotate/advance. Best-effort from here.
+  await emitMetrics(entries, ledgerRows.length, unmatchedCount);
+
+  const allRowKeys = [...ledgerAgg.values()].flatMap((agg) => agg.rowKeys);
+  await annotateRows(allRowKeys, computedAt);
+
+  await advanceWatermark(window.endSec);
+
+  if (tierBEnabled()) {
+    const gate = await tierBReconcile(window, ledgerAgg);
+    if (!gate.active) {
+      console.warn(
+        `cost-ledger-reconciler: Tier B gate inactive (${gate.reason})`,
+        { windowStartEpochSec: window.startSec },
+      );
+    }
+  }
+}
+
+/**
+ * Tier B skeleton (feature-flagged OFF). Ships the gate + signature + the
+ * inactive log path only — NOT the log-parsing/matching logic described in
+ * the design's follow-ups. Never throws, never mutates a ledger row.
+ */
+export async function tierBReconcile(
+  _window: ReconcilerWindow,
+  ledgerAgg: Map<string, LedgerModelAggregate>,
+): Promise<TierBGateResult> {
+  if (!tierBEnabled()) {
+    console.debug("cost-ledger-reconciler: Tier B disabled, skipping");
+    return { active: false, reason: "disabled" };
+  }
+
+  // Tier B is inert today because no ledger row carries a bedrockRequestId
+  // (upstream capture change is out of scope — follow-up). We check the
+  // in-window aggregate for any row that would plausibly carry one; today
+  // that is always none, by construction of `aggregateLedgerWindow`'s
+  // input shape.
+  void ledgerAgg;
+  console.warn(
+    "cost-ledger-reconciler: Tier B enabled but ledger rows carry no bedrockRequestId; " +
+      "per-row upgrade requires upstream capture (follow-up). Skipping.",
+  );
+  return { active: false, reason: "missing_requestId" };
+}
+
+export const handler = async (): Promise<{ windowsProcessed: number }> => {
+  const nowSec = Math.floor(Date.now() / 1000);
+  const targetEnd = alignToHour(nowSec - settleLagSec());
+
+  const watermark = await readWatermark();
+  // Cold start: reconcile exactly the single most-recent closed window.
+  const effectiveWatermark = watermark ?? alignToHour(nowSec) - HOUR_SEC;
+
+  const windows = enumerateWindows(
+    effectiveWatermark,
+    targetEnd,
+    maxWindowsPerRun(),
+  );
+  console.log("cost-ledger-reconciler: windows to process", {
+    count: windows.length,
+    watermark: effectiveWatermark,
+    targetEnd,
+  });
+
+  let processed = 0;
+  for (const window of windows) {
+    try {
+      await reconcileWindow(window);
+      processed += 1;
+    } catch (err: unknown) {
+      console.error(
+        "cost-ledger-reconciler: window processing error, continuing sweep",
+        {
+          windowStartEpochSec: window.startSec,
+          error: err instanceof Error ? err.message : String(err),
+        },
+      );
+    }
+  }
+
+  return { windowsProcessed: processed };
+};

--- a/backend/src/lambda/cost-ledger-writer.ts
+++ b/backend/src/lambda/cost-ledger-writer.ts
@@ -1,0 +1,400 @@
+/**
+ * Cost Ledger Writer — Lambda
+ *
+ * Pass 1 (usage-only, no pricing yet): consumes 3 EventBridge event shapes
+ * (task.completion, agent_intake.usage/intake.usage.captured,
+ * citadel.workflows/workflow.node.completed), applies the dedupe rule, and
+ * writes idempotent usage rows to the cost-ledger table.
+ *
+ * DEDUPE RULE (binding, per architect design):
+ *   - `workflow.node.completed` is authoritative for ALL workflow-node model
+ *     calls.
+ *   - `task.completion` is authoritative ONLY for standalone (non-workflow)
+ *     worker tasks. If a task.completion event carries workflow correlation
+ *     (`workflowExecutionId`/`nodeId`), it is DROPPED — the node.completed
+ *     event owns those calls.
+ *   - `intake.usage.captured` is unique (intake runtime) — always authoritative.
+ *
+ * IDEMPOTENCY: `PutCommand` with `ConditionExpression: attribute_not_exists(PK)`.
+ * `ConditionalCheckFailedException` is swallowed (logged at debug) — every
+ * other error is logged and rethrown so EventBridge retry/DLQ semantics apply.
+ *
+ * No pricing/cost math this pass: rows are written with `priced: false`,
+ * `tokenCost: null`, `costMicros: null`, `estimate: true`.
+ */
+
+import { DynamoDBClient } from "@aws-sdk/client-dynamodb";
+import { DynamoDBDocumentClient, PutCommand } from "@aws-sdk/lib-dynamodb";
+import type { EventBridgeEvent } from "aws-lambda";
+
+const dynamoClient = new DynamoDBClient({});
+const docClient = DynamoDBDocumentClient.from(dynamoClient);
+
+const COST_LEDGER_TABLE = process.env.COST_LEDGER_TABLE!;
+
+/** Thrown internally to make the conditional-check-failed branch explicit and testable. */
+export class ConditionalCheckFailedError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "ConditionalCheckFailedError";
+  }
+}
+
+/**
+ * Usage record schema — TS mirror of `arbiter/common/usage.py`'s
+ * `UsageRecord` dict. Numeric fields are defensively coerced; never trust
+ * an event payload blindly (it crossed a process/event boundary).
+ */
+export interface UsageRecord {
+  modelId?: string;
+  inputTokens?: unknown;
+  outputTokens?: unknown;
+  totalTokens?: unknown;
+  latencyMs?: unknown;
+  callIndex?: unknown;
+  capturedAt?: string;
+  source?: "worker" | "supervisor" | "intake" | "workflow_node";
+}
+
+interface TaskCompletionDetail {
+  taskId?: string;
+  orgId?: string;
+  projectId?: string;
+  appId?: string;
+  agentId?: string;
+  workflowExecutionId?: string;
+  nodeId?: string;
+  usage?: UsageRecord[];
+}
+
+interface IntakeUsageDetail {
+  orgId?: string;
+  projectId?: string;
+  appId?: string;
+  agentId?: string;
+  usage?: UsageRecord | UsageRecord[];
+}
+
+interface WorkflowNodeCompletedDetail {
+  orgId?: string;
+  projectId?: string;
+  appId?: string;
+  agentId?: string;
+  workflowExecutionId?: string;
+  nodeId?: string;
+  usage?: UsageRecord[];
+}
+
+export type IncomingDetail =
+  | TaskCompletionDetail
+  | IntakeUsageDetail
+  | WorkflowNodeCompletedDetail;
+
+/** Non-negative-int coercion mirroring `usage.py`'s `_coerce_non_negative_int`. Never throws. */
+function coerceNonNegativeInt(value: unknown): number {
+  if (typeof value === "boolean") return value ? 1 : 0;
+  if (typeof value === "number") {
+    if (Number.isNaN(value) || !Number.isFinite(value)) return 0;
+    return Math.max(0, Math.trunc(value));
+  }
+  if (typeof value === "string") {
+    const parsed = Number.parseFloat(value.trim());
+    if (Number.isNaN(parsed)) return 0;
+    return Math.max(0, Math.trunc(parsed));
+  }
+  return 0;
+}
+
+/** Sanitize an arbitrary value into an array of usage-record-shaped dicts. */
+function parseUsageArray(raw: unknown): UsageRecord[] {
+  if (Array.isArray(raw)) {
+    return raw.filter(
+      (entry): entry is UsageRecord =>
+        typeof entry === "object" && entry !== null,
+    );
+  }
+  if (typeof raw === "object" && raw !== null) {
+    return [raw as UsageRecord];
+  }
+  return [];
+}
+
+interface Dimensions {
+  orgId?: string;
+  projectId?: string;
+  appId?: string;
+  agentId?: string;
+  workflowExecutionId?: string;
+  nodeId?: string;
+}
+
+interface LedgerRow {
+  PK: string;
+  SK: string;
+  ledgerId: string;
+  eventId: string;
+  callIndex: number;
+  orgId: string;
+  projectId?: string;
+  appId?: string;
+  agentId?: string;
+  workflowExecutionId?: string;
+  nodeId?: string;
+  modelId: string;
+  source: string;
+  inputTokens: number;
+  outputTokens: number;
+  totalTokens: number;
+  latencyMs: number;
+  capturedAt: string;
+  ingestedAt: string;
+  // Pricing fields: intentionally null/false this pass — populated in pass 2.
+  currency: null;
+  tokenCost: null;
+  costMicros: null;
+  priced: false;
+  decomposition: null;
+  estimate: true;
+  schemaVersion: 1;
+  // Sparse GSI keys — present only when the dimension is present.
+  GSI1PK?: string;
+  GSI1SK?: string;
+  GSI2PK?: string;
+  GSI2SK?: string;
+  GSI3PK?: string;
+  GSI3SK?: string;
+  GSI4PK?: string;
+  GSI4SK?: string;
+}
+
+/** Builds one idempotent ledger row from a usage record + shared dimensions. */
+function buildLedgerRow(
+  eventId: string,
+  callIndex: number,
+  usage: UsageRecord,
+  dims: Dimensions,
+  source: string,
+  ingestedAt: string,
+): LedgerRow {
+  const capturedAt = usage.capturedAt || ingestedAt;
+  const orgId = dims.orgId && dims.orgId.length > 0 ? dims.orgId : "UNKNOWN";
+  const ledgerId = `${eventId}:${callIndex}`;
+  const inputTokens = coerceNonNegativeInt(usage.inputTokens);
+  const outputTokens = coerceNonNegativeInt(usage.outputTokens);
+  const totalTokens =
+    usage.totalTokens !== undefined
+      ? coerceNonNegativeInt(usage.totalTokens)
+      : inputTokens + outputTokens;
+
+  const row: LedgerRow = {
+    PK: `ORG#${orgId}`,
+    SK: `${capturedAt}#${ledgerId}`,
+    ledgerId,
+    eventId,
+    callIndex,
+    orgId,
+    modelId:
+      typeof usage.modelId === "string" && usage.modelId ? usage.modelId : "",
+    source,
+    inputTokens,
+    outputTokens,
+    totalTokens,
+    latencyMs: coerceNonNegativeInt(usage.latencyMs),
+    capturedAt,
+    ingestedAt,
+    currency: null,
+    tokenCost: null,
+    costMicros: null,
+    priced: false,
+    decomposition: null,
+    estimate: true,
+    schemaVersion: 1,
+  };
+
+  if (dims.projectId) {
+    row.projectId = dims.projectId;
+    row.GSI1PK = `PROJECT#${dims.projectId}`;
+    row.GSI1SK = `${capturedAt}#${ledgerId}`;
+  }
+  if (dims.appId) {
+    row.appId = dims.appId;
+    row.GSI2PK = `APP#${dims.appId}`;
+    row.GSI2SK = `${capturedAt}#${ledgerId}`;
+  }
+  if (dims.agentId) {
+    row.agentId = dims.agentId;
+    row.GSI3PK = `AGENT#${dims.agentId}`;
+    row.GSI3SK = `${capturedAt}#${ledgerId}`;
+  }
+  if (dims.workflowExecutionId) {
+    row.workflowExecutionId = dims.workflowExecutionId;
+    if (dims.nodeId) row.nodeId = dims.nodeId;
+    row.GSI4PK = `WORKFLOW#${dims.workflowExecutionId}`;
+    row.GSI4SK = `${capturedAt}#${dims.nodeId || ""}#${ledgerId}`;
+  }
+
+  return row;
+}
+
+/** Idempotent conditional write. Swallows ONLY ConditionalCheckFailedException. */
+async function writeLedgerRow(row: LedgerRow): Promise<void> {
+  try {
+    await docClient.send(
+      new PutCommand({
+        TableName: COST_LEDGER_TABLE,
+        Item: row,
+        ConditionExpression: "attribute_not_exists(PK)",
+      }),
+    );
+  } catch (err: unknown) {
+    if (
+      err instanceof Error &&
+      err.name === "ConditionalCheckFailedException"
+    ) {
+      console.debug(
+        `cost-ledger-writer: duplicate delivery skipped, ledgerId=${row.ledgerId}`,
+      );
+      return;
+    }
+    console.error(
+      "cost-ledger-writer: write failed, rethrowing for retry/DLQ",
+      {
+        ledgerId: row.ledgerId,
+        error: err instanceof Error ? err.message : String(err),
+      },
+    );
+    throw err;
+  }
+}
+
+function handleTaskCompletion(
+  eventId: string,
+  detail: TaskCompletionDetail,
+  ingestedAt: string,
+): LedgerRow[] {
+  // DEDUPE RULE: task.completion carrying workflow correlation is owned by
+  // workflow.node.completed — drop it to avoid double-billing.
+  if (detail.workflowExecutionId && detail.nodeId) {
+    console.debug(
+      `cost-ledger-writer: dropping task.completion with workflow correlation (owned by node.completed), taskId=${detail.taskId}`,
+    );
+    return [];
+  }
+
+  const usageRecords = parseUsageArray(detail.usage);
+  const dims: Dimensions = {
+    orgId: detail.orgId,
+    projectId: detail.projectId,
+    appId: detail.appId,
+    agentId: detail.agentId,
+  };
+
+  return usageRecords.map((usage, idx) =>
+    buildLedgerRow(
+      eventId,
+      coerceNonNegativeInt(usage.callIndex) || idx,
+      usage,
+      dims,
+      usage.source || "worker",
+      ingestedAt,
+    ),
+  );
+}
+
+function handleIntakeUsage(
+  eventId: string,
+  detail: IntakeUsageDetail,
+  ingestedAt: string,
+): LedgerRow[] {
+  const usageRecords = parseUsageArray(detail.usage);
+  const dims: Dimensions = {
+    orgId: detail.orgId,
+    projectId: detail.projectId,
+    appId: detail.appId,
+    agentId: detail.agentId,
+  };
+
+  return usageRecords.map((usage, idx) =>
+    buildLedgerRow(
+      eventId,
+      coerceNonNegativeInt(usage.callIndex) || idx,
+      usage,
+      dims,
+      "intake",
+      ingestedAt,
+    ),
+  );
+}
+
+function handleWorkflowNodeCompleted(
+  eventId: string,
+  detail: WorkflowNodeCompletedDetail,
+  ingestedAt: string,
+): LedgerRow[] {
+  const usageRecords = parseUsageArray(detail.usage);
+  const dims: Dimensions = {
+    orgId: detail.orgId,
+    projectId: detail.projectId,
+    appId: detail.appId,
+    agentId: detail.agentId,
+    workflowExecutionId: detail.workflowExecutionId,
+    nodeId: detail.nodeId,
+  };
+
+  return usageRecords.map((usage, idx) =>
+    buildLedgerRow(
+      eventId,
+      coerceNonNegativeInt(usage.callIndex) || idx,
+      usage,
+      dims,
+      "workflow_node",
+      ingestedAt,
+    ),
+  );
+}
+
+export const handler = async (
+  event: EventBridgeEvent<string, IncomingDetail>,
+): Promise<void> => {
+  const eventId = event.id || `no-id-${Date.now()}`;
+  const detailType = event["detail-type"];
+  const source = event.source;
+  const ingestedAt = new Date().toISOString();
+
+  let rows: LedgerRow[];
+
+  if (source === "task.completion" && detailType === "task.completion") {
+    rows = handleTaskCompletion(
+      eventId,
+      event.detail as TaskCompletionDetail,
+      ingestedAt,
+    );
+  } else if (
+    source === "agent_intake.usage" &&
+    detailType === "intake.usage.captured"
+  ) {
+    rows = handleIntakeUsage(
+      eventId,
+      event.detail as IntakeUsageDetail,
+      ingestedAt,
+    );
+  } else if (
+    source === "citadel.workflows" &&
+    detailType === "workflow.node.completed"
+  ) {
+    rows = handleWorkflowNodeCompleted(
+      eventId,
+      event.detail as WorkflowNodeCompletedDetail,
+      ingestedAt,
+    );
+  } else {
+    console.error(
+      `cost-ledger-writer: unrecognized event shape, source=${source}, detailType=${detailType}`,
+    );
+    return;
+  }
+
+  for (const row of rows) {
+    await writeLedgerRow(row);
+  }
+};

--- a/backend/src/lambda/cost-ledger-writer.ts
+++ b/backend/src/lambda/cost-ledger-writer.ts
@@ -1,10 +1,11 @@
 /**
  * Cost Ledger Writer — Lambda
  *
- * Pass 1 (usage-only, no pricing yet): consumes 3 EventBridge event shapes
- * (task.completion, agent_intake.usage/intake.usage.captured,
- * citadel.workflows/workflow.node.completed), applies the dedupe rule, and
- * writes idempotent usage rows to the cost-ledger table.
+ * Consumes 3 EventBridge event shapes (task.completion,
+ * agent_intake.usage/intake.usage.captured, citadel.workflows/
+ * workflow.node.completed), applies the dedupe rule, resolves per-row
+ * pricing from the model-catalog table, computes cost, and writes
+ * idempotent rows to the cost-ledger table.
  *
  * DEDUPE RULE (binding, per architect design):
  *   - `workflow.node.completed` is authoritative for ALL workflow-node model
@@ -19,18 +20,43 @@
  * `ConditionalCheckFailedException` is swallowed (logged at debug) — every
  * other error is logged and rethrown so EventBridge retry/DLQ semantics apply.
  *
- * No pricing/cost math this pass: rows are written with `priced: false`,
- * `tokenCost: null`, `costMicros: null`, `estimate: true`.
+ * PRICING / COST (pass 2): for each usage record, the modelId is resolved to
+ * a catalog `modelKey` (same slug logic as `model-catalog-sync.ts`) and a
+ * `GetItem` reads pricing from the model-catalog table. `cost-compute.ts`'s
+ * pure `computeTokenCost` turns tokens + pricing into `tokenCost`/`costMicros`.
+ *
+ * UNPRICED POLICY (never fabricate a price): if the catalog row is missing,
+ * OR present but lacking `inputPer1kTokens`/`outputPer1kTokens`/`currency`,
+ * OR the catalog read itself fails (transient DynamoDB error), the row is
+ * STILL WRITTEN with `priced:false`, `tokenCost:null`, `costMicros:null`,
+ * an `unpricedReason`, and a `console.warn`/`console.error` — a catalog-read
+ * failure must never drop a ledger row.
+ *
+ * DECOMPOSITION: `tokenCost` is populated (or null when unpriced);
+ * `compute`/`idle`/`memory` are always null this pass (AgentCore split is
+ * deferred to the reconciler story), with `runtimeComponentsPending:true`.
+ * Every row carries `estimate:true`.
  */
 
 import { DynamoDBClient } from "@aws-sdk/client-dynamodb";
-import { DynamoDBDocumentClient, PutCommand } from "@aws-sdk/lib-dynamodb";
+import {
+  DynamoDBDocumentClient,
+  GetCommand,
+  PutCommand,
+} from "@aws-sdk/lib-dynamodb";
 import type { EventBridgeEvent } from "aws-lambda";
+import { modelKeyFromId } from "./model-catalog-sync";
+import {
+  computeTokenCost,
+  type PricingInfo,
+  type UnpricedReason,
+} from "./utils/cost-compute";
 
 const dynamoClient = new DynamoDBClient({});
 const docClient = DynamoDBDocumentClient.from(dynamoClient);
 
 const COST_LEDGER_TABLE = process.env.COST_LEDGER_TABLE!;
+const MODEL_CATALOG_TABLE = process.env.MODEL_CATALOG_TABLE!;
 
 /** Thrown internally to make the conditional-check-failed branch explicit and testable. */
 export class ConditionalCheckFailedError extends Error {
@@ -128,6 +154,15 @@ interface Dimensions {
   nodeId?: string;
 }
 
+interface Decomposition {
+  currency: string | null;
+  tokenCost: number | null;
+  compute: null;
+  idle: null;
+  memory: null;
+  runtimeComponentsPending: true;
+}
+
 interface LedgerRow {
   PK: string;
   SK: string;
@@ -141,6 +176,7 @@ interface LedgerRow {
   workflowExecutionId?: string;
   nodeId?: string;
   modelId: string;
+  modelKey: string;
   source: string;
   inputTokens: number;
   outputTokens: number;
@@ -148,12 +184,14 @@ interface LedgerRow {
   latencyMs: number;
   capturedAt: string;
   ingestedAt: string;
-  // Pricing fields: intentionally null/false this pass — populated in pass 2.
-  currency: null;
-  tokenCost: null;
-  costMicros: null;
-  priced: false;
-  decomposition: null;
+  // Pricing fields (pass 2): populated when the catalog row resolves to a
+  // usable price; null + unpricedReason when it does not.
+  currency: string | null;
+  tokenCost: number | null;
+  costMicros: number | null;
+  priced: boolean;
+  unpricedReason?: UnpricedReason;
+  decomposition: Decomposition;
   estimate: true;
   schemaVersion: 1;
   // Sparse GSI keys — present only when the dimension is present.
@@ -167,15 +205,89 @@ interface LedgerRow {
   GSI4SK?: string;
 }
 
+/** Shape of the catalog row fields this writer reads — a narrow, defensive view. */
+interface CatalogPricingRow {
+  inputPer1kTokens?: unknown;
+  outputPer1kTokens?: unknown;
+  currency?: unknown;
+}
+
+/**
+ * Resolves pricing for a raw modelId via the model-catalog table.
+ *
+ * NEVER throws and NEVER drops the caller's row: a missing row, a row
+ * without usable pricing, or a transient DynamoDB read failure all resolve
+ * to `{pricing: undefined, reason}` — the caller (buildLedgerRow) passes
+ * that straight into `computeTokenCost`, which produces the unpriced shape.
+ * A catalog-read failure is logged at `error`; a missing/unpriced row is
+ * logged at `warn` (per design: "unpriced rows still written + warn log").
+ */
+async function resolvePricing(
+  modelId: string,
+): Promise<{
+  pricing: PricingInfo | undefined;
+  reason: UnpricedReason;
+  modelKey: string;
+}> {
+  const modelKey = modelId ? modelKeyFromId(modelId) : "";
+
+  let item: CatalogPricingRow | undefined;
+  try {
+    const result = await docClient.send(
+      new GetCommand({
+        TableName: MODEL_CATALOG_TABLE,
+        Key: { modelKey },
+      }),
+    );
+    item = result.Item as CatalogPricingRow | undefined;
+  } catch (err: unknown) {
+    console.error(
+      "cost-ledger-writer: model-catalog read failed; writing row unpriced (never dropped)",
+      { modelKey, error: err instanceof Error ? err.message : String(err) },
+    );
+    return { pricing: undefined, reason: "pricing_absent", modelKey };
+  }
+
+  if (!item) {
+    console.warn(
+      `cost-ledger-writer: modelKey not found in catalog, writing unpriced row: ${modelKey}`,
+    );
+    return { pricing: undefined, reason: "model_not_in_catalog", modelKey };
+  }
+
+  const usable =
+    typeof item.inputPer1kTokens === "number" &&
+    typeof item.outputPer1kTokens === "number" &&
+    typeof item.currency === "string" &&
+    item.currency.length > 0;
+
+  if (!usable) {
+    console.warn(
+      `cost-ledger-writer: catalog row for ${modelKey} has no usable pricing, writing unpriced row`,
+    );
+    return { pricing: undefined, reason: "pricing_absent", modelKey };
+  }
+
+  return {
+    pricing: {
+      inputPer1kTokens: item.inputPer1kTokens as number,
+      outputPer1kTokens: item.outputPer1kTokens as number,
+      currency: item.currency as string,
+    },
+    reason: "pricing_absent", // unused when pricing is defined
+    modelKey,
+  };
+}
+
 /** Builds one idempotent ledger row from a usage record + shared dimensions. */
-function buildLedgerRow(
+async function buildLedgerRow(
   eventId: string,
   callIndex: number,
   usage: UsageRecord,
   dims: Dimensions,
   source: string,
   ingestedAt: string,
-): LedgerRow {
+): Promise<LedgerRow> {
   const capturedAt = usage.capturedAt || ingestedAt;
   const orgId = dims.orgId && dims.orgId.length > 0 ? dims.orgId : "UNKNOWN";
   const ledgerId = `${eventId}:${callIndex}`;
@@ -186,6 +298,21 @@ function buildLedgerRow(
       ? coerceNonNegativeInt(usage.totalTokens)
       : inputTokens + outputTokens;
 
+  const modelId =
+    typeof usage.modelId === "string" && usage.modelId ? usage.modelId : "";
+
+  const { pricing, reason, modelKey } = await resolvePricing(modelId);
+  const cost = computeTokenCost(inputTokens, outputTokens, pricing, reason);
+
+  const decomposition: Decomposition = {
+    currency: cost.currency,
+    tokenCost: cost.tokenCost,
+    compute: null,
+    idle: null,
+    memory: null,
+    runtimeComponentsPending: true,
+  };
+
   const row: LedgerRow = {
     PK: `ORG#${orgId}`,
     SK: `${capturedAt}#${ledgerId}`,
@@ -193,8 +320,8 @@ function buildLedgerRow(
     eventId,
     callIndex,
     orgId,
-    modelId:
-      typeof usage.modelId === "string" && usage.modelId ? usage.modelId : "",
+    modelId,
+    modelKey,
     source,
     inputTokens,
     outputTokens,
@@ -202,14 +329,18 @@ function buildLedgerRow(
     latencyMs: coerceNonNegativeInt(usage.latencyMs),
     capturedAt,
     ingestedAt,
-    currency: null,
-    tokenCost: null,
-    costMicros: null,
-    priced: false,
-    decomposition: null,
+    currency: cost.currency,
+    tokenCost: cost.tokenCost,
+    costMicros: cost.costMicros,
+    priced: cost.priced,
+    decomposition,
     estimate: true,
     schemaVersion: 1,
   };
+
+  if (!cost.priced && cost.unpricedReason) {
+    row.unpricedReason = cost.unpricedReason;
+  }
 
   if (dims.projectId) {
     row.projectId = dims.projectId;
@@ -267,11 +398,11 @@ async function writeLedgerRow(row: LedgerRow): Promise<void> {
   }
 }
 
-function handleTaskCompletion(
+async function handleTaskCompletion(
   eventId: string,
   detail: TaskCompletionDetail,
   ingestedAt: string,
-): LedgerRow[] {
+): Promise<LedgerRow[]> {
   // DEDUPE RULE: task.completion carrying workflow correlation is owned by
   // workflow.node.completed — drop it to avoid double-billing.
   if (detail.workflowExecutionId && detail.nodeId) {
@@ -289,23 +420,25 @@ function handleTaskCompletion(
     agentId: detail.agentId,
   };
 
-  return usageRecords.map((usage, idx) =>
-    buildLedgerRow(
-      eventId,
-      coerceNonNegativeInt(usage.callIndex) || idx,
-      usage,
-      dims,
-      usage.source || "worker",
-      ingestedAt,
+  return Promise.all(
+    usageRecords.map((usage, idx) =>
+      buildLedgerRow(
+        eventId,
+        coerceNonNegativeInt(usage.callIndex) || idx,
+        usage,
+        dims,
+        usage.source || "worker",
+        ingestedAt,
+      ),
     ),
   );
 }
 
-function handleIntakeUsage(
+async function handleIntakeUsage(
   eventId: string,
   detail: IntakeUsageDetail,
   ingestedAt: string,
-): LedgerRow[] {
+): Promise<LedgerRow[]> {
   const usageRecords = parseUsageArray(detail.usage);
   const dims: Dimensions = {
     orgId: detail.orgId,
@@ -314,23 +447,25 @@ function handleIntakeUsage(
     agentId: detail.agentId,
   };
 
-  return usageRecords.map((usage, idx) =>
-    buildLedgerRow(
-      eventId,
-      coerceNonNegativeInt(usage.callIndex) || idx,
-      usage,
-      dims,
-      "intake",
-      ingestedAt,
+  return Promise.all(
+    usageRecords.map((usage, idx) =>
+      buildLedgerRow(
+        eventId,
+        coerceNonNegativeInt(usage.callIndex) || idx,
+        usage,
+        dims,
+        "intake",
+        ingestedAt,
+      ),
     ),
   );
 }
 
-function handleWorkflowNodeCompleted(
+async function handleWorkflowNodeCompleted(
   eventId: string,
   detail: WorkflowNodeCompletedDetail,
   ingestedAt: string,
-): LedgerRow[] {
+): Promise<LedgerRow[]> {
   const usageRecords = parseUsageArray(detail.usage);
   const dims: Dimensions = {
     orgId: detail.orgId,
@@ -341,14 +476,16 @@ function handleWorkflowNodeCompleted(
     nodeId: detail.nodeId,
   };
 
-  return usageRecords.map((usage, idx) =>
-    buildLedgerRow(
-      eventId,
-      coerceNonNegativeInt(usage.callIndex) || idx,
-      usage,
-      dims,
-      "workflow_node",
-      ingestedAt,
+  return Promise.all(
+    usageRecords.map((usage, idx) =>
+      buildLedgerRow(
+        eventId,
+        coerceNonNegativeInt(usage.callIndex) || idx,
+        usage,
+        dims,
+        "workflow_node",
+        ingestedAt,
+      ),
     ),
   );
 }
@@ -364,7 +501,7 @@ export const handler = async (
   let rows: LedgerRow[];
 
   if (source === "task.completion" && detailType === "task.completion") {
-    rows = handleTaskCompletion(
+    rows = await handleTaskCompletion(
       eventId,
       event.detail as TaskCompletionDetail,
       ingestedAt,
@@ -373,7 +510,7 @@ export const handler = async (
     source === "agent_intake.usage" &&
     detailType === "intake.usage.captured"
   ) {
-    rows = handleIntakeUsage(
+    rows = await handleIntakeUsage(
       eventId,
       event.detail as IntakeUsageDetail,
       ingestedAt,
@@ -382,7 +519,7 @@ export const handler = async (
     source === "citadel.workflows" &&
     detailType === "workflow.node.completed"
   ) {
-    rows = handleWorkflowNodeCompleted(
+    rows = await handleWorkflowNodeCompleted(
       eventId,
       event.detail as WorkflowNodeCompletedDetail,
       ingestedAt,

--- a/backend/src/lambda/cost-notifier.ts
+++ b/backend/src/lambda/cost-notifier.ts
@@ -1,0 +1,123 @@
+/**
+ * Cost Notifier — sanitize + PutEvents helper for the two budget-alert
+ * detail-types emitted by cost-budget-evaluator.ts, on the shared
+ * `agentEventBus`, source `citadel.telemetry`.
+ *
+ * Deliberately does NOT reuse `emitGovernanceEvent` (backend/src/utils
+ * governance-namespaced emitter): this is a distinct bounded context
+ * (telemetry, not governance) with its own detail-type set, per the
+ * architect design. It mirrors that module's fail-closed sanitisation
+ * (`<script>`/`<iframe>`/`<object>` tag stripping) so a budget scope/orgId
+ * value that somehow contains injected markup can never reach a downstream
+ * EventBridge consumer un-sanitised.
+ *
+ * This makes TelemetryStack an EventBridge *publisher* for the first time
+ * (previously consume-only) — the evaluator Lambda's role needs an
+ * `events:PutEvents` grant (added in telemetry-stack.ts).
+ */
+
+import {
+  EventBridgeClient,
+  PutEventsCommand,
+} from "@aws-sdk/client-eventbridge";
+
+export const BUDGET_DETAIL_TYPES = [
+  "cost.budget.threshold.crossed",
+  "cost.budget.breached",
+] as const;
+
+export type BudgetDetailType = (typeof BUDGET_DETAIL_TYPES)[number];
+
+export interface BudgetEventDetail {
+  orgId: string;
+  /** "org" or "app:<appId>" — mirrors the PUT /budgets/{scope} wire shape. */
+  scope: string;
+  periodKey: string;
+  threshold: number;
+  spentMicros: number;
+  limitMicros: number;
+  currency: string;
+}
+
+// Fail-closed sanitiser — identical contract to the governance notifier's:
+// strip <script>/<iframe>/<object> tags (and content), leave every other
+// character byte-for-byte intact, run to a fixed point so nested/overlapping
+// constructs cannot survive.
+const DANGEROUS_TAGS = "script|iframe|object";
+const PAIRED_TAG_RE = new RegExp(
+  `<\\s*(${DANGEROUS_TAGS})\\b[^>]*>[\\s\\S]*?<\\s*\\/\\s*\\1\\b[^>]*>`,
+  "gi",
+);
+const STRAY_TAG_RE = new RegExp(
+  `<\\s*\\/?\\s*(?:${DANGEROUS_TAGS})\\b[^>]*>?`,
+  "gi",
+);
+
+function sanitizeString(s: string): string {
+  let out = s;
+  let previous: string;
+  do {
+    previous = out;
+    out = out.replace(PAIRED_TAG_RE, "").replace(STRAY_TAG_RE, "");
+  } while (out !== previous);
+  return out;
+}
+
+function sanitizeDeep<T>(value: T): T {
+  if (typeof value === "string") return sanitizeString(value) as unknown as T;
+  if (Array.isArray(value))
+    return value.map((v) => sanitizeDeep(v)) as unknown as T;
+  if (value && typeof value === "object") {
+    const out: Record<string, unknown> = {};
+    for (const [k, v] of Object.entries(value as Record<string, unknown>)) {
+      out[k] = sanitizeDeep(v);
+    }
+    return out as unknown as T;
+  }
+  return value;
+}
+
+let _client: EventBridgeClient | null = null;
+function ebClient(): EventBridgeClient {
+  if (!_client) _client = new EventBridgeClient({});
+  return _client;
+}
+
+/**
+ * Publishes a budget alert event. Errors are NOT swallowed here — the
+ * caller (cost-budget-evaluator.ts) decides how to react to a publish
+ * failure, and per the binding rule "evaluator/notifier failures log and
+ * never corrupt budget rows", the evaluator issues its dedupe
+ * conditional-UpdateItem BEFORE calling this, so a publish failure can
+ * never leave a budget row in an inconsistent (notified-but-not-sent, or
+ * vice versa) state — worst case is a swallowed duplicate suppressed by
+ * the dedupe key, never a corrupted row.
+ */
+export async function emitBudgetEvent(
+  detailType: BudgetDetailType,
+  detail: BudgetEventDetail,
+): Promise<void> {
+  const sanitisedDetail = sanitizeDeep(detail);
+  const envelope = {
+    ...sanitisedDetail,
+    timestamp: new Date().toISOString(),
+  };
+
+  const command = new PutEventsCommand({
+    Entries: [
+      {
+        Source: "citadel.telemetry",
+        DetailType: detailType,
+        Detail: JSON.stringify(envelope),
+        EventBusName: process.env.EVENT_BUS_NAME || "default",
+      },
+    ],
+  });
+
+  await ebClient().send(command);
+}
+
+/** Test-only: reset the cached EventBridge client. Do not call from production code. */
+export function __resetCostNotifierForTest(): void {
+  _client = null;
+}

--- a/backend/src/lambda/cost-query-handler.ts
+++ b/backend/src/lambda/cost-query-handler.ts
@@ -1,0 +1,482 @@
+/**
+ * Cost Query Handler — single Lambda (HTTP API payload format 2.0)
+ * branching on `routeKey` for the 4 cost-query-surface routes:
+ *   GET /cost/summary?groupBy=app|agent|model|project&from&to
+ *   GET /cost/series?dimension=org|app|agent|model|project&id?&bucket=hour|day&from&to
+ *   GET /budgets[?orgId=] (admin only for orgId)
+ *   PUT /budgets/{scope}
+ *
+ * ORG-SCOPING (binding, security core): every non-admin read is a
+ * base-table Query with KeyConditionExpression `PK = :org AND SK BETWEEN
+ * :fromIso AND :toIso`, where `:org = 'ORG#' + <verified JWT claim>`. The
+ * org is NEVER taken from a query/path parameter for a non-admin caller —
+ * a non-admin passing a *different* `?orgId=` is rejected 403 before any
+ * DynamoDB call is made. Admins may pass `?orgId=` to read another org, or
+ * omit it for their own; admin "all orgs" is a separate, explicitly
+ * documented, paginated Scan exception (not implemented this pass — no
+ * route requests it yet, keeping the "never Scan on the org-scoped path"
+ * invariant simple to hold and test).
+ *
+ * SK-namespace: rollups bound SK with ISO timestamps only
+ * (`SK BETWEEN :fromIso AND :toIso`), so `BUDGET#...` rows (see
+ * cost-budget.ts's `budgetSortKey`) can never be swept in — see
+ * cost-ledger-sk-namespace.test.ts.
+ *
+ * Aggregation (groupBy / bucketing) happens in-Lambda via cost-aggregate.ts
+ * — required for groupBy=model since there is no ModelIndex GSI.
+ */
+
+import { DynamoDBClient } from "@aws-sdk/client-dynamodb";
+import {
+  DynamoDBDocumentClient,
+  QueryCommand,
+  UpdateCommand,
+} from "@aws-sdk/lib-dynamodb";
+import type { APIGatewayProxyEventV2WithJWTAuthorizer } from "aws-lambda";
+
+import {
+  extractOrgFromHttpEvent,
+  isAdminFromHttpEvent,
+} from "./utils/auth-http-event";
+import {
+  aggregateSummary,
+  aggregateSeries,
+  type CostLedgerRowForAggregation,
+  type SummaryGroupBy,
+  type SeriesBucket,
+} from "./utils/cost-aggregate";
+import {
+  budgetSortKey,
+  parseBudgetScope,
+  type BudgetPeriodType,
+} from "./utils/cost-budget";
+
+const dynamoClient = new DynamoDBClient({});
+const docClient = DynamoDBDocumentClient.from(dynamoClient);
+
+const COST_LEDGER_TABLE = process.env.COST_LEDGER_TABLE!;
+
+/** Hard cap on rows read per request across all pagination pages — bounds worst-case cost/latency; response is aggregated so the body stays small regardless. */
+const MAX_ROWS_PER_REQUEST = 50_000;
+const DEFAULT_WINDOW_DAYS = 30;
+const SUMMARY_GROUP_BYS: SummaryGroupBy[] = [
+  "app",
+  "agent",
+  "model",
+  "project",
+];
+const SERIES_BUCKETS: SeriesBucket[] = ["hour", "day"];
+const BUDGET_PERIOD_TYPES: BudgetPeriodType[] = ["monthly", "daily"];
+
+interface HttpResponse {
+  statusCode: number;
+  headers?: Record<string, string>;
+  body?: string;
+}
+
+function json(statusCode: number, payload: unknown): HttpResponse {
+  return {
+    statusCode,
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(payload),
+  };
+}
+
+function badRequest(message: string): HttpResponse {
+  return json(400, { error: message });
+}
+
+function forbidden(message = "Forbidden"): HttpResponse {
+  return json(403, { error: message });
+}
+
+function notFound(): HttpResponse {
+  return json(404, { error: "Not found" });
+}
+
+function defaultWindow(): { fromIso: string; toIso: string } {
+  const to = new Date();
+  const from = new Date(
+    to.getTime() - DEFAULT_WINDOW_DAYS * 24 * 60 * 60 * 1000,
+  );
+  return { fromIso: from.toISOString(), toIso: to.toISOString() };
+}
+
+/**
+ * Resolves which org's key condition a request may use.
+ * Returns `{ ok: false }` (→ caller responds 403) when a non-admin
+ * requests an org other than their own claim. Never returns an org that
+ * did not come from either the verified claim (non-admin) or an
+ * explicit, admin-authorized `?orgId=` (admin).
+ */
+function resolveScopedOrg(
+  event: APIGatewayProxyEventV2WithJWTAuthorizer,
+  requestedOrgId: string | undefined,
+): { ok: true; orgId: string } | { ok: false } {
+  const claimOrg = extractOrgFromHttpEvent(event);
+  if (!claimOrg) return { ok: false };
+
+  const isAdmin = isAdminFromHttpEvent(event);
+
+  if (!requestedOrgId || requestedOrgId === claimOrg) {
+    return { ok: true, orgId: claimOrg };
+  }
+
+  if (isAdmin) {
+    return { ok: true, orgId: requestedOrgId };
+  }
+
+  // Non-admin requesting a different org: deny. Never forward requestedOrgId
+  // to the key condition, and never silently fall back to the claim org for
+  // this branch — the caller explicitly asked for something they cannot have.
+  return { ok: false };
+}
+
+/**
+ * Paginated base-table Query, `PK = ORG#<orgId> AND SK BETWEEN fromIso AND
+ * toIso`. This is the ONLY DynamoDB access pattern for org-scoped reads in
+ * this handler — never a Scan, never a GSI, so the org-isolation guarantee
+ * lives entirely in this key condition (binding invariant).
+ */
+async function queryLedgerWindow(
+  orgId: string,
+  fromIso: string,
+  toIso: string,
+): Promise<{ rows: CostLedgerRowForAggregation[]; truncated: boolean }> {
+  const rows: CostLedgerRowForAggregation[] = [];
+  let exclusiveStartKey: Record<string, unknown> | undefined;
+  let truncated = false;
+
+  do {
+    const result = await docClient.send(
+      new QueryCommand({
+        TableName: COST_LEDGER_TABLE,
+        KeyConditionExpression: "PK = :org AND SK BETWEEN :fromIso AND :toIso",
+        ExpressionAttributeValues: {
+          ":org": `ORG#${orgId}`,
+          ":fromIso": fromIso,
+          ":toIso": toIso,
+        },
+        Limit: 1000,
+        ExclusiveStartKey: exclusiveStartKey,
+      }),
+    );
+
+    for (const item of result.Items ?? []) {
+      rows.push(item as unknown as CostLedgerRowForAggregation);
+      if (rows.length >= MAX_ROWS_PER_REQUEST) {
+        truncated = true;
+        break;
+      }
+    }
+
+    exclusiveStartKey = truncated
+      ? undefined
+      : (result.LastEvaluatedKey as Record<string, unknown> | undefined);
+  } while (exclusiveStartKey);
+
+  return { rows, truncated };
+}
+
+function qsp(
+  event: APIGatewayProxyEventV2WithJWTAuthorizer,
+): Record<string, string | undefined> {
+  return event.queryStringParameters ?? {};
+}
+
+async function handleSummary(
+  event: APIGatewayProxyEventV2WithJWTAuthorizer,
+): Promise<HttpResponse> {
+  const params = qsp(event);
+
+  const scoped = resolveScopedOrg(event, params.orgId);
+  if (!scoped.ok) return forbidden();
+
+  const groupBy = params.groupBy as SummaryGroupBy;
+  if (!SUMMARY_GROUP_BYS.includes(groupBy)) {
+    return badRequest(
+      `groupBy must be one of: ${SUMMARY_GROUP_BYS.join(", ")}`,
+    );
+  }
+
+  const { fromIso, toIso } =
+    params.from && params.to
+      ? { fromIso: params.from, toIso: params.to }
+      : defaultWindow();
+
+  const { rows, truncated } = await queryLedgerWindow(
+    scoped.orgId,
+    fromIso,
+    toIso,
+  );
+  const result = aggregateSummary(rows, groupBy);
+
+  // Mixed-currency guard: sums are only meaningful within one currency.
+  const currencies = new Set(
+    rows.filter((r) => r.priced && r.currency).map((r) => r.currency),
+  );
+  const currencyMixed = currencies.size > 1;
+
+  return json(200, {
+    groupBy,
+    from: fromIso,
+    to: toIso,
+    currency: currencyMixed ? null : (Array.from(currencies)[0] ?? null),
+    currencyMixed,
+    totalCostMicros: result.totalCostMicros,
+    pricedRows: result.pricedRows,
+    unpricedRows: result.unpricedRows,
+    estimate: true,
+    truncated,
+    buckets: result.buckets,
+  });
+}
+
+async function handleSeries(
+  event: APIGatewayProxyEventV2WithJWTAuthorizer,
+): Promise<HttpResponse> {
+  const params = qsp(event);
+
+  const scoped = resolveScopedOrg(event, params.orgId);
+  if (!scoped.ok) return forbidden();
+
+  const bucket = params.bucket as SeriesBucket;
+  if (!SERIES_BUCKETS.includes(bucket)) {
+    return badRequest(`bucket must be one of: ${SERIES_BUCKETS.join(", ")}`);
+  }
+  const dimension = params.dimension || "org";
+
+  const { fromIso, toIso } =
+    params.from && params.to
+      ? { fromIso: params.from, toIso: params.to }
+      : defaultWindow();
+
+  const { rows: allRows, truncated } = await queryLedgerWindow(
+    scoped.orgId,
+    fromIso,
+    toIso,
+  );
+
+  const rows =
+    dimension === "org" || !params.id
+      ? allRows
+      : allRows.filter((r) => {
+          const value =
+            dimension === "app"
+              ? r.appId
+              : dimension === "agent"
+                ? r.agentId
+                : dimension === "project"
+                  ? r.projectId
+                  : dimension === "model"
+                    ? r.modelKey
+                    : undefined;
+          return value === params.id;
+        });
+
+  const result = aggregateSeries(rows, bucket);
+  const currencies = new Set(
+    rows.filter((r) => r.priced && r.currency).map((r) => r.currency),
+  );
+
+  return json(200, {
+    dimension,
+    id: params.id,
+    bucket,
+    from: fromIso,
+    to: toIso,
+    currency: currencies.size === 1 ? Array.from(currencies)[0] : null,
+    estimate: true,
+    truncated,
+    unpricedCount: result.unpricedCount,
+    points: result.points,
+  });
+}
+
+async function handleListBudgets(
+  event: APIGatewayProxyEventV2WithJWTAuthorizer,
+): Promise<HttpResponse> {
+  const params = qsp(event);
+  const scoped = resolveScopedOrg(event, params.orgId);
+  if (!scoped.ok) return forbidden();
+
+  // Budget rows live under SK prefix BUDGET# on the same org partition —
+  // reuses the exact PK=ORG# key-condition discipline as ledger rollups.
+  const result = await docClient.send(
+    new QueryCommand({
+      TableName: COST_LEDGER_TABLE,
+      KeyConditionExpression: "PK = :org AND begins_with(SK, :prefix)",
+      ExpressionAttributeValues: {
+        ":org": `ORG#${scoped.orgId}`,
+        ":prefix": "BUDGET#",
+      },
+    }),
+  );
+
+  const budgets = (result.Items ?? []).map((item) => {
+    const sk = item.SK as string;
+    const scope =
+      sk === "BUDGET#ORG" ? "org" : `app:${sk.replace("BUDGET#APP#", "")}`;
+    return {
+      scope,
+      orgId: scoped.orgId,
+      appId: scope.startsWith("app:") ? scope.slice(4) : undefined,
+      periodType: item.periodType,
+      limitMicros: item.limitMicros,
+      thresholds: item.thresholds,
+      currency: item.currency,
+      updatedAt: item.updatedAt,
+    };
+  });
+
+  return json(200, { budgets });
+}
+
+interface PutBudgetBody {
+  periodType?: unknown;
+  limitMicros?: unknown;
+  thresholds?: unknown;
+  currency?: unknown;
+}
+
+function validatePutBudgetBody(
+  raw: unknown,
+):
+  | {
+      ok: true;
+      body: {
+        periodType: BudgetPeriodType;
+        limitMicros: number;
+        thresholds: number[];
+        currency: string;
+      };
+    }
+  | { ok: false; error: string } {
+  if (typeof raw !== "object" || raw === null) {
+    return { ok: false, error: "Request body must be a JSON object" };
+  }
+  const b = raw as PutBudgetBody;
+
+  if (
+    typeof b.periodType !== "string" ||
+    !BUDGET_PERIOD_TYPES.includes(b.periodType as BudgetPeriodType)
+  ) {
+    return {
+      ok: false,
+      error: `periodType must be one of: ${BUDGET_PERIOD_TYPES.join(", ")}`,
+    };
+  }
+  if (
+    typeof b.limitMicros !== "number" ||
+    !Number.isFinite(b.limitMicros) ||
+    b.limitMicros <= 0
+  ) {
+    return { ok: false, error: "limitMicros must be a positive number" };
+  }
+  if (
+    !Array.isArray(b.thresholds) ||
+    b.thresholds.length === 0 ||
+    !b.thresholds.every((t) => typeof t === "number" && t > 0 && t <= 1)
+  ) {
+    return {
+      ok: false,
+      error: "thresholds must be a non-empty array of numbers in (0, 1]",
+    };
+  }
+  if (typeof b.currency !== "string" || b.currency.length === 0) {
+    return { ok: false, error: "currency must be a non-empty string" };
+  }
+
+  return {
+    ok: true,
+    body: {
+      periodType: b.periodType as BudgetPeriodType,
+      limitMicros: b.limitMicros,
+      thresholds: b.thresholds as number[],
+      currency: b.currency,
+    },
+  };
+}
+
+async function handlePutBudget(
+  event: APIGatewayProxyEventV2WithJWTAuthorizer,
+): Promise<HttpResponse> {
+  const claimOrg = extractOrgFromHttpEvent(event);
+  if (!claimOrg) return forbidden();
+
+  const rawScope = event.pathParameters?.scope;
+  if (!rawScope) return badRequest("Missing {scope} path parameter");
+
+  let parsedScope: ReturnType<typeof parseBudgetScope>;
+  let sk: string;
+  try {
+    parsedScope = parseBudgetScope(rawScope);
+    sk = budgetSortKey(
+      rawScope === "org" ? "org" : `app#${parsedScope["appId" as never]}`,
+    );
+  } catch {
+    return badRequest(`Invalid budget scope: ${rawScope}`);
+  }
+
+  let rawBody: unknown;
+  try {
+    rawBody = event.body ? JSON.parse(event.body) : undefined;
+  } catch {
+    return badRequest("Request body must be valid JSON");
+  }
+
+  const validated = validatePutBudgetBody(rawBody);
+  if (!validated.ok) return badRequest(validated.error);
+
+  const updatedAt = new Date().toISOString();
+
+  await docClient.send(
+    new UpdateCommand({
+      TableName: COST_LEDGER_TABLE,
+      Key: { PK: `ORG#${claimOrg}`, SK: sk },
+      UpdateExpression:
+        "SET periodType = :periodType, limitMicros = :limitMicros, thresholds = :thresholds, currency = :currency, updatedAt = :updatedAt, GSI5PK = :gsi5pk, GSI5SK = :gsi5sk",
+      ExpressionAttributeValues: {
+        ":periodType": validated.body.periodType,
+        ":limitMicros": validated.body.limitMicros,
+        ":thresholds": validated.body.thresholds,
+        ":currency": validated.body.currency,
+        ":updatedAt": updatedAt,
+        ":gsi5pk": "BUDGET",
+        ":gsi5sk": `ORG#${claimOrg}#${sk}`,
+      },
+    }),
+  );
+
+  return json(200, {
+    scope: parsedScope.scopeType === "org" ? "org" : `app:${parsedScope.appId}`,
+    orgId: claimOrg,
+    ...validated.body,
+    updatedAt,
+  });
+}
+
+export const handler = async (
+  event: APIGatewayProxyEventV2WithJWTAuthorizer,
+): Promise<HttpResponse> => {
+  try {
+    switch (event.routeKey) {
+      case "GET /cost/summary":
+        return await handleSummary(event);
+      case "GET /cost/series":
+        return await handleSeries(event);
+      case "GET /budgets":
+        return await handleListBudgets(event);
+      case "PUT /budgets/{scope}":
+        return await handlePutBudget(event);
+      default:
+        return notFound();
+    }
+  } catch (err: unknown) {
+    console.error("cost-query-handler: unhandled error", {
+      routeKey: event.routeKey,
+      error: err instanceof Error ? err.message : String(err),
+    });
+    return json(500, { error: "Internal server error" });
+  }
+};

--- a/backend/src/lambda/execution-resolver.ts
+++ b/backend/src/lambda/execution-resolver.ts
@@ -1,10 +1,19 @@
-import { AppSyncResolverHandler, AppSyncResolverEvent } from 'aws-lambda';
-import { DynamoDBClient } from '@aws-sdk/client-dynamodb';
-import { DynamoDBDocumentClient, GetCommand, PutCommand, UpdateCommand, QueryCommand } from '@aws-sdk/lib-dynamodb';
-import { EventBridgeClient, PutEventsCommand } from '@aws-sdk/client-eventbridge';
-import { v4 as uuidv4 } from 'uuid';
-import { getUserId } from '../utils/appsync';
-import { extractOrgFromEvent } from '../utils/auth-event';
+import { AppSyncResolverHandler, AppSyncResolverEvent } from "aws-lambda";
+import { DynamoDBClient } from "@aws-sdk/client-dynamodb";
+import {
+  DynamoDBDocumentClient,
+  GetCommand,
+  PutCommand,
+  UpdateCommand,
+  QueryCommand,
+} from "@aws-sdk/lib-dynamodb";
+import {
+  EventBridgeClient,
+  PutEventsCommand,
+} from "@aws-sdk/client-eventbridge";
+import { v4 as uuidv4 } from "uuid";
+import { getUserId } from "../utils/appsync";
+import { extractOrgFromEvent } from "../utils/auth-event";
 
 const dynamoClient = new DynamoDBClient({});
 const docClient = DynamoDBDocumentClient.from(dynamoClient);
@@ -32,7 +41,19 @@ interface ExecutionNodeResult {
   agentId?: string;
   status: string;
   retryCount: number;
+  /** Additive: sanitized per-node worker usage records (usage rollup). */
+  usage?: unknown[];
+  /** Additive: this node's precomputed usage totals (usage rollup). */
+  usageTotals?: UsageTotals;
   [key: string]: unknown;
+}
+
+/** Usage rollup: per-node or execution-level aggregated token usage. */
+interface UsageTotals {
+  inputTokens: number;
+  outputTokens: number;
+  totalTokens: number;
+  callCount: number;
 }
 
 /** Shape of an execution item persisted in the executions table. */
@@ -51,10 +72,118 @@ interface ExecutionRecord {
   completedAt?: string | null;
   triggeredBy?: string;
   error?: string | null;
+  /** Additive: execution-level usage totals folded from nodeResults on read. */
+  usageTotals?: UsageTotals | null;
 }
 
-export const handler: AppSyncResolverHandler<ExecutionResolverArguments, unknown> = async (event) => {
-  console.log('Execution resolver event:', JSON.stringify(event, null, 2));
+function _coerceNonNegativeInt(value: unknown): number {
+  const n = typeof value === "string" ? Number(value) : value;
+  if (typeof n !== "number" || Number.isNaN(n) || !Number.isFinite(n)) return 0;
+  return Math.max(0, Math.trunc(n));
+}
+
+/**
+ * Sum a single node's usage into a UsageTotals shape, or null if the node
+ * carries no usage source at all. Preference order: `usageTotals` (already
+ * aggregated by the step runner) → `usage` (a sanitized usage array) →
+ * `output.usage` (the pre-rollup-feature location, `output` possibly a JSON
+ * string). Never throws — malformed shapes at any level are skipped.
+ */
+function _nodeUsageTotals(node: unknown): UsageTotals | null {
+  if (!node || typeof node !== "object") return null;
+  const n = node as ExecutionNodeResult;
+
+  if (n.usageTotals && typeof n.usageTotals === "object") {
+    const t = n.usageTotals;
+    return {
+      inputTokens: _coerceNonNegativeInt(t.inputTokens),
+      outputTokens: _coerceNonNegativeInt(t.outputTokens),
+      totalTokens: _coerceNonNegativeInt(t.totalTokens),
+      callCount: _coerceNonNegativeInt(t.callCount),
+    };
+  }
+
+  const fromArray = (arr: unknown): UsageTotals | null => {
+    if (!Array.isArray(arr) || arr.length === 0) return null;
+    let inputTokens = 0;
+    let outputTokens = 0;
+    let callCount = 0;
+    for (const rec of arr) {
+      if (!rec || typeof rec !== "object") continue;
+      const r = rec as Record<string, unknown>;
+      inputTokens += _coerceNonNegativeInt(r.inputTokens);
+      outputTokens += _coerceNonNegativeInt(r.outputTokens);
+      callCount += 1;
+    }
+    if (callCount === 0) return null;
+    return {
+      inputTokens,
+      outputTokens,
+      totalTokens: inputTokens + outputTokens,
+      callCount,
+    };
+  };
+
+  const fromUsageField = fromArray(n.usage);
+  if (fromUsageField) return fromUsageField;
+
+  let output: unknown = n.output;
+  if (typeof output === "string") {
+    try {
+      output = JSON.parse(output);
+    } catch {
+      return null;
+    }
+  }
+  if (output && typeof output === "object") {
+    return fromArray((output as Record<string, unknown>).usage);
+  }
+  return null;
+}
+
+/**
+ * Pure, additive reduction: fold every node's usage into execution-level
+ * totals. Returns `null` when no node in `nodeResults` carries any usage
+ * source at all (legacy runs predating this feature render unchanged).
+ * Never throws — a malformed `nodeResults` map, or malformed individual node
+ * entries, are skipped rather than propagating an error. Idempotent: calling
+ * with the same input always yields an equal result (no I/O, no mutation),
+ * so redelivery of the underlying event has no bearing on this read-side
+ * computation.
+ */
+export function computeExecutionUsageTotals(
+  nodeResults: Record<string, unknown> | undefined | null,
+): UsageTotals | null {
+  if (!nodeResults || typeof nodeResults !== "object") return null;
+
+  let inputTokens = 0;
+  let outputTokens = 0;
+  let callCount = 0;
+  let sawAny = false;
+
+  for (const node of Object.values(nodeResults)) {
+    const totals = _nodeUsageTotals(node);
+    if (!totals) continue;
+    sawAny = true;
+    inputTokens += totals.inputTokens;
+    outputTokens += totals.outputTokens;
+    callCount += totals.callCount;
+  }
+
+  if (!sawAny) return null;
+  return {
+    inputTokens,
+    outputTokens,
+    totalTokens: inputTokens + outputTokens,
+    callCount,
+  };
+}
+
+export const handler: AppSyncResolverHandler<
+  ExecutionResolverArguments,
+  unknown
+> = async (event) => {
+  console.log("Execution resolver event:", JSON.stringify(event, null, 2));
 
   const { info, arguments: args, identity } = event;
   const fieldName = info.fieldName;
@@ -62,15 +191,15 @@ export const handler: AppSyncResolverHandler<ExecutionResolverArguments, unknown
 
   try {
     switch (fieldName) {
-      case 'getExecution':
+      case "getExecution":
         return await getExecution(args.executionId, userId, event);
-      case 'listExecutions':
+      case "listExecutions":
         return await listExecutions(args.workflowId);
-      case 'startExecution':
+      case "startExecution":
         return await startExecution(args.workflowId, args.input, userId, event);
-      case 'cancelExecution':
+      case "cancelExecution":
         return await cancelExecution(args.executionId, userId, event);
-      case 'publishWorkflowProgress':
+      case "publishWorkflowProgress":
         // IAM-signed fan-out mutation: echo the input so AppSync delivers it
         // to onWorkflowProgress subscribers.
         return args.input;
@@ -78,16 +207,22 @@ export const handler: AppSyncResolverHandler<ExecutionResolverArguments, unknown
         throw new Error(`Unknown field: ${fieldName}`);
     }
   } catch (error) {
-    console.error('Execution resolver error:', error);
+    console.error("Execution resolver error:", error);
     throw error;
   }
 };
 
-async function getExecution(executionId: string, userId: string, event: ExecutionResolverEvent): Promise<ExecutionRecord | null> {
-  const result = await docClient.send(new GetCommand({
-    TableName: EXECUTIONS_TABLE,
-    Key: { executionId },
-  }));
+async function getExecution(
+  executionId: string,
+  userId: string,
+  event: ExecutionResolverEvent,
+): Promise<ExecutionRecord | null> {
+  const result = await docClient.send(
+    new GetCommand({
+      TableName: EXECUTIONS_TABLE,
+      Key: { executionId },
+    }),
+  );
 
   if (!result.Item) {
     return null;
@@ -95,48 +230,66 @@ async function getExecution(executionId: string, userId: string, event: Executio
 
   const userOrg = await extractOrgFromEvent(event);
   if (userOrg && result.Item.orgId !== userOrg) {
-    throw new Error('Access denied');
+    throw new Error("Access denied");
   }
 
-  return result.Item as ExecutionRecord;
+  const item = result.Item as ExecutionRecord;
+  // Additive: fold per-node usage into an execution-level total on read.
+  // Pure and idempotent — no stored/mutable counter, so redelivery of the
+  // underlying node-completed events has no bearing on this computation.
+  item.usageTotals = computeExecutionUsageTotals(item.nodeResults);
+  return item;
 }
 
-async function listExecutions(workflowId: string): Promise<{ items: unknown[]; nextToken?: string }> {
-  const result = await docClient.send(new QueryCommand({
-    TableName: EXECUTIONS_TABLE,
-    IndexName: 'WorkflowIndex',
-    KeyConditionExpression: 'workflowId = :workflowId',
-    ExpressionAttributeValues: {
-      ':workflowId': workflowId,
-    },
-    ScanIndexForward: false,
-  }));
+async function listExecutions(
+  workflowId: string,
+): Promise<{ items: unknown[]; nextToken?: string }> {
+  const result = await docClient.send(
+    new QueryCommand({
+      TableName: EXECUTIONS_TABLE,
+      IndexName: "WorkflowIndex",
+      KeyConditionExpression: "workflowId = :workflowId",
+      ExpressionAttributeValues: {
+        ":workflowId": workflowId,
+      },
+      ScanIndexForward: false,
+    }),
+  );
 
   return {
     items: result.Items || [],
-    nextToken: result.LastEvaluatedKey ? JSON.stringify(result.LastEvaluatedKey) : undefined,
+    nextToken: result.LastEvaluatedKey
+      ? JSON.stringify(result.LastEvaluatedKey)
+      : undefined,
   };
 }
 
-async function startExecution(workflowId: string, input: string | undefined, userId: string, event: ExecutionResolverEvent): Promise<unknown> {
+async function startExecution(
+  workflowId: string,
+  input: string | undefined,
+  userId: string,
+  event: ExecutionResolverEvent,
+): Promise<unknown> {
   // 1. Get workflow, verify PUBLISHED + org access
-  const workflowResult = await docClient.send(new GetCommand({
-    TableName: WORKFLOWS_TABLE,
-    Key: { workflowId },
-  }));
+  const workflowResult = await docClient.send(
+    new GetCommand({
+      TableName: WORKFLOWS_TABLE,
+      Key: { workflowId },
+    }),
+  );
 
   const workflow = workflowResult.Item;
   if (!workflow) {
-    throw new Error('Workflow not found');
+    throw new Error("Workflow not found");
   }
 
   const userOrg = await extractOrgFromEvent(event);
   if (userOrg && workflow.orgId !== userOrg) {
-    throw new Error('Access denied');
+    throw new Error("Access denied");
   }
 
-  if (workflow.status !== 'PUBLISHED') {
-    throw new Error('Only published workflows can be executed');
+  if (workflow.status !== "PUBLISHED") {
+    throw new Error("Only published workflows can be executed");
   }
 
   // 2. Parse definition, initialize nodeResults
@@ -147,7 +300,7 @@ async function startExecution(workflowId: string, input: string | undefined, use
     nodeResults[node.id] = {
       nodeId: node.id,
       agentId: node.agentId,
-      status: 'pending',
+      status: "pending",
       retryCount: 0,
     };
   }
@@ -161,7 +314,7 @@ async function startExecution(workflowId: string, input: string | undefined, use
     workflowId,
     appId: workflow.appId || null,
     orgId: workflow.orgId,
-    status: 'pending',
+    status: "pending",
     workflowVersion: workflow.version,
     currentNode: null,
     nodeResults,
@@ -173,13 +326,15 @@ async function startExecution(workflowId: string, input: string | undefined, use
     error: null,
   };
 
-  await docClient.send(new PutCommand({
-    TableName: EXECUTIONS_TABLE,
-    Item: execution,
-  }));
+  await docClient.send(
+    new PutCommand({
+      TableName: EXECUTIONS_TABLE,
+      Item: execution,
+    }),
+  );
 
   // 4. Publish execution.start.requested event
-  await emitEvent('execution.start.requested', {
+  await emitEvent("execution.start.requested", {
     executionId,
     workflowId,
   });
@@ -187,32 +342,38 @@ async function startExecution(workflowId: string, input: string | undefined, use
   return execution;
 }
 
-async function cancelExecution(executionId: string, userId: string, event: ExecutionResolverEvent): Promise<unknown> {
+async function cancelExecution(
+  executionId: string,
+  userId: string,
+  event: ExecutionResolverEvent,
+): Promise<unknown> {
   // 1. Get execution, verify org access
   const existing = await getExecution(executionId, userId, event);
   if (!existing) {
-    throw new Error('Execution not found');
+    throw new Error("Execution not found");
   }
 
   // 2. Update status to cancelled
   const now = new Date().toISOString();
-  const result = await docClient.send(new UpdateCommand({
-    TableName: EXECUTIONS_TABLE,
-    Key: { executionId },
-    UpdateExpression: 'SET #status = :status, #completedAt = :completedAt',
-    ExpressionAttributeNames: {
-      '#status': 'status',
-      '#completedAt': 'completedAt',
-    },
-    ExpressionAttributeValues: {
-      ':status': 'cancelled',
-      ':completedAt': now,
-    },
-    ReturnValues: 'ALL_NEW',
-  }));
+  const result = await docClient.send(
+    new UpdateCommand({
+      TableName: EXECUTIONS_TABLE,
+      Key: { executionId },
+      UpdateExpression: "SET #status = :status, #completedAt = :completedAt",
+      ExpressionAttributeNames: {
+        "#status": "status",
+        "#completedAt": "completedAt",
+      },
+      ExpressionAttributeValues: {
+        ":status": "cancelled",
+        ":completedAt": now,
+      },
+      ReturnValues: "ALL_NEW",
+    }),
+  );
 
   // 3. Publish execution.cancel.requested event
-  await emitEvent('execution.cancel.requested', {
+  await emitEvent("execution.cancel.requested", {
     executionId,
     workflowId: existing.workflowId,
   });
@@ -221,14 +382,16 @@ async function cancelExecution(executionId: string, userId: string, event: Execu
 }
 
 async function emitEvent(eventType: string, detail: unknown): Promise<void> {
-  await eventBridgeClient.send(new PutEventsCommand({
-    Entries: [
-      {
-        Source: 'citadel.workflows',
-        DetailType: eventType,
-        Detail: JSON.stringify(detail),
-        EventBusName: EVENT_BUS_NAME,
-      },
-    ],
-  }));
+  await eventBridgeClient.send(
+    new PutEventsCommand({
+      Entries: [
+        {
+          Source: "citadel.workflows",
+          DetailType: eventType,
+          Detail: JSON.stringify(detail),
+          EventBusName: EVENT_BUS_NAME,
+        },
+      ],
+    }),
+  );
 }

--- a/backend/src/lambda/model-catalog-sync.ts
+++ b/backend/src/lambda/model-catalog-sync.ts
@@ -17,14 +17,14 @@ import {
   BedrockClient,
   ListFoundationModelsCommand,
   ListInferenceProfilesCommand,
-} from '@aws-sdk/client-bedrock';
-import { DynamoDBClient } from '@aws-sdk/client-dynamodb';
+} from "@aws-sdk/client-bedrock";
+import { DynamoDBClient } from "@aws-sdk/client-dynamodb";
 import {
   DynamoDBDocumentClient,
   ScanCommand,
   PutCommand,
-} from '@aws-sdk/lib-dynamodb';
-import { publishEvent, createProjectEvent, EventTypes } from '../utils/events';
+} from "@aws-sdk/lib-dynamodb";
+import { publishEvent, createProjectEvent, EventTypes } from "../utils/events";
 
 const bedrock = new BedrockClient({});
 const docClient = DynamoDBDocumentClient.from(new DynamoDBClient({}));
@@ -43,15 +43,51 @@ interface ProviderCaps {
  * API-derived fields. Keyed by PROVIDER only — never by model id/family.
  */
 const PROVIDER_CAPABILITIES: Record<string, ProviderCaps> = {
-  anthropic: { supportsTools: true, supportsSystemPrompt: true, supportsConverse: true },
-  mistral: { supportsTools: true, supportsSystemPrompt: true, supportsConverse: true },
-  meta: { supportsTools: true, supportsSystemPrompt: true, supportsConverse: true },
-  amazon: { supportsTools: true, supportsSystemPrompt: true, supportsConverse: true },
-  cohere: { supportsTools: true, supportsSystemPrompt: true, supportsConverse: true },
-  ai21: { supportsTools: true, supportsSystemPrompt: true, supportsConverse: true },
-  openai: { supportsTools: true, supportsSystemPrompt: true, supportsConverse: true },
-  deepseek: { supportsTools: false, supportsSystemPrompt: true, supportsConverse: true },
-  stability: { supportsTools: false, supportsSystemPrompt: false, supportsConverse: false },
+  anthropic: {
+    supportsTools: true,
+    supportsSystemPrompt: true,
+    supportsConverse: true,
+  },
+  mistral: {
+    supportsTools: true,
+    supportsSystemPrompt: true,
+    supportsConverse: true,
+  },
+  meta: {
+    supportsTools: true,
+    supportsSystemPrompt: true,
+    supportsConverse: true,
+  },
+  amazon: {
+    supportsTools: true,
+    supportsSystemPrompt: true,
+    supportsConverse: true,
+  },
+  cohere: {
+    supportsTools: true,
+    supportsSystemPrompt: true,
+    supportsConverse: true,
+  },
+  ai21: {
+    supportsTools: true,
+    supportsSystemPrompt: true,
+    supportsConverse: true,
+  },
+  openai: {
+    supportsTools: true,
+    supportsSystemPrompt: true,
+    supportsConverse: true,
+  },
+  deepseek: {
+    supportsTools: false,
+    supportsSystemPrompt: true,
+    supportsConverse: true,
+  },
+  stability: {
+    supportsTools: false,
+    supportsSystemPrompt: false,
+    supportsConverse: false,
+  },
 };
 
 /** Conservative fallback for providers not in the overlay. */
@@ -61,21 +97,92 @@ const DEFAULT_CAPS: ProviderCaps = {
   supportsConverse: true,
 };
 
+interface ProviderPricing {
+  inputPer1kTokens: number;
+  outputPer1kTokens: number;
+  currency: string;
+}
+
+/**
+ * Pricing overlay keyed by lowercase provider name — mirrors
+ * PROVIDER_CAPABILITIES. The Bedrock ListFoundationModels API does NOT
+ * expose pricing, so this is the sanctioned source of SYNCED DEFAULT list
+ * prices. Applied ONLY when a catalog row has no pricing yet (see the
+ * preserve-like-status merge below) — an operator-set price is never
+ * overwritten by a sync. Values are illustrative list-price placeholders;
+ * operators are expected to correct them via the (deferred) pricing mutation
+ * or by editing the catalog row directly.
+ */
+const PROVIDER_PRICING: Record<string, ProviderPricing> = {
+  anthropic: { inputPer1kTokens: 3, outputPer1kTokens: 15, currency: "USD" },
+  mistral: { inputPer1kTokens: 2, outputPer1kTokens: 6, currency: "USD" },
+  meta: { inputPer1kTokens: 1, outputPer1kTokens: 3, currency: "USD" },
+  amazon: { inputPer1kTokens: 0.8, outputPer1kTokens: 1.6, currency: "USD" },
+  cohere: { inputPer1kTokens: 1.5, outputPer1kTokens: 2, currency: "USD" },
+  ai21: { inputPer1kTokens: 2, outputPer1kTokens: 2, currency: "USD" },
+  openai: { inputPer1kTokens: 5, outputPer1kTokens: 15, currency: "USD" },
+  deepseek: { inputPer1kTokens: 0.5, outputPer1kTokens: 1.5, currency: "USD" },
+  stability: { inputPer1kTokens: 0, outputPer1kTokens: 0, currency: "USD" },
+};
+
+/** Conservative fallback pricing for providers not in the overlay — never left unpriced. */
+const DEFAULT_PRICING: ProviderPricing = {
+  inputPer1kTokens: 1,
+  outputPer1kTokens: 3,
+  currency: "USD",
+};
+
+/** True when a catalog row already carries a complete, usable pricing set. */
+function hasPricing(entry: Record<string, unknown>): boolean {
+  return (
+    typeof entry.inputPer1kTokens === "number" &&
+    typeof entry.outputPer1kTokens === "number" &&
+    typeof entry.currency === "string" &&
+    (entry.currency as string).length > 0
+  );
+}
+
+/**
+ * Additive pricing fields to merge onto a row that has NO pricing yet.
+ * Returns an empty object when the row is already priced (operator or a
+ * prior sync) — the caller spreads this after the operator/existing fields
+ * so preservation is a pure no-op-if-present merge, exactly like `status`.
+ */
+function pricingOverlayFor(
+  provider: string,
+  existing: Record<string, unknown> | undefined,
+  now: string,
+): Partial<
+  ProviderPricing & { pricingSource: string; pricingUpdatedAt: string }
+> {
+  if (existing && hasPricing(existing)) {
+    return {};
+  }
+  const pricing = PROVIDER_PRICING[provider] || DEFAULT_PRICING;
+  return {
+    inputPer1kTokens: pricing.inputPer1kTokens,
+    outputPer1kTokens: pricing.outputPer1kTokens,
+    currency: pricing.currency,
+    pricingSource: "synced_default",
+    pricingUpdatedAt: now,
+  };
+}
+
 /** Derive a stable, slug-like partition key from a raw Bedrock model id. */
-function modelKeyFromId(id: string): string {
+export function modelKeyFromId(id: string): string {
   return id
     .toLowerCase()
-    .replace(/[^a-z0-9]+/g, '-')
-    .replace(/^-+|-+$/g, '');
+    .replace(/[^a-z0-9]+/g, "-")
+    .replace(/^-+|-+$/g, "");
 }
 
 /** Collapse Bedrock output modalities into a single coarse modality bucket. */
 function modalityFrom(outputModalities?: string[]): string {
   const mods = outputModalities || [];
-  if (mods.includes('TEXT')) return 'text';
-  if (mods.includes('EMBEDDING')) return 'embedding';
-  if (mods.includes('IMAGE')) return 'image';
-  return 'other';
+  if (mods.includes("TEXT")) return "text";
+  if (mods.includes("EMBEDDING")) return "embedding";
+  if (mods.includes("IMAGE")) return "image";
+  return "other";
 }
 
 /**
@@ -116,12 +223,12 @@ export async function syncModelCatalog(): Promise<{
   // 3. Map baseModelId -> { regionPrefix -> inferenceProfileId }.
   const regionProfileMap: Record<string, Record<string, string>> = {};
   for (const profile of inferenceProfileSummaries) {
-    const profileId: string = profile.inferenceProfileId || '';
+    const profileId: string = profile.inferenceProfileId || "";
     if (!profileId) continue;
-    const prefix = profileId.split('.')[0];
+    const prefix = profileId.split(".")[0];
     for (const model of profile.models || []) {
-      const modelArn: string = model.modelArn || '';
-      const baseModelId = modelArn.split('foundation-model/')[1];
+      const modelArn: string = model.modelArn || "";
+      const baseModelId = modelArn.split("foundation-model/")[1];
       if (!baseModelId) continue;
       if (!regionProfileMap[baseModelId]) regionProfileMap[baseModelId] = {};
       regionProfileMap[baseModelId][prefix] = profileId;
@@ -156,13 +263,13 @@ export async function syncModelCatalog(): Promise<{
   let deprecated = 0;
 
   for (const summary of modelSummaries) {
-    const modelId = summary.modelId || '';
+    const modelId = summary.modelId || "";
     if (!modelId) continue;
 
     const key = modelKeyFromId(modelId);
     seenKeys.add(key);
 
-    const provider = (summary.providerName || '').toLowerCase();
+    const provider = (summary.providerName || "").toLowerCase();
     const caps = PROVIDER_CAPABILITIES[provider] || DEFAULT_CAPS;
     const modality = modalityFrom(summary.outputModalities);
     const regionProfiles = regionProfileMap[modelId] || {};
@@ -172,7 +279,7 @@ export async function syncModelCatalog(): Promise<{
       provider,
       baseModelId: modelId,
       modality,
-      invocationMode: modality === 'text' ? 'converse' : 'invoke_model',
+      invocationMode: modality === "text" ? "converse" : "invoke_model",
       supportsTools: caps.supportsTools,
       supportsSystemPrompt: caps.supportsSystemPrompt,
       supportsStreaming: !!summary.responseStreamingSupported,
@@ -181,21 +288,30 @@ export async function syncModelCatalog(): Promise<{
 
     const existing = existingByKey[key];
     if (!existing) {
+      const pricingOverlay = pricingOverlayFor(provider, undefined, now);
       await docClient.send(
         new PutCommand({
           TableName: CATALOG_TABLE,
-          Item: { ...apiDerived, status: 'discovered', discoveredAt: now },
+          Item: {
+            ...apiDerived,
+            ...pricingOverlay,
+            status: "discovered",
+            discoveredAt: now,
+          },
         }),
       );
       discovered++;
     } else {
-      // Refresh API-derived metadata but PRESERVE the operator-owned status.
+      // Refresh API-derived metadata but PRESERVE the operator-owned status
+      // and any pricing already present (operator-set or from a prior sync).
+      const pricingOverlay = pricingOverlayFor(provider, existing, now);
       await docClient.send(
         new PutCommand({
           TableName: CATALOG_TABLE,
           Item: {
             ...existing,
             ...apiDerived,
+            ...pricingOverlay,
             status: existing.status,
             discoveredAt: existing.discoveredAt || now,
           },
@@ -207,11 +323,11 @@ export async function syncModelCatalog(): Promise<{
 
   // 6. Deprecate catalog entries Bedrock no longer returns.
   for (const [key, entry] of Object.entries(existingByKey)) {
-    if (!seenKeys.has(key) && entry.status !== 'deprecated') {
+    if (!seenKeys.has(key) && entry.status !== "deprecated") {
       await docClient.send(
         new PutCommand({
           TableName: CATALOG_TABLE,
-          Item: { ...entry, status: 'deprecated' },
+          Item: { ...entry, status: "deprecated" },
         }),
       );
       deprecated++;
@@ -227,7 +343,7 @@ export async function syncModelCatalog(): Promise<{
     syncedAt: now,
   };
   await publishEvent(
-    createProjectEvent(EventTypes.MODEL_CATALOG_SYNCED, 'catalog', summary),
+    createProjectEvent(EventTypes.MODEL_CATALOG_SYNCED, "catalog", summary),
   );
   return summary;
 }
@@ -242,10 +358,10 @@ export const handler = async (): Promise<{
 }> => {
   try {
     const summary = await syncModelCatalog();
-    console.log('[model-catalog-sync] summary:', JSON.stringify(summary));
+    console.log("[model-catalog-sync] summary:", JSON.stringify(summary));
     return { statusCode: 200, body: JSON.stringify(summary) };
   } catch (err) {
-    console.error('model-catalog-sync failed', err);
+    console.error("model-catalog-sync failed", err);
     throw err;
   }
 };

--- a/backend/src/lambda/model-config-resolver.ts
+++ b/backend/src/lambda/model-config-resolver.ts
@@ -1,7 +1,12 @@
-import { DynamoDBClient } from '@aws-sdk/client-dynamodb';
-import { DynamoDBDocumentClient, GetCommand, PutCommand, ScanCommand } from '@aws-sdk/lib-dynamodb';
-import { isAdminFromEvent } from '../utils/auth-event';
-import { publishEvent, createProjectEvent, EventTypes } from '../utils/events';
+import { DynamoDBClient } from "@aws-sdk/client-dynamodb";
+import {
+  DynamoDBDocumentClient,
+  GetCommand,
+  PutCommand,
+  ScanCommand,
+} from "@aws-sdk/lib-dynamodb";
+import { isAdminFromEvent } from "../utils/auth-event";
+import { publishEvent, createProjectEvent, EventTypes } from "../utils/events";
 
 const client = new DynamoDBClient({});
 const docClient = DynamoDBDocumentClient.from(client);
@@ -12,9 +17,14 @@ const MODEL_CATALOG_TABLE = process.env.MODEL_CATALOG_TABLE!;
 // Enum-ish value sets are enforced in-code. This resolver is DATA-DRIVEN: the
 // set of valid models lives entirely in the catalog table — there are no
 // hardcoded model-id literals anywhere in this file.
-const VALID_STATUS = new Set(['enabled', 'disabled', 'deprecated', 'discovered']);
-const VALID_LOCALITY = new Set(['off', 'regional_preferred', 'strict']);
-const DEFAULT_SCOPE = 'platform';
+const VALID_STATUS = new Set([
+  "enabled",
+  "disabled",
+  "deprecated",
+  "discovered",
+]);
+const VALID_LOCALITY = new Set(["off", "regional_preferred", "strict"]);
+const DEFAULT_SCOPE = "platform";
 
 interface ModelCatalogEntry {
   modelKey: string;
@@ -27,6 +37,13 @@ interface ModelCatalogEntry {
   supportsSystemPrompt: boolean;
   supportsStreaming: boolean;
   regionProfiles?: unknown;
+  // Pricing metadata (additive, pass 2) — read-through only, no mutation
+  // added this story. Absent on rows that have never been priced.
+  inputPer1kTokens?: number;
+  outputPer1kTokens?: number;
+  currency?: string;
+  pricingSource?: "seed" | "synced_default" | "operator";
+  pricingUpdatedAt?: string;
 }
 
 interface ModelConfig {
@@ -51,7 +68,11 @@ interface UpdateModelConfigInput {
 /** AppSync event slice this resolver reads. */
 interface ModelConfigResolverEvent {
   info: { fieldName: string };
-  identity?: { username?: string; claims?: { sub?: string }; [claim: string]: unknown };
+  identity?: {
+    username?: string;
+    claims?: { sub?: string };
+    [claim: string]: unknown;
+  };
   arguments: {
     scope?: string;
     modelKey: string;
@@ -61,36 +82,36 @@ interface ModelConfigResolverEvent {
 }
 
 export const handler = async (event: ModelConfigResolverEvent) => {
-  console.log('Event:', JSON.stringify(event, null, 2));
+  console.log("Event:", JSON.stringify(event, null, 2));
 
   const fieldName = event.info.fieldName;
 
   try {
     switch (fieldName) {
-      case 'listModelCatalog':
+      case "listModelCatalog":
         return await listModelCatalog();
 
-      case 'getModelConfig':
+      case "getModelConfig":
         return await getModelConfig(event.arguments?.scope);
 
-      case 'updateModelConfig':
+      case "updateModelConfig":
         return await updateModelConfig(event.arguments.input, event);
 
-      case 'setModelCatalogEntryStatus':
+      case "setModelCatalogEntryStatus":
         return await setModelCatalogEntryStatus(
           event.arguments.modelKey,
           event.arguments.status,
           event,
         );
 
-      case 'syncModelCatalog':
+      case "syncModelCatalog":
         return await syncModelCatalog(event);
 
       default:
         throw new Error(`Unknown field: ${fieldName}`);
     }
   } catch (error) {
-    console.error('Error:', error);
+    console.error("Error:", error);
     throw error;
   }
 };
@@ -128,7 +149,7 @@ async function getModelConfig(scope?: string): Promise<ModelConfig> {
       slotDefaults: {},
       orgDefaults: {},
       agentOverrides: {},
-      localityMode: 'off',
+      localityMode: "off",
     };
   }
 
@@ -154,9 +175,12 @@ async function loadCatalog(): Promise<Record<string, ModelCatalogEntry>> {
  * config row, stamps updatedAt/updatedBy, persists it, and emits
  * MODEL_CONFIG_CHANGED.
  */
-async function updateModelConfig(input: UpdateModelConfigInput, event: ModelConfigResolverEvent): Promise<ModelConfig> {
+async function updateModelConfig(
+  input: UpdateModelConfigInput,
+  event: ModelConfigResolverEvent,
+): Promise<ModelConfig> {
   if (!isAdminFromEvent(event)) {
-    throw new Error('Only administrators can update model configuration');
+    throw new Error("Only administrators can update model configuration");
   }
 
   if (
@@ -173,7 +197,7 @@ async function updateModelConfig(input: UpdateModelConfigInput, event: ModelConf
     if (!entry) {
       throw new Error(`Unknown model: ${key}`);
     }
-    if (entry.status !== 'enabled') {
+    if (entry.status !== "enabled") {
       throw new Error(`Model not enabled: ${key}`);
     }
   };
@@ -185,10 +209,12 @@ async function updateModelConfig(input: UpdateModelConfigInput, event: ModelConf
   let slotDefaults: Record<string, unknown> | undefined;
   if (input.slotDefaults !== undefined && input.slotDefaults !== null) {
     slotDefaults =
-      typeof input.slotDefaults === 'string'
+      typeof input.slotDefaults === "string"
         ? JSON.parse(input.slotDefaults)
         : input.slotDefaults;
-    for (const value of Object.values(slotDefaults as Record<string, unknown>)) {
+    for (const value of Object.values(
+      slotDefaults as Record<string, unknown>,
+    )) {
       assertEnabled(value as string);
     }
   }
@@ -201,18 +227,17 @@ async function updateModelConfig(input: UpdateModelConfigInput, event: ModelConf
       Key: { scope },
     }),
   );
-  const existing: ModelConfig =
-    (existingResult.Item as ModelConfig) || {
-      scope,
-      globalDefaultKey: null,
-      slotDefaults: {},
-      orgDefaults: {},
-      agentOverrides: {},
-      localityMode: 'off',
-    };
+  const existing: ModelConfig = (existingResult.Item as ModelConfig) || {
+    scope,
+    globalDefaultKey: null,
+    slotDefaults: {},
+    orgDefaults: {},
+    agentOverrides: {},
+    localityMode: "off",
+  };
 
   const updatedBy =
-    event.identity?.username || event.identity?.claims?.sub || 'unknown';
+    event.identity?.username || event.identity?.claims?.sub || "unknown";
 
   const merged: ModelConfig = {
     ...existing,
@@ -221,7 +246,8 @@ async function updateModelConfig(input: UpdateModelConfigInput, event: ModelConf
       input.globalDefaultKey !== undefined
         ? input.globalDefaultKey
         : existing.globalDefaultKey,
-    slotDefaults: slotDefaults !== undefined ? slotDefaults : existing.slotDefaults,
+    slotDefaults:
+      slotDefaults !== undefined ? slotDefaults : existing.slotDefaults,
     localityMode:
       input.localityMode !== undefined && input.localityMode !== null
         ? input.localityMode
@@ -259,7 +285,7 @@ async function setModelCatalogEntryStatus(
   event: ModelConfigResolverEvent,
 ): Promise<ModelCatalogEntry> {
   if (!isAdminFromEvent(event)) {
-    throw new Error('Only administrators can update model configuration');
+    throw new Error("Only administrators can update model configuration");
   }
 
   if (!VALID_STATUS.has(status)) {
@@ -292,7 +318,7 @@ async function setModelCatalogEntryStatus(
   await publishEvent(
     createProjectEvent(
       EventTypes.MODEL_CONFIG_CHANGED,
-      'catalog',
+      "catalog",
       { modelKey, status },
       undefined,
     ),
@@ -310,14 +336,14 @@ async function setModelCatalogEntryStatus(
  */
 async function syncModelCatalog(event: ModelConfigResolverEvent) {
   if (!isAdminFromEvent(event)) {
-    throw new Error('Only administrators can trigger a model catalog sync');
+    throw new Error("Only administrators can trigger a model catalog sync");
   }
   const requestedBy =
-    event.identity?.username || event.identity?.claims?.sub || 'unknown';
+    event.identity?.username || event.identity?.claims?.sub || "unknown";
   await publishEvent(
-    createProjectEvent(EventTypes.MODEL_CATALOG_SYNC_REQUESTED, 'catalog', {
+    createProjectEvent(EventTypes.MODEL_CATALOG_SYNC_REQUESTED, "catalog", {
       requestedBy,
     }),
   );
-  return { triggered: true, message: 'Model catalog sync started' };
+  return { triggered: true, message: "Model catalog sync started" };
 }

--- a/backend/src/lambda/seed-model-catalog/__tests__/index.test.ts
+++ b/backend/src/lambda/seed-model-catalog/__tests__/index.test.ts
@@ -4,27 +4,27 @@
  * baseline catalog + config Puts, idempotency conditions, and error handling.
  */
 
-import { mockClient } from 'aws-sdk-client-mock';
-import { DynamoDBClient } from '@aws-sdk/client-dynamodb';
-import { DynamoDBDocumentClient, PutCommand } from '@aws-sdk/lib-dynamodb';
+import { mockClient } from "aws-sdk-client-mock";
+import { DynamoDBClient } from "@aws-sdk/client-dynamodb";
+import { DynamoDBDocumentClient, PutCommand } from "@aws-sdk/lib-dynamodb";
 
-import { seedModelCatalog } from '../index';
+import { seedModelCatalog } from "../index";
 
 const ddbMock = mockClient(DynamoDBDocumentClient);
 
-const CATALOG_TABLE = 'citadel-model-catalog-test';
-const CONFIG_TABLE = 'citadel-model-config-test';
+const CATALOG_TABLE = "citadel-model-catalog-test";
+const CONFIG_TABLE = "citadel-model-config-test";
 
 function makeDoc(): DynamoDBDocumentClient {
   return DynamoDBDocumentClient.from(new DynamoDBClient({}));
 }
 
-describe('seed-model-catalog Lambda', () => {
+describe("seed-model-catalog Lambda", () => {
   beforeEach(() => {
     ddbMock.reset();
   });
 
-  test('seeds catalog item with modelKey and attribute_not_exists condition', async () => {
+  test("seeds catalog item with modelKey and attribute_not_exists condition", async () => {
     ddbMock.on(PutCommand).resolves({});
 
     await seedModelCatalog(makeDoc(), CATALOG_TABLE, CONFIG_TABLE);
@@ -35,11 +35,27 @@ describe('seed-model-catalog Lambda', () => {
     expect(catalogPut).toBeDefined();
 
     const input = catalogPut!.args[0].input;
-    expect(input.Item!.modelKey).toBe('anthropic-claude-sonnet-5');
-    expect(input.ConditionExpression).toContain('attribute_not_exists');
+    expect(input.Item!.modelKey).toBe("anthropic-claude-sonnet-5");
+    expect(input.ConditionExpression).toContain("attribute_not_exists");
   });
 
-  test('seeds config item with scope=platform and globalDefaultKey', async () => {
+  test('seeds catalog item with baseline pricing fields and pricingSource "seed"', async () => {
+    ddbMock.on(PutCommand).resolves({});
+
+    await seedModelCatalog(makeDoc(), CATALOG_TABLE, CONFIG_TABLE);
+
+    const catalogPut = ddbMock
+      .commandCalls(PutCommand)
+      .find((c) => c.args[0].input.TableName === CATALOG_TABLE);
+    const item = catalogPut!.args[0].input.Item!;
+    expect(item.inputPer1kTokens).toEqual(expect.any(Number));
+    expect(item.outputPer1kTokens).toEqual(expect.any(Number));
+    expect(item.currency).toEqual(expect.any(String));
+    expect(item.pricingSource).toBe("seed");
+    expect(item.pricingUpdatedAt).toEqual(expect.any(String));
+  });
+
+  test("seeds config item with scope=platform and globalDefaultKey", async () => {
     ddbMock.on(PutCommand).resolves({});
 
     await seedModelCatalog(makeDoc(), CATALOG_TABLE, CONFIG_TABLE);
@@ -50,18 +66,18 @@ describe('seed-model-catalog Lambda', () => {
     expect(configPut).toBeDefined();
 
     const input = configPut!.args[0].input;
-    expect(input.Item!.scope).toBe('platform');
-    expect(input.Item!.globalDefaultKey).toBe('anthropic-claude-sonnet-5');
+    expect(input.Item!.scope).toBe("platform");
+    expect(input.Item!.globalDefaultKey).toBe("anthropic-claude-sonnet-5");
     // Regression guard: `scope` is a DynamoDB reserved word, so the condition
     // must use an escaped #scope alias. aws-sdk-client-mock does not validate
     // reserved words, so assert the escaped form explicitly.
-    expect(input.ConditionExpression).toBe('attribute_not_exists(#scope)');
-    expect(input.ExpressionAttributeNames).toEqual({ '#scope': 'scope' });
+    expect(input.ConditionExpression).toBe("attribute_not_exists(#scope)");
+    expect(input.ExpressionAttributeNames).toEqual({ "#scope": "scope" });
   });
 
-  test('swallows ConditionalCheckFailedException so re-runs never clobber operator changes', async () => {
-    const conditionalError = new Error('The conditional request failed');
-    conditionalError.name = 'ConditionalCheckFailedException';
+  test("swallows ConditionalCheckFailedException so re-runs never clobber operator changes", async () => {
+    const conditionalError = new Error("The conditional request failed");
+    conditionalError.name = "ConditionalCheckFailedException";
     ddbMock.on(PutCommand).rejects(conditionalError);
 
     // Should not throw — idempotent behavior on re-deploy.
@@ -70,11 +86,11 @@ describe('seed-model-catalog Lambda', () => {
     ).resolves.not.toThrow();
   });
 
-  test('re-throws non-ConditionalCheckFailedException errors', async () => {
-    ddbMock.on(PutCommand).rejects(new Error('InternalServerError'));
+  test("re-throws non-ConditionalCheckFailedException errors", async () => {
+    ddbMock.on(PutCommand).rejects(new Error("InternalServerError"));
 
     await expect(
       seedModelCatalog(makeDoc(), CATALOG_TABLE, CONFIG_TABLE),
-    ).rejects.toThrow('InternalServerError');
+    ).rejects.toThrow("InternalServerError");
   });
 });

--- a/backend/src/lambda/seed-model-catalog/index.ts
+++ b/backend/src/lambda/seed-model-catalog/index.ts
@@ -12,15 +12,15 @@
  * Follows the existing seed-blueprints Custom Resource pattern.
  */
 
-import * as https from 'https';
-import * as url from 'url';
-import { DynamoDBClient } from '@aws-sdk/client-dynamodb';
-import { DynamoDBDocumentClient, PutCommand } from '@aws-sdk/lib-dynamodb';
+import * as https from "https";
+import * as url from "url";
+import { DynamoDBClient } from "@aws-sdk/client-dynamodb";
+import { DynamoDBDocumentClient, PutCommand } from "@aws-sdk/lib-dynamodb";
 import type {
   CloudFormationCustomResourceEvent,
   CloudFormationCustomResourceHandler,
   Context,
-} from 'aws-lambda';
+} from "aws-lambda";
 
 const dynamoClient = new DynamoDBClient({});
 const docClient = DynamoDBDocumentClient.from(dynamoClient);
@@ -29,29 +29,36 @@ const MODEL_CONFIG_TABLE = process.env.MODEL_CONFIG_TABLE!;
 
 /** Baseline catalog entry — the default invokable model. Operators may edit later. */
 export const SEED_MODEL_CATALOG_ITEM = {
-  modelKey: 'anthropic-claude-sonnet-5',
-  provider: 'anthropic',
-  baseModelId: 'anthropic.claude-sonnet-5',
-  status: 'enabled',
-  modality: 'text',
-  invocationMode: 'converse',
+  modelKey: "anthropic-claude-sonnet-5",
+  provider: "anthropic",
+  baseModelId: "anthropic.claude-sonnet-5",
+  status: "enabled",
+  modality: "text",
+  invocationMode: "converse",
   supportsTools: true,
   supportsSystemPrompt: true,
   supportsStreaming: true,
   regionProfiles: {
-    us: 'us.anthropic.claude-sonnet-5',
-    global: 'global.anthropic.claude-sonnet-5',
+    us: "us.anthropic.claude-sonnet-5",
+    global: "global.anthropic.claude-sonnet-5",
   },
+  // Baseline list pricing — additive, same shape as the sync overlay.
+  // Illustrative placeholder; operators may correct via the catalog row.
+  inputPer1kTokens: 3,
+  outputPer1kTokens: 15,
+  currency: "USD",
+  pricingSource: "seed",
+  pricingUpdatedAt: new Date().toISOString(),
 };
 
 /** Baseline platform config entry — resolved defaults. Operators may edit later. */
 export const SEED_MODEL_CONFIG_ITEM = {
-  scope: 'platform',
-  globalDefaultKey: 'anthropic-claude-sonnet-5',
+  scope: "platform",
+  globalDefaultKey: "anthropic-claude-sonnet-5",
   slotDefaults: {},
   orgDefaults: {},
   agentOverrides: {},
-  localityMode: 'off',
+  localityMode: "off",
 };
 
 /**
@@ -70,12 +77,17 @@ export async function seedModelCatalog(
       new PutCommand({
         TableName: catalogTable,
         Item: SEED_MODEL_CATALOG_ITEM,
-        ConditionExpression: 'attribute_not_exists(modelKey)',
+        ConditionExpression: "attribute_not_exists(modelKey)",
       }),
     );
-    console.log(`✓ Seeded model catalog entry: ${SEED_MODEL_CATALOG_ITEM.modelKey}`);
+    console.log(
+      `✓ Seeded model catalog entry: ${SEED_MODEL_CATALOG_ITEM.modelKey}`,
+    );
   } catch (err: unknown) {
-    if (err instanceof Error && err.name === 'ConditionalCheckFailedException') {
+    if (
+      err instanceof Error &&
+      err.name === "ConditionalCheckFailedException"
+    ) {
       console.log(
         `⊘ Model catalog entry already exists, skipping: ${SEED_MODEL_CATALOG_ITEM.modelKey}`,
       );
@@ -90,13 +102,16 @@ export async function seedModelCatalog(
         TableName: configTable,
         Item: SEED_MODEL_CONFIG_ITEM,
         // `scope` is a DynamoDB reserved word — escape it via an alias.
-        ConditionExpression: 'attribute_not_exists(#scope)',
-        ExpressionAttributeNames: { '#scope': 'scope' },
+        ConditionExpression: "attribute_not_exists(#scope)",
+        ExpressionAttributeNames: { "#scope": "scope" },
       }),
     );
     console.log(`✓ Seeded model config entry: ${SEED_MODEL_CONFIG_ITEM.scope}`);
   } catch (err: unknown) {
-    if (err instanceof Error && err.name === 'ConditionalCheckFailedException') {
+    if (
+      err instanceof Error &&
+      err.name === "ConditionalCheckFailedException"
+    ) {
       console.log(
         `⊘ Model config entry already exists, skipping: ${SEED_MODEL_CONFIG_ITEM.scope}`,
       );
@@ -110,7 +125,7 @@ export async function seedModelCatalog(
 async function sendCfnResponse(
   event: CloudFormationCustomResourceEvent,
   context: Context,
-  status: 'SUCCESS' | 'FAILED',
+  status: "SUCCESS" | "FAILED",
   data: Record<string, unknown>,
 ): Promise<void> {
   const responseBody = JSON.stringify({
@@ -131,37 +146,44 @@ async function sendCfnResponse(
         hostname: parsedUrl.hostname,
         port: 443,
         path: parsedUrl.path,
-        method: 'PUT',
+        method: "PUT",
         headers: {
-          'Content-Type': '',
-          'Content-Length': responseBody.length,
+          "Content-Type": "",
+          "Content-Length": responseBody.length,
         },
       },
       () => resolve(),
     );
-    req.on('error', reject);
+    req.on("error", reject);
     req.write(responseBody);
     req.end();
   });
 }
 
-export const handler: CloudFormationCustomResourceHandler = async (event, context) => {
-  console.log('Event:', JSON.stringify(event));
+export const handler: CloudFormationCustomResourceHandler = async (
+  event,
+  context,
+) => {
+  console.log("Event:", JSON.stringify(event));
 
-  if (event.RequestType === 'Delete') {
-    await sendCfnResponse(event, context, 'SUCCESS', { Message: 'Nothing to clean up' });
+  if (event.RequestType === "Delete") {
+    await sendCfnResponse(event, context, "SUCCESS", {
+      Message: "Nothing to clean up",
+    });
     return;
   }
 
   try {
     await seedModelCatalog(docClient, MODEL_CATALOG_TABLE, MODEL_CONFIG_TABLE);
 
-    await sendCfnResponse(event, context, 'SUCCESS', {
-      Message: 'Model catalog seeded successfully',
+    await sendCfnResponse(event, context, "SUCCESS", {
+      Message: "Model catalog seeded successfully",
     });
   } catch (err: unknown) {
-    console.error('Error seeding model catalog:', err);
-    await sendCfnResponse(event, context, 'FAILED', { Message: err instanceof Error ? err.message : String(err) });
+    console.error("Error seeding model catalog:", err);
+    await sendCfnResponse(event, context, "FAILED", {
+      Message: err instanceof Error ? err.message : String(err),
+    });
     throw err;
   }
 };

--- a/backend/src/lambda/utils/__tests__/auth-http-event.test.ts
+++ b/backend/src/lambda/utils/__tests__/auth-http-event.test.ts
@@ -1,0 +1,91 @@
+/**
+ * Tests for auth-http-event.ts — HTTP API (payload format 2.0) JWT-claims
+ * org/admin extraction. Mirrors backend/src/utils/auth-event.ts's claim
+ * reading discipline but targets the HttpUserPoolAuthorizer claims shape
+ * (`event.requestContext.authorizer.jwt.claims`), with NO Cognito
+ * AdminGetUser fallback — the JWT authorizer guarantees a validated token.
+ */
+import {
+  extractOrgFromHttpEvent,
+  isAdminFromHttpEvent,
+} from "../auth-http-event";
+import type { APIGatewayProxyEventV2WithJWTAuthorizer } from "aws-lambda";
+
+function makeEvent(
+  claims: Record<string, unknown>,
+): APIGatewayProxyEventV2WithJWTAuthorizer {
+  return {
+    requestContext: {
+      authorizer: {
+        jwt: {
+          claims,
+          scopes: null,
+        },
+      },
+    },
+  } as unknown as APIGatewayProxyEventV2WithJWTAuthorizer;
+}
+
+describe("extractOrgFromHttpEvent", () => {
+  test("returns the custom:organization claim when present", () => {
+    const event = makeEvent({ "custom:organization": "org-123" });
+    expect(extractOrgFromHttpEvent(event)).toBe("org-123");
+  });
+
+  test("returns null when the claim is absent", () => {
+    const event = makeEvent({});
+    expect(extractOrgFromHttpEvent(event)).toBeNull();
+  });
+
+  test("returns null when the claim is an empty string", () => {
+    const event = makeEvent({ "custom:organization": "" });
+    expect(extractOrgFromHttpEvent(event)).toBeNull();
+  });
+
+  test("returns null when authorizer/jwt/claims is entirely missing", () => {
+    const event = {} as unknown as APIGatewayProxyEventV2WithJWTAuthorizer;
+    expect(extractOrgFromHttpEvent(event)).toBeNull();
+  });
+});
+
+describe("isAdminFromHttpEvent", () => {
+  test("true when custom:role === 'admin'", () => {
+    const event = makeEvent({ "custom:role": "admin" });
+    expect(isAdminFromHttpEvent(event)).toBe(true);
+  });
+
+  test("false when custom:role is a non-admin role", () => {
+    const event = makeEvent({ "custom:role": "developer" });
+    expect(isAdminFromHttpEvent(event)).toBe(false);
+  });
+
+  test("true when cognito:groups is a JS array containing 'admin'", () => {
+    const event = makeEvent({ "cognito:groups": ["viewer", "admin"] });
+    expect(isAdminFromHttpEvent(event)).toBe(true);
+  });
+
+  test("true when cognito:groups is a comma-separated string containing 'admin'", () => {
+    const event = makeEvent({ "cognito:groups": "viewer, admin, editor" });
+    expect(isAdminFromHttpEvent(event)).toBe(true);
+  });
+
+  test("false when cognito:groups does not contain 'admin' (array)", () => {
+    const event = makeEvent({ "cognito:groups": ["viewer", "editor"] });
+    expect(isAdminFromHttpEvent(event)).toBe(false);
+  });
+
+  test("false when cognito:groups does not contain 'admin' (string)", () => {
+    const event = makeEvent({ "cognito:groups": "viewer,editor" });
+    expect(isAdminFromHttpEvent(event)).toBe(false);
+  });
+
+  test("false when neither claim is present", () => {
+    const event = makeEvent({});
+    expect(isAdminFromHttpEvent(event)).toBe(false);
+  });
+
+  test("false when authorizer/jwt/claims is entirely missing", () => {
+    const event = {} as unknown as APIGatewayProxyEventV2WithJWTAuthorizer;
+    expect(isAdminFromHttpEvent(event)).toBe(false);
+  });
+});

--- a/backend/src/lambda/utils/__tests__/cost-aggregate.test.ts
+++ b/backend/src/lambda/utils/__tests__/cost-aggregate.test.ts
@@ -1,0 +1,157 @@
+/**
+ * Tests for cost-aggregate.ts — pure in-Lambda rollup helpers for
+ * /cost/summary (groupBy) and /cost/series (time bucketing). No AWS SDK
+ * imports; callers pass already-Queried ledger rows in.
+ */
+import {
+  aggregateSummary,
+  aggregateSeries,
+  type CostLedgerRowForAggregation,
+} from "../cost-aggregate";
+
+function row(
+  overrides: Partial<CostLedgerRowForAggregation> = {},
+): CostLedgerRowForAggregation {
+  return {
+    orgId: "org-1",
+    appId: "app-1",
+    agentId: "agent-1",
+    projectId: "proj-1",
+    modelKey: "anthropic.claude-3",
+    capturedAt: "2026-07-01T10:15:00.000Z",
+    totalTokens: 100,
+    costMicros: 5_000_000,
+    tokenCost: 5,
+    currency: "USD",
+    priced: true,
+    ...overrides,
+  };
+}
+
+describe("aggregateSummary", () => {
+  test("groups by app, summing costMicros/tokens and counting rows", () => {
+    const rows = [
+      row({ appId: "app-a", costMicros: 1_000_000, totalTokens: 10 }),
+      row({ appId: "app-a", costMicros: 2_000_000, totalTokens: 20 }),
+      row({ appId: "app-b", costMicros: 3_000_000, totalTokens: 30 }),
+    ];
+
+    const result = aggregateSummary(rows, "app");
+
+    expect(result.totalCostMicros).toBe(6_000_000);
+    expect(result.pricedRows).toBe(3);
+    expect(result.unpricedRows).toBe(0);
+    const byKey = Object.fromEntries(result.buckets.map((b) => [b.key, b]));
+    expect(byKey["app-a"].costMicros).toBe(3_000_000);
+    expect(byKey["app-a"].rows).toBe(2);
+    expect(byKey["app-b"].costMicros).toBe(3_000_000);
+    expect(byKey["app-b"].rows).toBe(1);
+  });
+
+  test("groupBy=model uses modelKey (no ModelIndex GSI needed — in-Lambda only)", () => {
+    const rows = [
+      row({ modelKey: "model-x", costMicros: 1_000_000 }),
+      row({ modelKey: "model-y", costMicros: 4_000_000 }),
+    ];
+    const result = aggregateSummary(rows, "model");
+    const keys = result.buckets.map((b) => b.key).sort();
+    expect(keys).toEqual(["model-x", "model-y"]);
+  });
+
+  test("counts unpriced rows separately and excludes them from costMicros sums", () => {
+    const rows = [
+      row({ appId: "app-a", costMicros: 1_000_000, priced: true }),
+      row({
+        appId: "app-a",
+        costMicros: null,
+        tokenCost: null,
+        currency: null,
+        priced: false,
+      }),
+    ];
+    const result = aggregateSummary(rows, "app");
+    expect(result.totalCostMicros).toBe(1_000_000);
+    expect(result.pricedRows).toBe(1);
+    expect(result.unpricedRows).toBe(1);
+    const bucket = result.buckets[0];
+    expect(bucket.costMicros).toBe(1_000_000);
+    expect(bucket.unpricedRows).toBe(1);
+    expect(bucket.rows).toBe(2);
+  });
+
+  test("rows missing the requested dimension are grouped under 'unassigned'", () => {
+    const rows = [row({ appId: undefined })];
+    const result = aggregateSummary(rows, "app");
+    expect(result.buckets).toHaveLength(1);
+    expect(result.buckets[0].key).toBe("unassigned");
+  });
+
+  test("empty input yields zeroed totals and no buckets", () => {
+    const result = aggregateSummary([], "app");
+    expect(result.totalCostMicros).toBe(0);
+    expect(result.pricedRows).toBe(0);
+    expect(result.unpricedRows).toBe(0);
+    expect(result.buckets).toEqual([]);
+  });
+});
+
+describe("aggregateSeries", () => {
+  test("buckets by day (UTC) and sums costMicros per bucket", () => {
+    const rows = [
+      row({ capturedAt: "2026-07-01T01:00:00.000Z", costMicros: 1_000_000 }),
+      row({ capturedAt: "2026-07-01T23:59:00.000Z", costMicros: 2_000_000 }),
+      row({ capturedAt: "2026-07-02T00:00:01.000Z", costMicros: 3_000_000 }),
+    ];
+    const result = aggregateSeries(rows, "day");
+    const byT = Object.fromEntries(result.points.map((p) => [p.t, p]));
+    expect(byT["2026-07-01"].costMicros).toBe(3_000_000);
+    expect(byT["2026-07-02"].costMicros).toBe(3_000_000);
+  });
+
+  test("buckets by hour (UTC), zero-padded", () => {
+    const rows = [
+      row({ capturedAt: "2026-07-01T05:12:00.000Z", costMicros: 1_000_000 }),
+      row({ capturedAt: "2026-07-01T05:59:59.000Z", costMicros: 1_000_000 }),
+      row({ capturedAt: "2026-07-01T06:00:00.000Z", costMicros: 1_000_000 }),
+    ];
+    const result = aggregateSeries(rows, "hour");
+    const byT = Object.fromEntries(result.points.map((p) => [p.t, p]));
+    expect(byT["2026-07-01T05"].costMicros).toBe(2_000_000);
+    expect(byT["2026-07-01T06"].costMicros).toBe(1_000_000);
+  });
+
+  test("points are sorted ascending by bucket key", () => {
+    const rows = [
+      row({ capturedAt: "2026-07-03T00:00:00.000Z" }),
+      row({ capturedAt: "2026-07-01T00:00:00.000Z" }),
+      row({ capturedAt: "2026-07-02T00:00:00.000Z" }),
+    ];
+    const result = aggregateSeries(rows, "day");
+    expect(result.points.map((p) => p.t)).toEqual([
+      "2026-07-01",
+      "2026-07-02",
+      "2026-07-03",
+    ]);
+  });
+
+  test("tracks unpricedCount across all points without summing null costMicros", () => {
+    const rows = [
+      row({ capturedAt: "2026-07-01T00:00:00.000Z", costMicros: 1_000_000 }),
+      row({
+        capturedAt: "2026-07-01T00:00:00.000Z",
+        costMicros: null,
+        priced: false,
+      }),
+    ];
+    const result = aggregateSeries(rows, "day");
+    expect(result.unpricedCount).toBe(1);
+    expect(result.points[0].costMicros).toBe(1_000_000);
+    expect(result.points[0].unpricedRows).toBe(1);
+  });
+
+  test("empty input yields no points and zero unpricedCount", () => {
+    const result = aggregateSeries([], "day");
+    expect(result.points).toEqual([]);
+    expect(result.unpricedCount).toBe(0);
+  });
+});

--- a/backend/src/lambda/utils/__tests__/cost-budget.test.ts
+++ b/backend/src/lambda/utils/__tests__/cost-budget.test.ts
@@ -1,0 +1,96 @@
+/**
+ * Tests for cost-budget.ts — pure budget-domain helpers: periodKey
+ * derivation (UTC), threshold-crossing detection, and the notified-map
+ * escalation logic used by the evaluator's dedupe mechanism.
+ */
+import {
+  periodKeyFor,
+  periodStartIso,
+  crossedThresholds,
+  highestNotifiedThreshold,
+  shouldNotify,
+} from "../cost-budget";
+
+describe("periodKeyFor", () => {
+  test("monthly periodKey is YYYY-MM (UTC)", () => {
+    expect(periodKeyFor("monthly", new Date("2026-07-25T15:10:35.960Z"))).toBe(
+      "2026-07",
+    );
+  });
+
+  test("daily periodKey is YYYY-MM-DD (UTC)", () => {
+    expect(periodKeyFor("daily", new Date("2026-07-25T15:10:35.960Z"))).toBe(
+      "2026-07-25",
+    );
+  });
+
+  test("monthly periodKey uses UTC even near a local-time month boundary", () => {
+    // 2026-01-31T23:30Z is still January in UTC regardless of local tz.
+    expect(periodKeyFor("monthly", new Date("2026-01-31T23:30:00.000Z"))).toBe(
+      "2026-01",
+    );
+  });
+});
+
+describe("periodStartIso", () => {
+  test("monthly period start is the 1st of the month at 00:00:00.000Z", () => {
+    expect(periodStartIso("monthly", "2026-07")).toBe(
+      "2026-07-01T00:00:00.000Z",
+    );
+  });
+
+  test("daily period start is midnight UTC of that day", () => {
+    expect(periodStartIso("daily", "2026-07-25")).toBe(
+      "2026-07-25T00:00:00.000Z",
+    );
+  });
+});
+
+describe("crossedThresholds", () => {
+  test("returns thresholds whose fraction of limit is met or exceeded by spend", () => {
+    const result = crossedThresholds(800_000, 1_000_000, [0.5, 0.8, 1.0]);
+    expect(result).toEqual([0.5, 0.8]);
+  });
+
+  test("returns all thresholds when spend meets/exceeds the limit", () => {
+    const result = crossedThresholds(1_200_000, 1_000_000, [0.5, 0.8, 1.0]);
+    expect(result).toEqual([0.5, 0.8, 1.0]);
+  });
+
+  test("returns empty array when spend is below every threshold", () => {
+    const result = crossedThresholds(100_000, 1_000_000, [0.5, 0.8, 1.0]);
+    expect(result).toEqual([]);
+  });
+
+  test("handles an empty thresholds list", () => {
+    expect(crossedThresholds(1_000_000, 1_000_000, [])).toEqual([]);
+  });
+});
+
+describe("highestNotifiedThreshold", () => {
+  test("returns undefined when the period key is absent from the notified map", () => {
+    expect(highestNotifiedThreshold({}, "2026-07")).toBeUndefined();
+  });
+
+  test("returns the stored value for the given period key", () => {
+    expect(highestNotifiedThreshold({ "2026-07": 0.8 }, "2026-07")).toBe(0.8);
+  });
+});
+
+describe("shouldNotify (escalation semantics)", () => {
+  test("true when nothing has been notified yet for the period", () => {
+    expect(shouldNotify(undefined, 0.8)).toBe(true);
+  });
+
+  test("true when the crossed threshold escalates past the last notified one", () => {
+    expect(shouldNotify(0.8, 1.0)).toBe(true);
+  });
+
+  test("false when the crossed threshold was already notified", () => {
+    expect(shouldNotify(0.8, 0.8)).toBe(false);
+  });
+
+  test("false when the crossed threshold is lower than what was already notified", () => {
+    expect(shouldNotify(1.0, 0.8)).toBe(false);
+  });
+});

--- a/backend/src/lambda/utils/__tests__/cost-compute.test.ts
+++ b/backend/src/lambda/utils/__tests__/cost-compute.test.ts
@@ -1,0 +1,182 @@
+/**
+ * Unit + property tests for the pure cost-compute helper.
+ *
+ * Covers: token-cost math, half-up 8dp rounding, drift-free integer
+ * costMicros, currency propagation, and the unpriced fallback policy
+ * (missing model / missing pricing → priced:false, never a fabricated price).
+ */
+
+import fc from "fast-check";
+import { computeTokenCost, type PricingInfo } from "../cost-compute";
+
+describe("computeTokenCost — priced path", () => {
+  test("1000 in @ $3/1k + 500 out @ $15/1k => tokenCost 10.5, costMicros 10500000", () => {
+    const pricing: PricingInfo = {
+      inputPer1kTokens: 3,
+      outputPer1kTokens: 15,
+      currency: "USD",
+    };
+    const result = computeTokenCost(1000, 500, pricing);
+    expect(result.priced).toBe(true);
+    expect(result.tokenCost).toBeCloseTo(10.5, 8);
+    expect(result.costMicros).toBe(10500000);
+    expect(result.currency).toBe("USD");
+    expect(result.unpricedReason).toBeUndefined();
+  });
+
+  test("zero tokens => zero cost, still priced", () => {
+    const pricing: PricingInfo = {
+      inputPer1kTokens: 3,
+      outputPer1kTokens: 15,
+      currency: "USD",
+    };
+    const result = computeTokenCost(0, 0, pricing);
+    expect(result.priced).toBe(true);
+    expect(result.tokenCost).toBe(0);
+    expect(result.costMicros).toBe(0);
+  });
+
+  test("rounds tokenCost half-up to 8 decimal places", () => {
+    const pricing: PricingInfo = {
+      inputPer1kTokens: 0.333333335,
+      outputPer1kTokens: 0,
+      currency: "USD",
+    };
+    // 1000/1000 * 0.333333335 = 0.333333335 -> half-up 8dp = 0.33333334 (9th digit is 5, rounds up)
+    const result = computeTokenCost(1000, 0, pricing);
+    expect(result.tokenCost).toBe(0.33333334);
+  });
+
+  test("costMicros is an integer derived from rounded tokenCost (drift-free)", () => {
+    const pricing: PricingInfo = {
+      inputPer1kTokens: 1,
+      outputPer1kTokens: 1,
+      currency: "USD",
+    };
+    const result = computeTokenCost(333, 667, pricing);
+    expect(Number.isInteger(result.costMicros)).toBe(true);
+  });
+
+  test("propagates the catalog currency verbatim (non-USD)", () => {
+    const pricing: PricingInfo = {
+      inputPer1kTokens: 2,
+      outputPer1kTokens: 4,
+      currency: "EUR",
+    };
+    const result = computeTokenCost(1000, 1000, pricing);
+    expect(result.currency).toBe("EUR");
+  });
+});
+
+describe("computeTokenCost — unpriced fallback policy", () => {
+  test("missing pricing entirely => priced:false, null cost fields, reason pricing_absent", () => {
+    const result = computeTokenCost(100, 50, undefined);
+    expect(result.priced).toBe(false);
+    expect(result.tokenCost).toBeNull();
+    expect(result.costMicros).toBeNull();
+    expect(result.currency).toBeNull();
+    expect(result.unpricedReason).toBe("pricing_absent");
+  });
+
+  test("pricing object present but missing inputPer1kTokens => unpriced (never guesses)", () => {
+    const pricing = {
+      outputPer1kTokens: 15,
+      currency: "USD",
+    } as unknown as PricingInfo;
+    const result = computeTokenCost(100, 50, pricing);
+    expect(result.priced).toBe(false);
+    expect(result.tokenCost).toBeNull();
+    expect(result.costMicros).toBeNull();
+    expect(result.unpricedReason).toBe("pricing_absent");
+  });
+
+  test("pricing object present but missing outputPer1kTokens => unpriced", () => {
+    const pricing = {
+      inputPer1kTokens: 3,
+      currency: "USD",
+    } as unknown as PricingInfo;
+    const result = computeTokenCost(100, 50, pricing);
+    expect(result.priced).toBe(false);
+    expect(result.unpricedReason).toBe("pricing_absent");
+  });
+
+  test("missing currency => unpriced (never fabricates a currency either)", () => {
+    const pricing = {
+      inputPer1kTokens: 3,
+      outputPer1kTokens: 15,
+    } as unknown as PricingInfo;
+    const result = computeTokenCost(100, 50, pricing);
+    expect(result.priced).toBe(false);
+    expect(result.unpricedReason).toBe("pricing_absent");
+  });
+
+  test("model_not_in_catalog reason is distinct from pricing_absent", () => {
+    const result = computeTokenCost(100, 50, undefined, "model_not_in_catalog");
+    expect(result.priced).toBe(false);
+    expect(result.unpricedReason).toBe("model_not_in_catalog");
+  });
+});
+
+describe("computeTokenCost — property-based invariants", () => {
+  test("costMicros is always Math.round(tokenCost * 1e6) when priced", () => {
+    fc.assert(
+      fc.property(
+        fc.nat({ max: 1_000_000 }),
+        fc.nat({ max: 1_000_000 }),
+        fc.float({ min: 0, max: 100, noNaN: true }),
+        fc.float({ min: 0, max: 100, noNaN: true }),
+        (inputTokens, outputTokens, inRate, outRate) => {
+          const pricing: PricingInfo = {
+            inputPer1kTokens: inRate,
+            outputPer1kTokens: outRate,
+            currency: "USD",
+          };
+          const result = computeTokenCost(inputTokens, outputTokens, pricing);
+          expect(result.priced).toBe(true);
+          expect(result.costMicros).toBe(
+            Math.round((result.tokenCost as number) * 1e6),
+          );
+        },
+      ),
+    );
+  });
+
+  test("tokenCost is always non-negative for non-negative inputs", () => {
+    fc.assert(
+      fc.property(
+        fc.nat({ max: 1_000_000 }),
+        fc.nat({ max: 1_000_000 }),
+        fc.float({ min: 0, max: 100, noNaN: true }),
+        fc.float({ min: 0, max: 100, noNaN: true }),
+        (inputTokens, outputTokens, inRate, outRate) => {
+          const pricing: PricingInfo = {
+            inputPer1kTokens: inRate,
+            outputPer1kTokens: outRate,
+            currency: "USD",
+          };
+          const result = computeTokenCost(inputTokens, outputTokens, pricing);
+          expect((result.tokenCost as number) >= 0).toBe(true);
+        },
+      ),
+    );
+  });
+
+  test("missing pricing always yields the unpriced shape regardless of token counts", () => {
+    fc.assert(
+      fc.property(
+        fc.nat({ max: 1_000_000 }),
+        fc.nat({ max: 1_000_000 }),
+        (inputTokens, outputTokens) => {
+          const result = computeTokenCost(inputTokens, outputTokens, undefined);
+          expect(result).toEqual({
+            priced: false,
+            tokenCost: null,
+            costMicros: null,
+            currency: null,
+            unpricedReason: "pricing_absent",
+          });
+        },
+      ),
+    );
+  });
+});

--- a/backend/src/lambda/utils/__tests__/cost-drift.test.ts
+++ b/backend/src/lambda/utils/__tests__/cost-drift.test.ts
@@ -1,0 +1,235 @@
+/**
+ * Unit + property tests for the pure cost-drift helpers used by the
+ * cost-ledger reconciler (Tier A aggregate drift).
+ *
+ * Covers: drift-percentage math (never Infinity/NaN, null on unmatched),
+ * hour alignment idempotency, window enumeration boundaries/cap, and
+ * per-model ledger aggregation.
+ */
+
+import fc from "fast-check";
+import {
+  computeDriftPct,
+  alignToHour,
+  enumerateWindows,
+  aggregateLedgerWindow,
+} from "../cost-drift";
+import type { LedgerRowProjection } from "../cost-reconciler-types";
+
+describe("computeDriftPct", () => {
+  test("returns 0 when ledger equals metric, for any positive value", () => {
+    fc.assert(
+      fc.property(fc.float({ min: 1, max: 1_000_000, noNaN: true }), (x) => {
+        expect(computeDriftPct(x, x)).toBe(0);
+      }),
+    );
+  });
+
+  test("returns null when metric is exactly 0 (divide-by-zero guard)", () => {
+    expect(computeDriftPct(100, 0)).toBeNull();
+  });
+
+  test("returns null when metric is negative (never fabricates from a bad denom)", () => {
+    expect(computeDriftPct(100, -5)).toBeNull();
+  });
+
+  test("positive drift when ledger overcounts vs metric", () => {
+    const result = computeDriftPct(150, 100);
+    expect(result).not.toBeNull();
+    expect(result as number).toBeGreaterThan(0);
+  });
+
+  test("negative drift when ledger undercounts vs metric", () => {
+    const result = computeDriftPct(50, 100);
+    expect(result).not.toBeNull();
+    expect(result as number).toBeLessThan(0);
+  });
+
+  test("exact math: ledger=150, metric=100 => driftPct=50", () => {
+    expect(computeDriftPct(150, 100)).toBe(50);
+  });
+
+  test("rounds to 4 decimal places", () => {
+    // (100.00005 - 100) / 100 * 100 = 0.00005 -> rounds to 4dp = 0.0001 (half-up) or 0
+    const result = computeDriftPct(100.00005, 100);
+    expect(result).not.toBeNull();
+    expect(Math.round((result as number) * 10000) / 10000).toBe(result);
+  });
+
+  test("property: never returns Infinity or NaN for any finite non-negative ledger and any finite metric", () => {
+    fc.assert(
+      fc.property(
+        fc.float({ min: 0, max: 1_000_000, noNaN: true }),
+        fc.float({ min: -1_000_000, max: 1_000_000, noNaN: true }),
+        (ledgerTok, metricTok) => {
+          const result = computeDriftPct(ledgerTok, metricTok);
+          if (result !== null) {
+            expect(Number.isFinite(result)).toBe(true);
+            expect(Number.isNaN(result)).toBe(false);
+          }
+        },
+      ),
+    );
+  });
+
+  test("property: metric<=0 always yields null", () => {
+    fc.assert(
+      fc.property(
+        fc.float({ min: 0, max: 1_000_000, noNaN: true }),
+        fc.float({ min: -1_000_000, max: 0, noNaN: true }),
+        (ledgerTok, metricTok) => {
+          expect(computeDriftPct(ledgerTok, metricTok)).toBeNull();
+        },
+      ),
+    );
+  });
+});
+
+describe("alignToHour", () => {
+  test("is idempotent: f(f(x)) === f(x)", () => {
+    fc.assert(
+      fc.property(fc.nat({ max: 2_000_000_000 }), (x) => {
+        const once = alignToHour(x);
+        expect(alignToHour(once)).toBe(once);
+      }),
+    );
+  });
+
+  test("result is always <= input", () => {
+    fc.assert(
+      fc.property(fc.nat({ max: 2_000_000_000 }), (x) => {
+        expect(alignToHour(x)).toBeLessThanOrEqual(x);
+      }),
+    );
+  });
+
+  test("result is always a multiple of 3600", () => {
+    fc.assert(
+      fc.property(fc.nat({ max: 2_000_000_000 }), (x) => {
+        expect(alignToHour(x) % 3600).toBe(0);
+      }),
+    );
+  });
+
+  test("exact: 3661 aligns to 3600", () => {
+    expect(alignToHour(3661)).toBe(3600);
+  });
+});
+
+describe("enumerateWindows", () => {
+  test("empty array when watermark >= targetEnd (boundary edge)", () => {
+    expect(enumerateWindows(7200, 7200, 6)).toEqual([]);
+    expect(enumerateWindows(7200, 3600, 6)).toEqual([]);
+  });
+
+  test("produces contiguous hour-aligned half-open windows ascending", () => {
+    const windows = enumerateWindows(0, 3 * 3600, 10);
+    expect(windows).toEqual([
+      { startSec: 0, endSec: 3600 },
+      { startSec: 3600, endSec: 7200 },
+      { startSec: 7200, endSec: 10800 },
+    ]);
+  });
+
+  test("respects the maxWindows cap on catch-up", () => {
+    const windows = enumerateWindows(0, 10 * 3600, 6);
+    expect(windows).toHaveLength(6);
+    expect(windows[0]).toEqual({ startSec: 0, endSec: 3600 });
+    expect(windows[5]).toEqual({ startSec: 5 * 3600, endSec: 6 * 3600 });
+  });
+
+  test("a value exactly on an hour boundary is not double-counted (half-open)", () => {
+    const windows = enumerateWindows(3600, 7200, 6);
+    expect(windows).toEqual([{ startSec: 3600, endSec: 7200 }]);
+  });
+
+  test("property: never exceeds maxWindows and each window is exactly 3600s", () => {
+    fc.assert(
+      fc.property(
+        fc.nat({ max: 100 }),
+        fc.nat({ max: 100 }),
+        fc.integer({ min: 1, max: 20 }),
+        (wmHours, spanHours, maxWindows) => {
+          const watermark = wmHours * 3600;
+          const targetEnd = watermark + spanHours * 3600;
+          const windows = enumerateWindows(watermark, targetEnd, maxWindows);
+          expect(windows.length).toBeLessThanOrEqual(maxWindows);
+          for (const w of windows) {
+            expect(w.endSec - w.startSec).toBe(3600);
+          }
+        },
+      ),
+    );
+  });
+});
+
+describe("aggregateLedgerWindow", () => {
+  test("groups rows by modelKey, sums tokens, collects rowKeys", () => {
+    const rows: LedgerRowProjection[] = [
+      {
+        PK: "ORG#a",
+        SK: "s1",
+        modelKey: "claude-sonnet",
+        modelId: "anthropic.claude-sonnet-5",
+        inputTokens: 100,
+        outputTokens: 50,
+      },
+      {
+        PK: "ORG#a",
+        SK: "s2",
+        modelKey: "claude-sonnet",
+        modelId: "anthropic.claude-sonnet-5",
+        inputTokens: 20,
+        outputTokens: 10,
+      },
+      {
+        PK: "ORG#b",
+        SK: "s3",
+        modelKey: "claude-haiku",
+        modelId: "anthropic.claude-haiku-5",
+        inputTokens: 5,
+        outputTokens: 5,
+      },
+    ];
+
+    const agg = aggregateLedgerWindow(rows);
+    expect(agg.size).toBe(2);
+    const sonnet = agg.get("claude-sonnet");
+    expect(sonnet).toBeDefined();
+    expect(sonnet?.inputTokens).toBe(120);
+    expect(sonnet?.outputTokens).toBe(60);
+    expect(sonnet?.rowKeys).toHaveLength(2);
+    expect(sonnet?.modelId).toBe("anthropic.claude-sonnet-5");
+
+    const haiku = agg.get("claude-haiku");
+    expect(haiku?.inputTokens).toBe(5);
+  });
+
+  test("coerces missing/non-numeric tokens to 0 without throwing", () => {
+    const rows: LedgerRowProjection[] = [
+      {
+        PK: "ORG#a",
+        SK: "s1",
+        modelKey: "claude-sonnet",
+        modelId: "anthropic.claude-sonnet-5",
+        inputTokens: undefined,
+        outputTokens: "not-a-number",
+      },
+    ];
+    const agg = aggregateLedgerWindow(rows);
+    const sonnet = agg.get("claude-sonnet");
+    expect(sonnet?.inputTokens).toBe(0);
+    expect(sonnet?.outputTokens).toBe(0);
+  });
+
+  test("empty input yields empty map", () => {
+    expect(aggregateLedgerWindow([]).size).toBe(0);
+  });
+
+  test("rows with missing modelKey are skipped (never fabricate a model bucket)", () => {
+    const rows: LedgerRowProjection[] = [
+      { PK: "ORG#a", SK: "s1", modelId: "x", inputTokens: 10, outputTokens: 5 },
+    ];
+    expect(aggregateLedgerWindow(rows).size).toBe(0);
+  });
+});

--- a/backend/src/lambda/utils/__tests__/cost-ledger-sk-namespace.test.ts
+++ b/backend/src/lambda/utils/__tests__/cost-ledger-sk-namespace.test.ts
@@ -1,0 +1,37 @@
+/**
+ * SK-namespace invariant: BUDGET# rows must never be swept into an
+ * ISO-window ledger rollup Query. Rollup queries bound SK with ISO
+ * timestamps only (`SK BETWEEN :fromIso AND :toIso`) — never a high-byte
+ * sentinel. Budget rows use SK prefix `BUDGET#` ('B'=0x42 > '2'=0x32, the
+ * leading char of any realistic ISO year), so lexically `BUDGET#...`
+ * always sorts AFTER any ISO window upper bound this system would ever
+ * construct, and a plain string BETWEEN can never include it.
+ *
+ * This is a pure string-ordering test — no DynamoDB round-trip needed;
+ * DynamoDB's BETWEEN on a String (S) sort key uses byte-wise (lexical)
+ * ordering, identical to JS string comparison for ASCII ranges.
+ */
+import { budgetSortKey } from "../cost-budget";
+
+describe("SK-namespace invariant (BUDGET# vs ISO-window rollups)", () => {
+  test("a BUDGET# SK sorts after any realistic ISO-window upper bound", () => {
+    const budgetSk = budgetSortKey("org");
+    const farFutureIso = "2099-12-31T23:59:59.999Z";
+    // Lexical comparison mirrors DynamoDB's BETWEEN semantics on a String sort key.
+    expect(budgetSk > farFutureIso).toBe(true);
+  });
+
+  test("BETWEEN over any ISO window [from, to] never matches a BUDGET# SK", () => {
+    const fromIso = "2000-01-01T00:00:00.000Z";
+    const toIso = "2099-12-31T23:59:59.999Z";
+    const budgetSk = budgetSortKey("app#app-1");
+
+    const withinWindow = budgetSk >= fromIso && budgetSk <= toIso;
+    expect(withinWindow).toBe(false);
+  });
+
+  test("budgetSortKey produces the documented SK shapes for org and app scope", () => {
+    expect(budgetSortKey("org")).toBe("BUDGET#ORG");
+    expect(budgetSortKey("app#app-42")).toBe("BUDGET#APP#app-42");
+  });
+});

--- a/backend/src/lambda/utils/auth-http-event.ts
+++ b/backend/src/lambda/utils/auth-http-event.ts
@@ -1,0 +1,68 @@
+/**
+ * Auth HTTP Event — HTTP API (payload format 2.0) JWT-claims org/admin
+ * extraction for the cost query surface.
+ *
+ * Mirrors backend/src/utils/auth-event.ts's claim-reading discipline
+ * (`custom:organization`, `custom:role`, `cognito:groups` tolerant of both
+ * JS-array and comma-separated-string shapes) but targets the claims shape
+ * the API Gateway HttpUserPoolAuthorizer injects for HTTP APIs:
+ * `event.requestContext.authorizer.jwt.claims`.
+ *
+ * Deliberately has NO Cognito AdminGetUser fallback (unlike
+ * extractOrgFromEvent's AppSync counterpart): the HttpUserPoolAuthorizer
+ * validates iss/aud/signature before the Lambda ever runs, so a request
+ * reaching this handler always carries a fully-formed, current token — the
+ * fallback exists there only for the AppSync token-refresh transition
+ * window, which cannot occur on this path.
+ */
+
+import type { APIGatewayProxyEventV2WithJWTAuthorizer } from "aws-lambda";
+
+type JwtClaims = Record<string, unknown>;
+
+function readClaims(
+  event: APIGatewayProxyEventV2WithJWTAuthorizer | null | undefined,
+): JwtClaims {
+  return event?.requestContext?.authorizer?.jwt?.claims ?? {};
+}
+
+/**
+ * Extracts the caller's organization from the verified JWT claim
+ * `custom:organization`. Returns null when absent or empty — callers treat
+ * null as "deny" (403), never as "fall through to admin-all-orgs".
+ */
+export function extractOrgFromHttpEvent(
+  event: APIGatewayProxyEventV2WithJWTAuthorizer,
+): string | null {
+  const claims = readClaims(event);
+  const org = claims["custom:organization"];
+  return typeof org === "string" && org.length > 0 ? org : null;
+}
+
+/**
+ * True when the caller is an admin, via either:
+ *  1. `custom:role === 'admin'`
+ *  2. `cognito:groups` membership includes `'admin'` — tolerant of both the
+ *     JS-array shape (standard JWT decoding) and a comma-separated-string
+ *     shape (some proxy/authorizer configurations flatten it).
+ */
+export function isAdminFromHttpEvent(
+  event: APIGatewayProxyEventV2WithJWTAuthorizer,
+): boolean {
+  const claims = readClaims(event);
+
+  if (claims["custom:role"] === "admin") return true;
+
+  const groups = claims["cognito:groups"];
+  if (Array.isArray(groups)) {
+    return groups.some((g) => typeof g === "string" && g === "admin");
+  }
+  if (typeof groups === "string") {
+    return groups
+      .split(",")
+      .map((s) => s.trim())
+      .includes("admin");
+  }
+
+  return false;
+}

--- a/backend/src/lambda/utils/cost-aggregate.ts
+++ b/backend/src/lambda/utils/cost-aggregate.ts
@@ -1,0 +1,187 @@
+/**
+ * Cost Aggregate — pure in-Lambda rollup helpers for the cost query
+ * surface (`/cost/summary`, `/cost/series`).
+ *
+ * Org-scoped reads hit the BASE table (PK=ORG#<org>, SK=<capturedAt>#...)
+ * because the binding property test requires the org isolation guarantee
+ * to live in the DynamoDB key condition, never in a post-filter — and
+ * `groupBy=model` has no supporting GSI. Aggregation therefore happens
+ * here, in-Lambda, over rows the caller already Queried against the base
+ * table (or, for the admin all-orgs exception, a Scan).
+ *
+ * Pure and I/O-free — no AWS SDK imports. costMicros sums only include
+ * `priced===true` rows (unpriced rows are counted separately, per the
+ * "never fabricate a price" policy); a mixed-currency rollup would be
+ * meaningless to sum, so callers that need currency-safety should bucket
+ * upstream by currency before calling this (v1 assumes a single currency
+ * per org, matching the model-catalog's per-model single-currency rows).
+ */
+
+export type SummaryGroupBy = "app" | "agent" | "model" | "project";
+export type SeriesBucket = "hour" | "day";
+
+/** Narrow view of a ledger row this module needs — see cost-ledger-writer.ts's LedgerRow for the full shape. */
+export interface CostLedgerRowForAggregation {
+  orgId: string;
+  appId?: string;
+  agentId?: string;
+  projectId?: string;
+  modelKey?: string;
+  capturedAt: string;
+  totalTokens: number;
+  costMicros: number | null;
+  tokenCost: number | null;
+  currency: string | null;
+  priced: boolean;
+}
+
+export interface SummaryBucket {
+  key: string;
+  label: string;
+  costMicros: number;
+  tokenCost: number;
+  totalTokens: number;
+  rows: number;
+  unpricedRows: number;
+}
+
+export interface SummaryResult {
+  totalCostMicros: number;
+  pricedRows: number;
+  unpricedRows: number;
+  buckets: SummaryBucket[];
+}
+
+export interface SeriesPoint {
+  t: string;
+  costMicros: number;
+  totalTokens: number;
+  rows: number;
+  unpricedRows: number;
+}
+
+export interface SeriesResult {
+  points: SeriesPoint[];
+  unpricedCount: number;
+}
+
+const UNASSIGNED = "unassigned";
+
+function dimensionKey(
+  row: CostLedgerRowForAggregation,
+  groupBy: SummaryGroupBy,
+): string {
+  const value =
+    groupBy === "app"
+      ? row.appId
+      : groupBy === "agent"
+        ? row.agentId
+        : groupBy === "project"
+          ? row.projectId
+          : row.modelKey;
+  return value && value.length > 0 ? value : UNASSIGNED;
+}
+
+/**
+ * Groups rows by the requested dimension, summing cost/tokens per bucket.
+ * Rows missing the dimension attribute fall into a single `unassigned`
+ * bucket rather than being dropped — a dropped row would silently
+ * understate total spend.
+ */
+export function aggregateSummary(
+  rows: CostLedgerRowForAggregation[],
+  groupBy: SummaryGroupBy,
+): SummaryResult {
+  const buckets = new Map<string, SummaryBucket>();
+  let totalCostMicros = 0;
+  let pricedRows = 0;
+  let unpricedRows = 0;
+
+  for (const row of rows) {
+    const key = dimensionKey(row, groupBy);
+    let bucket = buckets.get(key);
+    if (!bucket) {
+      bucket = {
+        key,
+        label: key,
+        costMicros: 0,
+        tokenCost: 0,
+        totalTokens: 0,
+        rows: 0,
+        unpricedRows: 0,
+      };
+      buckets.set(key, bucket);
+    }
+
+    bucket.rows += 1;
+    bucket.totalTokens += row.totalTokens;
+
+    if (row.priced && row.costMicros !== null) {
+      bucket.costMicros += row.costMicros;
+      bucket.tokenCost += row.tokenCost ?? 0;
+      totalCostMicros += row.costMicros;
+      pricedRows += 1;
+    } else {
+      bucket.unpricedRows += 1;
+      unpricedRows += 1;
+    }
+  }
+
+  return {
+    totalCostMicros,
+    pricedRows,
+    unpricedRows,
+    buckets: Array.from(buckets.values()).sort((a, b) =>
+      a.key.localeCompare(b.key),
+    ),
+  };
+}
+
+/** UTC day bucket key, e.g. "2026-07-25". */
+function dayBucketKey(capturedAt: string): string {
+  return capturedAt.slice(0, 10);
+}
+
+/** UTC hour bucket key, e.g. "2026-07-25T05". */
+function hourBucketKey(capturedAt: string): string {
+  return capturedAt.slice(0, 13);
+}
+
+/**
+ * Buckets rows into a time series (hour or day, UTC), summing
+ * cost/tokens per bucket. Points are sorted ascending by bucket key —
+ * ISO-prefixed keys sort chronologically as plain strings, so no Date
+ * parsing is needed for ordering.
+ */
+export function aggregateSeries(
+  rows: CostLedgerRowForAggregation[],
+  bucket: SeriesBucket,
+): SeriesResult {
+  const keyFor = bucket === "hour" ? hourBucketKey : dayBucketKey;
+  const points = new Map<string, SeriesPoint>();
+  let unpricedCount = 0;
+
+  for (const row of rows) {
+    const t = keyFor(row.capturedAt);
+    let point = points.get(t);
+    if (!point) {
+      point = { t, costMicros: 0, totalTokens: 0, rows: 0, unpricedRows: 0 };
+      points.set(t, point);
+    }
+
+    point.rows += 1;
+    point.totalTokens += row.totalTokens;
+
+    if (row.priced && row.costMicros !== null) {
+      point.costMicros += row.costMicros;
+    } else {
+      point.unpricedRows += 1;
+      unpricedCount += 1;
+    }
+  }
+
+  return {
+    points: Array.from(points.values()).sort((a, b) => a.t.localeCompare(b.t)),
+    unpricedCount,
+  };
+}

--- a/backend/src/lambda/utils/cost-budget.ts
+++ b/backend/src/lambda/utils/cost-budget.ts
@@ -1,0 +1,93 @@
+/**
+ * Cost Budget — pure budget-domain helpers shared by cost-query-handler.ts
+ * (PUT /budgets validation/serialization) and cost-budget-evaluator.ts
+ * (period-to-date comparison + dedupe escalation logic).
+ *
+ * Pure and I/O-free — no AWS SDK imports.
+ */
+
+export type BudgetPeriodType = "monthly" | "daily";
+
+/** `scope` path-param shape: "org" or "app:<appId>" (see PUT /budgets/{scope}). */
+export type BudgetScope = "org" | `app:${string}`;
+
+/**
+ * Builds the ledger-table sort key for a budget row. Scope is normalized
+ * to the `SK` namespace `BUDGET#ORG` / `BUDGET#APP#<appId>` — deliberately
+ * NOT ISO-timestamp-prefixed, so it can never collide with (or be swept
+ * into) a `SK BETWEEN :fromIso AND :toIso` rollup Query. Accepts either
+ * the bare `"org"` / `"app#<id>"` internal form or the wire `"org"` /
+ * `"app:<id>"` scope param — both normalize to the same SK.
+ */
+export function budgetSortKey(scope: string): string {
+  const normalized = scope.replace(":", "#");
+  if (normalized === "org") return "BUDGET#ORG";
+  const match = /^app#(.+)$/.exec(normalized);
+  if (match) return `BUDGET#APP#${match[1]}`;
+  throw new Error(`cost-budget: invalid budget scope "${scope}"`);
+}
+
+/** Parses a wire scope param ("org" | "app:<appId>") into {scopeType, appId?}. */
+export function parseBudgetScope(
+  scope: string,
+): { scopeType: "org" } | { scopeType: "app"; appId: string } {
+  if (scope === "org") return { scopeType: "org" };
+  const match = /^app:(.+)$/.exec(scope);
+  if (match && match[1].length > 0) {
+    return { scopeType: "app", appId: match[1] };
+  }
+  throw new Error(`cost-budget: invalid budget scope "${scope}"`);
+}
+
+/** periodKey: "YYYY-MM" (monthly) or "YYYY-MM-DD" (daily), always UTC. */
+export function periodKeyFor(periodType: BudgetPeriodType, now: Date): string {
+  const iso = now.toISOString(); // e.g. 2026-07-25T15:10:35.960Z
+  return periodType === "monthly" ? iso.slice(0, 7) : iso.slice(0, 10);
+}
+
+/** ISO start-of-period timestamp (UTC midnight) for a given periodKey. */
+export function periodStartIso(
+  periodType: BudgetPeriodType,
+  periodKey: string,
+): string {
+  const day = periodType === "monthly" ? `${periodKey}-01` : periodKey;
+  return `${day}T00:00:00.000Z`;
+}
+
+/**
+ * Returns the subset of `thresholds` (fractions of `limitMicros`) that
+ * `spentMicros` meets or exceeds, in ascending order. An empty thresholds
+ * list yields an empty result.
+ */
+export function crossedThresholds(
+  spentMicros: number,
+  limitMicros: number,
+  thresholds: number[],
+): number[] {
+  if (limitMicros <= 0) return [];
+  const ratio = spentMicros / limitMicros;
+  return thresholds.filter((t) => ratio >= t).sort((a, b) => a - b);
+}
+
+/** The highest threshold already notified for `periodKey`, or undefined if none. */
+export function highestNotifiedThreshold(
+  notified: Record<string, number>,
+  periodKey: string,
+): number | undefined {
+  return notified[periodKey];
+}
+
+/**
+ * True when `crossedThreshold` represents a new escalation relative to
+ * `lastNotified` (undefined = nothing notified yet for this period). This
+ * is the pure predicate backing the evaluator's conditional-UpdateItem
+ * dedupe: notify once per (period, threshold), and again only if a higher
+ * threshold is subsequently crossed within the same period.
+ */
+export function shouldNotify(
+  lastNotified: number | undefined,
+  crossedThreshold: number,
+): boolean {
+  if (lastNotified === undefined) return true;
+  return crossedThreshold > lastNotified;
+}

--- a/backend/src/lambda/utils/cost-compute.ts
+++ b/backend/src/lambda/utils/cost-compute.ts
@@ -1,0 +1,94 @@
+/**
+ * Cost Compute — pure token-cost helper for the invocation cost ledger.
+ *
+ * tokenCost = inputTokens/1000 * inputPer1kTokens + outputTokens/1000 * outputPer1kTokens
+ *
+ * - Rounded half-up to 8 decimal places (`tokenCost`), plus a drift-free
+ *   integer `costMicros = Math.round(tokenCost * 1e6)` for downstream SUM
+ *   aggregations that must avoid float drift.
+ * - Currency is taken verbatim from the catalog pricing row — never inferred.
+ * - UNPRICED FALLBACK POLICY (never fabricate a price): if pricing is
+ *   missing, or lacks `inputPer1kTokens` / `outputPer1kTokens` / `currency`,
+ *   the result is `{priced:false, tokenCost:null, costMicros:null,
+ *   currency:null, unpricedReason}`. No price or currency is ever guessed.
+ *
+ * Pure and I/O-free — no AWS SDK imports, no env var reads. Callers resolve
+ * pricing (typically via a DynamoDB GetItem on the model-catalog table) and
+ * pass the result in.
+ */
+
+/** Pricing metadata read from a model-catalog row. */
+export interface PricingInfo {
+  inputPer1kTokens: number;
+  outputPer1kTokens: number;
+  currency: string;
+}
+
+/** Why a row could not be priced — used verbatim as `unpricedReason` on the ledger row. */
+export type UnpricedReason = "model_not_in_catalog" | "pricing_absent";
+
+export interface TokenCostResult {
+  priced: boolean;
+  tokenCost: number | null;
+  costMicros: number | null;
+  currency: string | null;
+  unpricedReason?: UnpricedReason;
+}
+
+/** Rounds `value` half-up to `decimals` decimal places without introducing float noise. */
+function roundHalfUp(value: number, decimals: number): number {
+  const factor = 10 ** decimals;
+  return Math.round((value + Number.EPSILON) * factor) / factor;
+}
+
+/** Type-guards a candidate pricing object: all three required fields present and numeric/string. */
+function isUsablePricing(
+  pricing: PricingInfo | undefined | null,
+): pricing is PricingInfo {
+  if (!pricing) return false;
+  return (
+    typeof pricing.inputPer1kTokens === "number" &&
+    Number.isFinite(pricing.inputPer1kTokens) &&
+    typeof pricing.outputPer1kTokens === "number" &&
+    Number.isFinite(pricing.outputPer1kTokens) &&
+    typeof pricing.currency === "string" &&
+    pricing.currency.length > 0
+  );
+}
+
+/**
+ * Computes token cost for a single usage record against a resolved pricing
+ * row. `unpricedFallbackReason` lets callers distinguish "model not found in
+ * catalog at all" from "model found but pricing fields absent" — defaults to
+ * `pricing_absent`, the correct reason when `pricing` is simply undefined.
+ */
+export function computeTokenCost(
+  inputTokens: number,
+  outputTokens: number,
+  pricing: PricingInfo | undefined | null,
+  unpricedFallbackReason: UnpricedReason = "pricing_absent",
+): TokenCostResult {
+  if (!isUsablePricing(pricing)) {
+    return {
+      priced: false,
+      tokenCost: null,
+      costMicros: null,
+      currency: null,
+      unpricedReason: unpricedFallbackReason,
+    };
+  }
+
+  const rawCost =
+    (inputTokens / 1000) * pricing.inputPer1kTokens +
+    (outputTokens / 1000) * pricing.outputPer1kTokens;
+
+  const tokenCost = roundHalfUp(rawCost, 8);
+  const costMicros = Math.round(tokenCost * 1e6);
+
+  return {
+    priced: true,
+    tokenCost,
+    costMicros,
+    currency: pricing.currency,
+  };
+}

--- a/backend/src/lambda/utils/cost-drift.ts
+++ b/backend/src/lambda/utils/cost-drift.ts
@@ -1,0 +1,137 @@
+/**
+ * Cost Drift — pure Tier-A aggregate-drift helpers for the cost-ledger
+ * reconciler.
+ *
+ * Pure and I/O-free — no AWS SDK imports, no env var reads, no Date.now()
+ * calls (callers pass epoch seconds explicitly so this stays deterministic
+ * and property-testable). Mirrors `cost-compute.ts`'s "never fabricate"
+ * ethos: unmatched/zero denominators return `null`, never `Infinity`/`NaN`/
+ * a guessed `0`.
+ */
+
+import type {
+  LedgerModelAggregate,
+  LedgerRowProjection,
+  ReconcilerWindow,
+} from "./cost-reconciler-types";
+
+const HOUR_SEC = 3600;
+
+/** Rounds `value` half-up to `decimals` decimal places without introducing float noise. */
+function roundHalfUp(value: number, decimals: number): number {
+  const factor = 10 ** decimals;
+  return Math.round((value + Number.EPSILON) * factor) / factor;
+}
+
+/**
+ * Floors `epochSec` down to the start of its containing hour. Idempotent:
+ * `alignToHour(alignToHour(x)) === alignToHour(x)`. Always `<= x` and a
+ * multiple of 3600.
+ */
+export function alignToHour(epochSec: number): number {
+  return Math.floor(epochSec / HOUR_SEC) * HOUR_SEC;
+}
+
+/**
+ * Computes the aggregate drift percentage between summed ledger tokens and
+ * summed CloudWatch metric tokens for one model in one window.
+ *
+ * `((ledgerTok - metricTok) / metricTok) * 100`, rounded to 4 decimal
+ * places. Positive = ledger over-estimated vs Bedrock; negative = under.
+ *
+ * Returns `null` (never `Infinity`/`NaN`/a fabricated `0`) whenever
+ * `metricTok <= 0` — that denominator means "no usable metric", not "metric
+ * is actually zero tokens".
+ */
+export function computeDriftPct(
+  ledgerTok: number,
+  metricTok: number,
+): number | null {
+  if (!Number.isFinite(ledgerTok) || !Number.isFinite(metricTok)) return null;
+  if (metricTok <= 0) return null;
+  const raw = ((ledgerTok - metricTok) / metricTok) * 100;
+  if (!Number.isFinite(raw)) return null;
+  return roundHalfUp(raw, 4);
+}
+
+/**
+ * Enumerates ascending, contiguous, hour-aligned half-open windows
+ * `[startSec, endSec)` from `watermarkSec` (exclusive lower bound — the
+ * last already-processed boundary) up to `targetEndSec` (exclusive upper
+ * bound), capped at `maxWindows` for bounded catch-up cost per run.
+ *
+ * Both bounds are expected to already be hour-aligned by the caller
+ * (`alignToHour`); this function does not re-align them, so a caller that
+ * passes non-aligned bounds gets non-aligned windows — callers are
+ * responsible for aligning first.
+ *
+ * Returns `[]` when `watermarkSec >= targetEndSec` (nothing to reconcile
+ * yet — including the exact-boundary edge case).
+ */
+export function enumerateWindows(
+  watermarkSec: number,
+  targetEndSec: number,
+  maxWindows: number,
+): ReconcilerWindow[] {
+  const windows: ReconcilerWindow[] = [];
+  let cursor = watermarkSec;
+  while (cursor < targetEndSec && windows.length < maxWindows) {
+    const endSec = cursor + HOUR_SEC;
+    windows.push({ startSec: cursor, endSec });
+    cursor = endSec;
+  }
+  return windows;
+}
+
+/** Non-negative-number coercion — never throws, mirrors the writer's defensive coercion. */
+function coerceNonNegativeNumber(value: unknown): number {
+  if (typeof value === "number" && Number.isFinite(value)) {
+    return Math.max(0, value);
+  }
+  return 0;
+}
+
+/**
+ * Groups a page of ledger row projections by `modelKey`, summing tokens and
+ * collecting row keys for later `driftCheckedAt` annotation. Rows missing a
+ * non-empty `modelKey` are skipped entirely rather than bucketed under a
+ * fabricated key — an aggregate can't attribute tokens to "unknown".
+ */
+export function aggregateLedgerWindow(
+  rows: LedgerRowProjection[],
+): Map<string, LedgerModelAggregate> {
+  const byModel = new Map<string, LedgerModelAggregate>();
+
+  for (const row of rows) {
+    const modelKey =
+      typeof row.modelKey === "string" && row.modelKey.length > 0
+        ? row.modelKey
+        : undefined;
+    if (!modelKey) continue;
+
+    const modelId =
+      typeof row.modelId === "string" && row.modelId.length > 0
+        ? row.modelId
+        : "";
+
+    const inputTokens = coerceNonNegativeNumber(row.inputTokens);
+    const outputTokens = coerceNonNegativeNumber(row.outputTokens);
+
+    const existing = byModel.get(modelKey);
+    if (existing) {
+      existing.inputTokens += inputTokens;
+      existing.outputTokens += outputTokens;
+      existing.rowKeys.push({ PK: row.PK, SK: row.SK });
+      if (!existing.modelId && modelId) existing.modelId = modelId;
+    } else {
+      byModel.set(modelKey, {
+        modelId,
+        inputTokens,
+        outputTokens,
+        rowKeys: [{ PK: row.PK, SK: row.SK }],
+      });
+    }
+  }
+
+  return byModel;
+}

--- a/backend/src/lambda/utils/cost-reconciler-types.ts
+++ b/backend/src/lambda/utils/cost-reconciler-types.ts
@@ -1,0 +1,85 @@
+/**
+ * Cost Ledger Reconciler — shared types + reserved-key constants.
+ *
+ * Watermark/window state lives in the cost-ledger table itself as reserved
+ * meta rows under `PK="RECON#COST"` — never colliding with `ORG#...` data
+ * rows. See `cost-ledger-reconciler.ts` for the read-modify-write algorithm
+ * that uses these shapes.
+ */
+
+/** Reserved partition key for all reconciler meta rows (watermark + window markers). */
+export const RECON_PK = "RECON#COST";
+
+/** Sort key for the single global watermark row. */
+export const WATERMARK_SK = "WATERMARK";
+
+/** Sort key for a per-window idempotency marker / durable drift record. */
+export function windowSk(windowStartEpochSec: number): string {
+  return `WINDOW#${windowStartEpochSec}`;
+}
+
+/** `PK="RECON#COST", SK="WATERMARK"` — single global monotonic watermark. */
+export interface WatermarkRow {
+  PK: typeof RECON_PK;
+  SK: typeof WATERMARK_SK;
+  watermarkEpochSec: number;
+  updatedAt: string;
+}
+
+/** Per-model drift comparison result within one window. */
+export interface ModelDriftEntry {
+  modelKey: string;
+  modelId: string;
+  ledgerInputTokens: number;
+  ledgerOutputTokens: number;
+  metricInputTokens: number | null;
+  metricOutputTokens: number | null;
+  driftPct: number | null;
+  match: "matched" | "metricsMissing";
+}
+
+/** `PK="RECON#COST", SK="WINDOW#<start>"` — idempotency anchor + durable drift record. */
+export interface LedgerWindowMarkerRow {
+  PK: typeof RECON_PK;
+  SK: string;
+  windowStartEpochSec: number;
+  windowEndEpochSec: number;
+  computedAt: string;
+  tier: "A";
+  models: ModelDriftEntry[];
+  ledgerRowCount: number;
+  unmatchedModelCount: number;
+}
+
+/** A half-open `[startSec, endSec)` hour-aligned reconciliation window. */
+export interface ReconcilerWindow {
+  startSec: number;
+  endSec: number;
+}
+
+/** Aggregated per-model ledger totals for one window, keyed by modelKey. */
+export interface LedgerModelAggregate {
+  modelId: string;
+  inputTokens: number;
+  outputTokens: number;
+  rowKeys: Array<{ PK: string; SK: string }>;
+}
+
+/** Narrow shape of a ledger row as read (Scan/Query projection) for aggregation. */
+export interface LedgerRowProjection {
+  PK: string;
+  SK: string;
+  modelKey?: unknown;
+  modelId?: unknown;
+  inputTokens?: unknown;
+  outputTokens?: unknown;
+  capturedAt?: unknown;
+  bedrockRequestId?: unknown;
+  estimate?: unknown;
+}
+
+/** Result of the Tier B feature-gate check (skeleton only — no matching logic). */
+export interface TierBGateResult {
+  active: boolean;
+  reason: "disabled" | "missing_requestId";
+}

--- a/backend/src/schema/schema.graphql
+++ b/backend/src/schema/schema.graphql
@@ -1874,6 +1874,10 @@ type Execution {
   completedAt: AWSDateTime
   triggeredBy: String!
   error: String
+  # Additive (usage rollup): execution-level token usage folded from
+  # nodeResults[*].usageTotals on read. Null when no node carries usage
+  # (e.g. a run predating this feature).
+  usageTotals: AWSJSON
 }
 
 type ExecutionConnection {

--- a/backend/test/telemetry-stack.test.ts
+++ b/backend/test/telemetry-stack.test.ts
@@ -1,7 +1,158 @@
+describe("TelemetryStack — cost query surface (pass 1: API + authorizer + budgets)", () => {
+  let template: Template;
+
+  beforeAll(() => {
+    ({ template } = createTestStack());
+  });
+
+  test("declares an HttpApi with CORS from the deploy-time frontend origin", () => {
+    template.hasResourceProperties("AWS::ApiGatewayV2::Api", {
+      ProtocolType: "HTTP",
+      CorsConfiguration: Match.objectLike({
+        AllowOrigins: ["https://app.example.com"],
+        AllowMethods: Match.arrayWith(["GET", "PUT"]),
+      }),
+    });
+  });
+
+  test("declares a JWT authorizer with issuer=user-pool and audience=client", () => {
+    template.hasResourceProperties("AWS::ApiGatewayV2::Authorizer", {
+      AuthorizerType: "JWT",
+      JwtConfiguration: Match.objectLike({
+        Issuer: Match.anyValue(),
+        Audience: Match.anyValue(),
+      }),
+    });
+  });
+
+  test("declares all 4 cost-query routes", () => {
+    const routes = template.findResources("AWS::ApiGatewayV2::Route");
+    const routeKeys = Object.values(routes)
+      .map((r: any) => r.Properties.RouteKey)
+      .sort();
+    expect(routeKeys).toEqual(
+      [
+        "GET /budgets",
+        "GET /cost/series",
+        "GET /cost/summary",
+        "PUT /budgets/{scope}",
+      ].sort(),
+    );
+  });
+
+  test("every route is authorized (none use AuthorizationType NONE)", () => {
+    const routes = template.findResources("AWS::ApiGatewayV2::Route");
+    for (const route of Object.values(routes) as any[]) {
+      expect(route.Properties.AuthorizationType).not.toBe("NONE");
+      expect(
+        route.Properties.AuthorizerId ?? route.Properties.AuthorizationType,
+      ).toBeDefined();
+    }
+  });
+
+  test("declares the sparse BudgetIndex GSI on the cost ledger table", () => {
+    const tables = template.findResources("AWS::DynamoDB::Table", {
+      Properties: { TableName: "citadel-cost-ledger-test" },
+    });
+    const logicalId = Object.keys(tables)[0];
+    const gsis = tables[logicalId].Properties.GlobalSecondaryIndexes;
+    const byName: Record<string, any> = {};
+    for (const g of gsis) byName[g.IndexName] = g;
+
+    expect(byName.BudgetIndex).toBeDefined();
+    expect(byName.BudgetIndex.KeySchema).toEqual([
+      { AttributeName: "GSI5PK", KeyType: "HASH" },
+      { AttributeName: "GSI5SK", KeyType: "RANGE" },
+    ]);
+  });
+
+  test("declares the evaluator Lambda with its own hourly schedule rule, separate from the reconciler's", () => {
+    template.hasResourceProperties("AWS::Lambda::Function", {
+      Handler: "cost-budget-evaluator.handler",
+    });
+
+    const hourlyRules = template.findResources("AWS::Events::Rule", {
+      Properties: { ScheduleExpression: "rate(1 hour)" },
+    });
+    // reconciler's rule + the new evaluator rule = 2 distinct rate(1 hour) rules.
+    expect(Object.keys(hourlyRules).length).toBeGreaterThanOrEqual(2);
+
+    const evaluatorFn = template.findResources("AWS::Lambda::Function", {
+      Properties: { Handler: "cost-budget-evaluator.handler" },
+    });
+    const evaluatorFnId = Object.keys(evaluatorFn)[0];
+    const evaluatorRule = Object.values(hourlyRules).find((r: any) =>
+      r.Properties.Targets.some(
+        (t: any) => t.Arn?.["Fn::GetAtt"]?.[0] === evaluatorFnId,
+      ),
+    );
+    expect(evaluatorRule).toBeDefined();
+  });
+
+  test("evaluator role is granted events:PutEvents on the shared bus (telemetry becomes a publisher)", () => {
+    const evaluatorFn = template.findResources("AWS::Lambda::Function", {
+      Properties: { Handler: "cost-budget-evaluator.handler" },
+    });
+    const evaluatorFnId = Object.keys(evaluatorFn)[0];
+    expect(evaluatorFnId).toBeDefined();
+
+    const policies = template.findResources("AWS::IAM::Policy");
+    const ownPolicies = Object.values(policies).filter((p: any) => {
+      const roles = p.Properties?.Roles || [];
+      return roles.some((r: any) =>
+        (r?.Ref || "").includes("CostBudgetEvaluator"),
+      );
+    });
+    const allActions = ownPolicies.flatMap((p: any) => {
+      const statements = p.Properties?.PolicyDocument?.Statement || [];
+      return statements.flatMap((s: any) =>
+        Array.isArray(s.Action) ? s.Action : [s.Action],
+      );
+    });
+    expect(allActions).toEqual(expect.arrayContaining(["events:PutEvents"]));
+  });
+
+  test("query handler role has ledger table read access (Query) and no Scan/write grant", () => {
+    const queryFn = template.findResources("AWS::Lambda::Function", {
+      Properties: { Handler: "cost-query-handler.handler" },
+    });
+    const queryFnId = Object.keys(queryFn)[0];
+    expect(queryFnId).toBeDefined();
+
+    const policies = template.findResources("AWS::IAM::Policy");
+    const ownPolicies = Object.values(policies).filter((p: any) => {
+      const roles = p.Properties?.Roles || [];
+      return roles.some((r: any) =>
+        (r?.Ref || "").includes("CostQueryHandler"),
+      );
+    });
+    const allActions = ownPolicies.flatMap((p: any) => {
+      const statements = p.Properties?.PolicyDocument?.Statement || [];
+      return statements.flatMap((s: any) =>
+        Array.isArray(s.Action) ? s.Action : [s.Action],
+      );
+    });
+    expect(allActions).toEqual(expect.arrayContaining(["dynamodb:Query"]));
+    // PUT /budgets needs UpdateItem on the same table; no DeleteItem/Scan needed.
+    expect(allActions).not.toEqual(expect.arrayContaining(["dynamodb:Scan"]));
+    expect(allActions).not.toEqual(
+      expect.arrayContaining(["dynamodb:DeleteItem"]),
+    );
+  });
+
+  test("exposes costApiUrl as a stack output for pass-2 frontend plumbing", () => {
+    const outputs = template.findOutputs("*");
+    const hasCostApiUrl = Object.keys(outputs).some((k) =>
+      k.toLowerCase().includes("costapiurl"),
+    );
+    expect(hasCostApiUrl).toBe(true);
+  });
+});
 import * as cdk from "aws-cdk-lib";
 import { Template, Match } from "aws-cdk-lib/assertions";
 import * as dynamodb from "aws-cdk-lib/aws-dynamodb";
 import * as events from "aws-cdk-lib/aws-events";
+import * as cognito from "aws-cdk-lib/aws-cognito";
 import * as path from "path";
 import * as fs from "fs";
 
@@ -35,11 +186,17 @@ function createTestStack(): { stack: TelemetryStack; template: Template } {
     },
   );
 
+  const userPool = new cognito.UserPool(helperStack, "UserPool");
+  const userPoolClient = userPool.addClient("UserPoolClient");
+
   const stack = new TelemetryStack(app, "TestTelemetryStack", {
     environment: "test",
     env: { account: "123456789012", region: "us-east-1" },
     agentEventBus,
     modelCatalogTable,
+    userPool,
+    userPoolClient,
+    frontendOrigin: "https://app.example.com",
   });
 
   const template = Template.fromStack(stack);
@@ -69,7 +226,7 @@ describe("TelemetryStack — cost ledger (pass 1)", () => {
     });
   });
 
-  test("cost ledger table has 4 sparse time-prefixed GSIs: Project/App/Agent/Workflow", () => {
+  test("cost ledger table has 4 sparse time-prefixed GSIs (Project/App/Agent/Workflow) plus the BudgetIndex GSI added for the cost query surface", () => {
     const tables = template.findResources("AWS::DynamoDB::Table", {
       Properties: { TableName: "citadel-cost-ledger-test" },
     });
@@ -77,12 +234,13 @@ describe("TelemetryStack — cost ledger (pass 1)", () => {
     expect(logicalId).toBeDefined();
 
     const gsis = tables[logicalId].Properties.GlobalSecondaryIndexes;
-    expect(gsis).toHaveLength(4);
+    expect(gsis).toHaveLength(5);
 
     const gsiNames = gsis.map((g: any) => g.IndexName).sort();
     expect(gsiNames).toEqual([
       "AgentIndex",
       "AppIndex",
+      "BudgetIndex",
       "ProjectIndex",
       "WorkflowIndex",
     ]);

--- a/backend/test/telemetry-stack.test.ts
+++ b/backend/test/telemetry-stack.test.ts
@@ -1,0 +1,217 @@
+import * as cdk from "aws-cdk-lib";
+import { Template, Match } from "aws-cdk-lib/assertions";
+import * as dynamodb from "aws-cdk-lib/aws-dynamodb";
+import * as events from "aws-cdk-lib/aws-events";
+import * as path from "path";
+import * as fs from "fs";
+
+// Ensure asset directories exist for CDK synthesis
+const assetDirs = [path.resolve(__dirname, "../dist/lambda")];
+for (const dir of assetDirs) {
+  if (!fs.existsSync(dir)) fs.mkdirSync(dir, { recursive: true });
+}
+
+import { TelemetryStack } from "../lib/telemetry-stack";
+
+function createTestStack(): { stack: TelemetryStack; template: Template } {
+  const app = new cdk.App();
+
+  const helperStack = new cdk.Stack(app, "HelperStack", {
+    env: { account: "123456789012", region: "us-east-1" },
+  });
+
+  const agentEventBus = new events.EventBus(helperStack, "EventBus", {
+    eventBusName: "citadel-agents-test",
+  });
+
+  const modelCatalogTable = new dynamodb.Table(
+    helperStack,
+    "ModelCatalogTable",
+    {
+      tableName: "citadel-model-catalog-test",
+      partitionKey: { name: "modelKey", type: dynamodb.AttributeType.STRING },
+      billingMode: dynamodb.BillingMode.PAY_PER_REQUEST,
+      removalPolicy: cdk.RemovalPolicy.DESTROY,
+    },
+  );
+
+  const stack = new TelemetryStack(app, "TestTelemetryStack", {
+    environment: "test",
+    env: { account: "123456789012", region: "us-east-1" },
+    agentEventBus,
+    modelCatalogTable,
+  });
+
+  const template = Template.fromStack(stack);
+  return { stack, template };
+}
+
+describe("TelemetryStack — cost ledger (pass 1)", () => {
+  let template: Template;
+
+  beforeAll(() => {
+    ({ template } = createTestStack());
+  });
+
+  test("cost ledger table has PK/SK, PAY_PER_REQUEST, PITR, and RETAIN", () => {
+    template.hasResource("AWS::DynamoDB::Table", {
+      Properties: Match.objectLike({
+        TableName: "citadel-cost-ledger-test",
+        KeySchema: [
+          { AttributeName: "PK", KeyType: "HASH" },
+          { AttributeName: "SK", KeyType: "RANGE" },
+        ],
+        BillingMode: "PAY_PER_REQUEST",
+        PointInTimeRecoverySpecification: { PointInTimeRecoveryEnabled: true },
+      }),
+      DeletionPolicy: "Retain",
+      UpdateReplacePolicy: "Retain",
+    });
+  });
+
+  test("cost ledger table has 4 sparse time-prefixed GSIs: Project/App/Agent/Workflow", () => {
+    const tables = template.findResources("AWS::DynamoDB::Table", {
+      Properties: { TableName: "citadel-cost-ledger-test" },
+    });
+    const logicalId = Object.keys(tables)[0];
+    expect(logicalId).toBeDefined();
+
+    const gsis = tables[logicalId].Properties.GlobalSecondaryIndexes;
+    expect(gsis).toHaveLength(4);
+
+    const gsiNames = gsis.map((g: any) => g.IndexName).sort();
+    expect(gsiNames).toEqual([
+      "AgentIndex",
+      "AppIndex",
+      "ProjectIndex",
+      "WorkflowIndex",
+    ]);
+
+    const byName: Record<string, any> = {};
+    for (const g of gsis) byName[g.IndexName] = g;
+
+    expect(byName.ProjectIndex.KeySchema).toEqual([
+      { AttributeName: "GSI1PK", KeyType: "HASH" },
+      { AttributeName: "GSI1SK", KeyType: "RANGE" },
+    ]);
+    expect(byName.AppIndex.KeySchema).toEqual([
+      { AttributeName: "GSI2PK", KeyType: "HASH" },
+      { AttributeName: "GSI2SK", KeyType: "RANGE" },
+    ]);
+    expect(byName.AgentIndex.KeySchema).toEqual([
+      { AttributeName: "GSI3PK", KeyType: "HASH" },
+      { AttributeName: "GSI3SK", KeyType: "RANGE" },
+    ]);
+    expect(byName.WorkflowIndex.KeySchema).toEqual([
+      { AttributeName: "GSI4PK", KeyType: "HASH" },
+      { AttributeName: "GSI4SK", KeyType: "RANGE" },
+    ]);
+  });
+
+  test("cost-ledger-writer Lambda: nodejs24.x, 30s timeout, own LogGroup", () => {
+    template.hasResourceProperties("AWS::Lambda::Function", {
+      Handler: "cost-ledger-writer.handler",
+      Runtime: "nodejs24.x",
+      Timeout: 30,
+      Environment: {
+        Variables: Match.objectLike({
+          COST_LEDGER_TABLE: Match.anyValue(),
+          MODEL_CATALOG_TABLE: Match.anyValue(),
+        }),
+      },
+    });
+
+    const functions = template.findResources("AWS::Lambda::Function", {
+      Properties: { Handler: "cost-ledger-writer.handler" },
+    });
+    const logicalId = Object.keys(functions)[0];
+    expect(logicalId).toBeDefined();
+
+    const logGroups = template.findResources("AWS::Logs::LogGroup");
+    expect(Object.keys(logGroups).length).toBeGreaterThan(0);
+  });
+
+  test("3 EventBridge rules target the writer with correct source/detailType", () => {
+    template.hasResourceProperties("AWS::Events::Rule", {
+      EventPattern: Match.objectLike({
+        source: ["task.completion"],
+        "detail-type": ["task.completion"],
+      }),
+    });
+    template.hasResourceProperties("AWS::Events::Rule", {
+      EventPattern: Match.objectLike({
+        source: ["agent_intake.usage"],
+        "detail-type": ["intake.usage.captured"],
+      }),
+    });
+    template.hasResourceProperties("AWS::Events::Rule", {
+      EventPattern: Match.objectLike({
+        source: ["citadel.workflows"],
+        "detail-type": ["workflow.node.completed"],
+      }),
+    });
+
+    const functions = template.findResources("AWS::Lambda::Function", {
+      Properties: { Handler: "cost-ledger-writer.handler" },
+    });
+    const fnLogicalId = Object.keys(functions)[0];
+
+    const rules = template.findResources("AWS::Events::Rule");
+    const ruleIds = Object.keys(rules);
+    expect(ruleIds.length).toBeGreaterThanOrEqual(3);
+
+    for (const ruleId of ruleIds) {
+      const targets = rules[ruleId].Properties.Targets;
+      expect(targets).toHaveLength(1);
+      expect(targets[0].RetryPolicy).toMatchObject({
+        MaximumRetryAttempts: 2,
+      });
+      expect(typeof targets[0].RetryPolicy.MaximumEventAgeInSeconds).toBe(
+        "number",
+      );
+      const getAtt = targets[0].Arn?.["Fn::GetAtt"];
+      expect(Array.isArray(getAtt) && getAtt[0] === fnLogicalId).toBe(true);
+    }
+  });
+
+  test("writer has write access to ledger table and read access to catalog table, no other grants", () => {
+    const functions = template.findResources("AWS::Lambda::Function", {
+      Properties: { Handler: "cost-ledger-writer.handler" },
+    });
+    const fnLogicalId = Object.keys(functions)[0];
+    expect(fnLogicalId).toBeDefined();
+
+    const policies = template.findResources("AWS::IAM::Policy");
+    const ownPolicies = Object.values(policies).filter((p: any) => {
+      const roles = p.Properties?.Roles || [];
+      return roles.some((r: any) =>
+        (r?.Ref || "").includes("CostLedgerWriter"),
+      );
+    });
+    expect(ownPolicies.length).toBeGreaterThan(0);
+
+    const allActions = ownPolicies.flatMap((p: any) => {
+      const statements = p.Properties?.PolicyDocument?.Statement || [];
+      return statements.flatMap((s: any) =>
+        Array.isArray(s.Action) ? s.Action : [s.Action],
+      );
+    });
+
+    expect(allActions).toEqual(
+      expect.arrayContaining(["dynamodb:PutItem", "dynamodb:GetItem"]),
+    );
+    // Least-privilege: writer must not be granted delete/write on the catalog
+    // table (grantReadData only) — read-only pricing lookup.
+    const catalogGrantActions = ownPolicies.flatMap((p: any) => {
+      const statements = p.Properties?.PolicyDocument?.Statement || [];
+      return statements
+        .filter((s: any) =>
+          JSON.stringify(s.Resource || "").includes("ModelCatalogTable"),
+        )
+        .flatMap((s: any) => (Array.isArray(s.Action) ? s.Action : [s.Action]));
+    });
+    expect(catalogGrantActions).not.toEqual(
+      expect.arrayContaining(["dynamodb:PutItem", "dynamodb:DeleteItem"]),
+    );
+  });
+});

--- a/backend/test/telemetry-stack.test.ts
+++ b/backend/test/telemetry-stack.test.ts
@@ -156,12 +156,17 @@ describe("TelemetryStack — cost ledger (pass 1)", () => {
     });
     const fnLogicalId = Object.keys(functions)[0];
 
-    const rules = template.findResources("AWS::Events::Rule");
-    const ruleIds = Object.keys(rules);
+    // Scope to event-pattern rules only — the reconciler's schedule-based
+    // rule (rate(1 hour), no EventPattern) is a separate rule asserted in
+    // its own describe block below.
+    const allRules = template.findResources("AWS::Events::Rule");
+    const ruleIds = Object.keys(allRules).filter(
+      (id) => allRules[id].Properties?.EventPattern !== undefined,
+    );
     expect(ruleIds.length).toBeGreaterThanOrEqual(3);
 
     for (const ruleId of ruleIds) {
-      const targets = rules[ruleId].Properties.Targets;
+      const targets = allRules[ruleId].Properties.Targets;
       expect(targets).toHaveLength(1);
       expect(targets[0].RetryPolicy).toMatchObject({
         MaximumRetryAttempts: 2,
@@ -213,5 +218,115 @@ describe("TelemetryStack — cost ledger (pass 1)", () => {
     expect(catalogGrantActions).not.toEqual(
       expect.arrayContaining(["dynamodb:PutItem", "dynamodb:DeleteItem"]),
     );
+  });
+});
+
+describe("TelemetryStack — cost ledger reconciler (Tier A + Tier B skeleton)", () => {
+  let template: Template;
+
+  beforeAll(() => {
+    ({ template } = createTestStack());
+  });
+
+  test("reconciler Lambda: nodejs24.x, 5min timeout, expected env vars incl. Tier B off by default", () => {
+    template.hasResourceProperties("AWS::Lambda::Function", {
+      Handler: "cost-ledger-reconciler.handler",
+      Runtime: "nodejs24.x",
+      Timeout: 300,
+      Environment: {
+        Variables: Match.objectLike({
+          COST_LEDGER_TABLE: Match.anyValue(),
+          ENVIRONMENT: "test",
+          SETTLE_LAG_MINUTES: Match.anyValue(),
+          MAX_WINDOWS_PER_RUN: Match.anyValue(),
+          METRIC_NAMESPACE: "Citadel/CostReconciler",
+          COST_RECONCILER_TIER_B_ENABLED: "false",
+        }),
+      },
+    });
+  });
+
+  test("EventBridge rule schedules the reconciler at rate(1 hour)", () => {
+    template.hasResourceProperties("AWS::Events::Rule", {
+      ScheduleExpression: "rate(1 hour)",
+    });
+
+    const functions = template.findResources("AWS::Lambda::Function", {
+      Properties: { Handler: "cost-ledger-reconciler.handler" },
+    });
+    const fnLogicalId = Object.keys(functions)[0];
+    expect(fnLogicalId).toBeDefined();
+
+    const rules = template.findResources("AWS::Events::Rule", {
+      Properties: { ScheduleExpression: "rate(1 hour)" },
+    });
+    const ruleId = Object.keys(rules)[0];
+    expect(ruleId).toBeDefined();
+    const targets = rules[ruleId].Properties.Targets;
+    expect(targets).toHaveLength(1);
+    const getAtt = targets[0].Arn?.["Fn::GetAtt"];
+    expect(Array.isArray(getAtt) && getAtt[0] === fnLogicalId).toBe(true);
+  });
+
+  test("reconciler IAM: has Query/Scan/PutItem/UpdateItem + GetMetricData/PutMetricData, and NO DeleteItem/logs:*", () => {
+    const functions = template.findResources("AWS::Lambda::Function", {
+      Properties: { Handler: "cost-ledger-reconciler.handler" },
+    });
+    const fnLogicalId = Object.keys(functions)[0];
+    expect(fnLogicalId).toBeDefined();
+
+    const policies = template.findResources("AWS::IAM::Policy");
+    const ownPolicies = Object.values(policies).filter((p: any) => {
+      const roles = p.Properties?.Roles || [];
+      return roles.some((r: any) =>
+        (r?.Ref || "").includes("CostLedgerReconciler"),
+      );
+    });
+    expect(ownPolicies.length).toBeGreaterThan(0);
+
+    const allStatements = ownPolicies.flatMap(
+      (p: any) => p.Properties?.PolicyDocument?.Statement || [],
+    );
+    const allActions = allStatements.flatMap((s: any) =>
+      Array.isArray(s.Action) ? s.Action : [s.Action],
+    );
+
+    expect(allActions).toEqual(
+      expect.arrayContaining([
+        "dynamodb:Query",
+        "dynamodb:Scan",
+        "dynamodb:PutItem",
+        "dynamodb:UpdateItem",
+      ]),
+    );
+    expect(allActions).not.toEqual(
+      expect.arrayContaining(["dynamodb:DeleteItem"]),
+    );
+    expect(allActions.some((a: string) => a.startsWith("logs:"))).toBe(false);
+
+    expect(allActions).toEqual(
+      expect.arrayContaining(["cloudwatch:GetMetricData"]),
+    );
+    expect(allActions).toEqual(
+      expect.arrayContaining(["cloudwatch:PutMetricData"]),
+    );
+
+    // PutMetricData must be namespace-conditioned, not a bare grant on '*'.
+    const putMetricStatement = allStatements.find((s: any) => {
+      const actions = Array.isArray(s.Action) ? s.Action : [s.Action];
+      return actions.includes("cloudwatch:PutMetricData");
+    });
+    expect(putMetricStatement?.Condition).toBeDefined();
+  });
+
+  test("cost ledger table remains RETAIN + PITR (regression guard, reconciler must not weaken it)", () => {
+    template.hasResource("AWS::DynamoDB::Table", {
+      Properties: Match.objectLike({
+        TableName: "citadel-cost-ledger-test",
+        PointInTimeRecoverySpecification: { PointInTimeRecoveryEnabled: true },
+      }),
+      DeletionPolicy: "Retain",
+      UpdateReplacePolicy: "Retain",
+    });
   });
 });

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -177,11 +177,23 @@ BackendStack (core infra — no dependencies)
   │                              BackendStack.workflowsTable, BackendStack.executionsTable)
   ├── GatewayStack (depends on: BackendStack.appsTable, BackendStack.eventBus,
   │                              BackendStack.idempotencyTable)
-  └── FrontendStack (depends on: BackendStack.appSyncApi, BackendStack.userPool)
+  ├── TelemetryStack (depends on: BackendStack.agentEventBus, BackendStack.modelCatalogTable,
+  │                                BackendStack.userPool, BackendStack.userPoolClient)
+  └── FrontendStack (depends on: BackendStack.appSyncApi, BackendStack.userPool,
+                                   TelemetryStack.costApiUrl)
 
 KnowledgeBaseStack — standalone (Bedrock Knowledge Base for document ingestion)
 PipelineStack — standalone (CI/CD CodePipeline, self-mutating, multi-env)
 ```
+
+### TelemetryStack — invocation cost ledger, cost query API, and budget alerts
+
+`TelemetryStack` owns the invocation cost ledger (`citadel-cost-ledger-{env}`, populated by `cost-ledger-writer` from `task.completion` / `intake.usage.captured` / `workflow.node.completed` events) plus two additions layered on the same single-table design:
+
+- **Cost query HttpApi** (`citadel-cost-api-{env}`) — a Cognito-JWT-authorized HTTP API (`GET /cost/summary`, `GET /cost/series`, `GET`/`PUT /budgets`) fronting a single `cost-query-handler` Lambda. Every non-admin read is a base-table `Query` keyed on `PK=ORG#<verified JWT claim>` — never a Scan, never a dimension GSI — so org isolation lives in the DynamoDB key condition itself. The stack exposes `costApiUrl` (the HttpApi endpoint), threaded into `FrontendStack` as `aws_cost_api_url` in `aws-exports.json` (see [COST_QUERY.md](./COST_QUERY.md)).
+- **Budget alerts** — budget rows share the ledger table under `SK=BUDGET#ORG` / `BUDGET#APP#<appId>` (disjoint from the ISO-timestamped cost rows), enumerated via a sparse `BudgetIndex` GSI. A separate hourly-scheduled `cost-budget-evaluator` Lambda computes period-to-date spend and publishes `cost.budget.threshold.crossed` / `cost.budget.breached` to the shared event bus — making `TelemetryStack` an EventBridge **publisher** for the first time (it was consume-only before). See [EVENTBRIDGE_CATALOG.md](./EVENTBRIDGE_CATALOG.md#cost-budget-events).
+
+This keeps the platform at **7 stacks** (BackendStack, ServicesStack, ArbiterStack, GatewayStack, TelemetryStack, FrontendStack, GovernanceStack) — the cost query/budget surface is additive to the existing TelemetryStack rather than a new stack.
 
 ## Key Architectural Patterns
 

--- a/docs/COST_QUERY.md
+++ b/docs/COST_QUERY.md
@@ -1,0 +1,127 @@
+# Cost Query API & Budgets
+
+Citadel tracks estimated model-invocation spend per organization and exposes it through a dedicated HTTP API, plus a lightweight budget-alerting system, both hosted in `TelemetryStack` alongside the existing invocation cost ledger.
+
+## Overview
+
+- **Ledger**: `citadel-cost-ledger-{env}` (DynamoDB). Rows are written by `cost-ledger-writer.ts` from three EventBridge sources (`task.completion`, `agent_intake.usage`, workflow node completion). Every row carries `estimate: true` — costs are derived from token usage and catalog pricing, never a billing invoice.
+- **Query surface**: a Cognito-JWT-authorized HTTP API (`citadel-cost-api-{env}`), single Lambda (`cost-query-handler.ts`) branching on route.
+- **Budgets**: stored in the same ledger table under a disjoint `SK` namespace, evaluated hourly by a separate Lambda, with alerts published to the shared EventBridge bus.
+
+## Routes
+
+All routes require a valid Cognito JWT (the HttpApi's default authorizer). CORS is restricted to the deployed frontend origin (`FRONTEND_ORIGIN` env/context) — no wildcard origin, since this is a bearer-token-authorized API.
+
+### `GET /cost/summary?groupBy=app|agent|model|project&from&to`
+
+Dimension rollup for the caller's org. `from`/`to` default to the last 30 days (UTC ISO). Response:
+
+```json
+{
+  "groupBy": "app",
+  "from": "2026-06-25T00:00:00.000Z",
+  "to": "2026-07-25T00:00:00.000Z",
+  "currency": "USD",
+  "currencyMixed": false,
+  "totalCostMicros": 12345678,
+  "pricedRows": 940,
+  "unpricedRows": 6,
+  "estimate": true,
+  "truncated": false,
+  "buckets": [
+    { "key": "app-123", "label": "app-123", "costMicros": 4000000, "tokenCost": 4.0, "totalTokens": 52000, "rows": 210, "unpricedRows": 1 }
+  ]
+}
+```
+
+- `currencyMixed: true` means the org's rows span more than one currency in the window — `currency` is `null` and totals should be read per-bucket, never summed, until the frontend buckets by currency.
+- `unpricedRows` rows are excluded from `totalCostMicros` (never fabricate a price for a call the catalog couldn't price) but are counted so the UI can disclose them via the unpriced chip.
+- `truncated: true` means the window was capped at `MAX_ROWS_PER_REQUEST` (50,000) rows server-side before aggregation — the response body itself stays small regardless, since aggregation happens in the Lambda.
+
+### `GET /cost/series?dimension=org|app|agent|model|project&id?&bucket=hour|day&from&to`
+
+Time series for the caller's org, optionally filtered to one dimension value (`id`). Omitting `id` returns the whole-org series for that dimension type; `id` is required to drill into a specific app/agent/model/project.
+
+```json
+{
+  "dimension": "app",
+  "id": "app-123",
+  "bucket": "day",
+  "from": "2026-06-25T00:00:00.000Z",
+  "to": "2026-07-25T00:00:00.000Z",
+  "currency": "USD",
+  "estimate": true,
+  "truncated": false,
+  "unpricedCount": 2,
+  "points": [
+    { "t": "2026-07-20", "costMicros": 1200000, "totalTokens": 15000, "rows": 40, "unpricedRows": 0 }
+  ]
+}
+```
+
+`t` is the UTC bucket start — `YYYY-MM-DD` for `bucket=day`, `YYYY-MM-DDTHH` for `bucket=hour`.
+
+### `GET /budgets[?orgId=]`
+
+Lists budgets for the caller's org (or another org, if the caller is an admin).
+
+```json
+{
+  "budgets": [
+    {
+      "scope": "org",
+      "orgId": "org-1",
+      "periodType": "monthly",
+      "limitMicros": 500000000,
+      "thresholds": [0.8, 1.0],
+      "currency": "USD",
+      "updatedAt": "2026-07-01T00:00:00.000Z"
+    }
+  ]
+}
+```
+
+### `PUT /budgets/{scope}`
+
+Upserts a budget. `{scope}` is `org` or `app:<appId>`. Body:
+
+```json
+{ "periodType": "monthly", "limitMicros": 500000000, "thresholds": [0.8, 1.0], "currency": "USD" }
+```
+
+`limitMicros` and `thresholds` (fractions in `(0, 1]`) are validated server-side; invalid bodies return `400`.
+
+## Org-scoping (security model)
+
+Every non-admin read is a **base-table Query** with `KeyConditionExpression: PK = :org AND SK BETWEEN :fromIso AND :toIso`, where `:org` is derived **only** from the verified JWT claim `custom:organization` — never from a query parameter. A non-admin passing a different `?orgId=` is rejected with `403` before any DynamoDB call is made. Admins may pass `?orgId=` to read another org's data; an admin "all orgs" view would be a separate, explicitly documented Scan exception (not implemented — no route requests it).
+
+There is deliberately **no ModelIndex GSI**: `groupBy=model` and per-model series both require aggregating base-table rows in-Lambda, which is also why every org-scoped read hits the base table rather than the per-dimension GSIs (App/Agent/Project/Workflow) — those GSI partitions aren't org-keyed, so reading them for an org rollup would require an unsafe post-filter.
+
+## Budget model
+
+Budgets reuse the ledger table's existing `PK=ORG#<org>` partitioning (same org-isolation discipline as cost rows) under a disjoint `SK` namespace:
+
+- `SK = BUDGET#ORG` — org-wide budget
+- `SK = BUDGET#APP#<appId>` — per-app budget
+
+`BUDGET#` sorts after any ISO-timestamped cost row (`'B'` > any digit that starts an ISO year), so a `SK BETWEEN :fromIso AND :toIso` rollup query can never sweep a budget row in by accident.
+
+A sparse `BudgetIndex` GSI (only budget rows are projected) lets the hourly evaluator enumerate every org's budgets with a single `Query` — never a Scan, even as the ledger grows.
+
+### Evaluation and alerts
+
+`cost-budget-evaluator.ts` runs hourly:
+
+1. Enumerate all budgets via `BudgetIndex`.
+2. For each, compute period-to-date spend (`PK=ORG#<org> AND SK BETWEEN periodStartIso AND nowIso`, summing only `priced===true` rows — unpriced calls are tracked, never guessed at).
+3. Compare against each configured threshold (e.g. `0.8`, `1.0`).
+4. On a crossing, attempt an atomic conditional `UpdateItem` (`notified.<periodKey> < :threshold` or unset) — this is the dedupe: at most one publish per `(period, threshold)`, safe under concurrent/retried evaluator runs. A higher threshold crossed later in the same period (0.8 → 1.0) publishes again.
+5. On a successful conditional update, publish `cost.budget.threshold.crossed` (or `cost.budget.breached` for the `1.0` threshold) to the shared EventBridge bus, source `citadel.telemetry`. See [EVENTBRIDGE_CATALOG.md](./EVENTBRIDGE_CATALOG.md#cost-budget-events) for the full event schema.
+
+## Frontend integration
+
+`frontend/src/services/costService.ts` is the only client for this API. Unlike `appApiService` (AppSync/GraphQL, where Amplify attaches the Cognito token implicitly), this is a raw HTTP API — the client calls `fetchAuthSession()` and attaches `Authorization: Bearer <idToken>` explicitly on every request.
+
+The service degrades gracefully when `costApiUrl` isn't configured (a deployment or local-dev environment that hasn't threaded `TelemetryStack.costApiUrl` through `aws-exports.json` yet): every method resolves to `{ available: false, reason: 'unconfigured' }` instead of throwing or issuing a fetch to a placeholder origin, and the dashboard cost panels (`CostChartRow`, the per-app panel in `AppApiDashboard`) render nothing rather than an error state.
+
+Config plumbing: `TelemetryStack.costApiUrl` → `FrontendStackProps.costApiUrl` → `frontend-stack.ts`'s `frontendConfig.aws_cost_api_url` (rides the existing `aws-exports.json` deployment) → `frontend/src/config/awsExportsConfig.ts`'s `convertAWSExportsToConfig` → `AmplifyConfig.costApiUrl` (`server.ts`) → `costService.ts`.

--- a/docs/EVENTBRIDGE_CATALOG.md
+++ b/docs/EVENTBRIDGE_CATALOG.md
@@ -15,6 +15,7 @@ All async coordination in Citadel flows through a single EventBridge bus: `citad
 | `citadel.backend` | Backend | Lambda resolver events (project, agent, document lifecycle) |
 | `citadel.workflows` | Arbiter (StepRunner) | Workflow execution lifecycle events |
 | `citadel.apps` | Backend | App status transitions and component changes |
+| `citadel.telemetry` | Backend (TelemetryStack) | Cost budget threshold/breach notifications — the one publisher exception in an otherwise consume-only stack |
 | `agent_intake.<phase>` | Service (intake runtime), Arbiter (Fabricator), Backend (app publish handler) | Intake project-progress milestones — one source per phase: `agent_intake.assessment`, `agent_intake.design`, `agent_intake.planning`, `agent_intake.implementation` |
 | `task.request` | Backend | New task submissions for the Supervisor |
 | `task.completion` | Arbiter (Worker) | Worker agent task completion signals |
@@ -719,6 +720,38 @@ This prevents double-billing without any cross-event lookup.
 ### Pricing resolution (per row)
 
 For each usage record, the writer resolves the raw `modelId` to a catalog `modelKey` (same slug logic as `model-catalog-sync.ts`'s `modelKeyFromId`) and reads pricing via `GetItem` on the model-catalog table. A catalog-read failure, a missing row, or a row without usable pricing (`inputPer1kTokens`/`outputPer1kTokens`/`currency`) never drops the ledger row — it is written with `priced:false`, null cost fields, and an `unpricedReason` (`model_not_in_catalog` | `pricing_absent`), logged via `console.warn`/`console.error`. See [MODEL_SELECTION.md](./MODEL_SELECTION.md#pricing-metadata) for the pricing field contract.
+
+## Cost Budget Events (producer: `cost-budget-evaluator` / `cost-notifier`, source: `citadel.telemetry`)
+
+`TelemetryStack` is a consume-only bus subscriber everywhere else in this catalog (see Cost Ledger Events above). The budget evaluator is the **one exception**: it is a bus **publisher**, emitting threshold-crossing notifications so downstream SNS/notification subscribers can alert users. `agentEventBus.grantPutEventsTo(evaluator)` is granted specifically for this.
+
+| Source | DetailType | Meaning |
+|--------|------------|---------|
+| `citadel.telemetry` | `cost.budget.threshold.crossed` | A budget's period-to-date spend crossed a configured soft threshold (e.g. 0.8 of `limitMicros`) |
+| `citadel.telemetry` | `cost.budget.breached` | A budget's period-to-date spend crossed the 1.0 (hard) threshold |
+
+### Event schema
+
+```json
+{
+  "source": "citadel.telemetry",
+  "detail-type": "cost.budget.threshold.crossed",
+  "detail": {
+    "orgId": "string",
+    "scope": "org | app:<appId>",
+    "periodType": "monthly | daily",
+    "periodKey": "YYYY-MM | YYYY-MM-DD",
+    "threshold": "number (0-1 fraction of limitMicros)",
+    "spentMicros": "number",
+    "limitMicros": "number",
+    "currency": "string"
+  }
+}
+```
+
+### Producer and dedupe
+
+Emitted by `backend/src/lambda/cost-budget-evaluator.ts` (hourly `CostBudgetEvaluatorScheduleRule`) via `backend/src/lambda/cost-notifier.ts`. Each budget row (enumerated via the sparse `BudgetIndex` GSI, never a Scan) is compared against its thresholds using period-to-date spend from a base-table Query (`PK=ORG#<org> AND SK BETWEEN periodStartIso AND nowIso`, summing only `priced===true` rows). Publication is gated by an atomic conditional `UpdateItem` on the budget row's `notified.<periodKey>` map (`ConditionExpression: attribute_not_exists(...) OR notified.<periodKey> < :threshold`) — this guarantees at most one publish per (period, threshold) even under concurrent or retried evaluator runs, and a higher threshold crossed later in the same period (e.g. 0.8 → 1.0) publishes again as a new escalation.
 
 ## Adding a New Event Type
 

--- a/docs/EVENTBRIDGE_CATALOG.md
+++ b/docs/EVENTBRIDGE_CATALOG.md
@@ -696,6 +696,30 @@ All EventBridge-triggered handlers use the `IdempotencyGuard` class (`backend/sr
 
 This ensures safe retries — EventBridge may deliver the same event multiple times, and the system produces the same result without duplicate side effects.
 
+## Cost Ledger Events (consumer: `cost-ledger-writer`)
+
+The invocation cost ledger (`citadel-cost-ledger-{env}`, `TelemetryStack`) is populated by a single writer Lambda, `backend/src/lambda/cost-ledger-writer.ts`, subscribed to three separate EventBridge rules that all target the **same** function. The writer branches on `source`/`detail-type` and applies its own idempotency (`PutCommand` + `ConditionExpression: attribute_not_exists(PK)`, keyed on `<eventId>:<callIndex>`) rather than the shared `IdempotencyGuard` table.
+
+| Source | DetailType | Meaning |
+|--------|------------|---------|
+| `task.completion` | `task.completion` | Standalone (non-workflow) worker task usage |
+| `agent_intake.usage` | `intake.usage.captured` | Intake-runtime model usage |
+| `citadel.workflows` | `workflow.node.completed` | Per-node workflow usage |
+
+### Dedupe rule (cross-source, enforced in the writer)
+
+`task.completion` and `workflow.node.completed` can describe the **same** model calls for a workflow node (the worker task ran inside a StepRunner node). EventBridge patterns cannot correlate across sources, so the writer enforces this stateless rule itself:
+
+- `workflow.node.completed` is **authoritative for all workflow-node model calls** — always written.
+- `task.completion` is authoritative **only** for standalone tasks. If its detail carries workflow correlation (`workflowExecutionId` **and** `nodeId`), the event is **dropped** — those calls are already owned by the corresponding `node.completed` event.
+- `intake.usage.captured` never overlaps the other two sources and is always authoritative.
+
+This prevents double-billing without any cross-event lookup.
+
+### Pricing resolution (per row)
+
+For each usage record, the writer resolves the raw `modelId` to a catalog `modelKey` (same slug logic as `model-catalog-sync.ts`'s `modelKeyFromId`) and reads pricing via `GetItem` on the model-catalog table. A catalog-read failure, a missing row, or a row without usable pricing (`inputPer1kTokens`/`outputPer1kTokens`/`currency`) never drops the ledger row — it is written with `priced:false`, null cost fields, and an `unpricedReason` (`model_not_in_catalog` | `pricing_absent`), logged via `console.warn`/`console.error`. See [MODEL_SELECTION.md](./MODEL_SELECTION.md#pricing-metadata) for the pricing field contract.
+
 ## Adding a New Event Type
 
 1. Add the event type constant to `EventTypes` in `backend/src/utils/events.ts`

--- a/docs/MODEL_SELECTION.md
+++ b/docs/MODEL_SELECTION.md
@@ -96,6 +96,24 @@ Partition key: `modelKey` (a slug derived from the Bedrock model id).
 | `regionProfiles` | AWSJSON | Map of cross-region prefix → inference-profile id (e.g. `{"us": "...", "global": "..."}`) |
 | `discoveredAt` | String | Timestamp first seen by the sync |
 
+### Pricing metadata
+
+Additive fields on the same catalog row, read by the cost-ledger writer (`backend/src/lambda/cost-ledger-writer.ts`, see [EVENTBRIDGE_CATALOG.md](./EVENTBRIDGE_CATALOG.md#cost-ledger-events-consumer-cost-ledger-writer)) to compute per-invocation token cost. The Bedrock `ListFoundationModels` API does not expose pricing, so these fields are populated by the sync's `PROVIDER_PRICING` overlay (provider-keyed, mirroring `PROVIDER_CAPABILITIES`) or the deployment-time seed — never by the resolver.
+
+| Field | Type | Notes |
+|-------|------|-------|
+| `inputPer1kTokens` | Number | List price per 1000 input tokens |
+| `outputPer1kTokens` | Number | List price per 1000 output tokens |
+| `currency` | String | ISO 4217 code, e.g. `USD` |
+| `pricingSource` | String | `seed` \| `synced_default` \| `operator` |
+| `pricingUpdatedAt` | String | ISO 8601 timestamp of the last pricing write |
+
+**Additive-only merge.** `model-catalog-sync.ts` applies the provider default pricing **only when the row has no pricing yet** — exactly like the existing operator-`status` preservation (`{...existing, ...apiDerived, status: existing.status}`): a row with any usable pricing (all three of `inputPer1kTokens`/`outputPer1kTokens`/`currency` present) keeps its values untouched on every subsequent sync, and `pricingSource` is left as `'operator'` rather than being overwritten to `'synced_default'`. Newly-discovered rows and the deployment seed get `pricingSource: 'synced_default'` / `'seed'` respectively.
+
+**No mutation added this story.** `listModelCatalog` passes pricing fields through verbatim (interface passthrough only — `ModelCatalogEntry` in `model-config-resolver.ts` was extended with the five optional fields above). An operator-facing `updateModelPricing` mutation to edit pricing directly through the GraphQL API is a **deferred follow-up**; until it lands, pricing is set by the seed, the sync overlay, or a direct edit of the catalog row.
+
+**Unpriced policy.** The cost-ledger writer never fabricates a price: a model absent from the catalog, or present without a complete pricing set, produces `priced:false` with null cost fields rather than a guessed value — see [EVENTBRIDGE_CATALOG.md](./EVENTBRIDGE_CATALOG.md#pricing-resolution-per-row) for the full policy.
+
 ### `citadel-model-config-{env}` — resolved defaults & overrides
 
 Partition key: `scope` (the platform-wide row uses `scope = "platform"`).

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -6272,11 +6272,14 @@
                   }
             },
             "node_modules/balanced-match": {
-                  "version": "1.0.2",
-                  "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
-                  "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+                  "version": "4.0.4",
+                  "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
+                  "integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
                   "dev": true,
-                  "license": "MIT"
+                  "license": "MIT",
+                  "engines": {
+                        "node": "18 || 20 || >=22"
+                  }
             },
             "node_modules/base64-js": {
                   "version": "1.5.1",
@@ -6318,14 +6321,16 @@
                   "license": "MIT"
             },
             "node_modules/brace-expansion": {
-                  "version": "1.1.16",
-                  "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.16.tgz",
-                  "integrity": "sha512-IDw48K2/2kRkg9LdJxurvq3lV3aBgq0REY89duEqFRthjlPdXHKMj7EnQOXVckxzgisinf3nHfrcE2FufFLXMw==",
+                  "version": "5.0.8",
+                  "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.8.tgz",
+                  "integrity": "sha512-JZyDyq3D4AUifKTPOB7DELf6XsB3WdPuNxCtob1vFXPsSXhdAiHBWJ/tJ8HAc9aH84BK+5JFZLNkJKx3G9kzQg==",
                   "dev": true,
                   "license": "MIT",
                   "dependencies": {
-                        "balanced-match": "^1.0.0",
-                        "concat-map": "0.0.1"
+                        "balanced-match": "^4.0.2"
+                  },
+                  "engines": {
+                        "node": "20 || >=22"
                   }
             },
             "node_modules/braces": {
@@ -6692,13 +6697,6 @@
                         "type": "github",
                         "url": "https://github.com/sponsors/wooorm"
                   }
-            },
-            "node_modules/concat-map": {
-                  "version": "0.0.1",
-                  "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
-                  "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
-                  "dev": true,
-                  "license": "MIT"
             },
             "node_modules/convert-source-map": {
                   "version": "2.0.0",
@@ -10914,13 +10912,13 @@
                   }
             },
             "node_modules/monaco-editor": {
-                  "version": "0.55.1",
-                  "resolved": "https://registry.npmjs.org/monaco-editor/-/monaco-editor-0.55.1.tgz",
-                  "integrity": "sha512-jz4x+TJNFHwHtwuV9vA9rMujcZRb0CEilTEwG2rRSpe/A7Jdkuj8xPKttCgOh+v/lkHy7HsZ64oj+q3xoAFl9A==",
+                  "version": "0.56.0",
+                  "resolved": "https://registry.npmjs.org/monaco-editor/-/monaco-editor-0.56.0.tgz",
+                  "integrity": "sha512-sXboRm3BeBeLm938eaiyLMe0OxzfXIlZvbv4ir/jVgQy1zDhWjgmny0WoN45fuDKhCCQsYMbBJrv/A6jd8aCUg==",
                   "license": "MIT",
                   "peer": true,
                   "dependencies": {
-                        "dompurify": "3.2.7",
+                        "dompurify": "3.4.8",
                         "marked": "14.0.0"
                   }
             },

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -95,6 +95,12 @@
       "overrides": {
             "dompurify": "^3.4.12",
             "form-data": "^4.0.6",
-            "js-yaml": "^4.3.0"
+            "js-yaml": "^4.3.0",
+            "brace-expansion": ">=5.0.8",
+            "jest": {
+                  "minimatch": {
+                        "brace-expansion": ">=5.0.8"
+                  }
+            }
       }
 }

--- a/frontend/src/components/ChartSkeletons.tsx
+++ b/frontend/src/components/ChartSkeletons.tsx
@@ -96,3 +96,28 @@ export function ChartRow4Skeleton() {
     </div>
   );
 }
+
+/**
+ * Skeleton for the Cost Row: Cost Over Time + By App/Model/Agent panels.
+ * Matches: mt-5 wrapper, one full-width chart + two-up dimension charts.
+ */
+export function CostChartRowSkeleton() {
+  return (
+    <div className="mt-5" data-testid="cost-chart-row-skeleton">
+      <div className="mb-4">
+        <div className="h-5 w-16 bg-accent rounded animate-pulse mb-2" />
+        <div className="h-4 w-64 bg-accent rounded animate-pulse" />
+      </div>
+      <Card className="rounded-lg p-[15px] gap-0 mb-4">
+        <div className="h-[300px] bg-accent rounded animate-pulse" />
+      </Card>
+      <div className="grid grid-cols-1 lg:grid-cols-2 gap-4">
+        {[0, 1].map((i) => (
+          <Card key={i} className="rounded-lg p-[15px] gap-0">
+            <div className="h-[300px] bg-accent rounded animate-pulse" />
+          </Card>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/components/ExecutionDetailSheet.tsx
+++ b/frontend/src/components/ExecutionDetailSheet.tsx
@@ -20,6 +20,14 @@ import { toast } from 'sonner';
 
 // ---- Types ----
 
+/** Usage rollup: aggregated token usage (per-node or execution-level). */
+export interface UsageTotals {
+  inputTokens: number;
+  outputTokens: number;
+  totalTokens: number;
+  callCount: number;
+}
+
 export interface ExecutionNodeResult {
   nodeId: string;
   agentId?: string | null;
@@ -29,6 +37,8 @@ export interface ExecutionNodeResult {
   output?: string | null;
   error?: string | null;
   retryCount?: number | null;
+  /** Additive: this node's precomputed usage totals (usage rollup). */
+  usageTotals?: UsageTotals | null;
 }
 
 export interface ExecutionDetail {
@@ -44,6 +54,8 @@ export interface ExecutionDetail {
   error?: string | null;
   /** JSON string map keyed by nodeId (AWSJSON) or an already-parsed object. */
   nodeResults?: string | Record<string, unknown> | null;
+  /** Additive: execution-level usage totals (AWSJSON string or parsed object). */
+  usageTotals?: string | UsageTotals | null;
 }
 
 interface ExecutionDetailSheetProps {
@@ -103,6 +115,7 @@ function parseNodeResults(raw?: string | Record<string, unknown> | null): Execut
       output: typeof v.output === 'string' ? v.output : null,
       error: typeof v.error === 'string' ? v.error : null,
       retryCount: typeof v.retryCount === 'number' ? v.retryCount : 0,
+      usageTotals: parseUsageTotals(v.usageTotals),
     };
   });
   nodes.sort((a, b) => {
@@ -112,6 +125,35 @@ function parseNodeResults(raw?: string | Record<string, unknown> | null): Execut
     return a.startedAt.localeCompare(b.startedAt);
   });
   return nodes;
+}
+
+/** Parse a usageTotals value (JSON string, already-parsed object, or absent)
+ * into a UsageTotals shape, or null when absent/malformed/all-zero. Never
+ * throws — a corrupted string or a non-object value degrades to null so the
+ * caller can render nothing for it (legacy runs before this feature). */
+function parseUsageTotals(raw: unknown): UsageTotals | null {
+  let value: unknown = raw;
+  if (typeof value === 'string') {
+    if (value === '') return null;
+    try {
+      value = JSON.parse(value);
+    } catch {
+      return null;
+    }
+  }
+  if (!value || typeof value !== 'object' || Array.isArray(value)) return null;
+  const v = value as Record<string, unknown>;
+  const toNonNegInt = (x: unknown): number => {
+    const n = typeof x === 'string' ? Number(x) : x;
+    return typeof n === 'number' && Number.isFinite(n) ? Math.max(0, Math.trunc(n)) : 0;
+  };
+  const totals: UsageTotals = {
+    inputTokens: toNonNegInt(v.inputTokens),
+    outputTokens: toNonNegInt(v.outputTokens),
+    totalTokens: toNonNegInt(v.totalTokens),
+    callCount: toNonNegInt(v.callCount),
+  };
+  return totals;
 }
 
 function formatDate(dateStr?: string | null): string {
@@ -167,6 +209,10 @@ export function ExecutionDetailSheet({ execution, open, onClose }: ExecutionDeta
   );
   const prettyOutput = useMemo(() => prettyJson(execution?.output), [execution?.output]);
   const prettyInput = useMemo(() => prettyJson(execution?.input), [execution?.input]);
+  const executionUsageTotals = useMemo(
+    () => parseUsageTotals(execution?.usageTotals),
+    [execution?.usageTotals],
+  );
 
   if (!execution) return null;
 
@@ -213,6 +259,9 @@ export function ExecutionDetailSheet({ execution, open, onClose }: ExecutionDeta
             {execution.triggeredBy && <span>Triggered by {execution.triggeredBy}</span>}
             {execution.workflowVersion != null && (
               <span>Workflow v{execution.workflowVersion}</span>
+            )}
+            {executionUsageTotals && executionUsageTotals.totalTokens > 0 && (
+              <span>Total tokens {executionUsageTotals.totalTokens.toLocaleString()}</span>
             )}
           </div>
         </SheetHeader>
@@ -288,6 +337,14 @@ export function ExecutionDetailSheet({ execution, open, onClose }: ExecutionDeta
                         <span className="ml-auto text-muted-foreground flex-shrink-0">
                           {computeDuration(node.startedAt, node.completedAt)}
                         </span>
+                        {node.usageTotals && node.usageTotals.totalTokens > 0 && (
+                          <span
+                            className="text-muted-foreground flex-shrink-0"
+                            title={`in ${node.usageTotals.inputTokens} / out ${node.usageTotals.outputTokens}`}
+                          >
+                            {node.usageTotals.totalTokens.toLocaleString()} tok
+                          </span>
+                        )}
                         {retryCount > 0 && (
                           <Badge className="bg-chart-4/20 text-chart-4 text-xs border-0 flex-shrink-0">
                             {retryCount} {retryCount === 1 ? 'retry' : 'retries'}
@@ -300,6 +357,13 @@ export function ExecutionDetailSheet({ execution, open, onClose }: ExecutionDeta
                             <div className="rounded-md border border-destructive/50 bg-destructive/10 p-2 text-xs text-destructive whitespace-pre-wrap">
                               {node.error}
                             </div>
+                          )}
+                          {node.usageTotals && node.usageTotals.totalTokens > 0 && (
+                            <p className="text-xs text-muted-foreground">
+                              Input {node.usageTotals.inputTokens} · Output {node.usageTotals.outputTokens} ·
+                              {' '}Total {node.usageTotals.totalTokens} · {node.usageTotals.callCount}{' '}
+                              {node.usageTotals.callCount === 1 ? 'call' : 'calls'}
+                            </p>
                           )}
                           {nodeOutput !== null ? (
                             <pre className={PRE_CLASSES}>{nodeOutput}</pre>

--- a/frontend/src/components/__tests__/ExecutionDetailSheet.test.tsx
+++ b/frontend/src/components/__tests__/ExecutionDetailSheet.test.tsx
@@ -257,4 +257,95 @@ describe('ExecutionDetailSheet', () => {
 
     expect(screen.queryByText('Result')).not.toBeInTheDocument();
   });
+
+  // ─── Usage rollup (additive: per-node tokens + execution total) ───
+
+  describe('usage rollup', () => {
+    const execWithUsage = {
+      ...baseExecution,
+      usageTotals: JSON.stringify({ inputTokens: 30, outputTokens: 20, totalTokens: 50, callCount: 3 }),
+      nodeResults: JSON.stringify({
+        'node-b': {
+          nodeId: 'node-b',
+          agentId: 'agent-2',
+          status: 'completed',
+          startedAt: '2024-03-01T12:02:00Z',
+          completedAt: '2024-03-01T12:05:00Z',
+          output: '{"step":"two"}',
+          error: null,
+          retryCount: 2,
+          usageTotals: { inputTokens: 12, outputTokens: 8, totalTokens: 20, callCount: 1 },
+        },
+        'node-a': {
+          nodeId: 'node-a',
+          agentId: 'agent-1',
+          status: 'completed',
+          startedAt: '2024-03-01T12:00:00Z',
+          completedAt: '2024-03-01T12:02:00Z',
+          output: '{"step":"one"}',
+          error: null,
+          retryCount: 0,
+          usageTotals: { inputTokens: 18, outputTokens: 12, totalTokens: 30, callCount: 2 },
+        },
+      }),
+    };
+
+    it('shows a per-node token badge next to duration when usageTotals.totalTokens > 0', () => {
+      render(<ExecutionDetailSheet execution={execWithUsage} open onClose={jest.fn()} />);
+
+      const stepA = screen.getByRole('button', { name: /node-a/ });
+      const stepB = screen.getByRole('button', { name: /node-b/ });
+
+      expect(within(stepA).getByText('30 tok')).toBeInTheDocument();
+      expect(within(stepB).getByText('20 tok')).toBeInTheDocument();
+    });
+
+    it('omits the per-node token badge when a node has no usage (legacy/zero)', () => {
+      render(<ExecutionDetailSheet execution={baseExecution} open onClose={jest.fn()} />);
+
+      const stepA = screen.getByRole('button', { name: /node-a/ });
+      expect(within(stepA).queryByText(/tok$/)).not.toBeInTheDocument();
+    });
+
+    it('shows an input/output/total/call-count breakdown in the expanded node body', () => {
+      render(<ExecutionDetailSheet execution={execWithUsage} open onClose={jest.fn()} />);
+
+      fireEvent.click(screen.getByRole('button', { name: /node-a/ }));
+
+      expect(screen.getByText(/Input 18/)).toBeInTheDocument();
+      expect(screen.getByText(/Output 12/)).toBeInTheDocument();
+      expect(screen.getByText(/Total 30/)).toBeInTheDocument();
+      expect(screen.getByText(/2 calls/)).toBeInTheDocument();
+    });
+
+    it('shows the execution total tokens in the header metadata block', () => {
+      render(<ExecutionDetailSheet execution={execWithUsage} open onClose={jest.fn()} />);
+
+      expect(screen.getByText(/Total tokens 50/)).toBeInTheDocument();
+    });
+
+    it('omits the header total-tokens line when the execution has no usage', () => {
+      render(<ExecutionDetailSheet execution={baseExecution} open onClose={jest.fn()} />);
+
+      expect(screen.queryByText(/Total tokens/)).not.toBeInTheDocument();
+    });
+
+    it('accepts an already-parsed usageTotals object (not just a JSON string)', () => {
+      const exec = {
+        ...execWithUsage,
+        usageTotals: { inputTokens: 30, outputTokens: 20, totalTokens: 50, callCount: 3 },
+      };
+      render(<ExecutionDetailSheet execution={exec} open onClose={jest.fn()} />);
+
+      expect(screen.getByText(/Total tokens 50/)).toBeInTheDocument();
+    });
+
+    it('never throws on malformed usageTotals and simply omits the header line', () => {
+      const exec = { ...execWithUsage, usageTotals: 'not-json{' };
+      expect(() =>
+        render(<ExecutionDetailSheet execution={exec} open onClose={jest.fn()} />),
+      ).not.toThrow();
+      expect(screen.queryByText(/Total tokens/)).not.toBeInTheDocument();
+    });
+  });
 });

--- a/frontend/src/components/cost/CostByDimensionChart.tsx
+++ b/frontend/src/components/cost/CostByDimensionChart.tsx
@@ -1,0 +1,92 @@
+/**
+ * CostByDimensionChart
+ *
+ * Renders a `/cost/summary` response as a BarChart, one bar per dimension
+ * bucket (app/agent/model/project). Honest states: EstimateBadge shown
+ * alongside real data, UnpricedChip shows the unpriced-row count, empty
+ * state when there are no buckets, and a currency-mixed warning when the
+ * org's rows span more than one currency (costs cannot be meaningfully
+ * summed across currencies — see cost-query-handler.ts's `currencyMixed`).
+ */
+import {
+  BarChart, Bar, XAxis, YAxis, CartesianGrid, Tooltip, ResponsiveContainer,
+} from 'recharts';
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '../ui/card';
+import { Skeleton } from '../ui/skeleton';
+import { EstimateBadge } from './EstimateBadge';
+import { UnpricedChip } from './UnpricedChip';
+import type { CostSummaryResponse } from '../../services/costService';
+import { CHART_GRID_STROKE, CHART_AXIS_STROKE, CHART_TOOLTIP_STYLE, cssVar } from '../../pages/dashboard/chartStyles';
+
+export interface CostByDimensionChartProps {
+  title?: string;
+  description?: string;
+  data: CostSummaryResponse | null;
+  loading: boolean;
+}
+
+function formatCost(costMicros: number, currency: string | null): string {
+  const amount = (costMicros / 1_000_000).toFixed(2);
+  return currency ? `${amount} ${currency}` : amount;
+}
+
+export function CostByDimensionChart({
+  title = 'Cost by Dimension',
+  description = 'Estimated spend grouped by dimension',
+  data,
+  loading,
+}: CostByDimensionChartProps) {
+  const buckets = data?.buckets ?? [];
+  const chartData = buckets.map((b) => ({
+    label: b.label,
+    cost: b.costMicros / 1_000_000,
+  }));
+
+  return (
+    <Card className="rounded-lg p-[15px] gap-0" data-testid="cost-by-dimension-chart">
+      <CardHeader className="p-0 mb-4">
+        <div className="flex items-center justify-between">
+          <div>
+            <CardTitle className="text-lg font-semibold">{title}</CardTitle>
+            <CardDescription>{description}</CardDescription>
+          </div>
+          {data && (
+            <div className="flex items-center gap-2">
+              <EstimateBadge show={buckets.length > 0} />
+              <UnpricedChip count={data.unpricedRows} />
+            </div>
+          )}
+        </div>
+      </CardHeader>
+      <CardContent className="p-0">
+        {data?.currencyMixed && (
+          <div className="text-xs text-chart-4 mb-2">
+            Spend spans multiple currencies — totals are shown per-currency, not summed.
+          </div>
+        )}
+        {loading ? (
+          <Skeleton className="h-[300px] w-full" />
+        ) : chartData.length === 0 ? (
+          <div className="h-[300px] flex items-center justify-center text-muted-foreground text-sm">
+            No cost data available for this period
+          </div>
+        ) : (
+          <ResponsiveContainer width="100%" height={300}>
+            <BarChart data={chartData}>
+              <CartesianGrid strokeDasharray="3 3" stroke={CHART_GRID_STROKE} />
+              <XAxis dataKey="label" stroke={CHART_AXIS_STROKE} style={{ fontSize: '12px' }} />
+              <YAxis stroke={CHART_AXIS_STROKE} style={{ fontSize: '12px' }} />
+              <Tooltip
+                contentStyle={CHART_TOOLTIP_STYLE}
+                formatter={(value: number) => formatCost(value * 1_000_000, data?.currency ?? null)}
+              />
+              <Bar dataKey="cost" fill={cssVar('--chart-2')} radius={[4, 4, 0, 0]} />
+            </BarChart>
+          </ResponsiveContainer>
+        )}
+      </CardContent>
+    </Card>
+  );
+}
+
+export default CostByDimensionChart;

--- a/frontend/src/components/cost/CostOverTimeChart.tsx
+++ b/frontend/src/components/cost/CostOverTimeChart.tsx
@@ -1,0 +1,94 @@
+/**
+ * CostOverTimeChart
+ *
+ * Renders a `/cost/series` response as an AreaChart (cost per time
+ * bucket). Honest states: EstimateBadge is always shown alongside real
+ * data (every series row is `estimate:true`), UnpricedChip shows the
+ * unpriced-call count, and an explicit empty state renders when there are
+ * no points rather than a misleadingly flat/zero chart. Loading uses a
+ * Skeleton matched to the chart's rendered height to avoid layout shift.
+ */
+import {
+  AreaChart, Area, XAxis, YAxis, CartesianGrid, Tooltip, ResponsiveContainer,
+} from 'recharts';
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '../ui/card';
+import { Skeleton } from '../ui/skeleton';
+import { EstimateBadge } from './EstimateBadge';
+import { UnpricedChip } from './UnpricedChip';
+import type { CostSeriesResponse } from '../../services/costService';
+import { CHART_GRID_STROKE, CHART_AXIS_STROKE, CHART_TOOLTIP_STYLE, cssVar } from '../../pages/dashboard/chartStyles';
+
+export interface CostOverTimeChartProps {
+  title?: string;
+  description?: string;
+  data: CostSeriesResponse | null;
+  loading: boolean;
+}
+
+/** costMicros → display dollars, 6 decimal-place micros → 2dp currency string. Never fabricates a currency symbol when currency is unknown. */
+function formatCost(costMicros: number, currency: string | null): string {
+  const amount = (costMicros / 1_000_000).toFixed(2);
+  return currency ? `${amount} ${currency}` : amount;
+}
+
+export function CostOverTimeChart({
+  title = 'Cost Over Time',
+  description = 'Estimated spend per day across the organization',
+  data,
+  loading,
+}: CostOverTimeChartProps) {
+  const points = data?.points ?? [];
+  const chartData = points.map((p) => ({
+    t: p.t,
+    cost: p.costMicros / 1_000_000,
+  }));
+
+  return (
+    <Card className="rounded-lg p-[15px] gap-0" data-testid="cost-over-time-chart">
+      <CardHeader className="p-0 mb-4">
+        <div className="flex items-center justify-between">
+          <div>
+            <CardTitle className="text-lg font-semibold">{title}</CardTitle>
+            <CardDescription>{description}</CardDescription>
+          </div>
+          {data && (
+            <div className="flex items-center gap-2">
+              <EstimateBadge show={points.length > 0} />
+              <UnpricedChip count={data.unpricedCount} />
+            </div>
+          )}
+        </div>
+      </CardHeader>
+      <CardContent className="p-0">
+        {loading ? (
+          <Skeleton className="h-[300px] w-full" />
+        ) : chartData.length === 0 ? (
+          <div className="h-[300px] flex items-center justify-center text-muted-foreground text-sm">
+            No cost data available for this period
+          </div>
+        ) : (
+          <ResponsiveContainer width="100%" height={300}>
+            <AreaChart data={chartData}>
+              <defs>
+                <linearGradient id="colorCost" x1="0" y1="0" x2="0" y2="1">
+                  <stop offset="5%" stopColor={cssVar('--chart-1')} stopOpacity={0.8} />
+                  <stop offset="95%" stopColor={cssVar('--chart-1')} stopOpacity={0.1} />
+                </linearGradient>
+              </defs>
+              <CartesianGrid strokeDasharray="3 3" stroke={CHART_GRID_STROKE} />
+              <XAxis dataKey="t" stroke={CHART_AXIS_STROKE} style={{ fontSize: '12px' }} />
+              <YAxis stroke={CHART_AXIS_STROKE} style={{ fontSize: '12px' }} />
+              <Tooltip
+                contentStyle={CHART_TOOLTIP_STYLE}
+                formatter={(value: number) => formatCost(value * 1_000_000, data?.currency ?? null)}
+              />
+              <Area type="monotone" dataKey="cost" stroke={cssVar('--chart-1')} strokeWidth={2} fillOpacity={1} fill="url(#colorCost)" />
+            </AreaChart>
+          </ResponsiveContainer>
+        )}
+      </CardContent>
+    </Card>
+  );
+}
+
+export default CostOverTimeChart;

--- a/frontend/src/components/cost/EstimateBadge.tsx
+++ b/frontend/src/components/cost/EstimateBadge.tsx
@@ -1,0 +1,26 @@
+/**
+ * EstimateBadge
+ *
+ * Honest-state indicator for cost panels: every ledger-derived cost row
+ * carries `estimate: true` (see cost-query-handler.ts response shapes),
+ * so this badge is shown whenever a cost dataset is rendered — it must
+ * never be silently omitted, since that would imply the figures are
+ * exact/priced-with-certainty rather than model-derived estimates.
+ */
+import { Badge } from '../ui/badge';
+
+export interface EstimateBadgeProps {
+  /** Show the badge. Callers pass `true` whenever any row in the dataset has `estimate:true` (i.e. essentially always, per the API contract) — kept explicit rather than hardcoded so a future non-estimate data source can opt out. */
+  show: boolean;
+}
+
+export function EstimateBadge({ show }: EstimateBadgeProps) {
+  if (!show) return null;
+  return (
+    <Badge variant="info" title="Costs are estimated from token usage and catalog pricing, not a billing invoice.">
+      Estimate
+    </Badge>
+  );
+}
+
+export default EstimateBadge;

--- a/frontend/src/components/cost/UnpricedChip.tsx
+++ b/frontend/src/components/cost/UnpricedChip.tsx
@@ -1,0 +1,28 @@
+/**
+ * UnpricedChip
+ *
+ * Honest-state indicator showing how many ledger rows in the current
+ * dataset could not be priced (missing catalog entry, missing pricing
+ * fields — see cost-ledger-writer.ts's `unpricedReason`). Rendered
+ * whenever `count > 0` so totals never silently understate spend without
+ * disclosure; hidden entirely when there are no unpriced rows.
+ */
+import { Badge } from '../ui/badge';
+
+export interface UnpricedChipProps {
+  count: number;
+}
+
+export function UnpricedChip({ count }: UnpricedChipProps) {
+  if (count <= 0) return null;
+  return (
+    <Badge
+      variant="warning"
+      title="These calls could not be matched to catalog pricing and are excluded from the cost totals."
+    >
+      {count} unpriced
+    </Badge>
+  );
+}
+
+export default UnpricedChip;

--- a/frontend/src/components/cost/__tests__/CostByDimensionChart.test.tsx
+++ b/frontend/src/components/cost/__tests__/CostByDimensionChart.test.tsx
@@ -1,0 +1,78 @@
+/**
+ * CostByDimensionChart tests
+ *
+ * Covers: loading skeleton, empty state (no buckets), data rendering with
+ * EstimateBadge, UnpricedChip, and the currency-mixed warning banner.
+ */
+import { render, screen } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import { CostByDimensionChart } from '../CostByDimensionChart';
+import type { CostSummaryResponse } from '../../../services/costService';
+
+function makeSummary(overrides: Partial<CostSummaryResponse> = {}): CostSummaryResponse {
+  return {
+    groupBy: 'app',
+    from: '2026-06-25T00:00:00.000Z',
+    to: '2026-07-25T00:00:00.000Z',
+    currency: 'USD',
+    currencyMixed: false,
+    totalCostMicros: 0,
+    pricedRows: 0,
+    unpricedRows: 0,
+    estimate: true,
+    truncated: false,
+    buckets: [],
+    ...overrides,
+  };
+}
+
+describe('CostByDimensionChart', () => {
+  it('renders a loading skeleton when loading is true', () => {
+    render(<CostByDimensionChart data={null} loading={true} />);
+    expect(screen.getByTestId('cost-by-dimension-chart')).toBeInTheDocument();
+  });
+
+  it('renders an empty state when there are no buckets', () => {
+    render(<CostByDimensionChart data={makeSummary({ buckets: [] })} loading={false} />);
+    expect(screen.getByText(/No cost data available for this period/i)).toBeInTheDocument();
+  });
+
+  it('renders the EstimateBadge when buckets are present', () => {
+    render(
+      <CostByDimensionChart
+        data={makeSummary({
+          buckets: [{ key: 'app-1', label: 'app-1', costMicros: 2_000_000, tokenCost: 2, totalTokens: 500, rows: 4, unpricedRows: 0 }],
+        })}
+        loading={false}
+      />,
+    );
+    expect(screen.getByText('Estimate')).toBeInTheDocument();
+  });
+
+  it('renders the UnpricedChip when unpricedRows > 0', () => {
+    render(
+      <CostByDimensionChart
+        data={makeSummary({
+          buckets: [{ key: 'app-1', label: 'app-1', costMicros: 2_000_000, tokenCost: 2, totalTokens: 500, rows: 4, unpricedRows: 2 }],
+          unpricedRows: 2,
+        })}
+        loading={false}
+      />,
+    );
+    expect(screen.getByText('2 unpriced')).toBeInTheDocument();
+  });
+
+  it('shows a currency-mixed warning when currencyMixed is true', () => {
+    render(
+      <CostByDimensionChart
+        data={makeSummary({
+          currencyMixed: true,
+          currency: null,
+          buckets: [{ key: 'app-1', label: 'app-1', costMicros: 1_000_000, tokenCost: 1, totalTokens: 100, rows: 1, unpricedRows: 0 }],
+        })}
+        loading={false}
+      />,
+    );
+    expect(screen.getByText(/multiple currencies/i)).toBeInTheDocument();
+  });
+});

--- a/frontend/src/components/cost/__tests__/CostOverTimeChart.test.tsx
+++ b/frontend/src/components/cost/__tests__/CostOverTimeChart.test.tsx
@@ -1,0 +1,65 @@
+/**
+ * CostOverTimeChart tests
+ *
+ * Covers: loading skeleton, empty state (no points), data rendering with
+ * EstimateBadge, and UnpricedChip showing the unpriced count.
+ */
+import { render, screen } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import { CostOverTimeChart } from '../CostOverTimeChart';
+import type { CostSeriesResponse } from '../../../services/costService';
+
+function makeSeries(overrides: Partial<CostSeriesResponse> = {}): CostSeriesResponse {
+  return {
+    dimension: 'org',
+    bucket: 'day',
+    from: '2026-06-25T00:00:00.000Z',
+    to: '2026-07-25T00:00:00.000Z',
+    currency: 'USD',
+    estimate: true,
+    truncated: false,
+    unpricedCount: 0,
+    points: [],
+    ...overrides,
+  };
+}
+
+describe('CostOverTimeChart', () => {
+  it('renders a loading skeleton when loading is true', () => {
+    render(<CostOverTimeChart data={null} loading={true} />);
+    expect(screen.getByTestId('cost-over-time-chart')).toBeInTheDocument();
+    expect(screen.queryByText(/No cost data available/i)).not.toBeInTheDocument();
+  });
+
+  it('renders an empty state when there are no points', () => {
+    render(<CostOverTimeChart data={makeSeries({ points: [] })} loading={false} />);
+    expect(screen.getByText(/No cost data available for this period/i)).toBeInTheDocument();
+  });
+
+  it('renders the EstimateBadge and no UnpricedChip when data has points and no unpriced rows', () => {
+    render(
+      <CostOverTimeChart
+        data={makeSeries({
+          points: [{ t: '2026-07-20', costMicros: 5_000_000, totalTokens: 100, rows: 2, unpricedRows: 0 }],
+          unpricedCount: 0,
+        })}
+        loading={false}
+      />,
+    );
+    expect(screen.getByText('Estimate')).toBeInTheDocument();
+    expect(screen.queryByText(/unpriced/)).not.toBeInTheDocument();
+  });
+
+  it('renders the UnpricedChip with the unpriced count when unpricedCount > 0', () => {
+    render(
+      <CostOverTimeChart
+        data={makeSeries({
+          points: [{ t: '2026-07-20', costMicros: 5_000_000, totalTokens: 100, rows: 3, unpricedRows: 1 }],
+          unpricedCount: 3,
+        })}
+        loading={false}
+      />,
+    );
+    expect(screen.getByText('3 unpriced')).toBeInTheDocument();
+  });
+});

--- a/frontend/src/components/cost/__tests__/badges.test.tsx
+++ b/frontend/src/components/cost/__tests__/badges.test.tsx
@@ -1,0 +1,40 @@
+/**
+ * EstimateBadge / UnpricedChip tests
+ *
+ * Covers honest-state rendering rules: EstimateBadge shown whenever any
+ * row is estimate:true (i.e. whenever `show` is true), hidden otherwise;
+ * UnpricedChip shows the count whenever unpricedRows > 0, hidden at 0.
+ */
+import { render, screen } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import { EstimateBadge } from '../EstimateBadge';
+import { UnpricedChip } from '../UnpricedChip';
+
+describe('EstimateBadge', () => {
+  it('renders the "Estimate" label when show is true', () => {
+    render(<EstimateBadge show={true} />);
+    expect(screen.getByText('Estimate')).toBeInTheDocument();
+  });
+
+  it('renders nothing when show is false', () => {
+    const { container } = render(<EstimateBadge show={false} />);
+    expect(container).toBeEmptyDOMElement();
+  });
+});
+
+describe('UnpricedChip', () => {
+  it('renders the unpriced count when count > 0', () => {
+    render(<UnpricedChip count={7} />);
+    expect(screen.getByText('7 unpriced')).toBeInTheDocument();
+  });
+
+  it('renders nothing when count is 0', () => {
+    const { container } = render(<UnpricedChip count={0} />);
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it('renders nothing when count is negative', () => {
+    const { container } = render(<UnpricedChip count={-1} />);
+    expect(container).toBeEmptyDOMElement();
+  });
+});

--- a/frontend/src/config/__tests__/amplify.costApiUrl.test.ts
+++ b/frontend/src/config/__tests__/amplify.costApiUrl.test.ts
@@ -1,0 +1,45 @@
+/**
+ * amplify config threading tests
+ *
+ * Covers: `aws_cost_api_url` from aws-exports.json threads into
+ * `convertAWSExportsToConfig()`'s `costApiUrl` field (pass 2 config
+ * plumbing).
+ *
+ * Imports from `awsExportsConfig.ts` (not `amplify.ts`) deliberately:
+ * `amplify.ts` also references `import.meta.env` (Vite-only syntax) in its
+ * environment-variable fallback path, which ts-jest cannot transform to
+ * CommonJS regardless of which exported function a test actually calls —
+ * the whole file fails to compile if that syntax appears anywhere in it.
+ * `convertAWSExportsToConfig` was extracted to its own `import.meta`-free
+ * module specifically so this pass's config-threading change is testable
+ * under this repo's Jest runner.
+ */
+
+import { convertAWSExportsToConfig } from '../awsExportsConfig';
+
+describe('convertAWSExportsToConfig: aws_cost_api_url threading', () => {
+  const baseAwsExports = {
+    aws_project_region: 'us-east-1',
+    aws_cognito_region: 'us-east-1',
+    aws_user_pools_id: 'pool-id',
+    aws_user_pools_web_client_id: 'client-id',
+    aws_appsync_graphqlEndpoint: 'https://appsync.example.com/graphql',
+    aws_appsync_region: 'us-east-1',
+    aws_appsync_authenticationType: 'AMAZON_COGNITO_USER_POOLS' as const,
+  };
+
+  it('maps aws_cost_api_url into costApiUrl when present', () => {
+    const config = convertAWSExportsToConfig({
+      ...baseAwsExports,
+      aws_cost_api_url: 'https://cost.example.com',
+    });
+
+    expect(config.costApiUrl).toBe('https://cost.example.com');
+  });
+
+  it('defaults costApiUrl to an empty string when aws_cost_api_url is absent', () => {
+    const config = convertAWSExportsToConfig({ ...baseAwsExports });
+
+    expect(config.costApiUrl).toBe('');
+  });
+});

--- a/frontend/src/config/amplify.ts
+++ b/frontend/src/config/amplify.ts
@@ -4,20 +4,9 @@
  */
 
 import serverService from '../services/server';
+import { convertAWSExportsToConfig, type AWSExports } from './awsExportsConfig';
 
-interface AWSExports {
-  aws_project_region: string;
-  aws_cognito_region: string;
-  aws_user_pools_id: string;
-  aws_user_pools_web_client_id: string;
-  aws_cognito_identity_pool_id?: string;
-  aws_appsync_graphqlEndpoint: string;
-  aws_appsync_region: string;
-  aws_appsync_authenticationType: 'API_KEY' | 'AMAZON_COGNITO_USER_POOLS' | 'AWS_IAM';
-  aws_appsync_apiKey?: string;
-  environment?: string;
-  aws_event_bus_url?: string;
-}
+export { convertAWSExportsToConfig, type AWSExports };
 
 /**
  * Load AWS configuration from aws-exports.json file
@@ -56,24 +45,7 @@ function getEnvConfig() {
     appsyncApiKey: import.meta.env.VITE_APPSYNC_API_KEY,
     environment: import.meta.env.VITE_ENVIRONMENT,
     eventBusUrl: import.meta.env.VITE_EVENT_BUS_URL || '',
-  };
-}
-
-/**
- * Convert AWS exports format to Amplify config format
- */
-function convertAWSExportsToConfig(awsExports: AWSExports) {
-  return {
-    region: awsExports.aws_project_region,
-    userPoolId: awsExports.aws_user_pools_id,
-    userPoolClientId: awsExports.aws_user_pools_web_client_id,
-    identityPoolId: awsExports.aws_cognito_identity_pool_id,
-    appsyncEndpoint: awsExports.aws_appsync_graphqlEndpoint,
-    appsyncRegion: awsExports.aws_appsync_region,
-    appsyncAuthenticationType: awsExports.aws_appsync_authenticationType,
-    appsyncApiKey: awsExports.aws_appsync_apiKey,
-    environment: awsExports.environment,
-    eventBusUrl: awsExports.aws_event_bus_url || '',
+    costApiUrl: import.meta.env.VITE_COST_API_URL || '',
   };
 }
 

--- a/frontend/src/config/awsExportsConfig.ts
+++ b/frontend/src/config/awsExportsConfig.ts
@@ -1,0 +1,47 @@
+/**
+ * AWS Exports Config Conversion
+ *
+ * Pure conversion from the `aws-exports.json` wire format to the
+ * `AmplifyConfig` shape consumed by `serverService.configure()`. Split out
+ * of `amplify.ts` so it can be unit-tested under Jest: `amplify.ts` also
+ * references `import.meta.env` (Vite-only syntax) in its environment-
+ * variable fallback path, which ts-jest cannot transform to CommonJS even
+ * when the offending function is never called — the whole file fails to
+ * compile if that syntax appears anywhere in it. This module contains none
+ * of that syntax, so it transforms and tests cleanly.
+ */
+
+export interface AWSExports {
+  aws_project_region: string;
+  aws_cognito_region: string;
+  aws_user_pools_id: string;
+  aws_user_pools_web_client_id: string;
+  aws_cognito_identity_pool_id?: string;
+  aws_appsync_graphqlEndpoint: string;
+  aws_appsync_region: string;
+  aws_appsync_authenticationType: 'API_KEY' | 'AMAZON_COGNITO_USER_POOLS' | 'AWS_IAM';
+  aws_appsync_apiKey?: string;
+  environment?: string;
+  aws_event_bus_url?: string;
+  /** Cost query HttpApi endpoint (TelemetryStack). Absent when the cost surface isn't deployed/threaded yet. */
+  aws_cost_api_url?: string;
+}
+
+/**
+ * Convert AWS exports format to Amplify config format
+ */
+export function convertAWSExportsToConfig(awsExports: AWSExports) {
+  return {
+    region: awsExports.aws_project_region,
+    userPoolId: awsExports.aws_user_pools_id,
+    userPoolClientId: awsExports.aws_user_pools_web_client_id,
+    identityPoolId: awsExports.aws_cognito_identity_pool_id,
+    appsyncEndpoint: awsExports.aws_appsync_graphqlEndpoint,
+    appsyncRegion: awsExports.aws_appsync_region,
+    appsyncAuthenticationType: awsExports.aws_appsync_authenticationType,
+    appsyncApiKey: awsExports.aws_appsync_apiKey,
+    environment: awsExports.environment,
+    eventBusUrl: awsExports.aws_event_bus_url || '',
+    costApiUrl: awsExports.aws_cost_api_url || '',
+  };
+}

--- a/frontend/src/pages/AppApiDashboard.tsx
+++ b/frontend/src/pages/AppApiDashboard.tsx
@@ -45,6 +45,9 @@ import serverService from '../services/server';
 import { EndpointUrlDisplay } from './components/EndpointUrlDisplay';
 import { PlaintextKeyReveal } from './components/PlaintextKeyReveal';
 import { useMetricsAutoRefresh } from '../hooks/useMetricsAutoRefresh';
+import { costService } from '../services/costService';
+import type { CostSeriesResponse } from '../services/costService';
+import { CostOverTimeChart } from '../components/cost/CostOverTimeChart';
 
 // ---- Types ----
 
@@ -150,6 +153,12 @@ export function AppApiDashboard({ appId, onBack, onNavigate: _onNavigate }: AppA
   const [metricsError, setMetricsError] = useState<string | null>(null);
   const [selectedRange, setSelectedRange] = useState(TIME_RANGES[2]); // default 24h
 
+  // Cost state (per-app panel, dimension=app) — gracefully hidden when
+  // the cost API isn't configured for this deployment.
+  const [costAvailable, setCostAvailable] = useState(false);
+  const [costSeries, setCostSeries] = useState<CostSeriesResponse | null>(null);
+  const [costLoading, setCostLoading] = useState(true);
+
   // ---- Data fetching ----
 
   const fetchApp = useCallback(async () => {
@@ -207,6 +216,22 @@ export function AppApiDashboard({ appId, onBack, onNavigate: _onNavigate }: AppA
     }
   }, [appId]);
 
+  // Per-app cost panel (dimension=app). Gracefully degrades to "hidden"
+  // when the cost API isn't configured — no fetch attempt, no error UI.
+  const fetchCost = useCallback(async (hours: number) => {
+    if (!costService.isAvailable()) {
+      setCostAvailable(false);
+      return;
+    }
+    setCostAvailable(true);
+    const from = new Date(Date.now() - hours * 60 * 60 * 1000).toISOString();
+    const to = new Date().toISOString();
+    const result = await costService.getSeries('app', appId, 'day', from, to);
+    if (result.available) {
+      setCostSeries(result.data);
+    }
+  }, [appId]);
+
   useEffect(() => {
     fetchApp();
   }, [fetchApp]);
@@ -215,13 +240,24 @@ export function AppApiDashboard({ appId, onBack, onNavigate: _onNavigate }: AppA
     if (appStatus === 'PUBLISHED') {
       fetchKeys();
       fetchMetrics(selectedRange.hours);
+      setCostLoading(true);
+      fetchCost(selectedRange.hours)
+        .catch(() => console.warn('AppApiDashboard: failed to load cost data'))
+        .finally(() => setCostLoading(false));
     }
-  }, [appStatus, fetchKeys, fetchMetrics, selectedRange.hours]);
+  }, [appStatus, fetchKeys, fetchMetrics, fetchCost, selectedRange.hours]);
 
-  // Auto-refresh metrics (Req 12)
+  // Auto-refresh metrics + per-app cost (Req 12). Cost refresh reuses
+  // fetchCost's own unconfigured-guard, so this is a no-op when the cost
+  // API isn't configured.
   const autoRefreshCallback = useMemo(
-    () => () => refreshMetrics(selectedRange.hours),
-    [refreshMetrics, selectedRange.hours],
+    () => () => {
+      refreshMetrics(selectedRange.hours);
+      fetchCost(selectedRange.hours).catch(() =>
+        console.warn('AppApiDashboard: failed to refresh cost data'),
+      );
+    },
+    [refreshMetrics, fetchCost, selectedRange.hours],
   );
   useMetricsAutoRefresh({
     enabled: appStatus === 'PUBLISHED',
@@ -705,6 +741,17 @@ export function AppApiDashboard({ appId, onBack, onNavigate: _onNavigate }: AppA
             </>
           ) : null}
         </Card>
+
+        {/* ===== Cost Section (per-app, dimension=app) ===== */}
+        {/* Gracefully hidden when the cost API isn't configured for this deployment. */}
+        {costAvailable && (
+          <CostOverTimeChart
+            title="App Cost Over Time"
+            description="Estimated model invocation spend for this app"
+            data={costSeries}
+            loading={costLoading}
+          />
+        )}
 
         {/* ===== Create API Key Dialog (two-step state machine) ===== */}
         <Dialog

--- a/frontend/src/pages/Dashboard.tsx
+++ b/frontend/src/pages/Dashboard.tsx
@@ -7,10 +7,11 @@ import { PageContainer } from '../components/PageContainer';
 import { LazyLoadSection } from '../components/LazyLoadSection';
 import { ErrorBoundary } from '../components/ErrorBoundary';
 import { Skeleton } from '../components/ui/skeleton';
-import { ChartRow2Skeleton, ChartRow3Skeleton, ChartRow4Skeleton } from '../components/ChartSkeletons';
+import { ChartRow2Skeleton, ChartRow3Skeleton, ChartRow4Skeleton, CostChartRowSkeleton } from '../components/ChartSkeletons';
 import ChartRow2 from './dashboard/ChartRow2';
 import ChartRow3 from './dashboard/ChartRow3';
 import ChartRow4 from './dashboard/ChartRow4';
+import CostChartRow from './dashboard/CostChartRow';
 import { useDashboardData } from '../hooks/useDashboardData';
 import { appApiService } from '../services/appApiService';
 import { CHART_TOOLTIP_STYLE, CHART_GRID_STROKE, CHART_AXIS_STROKE, CHART_LEGEND_STYLE } from './dashboard/chartStyles';
@@ -190,6 +191,12 @@ export function Dashboard() {
         <ErrorBoundary>
           <LazyLoadSection fallback={<ChartRow4Skeleton />}>
             <ChartRow4 counts={counts} dataStores={dataStores} />
+          </LazyLoadSection>
+        </ErrorBoundary>
+
+        <ErrorBoundary>
+          <LazyLoadSection fallback={<CostChartRowSkeleton />}>
+            <CostChartRow />
           </LazyLoadSection>
         </ErrorBoundary>
       </div>

--- a/frontend/src/pages/__tests__/AppApiDashboard.cost-panel.test.tsx
+++ b/frontend/src/pages/__tests__/AppApiDashboard.cost-panel.test.tsx
@@ -1,0 +1,107 @@
+/**
+ * AppApiDashboard per-app cost panel tests
+ *
+ * Covers: the cost panel is hidden entirely when the cost API is
+ * unconfigured (no costService fetch calls), and rendered with the
+ * app-scoped series data when configured.
+ */
+import React from 'react';
+import { render, screen, waitFor } from '@testing-library/react';
+import '@testing-library/jest-dom';
+
+jest.mock('@/components/ui/badge', () => ({
+  Badge: ({ children, className }: any) =>
+    React.createElement('span', { className, 'data-testid': 'badge' }, children),
+}));
+jest.mock('@/components/ui/button', () => ({
+  Button: ({ children, onClick, disabled, className, ...props }: any) =>
+    React.createElement('button', { onClick, disabled, className, ...props }, children),
+}));
+jest.mock('@/components/ui/dialog', () => ({
+  Dialog: ({ children, open }: any) =>
+    open ? React.createElement('div', { 'data-testid': 'dialog' }, children) : null,
+  DialogContent: ({ children }: any) => React.createElement('div', null, children),
+  DialogHeader: ({ children }: any) => React.createElement('div', null, children),
+  DialogTitle: ({ children }: any) => React.createElement('h2', null, children),
+  DialogDescription: ({ children }: any) => React.createElement('p', null, children),
+  DialogFooter: ({ children }: any) => React.createElement('div', null, children),
+}));
+jest.mock('@/components/ui/input', () => ({
+  Input: (props: any) => React.createElement('input', props),
+}));
+jest.mock('@/components/ui/skeleton', () => ({
+  Skeleton: ({ className }: any) =>
+    React.createElement('div', { 'data-testid': 'skeleton', className }),
+}));
+jest.mock('@/components/ui/utils', () => ({
+  cn: (...args: any[]) => args.filter(Boolean).join(' '),
+}));
+jest.mock('recharts', () => ({
+  ResponsiveContainer: ({ children }: any) =>
+    React.createElement('div', { 'data-testid': 'responsive-container' }, children),
+  LineChart: ({ children }: any) => React.createElement('div', null, children),
+  AreaChart: ({ children }: any) => React.createElement('div', null, children),
+  Area: () => null,
+  Line: () => null,
+  XAxis: () => null,
+  YAxis: () => null,
+  CartesianGrid: () => null,
+  Tooltip: () => null,
+}));
+
+jest.mock('@/services/appApiService', () => ({
+  appApiService: {
+    getApp: jest.fn().mockResolvedValue({ name: 'Test App', status: 'PUBLISHED', appId: 'app-123' }),
+    listAppApiKeys: jest.fn().mockResolvedValue([]),
+    getAppMetrics: jest.fn().mockResolvedValue({
+      totalRequests: 0, successCount: 0, clientErrorCount: 0, serverErrorCount: 0,
+      p50Latency: 0, p95Latency: 0, p99Latency: 0, timeSeries: [],
+    }),
+  },
+}));
+
+jest.mock('../../services/costService', () => ({
+  costService: {
+    isAvailable: jest.fn(),
+    getSeries: jest.fn(),
+    getSummary: jest.fn(),
+    listBudgets: jest.fn(),
+    putBudget: jest.fn(),
+  },
+}));
+
+import { costService } from '../../services/costService';
+import { AppApiDashboard } from '../../pages/AppApiDashboard';
+
+describe('AppApiDashboard: per-app cost panel', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('does not render the cost panel or call costService when the cost API is unconfigured', async () => {
+    (costService.isAvailable as jest.Mock).mockReturnValue(false);
+
+    render(<AppApiDashboard appId="app-123" onBack={jest.fn()} />);
+
+    await waitFor(() => expect(screen.getByText('Test App')).toBeInTheDocument());
+    expect(screen.queryByText('App Cost Over Time')).not.toBeInTheDocument();
+    expect(costService.getSeries).not.toHaveBeenCalled();
+  });
+
+  it('renders the per-app cost panel scoped to dimension=app when the cost API is configured', async () => {
+    (costService.isAvailable as jest.Mock).mockReturnValue(true);
+    (costService.getSeries as jest.Mock).mockResolvedValue({
+      available: true,
+      data: {
+        dimension: 'app', id: 'app-123', bucket: 'day', from: '', to: '', currency: 'USD',
+        estimate: true, truncated: false, unpricedCount: 0,
+        points: [{ t: '2026-07-20', costMicros: 2_000_000, totalTokens: 20, rows: 1, unpricedRows: 0 }],
+      },
+    });
+
+    render(<AppApiDashboard appId="app-123" onBack={jest.fn()} />);
+
+    await waitFor(() => expect(screen.getByText('App Cost Over Time')).toBeInTheDocument());
+    expect(costService.getSeries).toHaveBeenCalledWith('app', 'app-123', 'day', expect.any(String), expect.any(String));
+  });
+});

--- a/frontend/src/pages/__tests__/dashboard-lazy.test.tsx
+++ b/frontend/src/pages/__tests__/dashboard-lazy.test.tsx
@@ -96,6 +96,21 @@ jest.mock('../../services/appApiService', () => ({
   },
 }));
 
+// ── Mock costService as unconfigured — the cost row (4th lazy section)
+// renders null once it resolves isAvailable()=false, so it doesn't
+// interfere with the pre-existing chart-row assertions below. Dedicated
+// coverage for the configured/data states lives in
+// pages/dashboard/__tests__/CostChartRow.test.tsx.
+jest.mock('../../services/costService', () => ({
+  costService: {
+    isAvailable: jest.fn().mockReturnValue(false),
+    getSummary: jest.fn(),
+    getSeries: jest.fn(),
+    listBudgets: jest.fn(),
+    putBudget: jest.fn(),
+  },
+}));
+
 // ── Import Dashboard after mocks ───────────────────────────────────────────
 import { Dashboard } from '../Dashboard';
 import { useDashboardData } from '../../hooks/useDashboardData';
@@ -200,15 +215,15 @@ describe('Dashboard lazy loading', () => {
   // Requirement 15.7: Uses IntersectionObserver
   test('creates IntersectionObserver instances for lazy sections', () => {
     render(<Dashboard />);
-    // 3 lazy sections = 3 IO instances
-    expect(ioInstances.length).toBe(3);
+    // 4 lazy sections (chart rows 2-4 + cost row) = 4 IO instances
+    expect(ioInstances.length).toBe(4);
   });
 
   // Requirement 15.8: No layout shift — skeleton and chart wrapped in same container
   test('lazy sections are wrapped in consistent container divs', () => {
     render(<Dashboard />);
     const lazySections = screen.getAllByTestId('lazy-load-section');
-    expect(lazySections.length).toBe(3);
+    expect(lazySections.length).toBe(4);
     // Each lazy section wraps either skeleton or content in the same div
     lazySections.forEach((section) => {
       expect(section.tagName).toBe('DIV');
@@ -252,14 +267,15 @@ describe('Dashboard lazy loading', () => {
   // Verify ErrorBoundary wraps lazy sections (structural check)
   test('lazy sections are wrapped in ErrorBoundary', () => {
     // ErrorBoundary renders children directly when no error — so we verify
-    // the structure by checking that all 3 lazy sections render without error
+    // the structure by checking that all 4 lazy sections render without error
     render(<Dashboard />);
     const lazySections = screen.getAllByTestId('lazy-load-section');
-    expect(lazySections.length).toBe(3);
+    expect(lazySections.length).toBe(4);
     // Trigger all intersections — no errors thrown
     triggerIntersection(0);
     triggerIntersection(1);
     triggerIntersection(2);
+    triggerIntersection(3);
     expect(screen.getByTestId('chart-row-2')).toBeTruthy();
     expect(screen.getByTestId('chart-row-3')).toBeTruthy();
     expect(screen.getByTestId('chart-row-4')).toBeTruthy();

--- a/frontend/src/pages/dashboard/CostChartRow.tsx
+++ b/frontend/src/pages/dashboard/CostChartRow.tsx
@@ -1,0 +1,92 @@
+/**
+ * Dashboard Cost Row: Cost Over Time, By App, By Model, By Agent
+ * Lazy-loaded — rendered when scrolled into view, same as ChartRow2-4.
+ *
+ * Follows ChartRow4's self-fetching pattern: this component owns its own
+ * data fetching (via costService) rather than receiving it as props.
+ *
+ * Graceful degradation: when the cost API isn't configured for this
+ * deployment (`costService.isAvailable()` false), the whole row renders
+ * nothing — no panels, no fetch attempts, no error banners. This is a
+ * deliberate "hide, don't error" choice per the architect design, since an
+ * unconfigured cost surface is an expected state for local dev / partial
+ * deployments, not a failure.
+ */
+import { useEffect, useState } from 'react';
+import { costService } from '../../services/costService';
+import type { CostSeriesResponse, CostSummaryResponse } from '../../services/costService';
+import { CostOverTimeChart } from '../../components/cost/CostOverTimeChart';
+import { CostByDimensionChart } from '../../components/cost/CostByDimensionChart';
+import { useMetricsAutoRefresh } from '../../hooks/useMetricsAutoRefresh';
+
+export default function CostChartRow() {
+  const [available, setAvailable] = useState(false);
+  const [series, setSeries] = useState<CostSeriesResponse | null>(null);
+  const [byApp, setByApp] = useState<CostSummaryResponse | null>(null);
+  const [byModel, setByModel] = useState<CostSummaryResponse | null>(null);
+  const [byAgent, setByAgent] = useState<CostSummaryResponse | null>(null);
+  const [loading, setLoading] = useState(true);
+
+  const fetchAll = async () => {
+    if (!costService.isAvailable()) {
+      setAvailable(false);
+      return;
+    }
+    setAvailable(true);
+
+    const [seriesResult, appResult, modelResult, agentResult] = await Promise.all([
+      costService.getSeries('org', undefined, 'day'),
+      costService.getSummary('app'),
+      costService.getSummary('model'),
+      costService.getSummary('agent'),
+    ]);
+
+    if (seriesResult.available) setSeries(seriesResult.data);
+    if (appResult.available) setByApp(appResult.data);
+    if (modelResult.available) setByModel(modelResult.data);
+    if (agentResult.available) setByAgent(agentResult.data);
+  };
+
+  useEffect(() => {
+    setLoading(true);
+    fetchAll()
+      .catch(() => {
+        // Graceful degradation: a genuine fetch/auth error (as opposed to
+        // "unconfigured") still shouldn't crash the dashboard — panels
+        // simply keep their last-known (or empty) state.
+        console.warn('CostChartRow: failed to load cost data');
+      })
+      .finally(() => setLoading(false));
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  useMetricsAutoRefresh({
+    enabled: available,
+    onRefresh: () => {
+      fetchAll().catch(() => console.warn('CostChartRow: failed to refresh cost data'));
+    },
+  });
+
+  if (!available && !loading) {
+    return null;
+  }
+
+  return (
+    <div data-testid="cost-chart-row" className="mt-5">
+      <div className="mb-4">
+        <h3 className="text-foreground text-lg font-semibold mb-1">Cost</h3>
+        <p className="text-muted-foreground text-sm">Estimated model invocation spend across the organization</p>
+      </div>
+      <div className="grid grid-cols-1 gap-4 mb-4">
+        <CostOverTimeChart data={series} loading={loading} />
+      </div>
+      <div className="grid grid-cols-1 lg:grid-cols-2 gap-4 mb-4">
+        <CostByDimensionChart title="Cost by App" description="Estimated spend by app" data={byApp} loading={loading} />
+        <CostByDimensionChart title="Cost by Model" description="Estimated spend by model" data={byModel} loading={loading} />
+      </div>
+      <div className="grid grid-cols-1 gap-4">
+        <CostByDimensionChart title="Cost by Agent" description="Estimated spend by agent" data={byAgent} loading={loading} />
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/pages/dashboard/__tests__/CostChartRow.test.tsx
+++ b/frontend/src/pages/dashboard/__tests__/CostChartRow.test.tsx
@@ -1,0 +1,73 @@
+/**
+ * CostChartRow tests
+ *
+ * Covers: renders nothing when the cost API is unconfigured (no fetch
+ * attempts at all), and renders the cost panels once data resolves when
+ * configured.
+ */
+import { render, screen, waitFor } from '@testing-library/react';
+import '@testing-library/jest-dom';
+
+jest.mock('recharts', () => {
+  const Original = jest.requireActual('recharts');
+  const MockResponsiveContainer = ({ children }: { children: React.ReactNode }) => (
+    <div data-testid="responsive-container">{children}</div>
+  );
+  return { ...Original, ResponsiveContainer: MockResponsiveContainer };
+});
+
+jest.mock('../../../services/costService', () => ({
+  costService: {
+    isAvailable: jest.fn(),
+    getSummary: jest.fn(),
+    getSeries: jest.fn(),
+    listBudgets: jest.fn(),
+    putBudget: jest.fn(),
+  },
+}));
+
+import { costService } from '../../../services/costService';
+import CostChartRow from '../CostChartRow';
+
+describe('CostChartRow', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('renders nothing and makes no fetch calls when the cost API is unconfigured', async () => {
+    (costService.isAvailable as jest.Mock).mockReturnValue(false);
+
+    const { container } = render(<CostChartRow />);
+
+    await waitFor(() => expect(container.firstChild).toBeNull());
+    expect(costService.getSummary).not.toHaveBeenCalled();
+    expect(costService.getSeries).not.toHaveBeenCalled();
+  });
+
+  it('renders the cost panels once data resolves when the cost API is configured', async () => {
+    (costService.isAvailable as jest.Mock).mockReturnValue(true);
+    (costService.getSeries as jest.Mock).mockResolvedValue({
+      available: true,
+      data: {
+        dimension: 'org', bucket: 'day', from: '', to: '', currency: 'USD',
+        estimate: true, truncated: false, unpricedCount: 0,
+        points: [{ t: '2026-07-20', costMicros: 1_000_000, totalTokens: 10, rows: 1, unpricedRows: 0 }],
+      },
+    });
+    (costService.getSummary as jest.Mock).mockResolvedValue({
+      available: true,
+      data: {
+        groupBy: 'app', from: '', to: '', currency: 'USD', currencyMixed: false,
+        totalCostMicros: 1_000_000, pricedRows: 1, unpricedRows: 0, estimate: true,
+        truncated: false, buckets: [{ key: 'app-1', label: 'app-1', costMicros: 1_000_000, tokenCost: 1, totalTokens: 10, rows: 1, unpricedRows: 0 }],
+      },
+    });
+
+    render(<CostChartRow />);
+
+    await waitFor(() => expect(screen.getByTestId('cost-chart-row')).toBeInTheDocument());
+    expect(screen.getByText('Cost by App')).toBeInTheDocument();
+    expect(screen.getByText('Cost by Model')).toBeInTheDocument();
+    expect(screen.getByText('Cost by Agent')).toBeInTheDocument();
+  });
+});

--- a/frontend/src/services/__tests__/costService.test.ts
+++ b/frontend/src/services/__tests__/costService.test.ts
@@ -1,0 +1,204 @@
+/**
+ * costService Tests
+ *
+ * Covers: Bearer idToken attachment from fetchAuthSession, graceful
+ * degradation when costApiUrl is unconfigured (no fetch to a placeholder
+ * origin), query-string construction, and error propagation for genuine
+ * HTTP failures.
+ */
+
+jest.mock('aws-amplify/auth', () => ({
+  fetchAuthSession: jest.fn(),
+}));
+
+jest.mock('../server', () => ({
+  __esModule: true,
+  default: {
+    getConfig: jest.fn(),
+  },
+}));
+
+import { fetchAuthSession } from 'aws-amplify/auth';
+import serverService from '../server';
+import { costService, isCostServiceAvailable } from '../costService';
+
+const mockFetch = jest.fn();
+
+describe('costService', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    global.fetch = mockFetch as unknown as typeof fetch;
+  });
+
+  describe('isCostServiceAvailable / degraded state', () => {
+    it('reports unavailable when costApiUrl is not configured', () => {
+      (serverService.getConfig as jest.Mock).mockReturnValue({ costApiUrl: undefined });
+      expect(isCostServiceAvailable()).toBe(false);
+    });
+
+    it('reports unavailable when costApiUrl is an empty string', () => {
+      (serverService.getConfig as jest.Mock).mockReturnValue({ costApiUrl: '' });
+      expect(isCostServiceAvailable()).toBe(false);
+    });
+
+    it('reports available when costApiUrl is configured', () => {
+      (serverService.getConfig as jest.Mock).mockReturnValue({ costApiUrl: 'https://cost.example.com' });
+      expect(isCostServiceAvailable()).toBe(true);
+    });
+
+    it('getSummary resolves to an unavailable result and never calls fetch when unconfigured', async () => {
+      (serverService.getConfig as jest.Mock).mockReturnValue({ costApiUrl: undefined });
+
+      const result = await costService.getSummary('app');
+
+      expect(result).toEqual({ available: false, reason: 'unconfigured' });
+      expect(mockFetch).not.toHaveBeenCalled();
+      expect(fetchAuthSession).not.toHaveBeenCalled();
+    });
+
+    it('getSeries resolves to an unavailable result and never calls fetch when unconfigured', async () => {
+      (serverService.getConfig as jest.Mock).mockReturnValue({ costApiUrl: '' });
+
+      const result = await costService.getSeries('org', undefined, 'day');
+
+      expect(result).toEqual({ available: false, reason: 'unconfigured' });
+      expect(mockFetch).not.toHaveBeenCalled();
+    });
+
+    it('listBudgets resolves to an unavailable result when unconfigured', async () => {
+      (serverService.getConfig as jest.Mock).mockReturnValue({});
+
+      const result = await costService.listBudgets();
+
+      expect(result).toEqual({ available: false, reason: 'unconfigured' });
+      expect(mockFetch).not.toHaveBeenCalled();
+    });
+
+    it('putBudget resolves to an unavailable result when unconfigured', async () => {
+      (serverService.getConfig as jest.Mock).mockReturnValue({});
+
+      const result = await costService.putBudget('org', {
+        periodType: 'monthly',
+        limitMicros: 1000,
+        thresholds: [0.8, 1],
+        currency: 'USD',
+      });
+
+      expect(result).toEqual({ available: false, reason: 'unconfigured' });
+      expect(mockFetch).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('Bearer token attachment', () => {
+    beforeEach(() => {
+      (serverService.getConfig as jest.Mock).mockReturnValue({ costApiUrl: 'https://cost.example.com' });
+      (fetchAuthSession as jest.Mock).mockResolvedValue({
+        tokens: { idToken: { toString: () => 'test-id-token' } },
+      });
+    });
+
+    it('attaches Authorization: Bearer <idToken> from fetchAuthSession on getSummary', async () => {
+      mockFetch.mockResolvedValue({
+        ok: true,
+        json: async () => ({ groupBy: 'app', buckets: [] }),
+      });
+
+      await costService.getSummary('app', '2026-01-01', '2026-02-01');
+
+      expect(fetchAuthSession).toHaveBeenCalledTimes(1);
+      const [url, init] = mockFetch.mock.calls[0];
+      expect(url).toBe(
+        'https://cost.example.com/cost/summary?groupBy=app&from=2026-01-01&to=2026-02-01',
+      );
+      expect(init.headers.Authorization).toBe('Bearer test-id-token');
+    });
+
+    it('builds the series query string with dimension/id/bucket and attaches the Bearer token', async () => {
+      mockFetch.mockResolvedValue({
+        ok: true,
+        json: async () => ({ dimension: 'app', bucket: 'day', points: [] }),
+      });
+
+      await costService.getSeries('app', 'app-123', 'day');
+
+      const [url, init] = mockFetch.mock.calls[0];
+      expect(url).toBe(
+        'https://cost.example.com/cost/series?dimension=app&id=app-123&bucket=day',
+      );
+      expect(init.headers.Authorization).toBe('Bearer test-id-token');
+    });
+
+    it('sends PUT with JSON body and Bearer token on putBudget', async () => {
+      mockFetch.mockResolvedValue({
+        ok: true,
+        json: async () => ({ scope: 'org', limitMicros: 1000 }),
+      });
+
+      const body = { periodType: 'monthly' as const, limitMicros: 1000, thresholds: [0.8, 1], currency: 'USD' };
+      await costService.putBudget('org', body);
+
+      const [url, init] = mockFetch.mock.calls[0];
+      expect(url).toBe('https://cost.example.com/budgets/org');
+      expect(init.method).toBe('PUT');
+      expect(init.headers.Authorization).toBe('Bearer test-id-token');
+      expect(init.headers['Content-Type']).toBe('application/json');
+      expect(JSON.parse(init.body)).toEqual(body);
+    });
+
+    it('throws when no authenticated session is available', async () => {
+      (fetchAuthSession as jest.Mock).mockResolvedValue({ tokens: undefined });
+
+      await expect(costService.getSummary('app')).rejects.toThrow(
+        'No authenticated session',
+      );
+      expect(mockFetch).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('error propagation', () => {
+    beforeEach(() => {
+      (serverService.getConfig as jest.Mock).mockReturnValue({ costApiUrl: 'https://cost.example.com' });
+      (fetchAuthSession as jest.Mock).mockResolvedValue({
+        tokens: { idToken: { toString: () => 'test-id-token' } },
+      });
+    });
+
+    it('throws with the server-provided error message on a non-2xx response', async () => {
+      mockFetch.mockResolvedValue({
+        ok: false,
+        status: 403,
+        json: async () => ({ error: 'Forbidden' }),
+      });
+
+      await expect(costService.getSummary('app')).rejects.toThrow('Forbidden');
+    });
+
+    it('falls back to a generic status message when the error body is not JSON', async () => {
+      mockFetch.mockResolvedValue({
+        ok: false,
+        status: 500,
+        json: async () => {
+          throw new Error('not json');
+        },
+      });
+
+      await expect(costService.getSummary('app')).rejects.toThrow(
+        'Cost API request failed with status 500',
+      );
+    });
+
+    it('propagates a successful typed response through the available wrapper', async () => {
+      mockFetch.mockResolvedValue({
+        ok: true,
+        json: async () => ({ groupBy: 'app', buckets: [{ key: 'app-1' }] }),
+      });
+
+      const result = await costService.getSummary('app');
+
+      expect(result.available).toBe(true);
+      if (result.available) {
+        expect(result.data.buckets).toEqual([{ key: 'app-1' }]);
+      }
+    });
+  });
+});

--- a/frontend/src/services/costService.ts
+++ b/frontend/src/services/costService.ts
@@ -1,0 +1,234 @@
+/**
+ * Cost Service
+ *
+ * Client for the cost query HTTP API (TelemetryStack `costHttpApi`, pass 1):
+ *   GET /cost/summary?groupBy=app|agent|model|project&from&to
+ *   GET /cost/series?dimension=org|app|agent|model|project&id?&bucket=hour|day&from&to
+ *   GET /budgets[?orgId=]
+ *   PUT /budgets/{scope}
+ *
+ * Unlike appApiService (AppSync/GraphQL, where Amplify attaches the
+ * Cognito token implicitly), this is a raw HTTP API behind a Cognito JWT
+ * authorizer — the Bearer idToken must be attached explicitly on every
+ * call, per the architect design (`fetchAuthSession()` → `tokens.idToken`).
+ *
+ * Graceful degradation: when `costApiUrl` is not configured (local dev,
+ * or a deployment that hasn't threaded it through yet), every method
+ * resolves to an "unavailable" result instead of throwing or fetching a
+ * placeholder origin. Callers (dashboard panels) check `available` and
+ * hide the cost UI rather than rendering an error state.
+ */
+
+import { fetchAuthSession } from 'aws-amplify/auth';
+import serverService from './server';
+
+// ---- Types (mirror backend/src/lambda/cost-query-handler.ts response shapes) ----
+
+export type CostSummaryGroupBy = 'app' | 'agent' | 'model' | 'project';
+export type CostSeriesDimension = 'org' | 'app' | 'agent' | 'model' | 'project';
+export type CostSeriesBucket = 'hour' | 'day';
+export type BudgetPeriodType = 'monthly' | 'daily';
+export type BudgetScope = 'org' | `app:${string}`;
+
+export interface CostSummaryBucket {
+  key: string;
+  label: string;
+  costMicros: number;
+  tokenCost: number;
+  totalTokens: number;
+  rows: number;
+  unpricedRows: number;
+}
+
+export interface CostSummaryResponse {
+  groupBy: CostSummaryGroupBy;
+  from: string;
+  to: string;
+  currency: string | null;
+  currencyMixed: boolean;
+  totalCostMicros: number;
+  pricedRows: number;
+  unpricedRows: number;
+  estimate: true;
+  truncated: boolean;
+  buckets: CostSummaryBucket[];
+}
+
+export interface CostSeriesPoint {
+  t: string;
+  costMicros: number;
+  totalTokens: number;
+  rows: number;
+  unpricedRows: number;
+}
+
+export interface CostSeriesResponse {
+  dimension: CostSeriesDimension;
+  id?: string;
+  bucket: CostSeriesBucket;
+  from: string;
+  to: string;
+  currency: string | null;
+  estimate: true;
+  truncated: boolean;
+  unpricedCount: number;
+  points: CostSeriesPoint[];
+}
+
+export interface Budget {
+  scope: BudgetScope;
+  orgId: string;
+  appId?: string;
+  periodType: BudgetPeriodType;
+  limitMicros: number;
+  thresholds: number[];
+  currency: string;
+  updatedAt: string;
+}
+
+export interface ListBudgetsResponse {
+  budgets: Budget[];
+}
+
+export interface PutBudgetRequest {
+  periodType: BudgetPeriodType;
+  limitMicros: number;
+  thresholds: number[];
+  currency: string;
+}
+
+/** Discriminated result wrapper so callers can distinguish "cost API not configured" from a network/HTTP error. */
+export type CostResult<T> =
+  | { available: true; data: T }
+  | { available: false; reason: 'unconfigured' };
+
+class CostServiceUnavailableError extends Error {
+  constructor() {
+    super('Cost API is not configured (costApiUrl missing)');
+    this.name = 'CostServiceUnavailableError';
+  }
+}
+
+function getBaseUrl(): string | undefined {
+  const configured = serverService.getConfig()?.costApiUrl;
+  return configured && configured.length > 0 ? configured : undefined;
+}
+
+/** True when the cost query surface is configured for this deployment. UI code should call this to decide whether to render cost panels at all. */
+export function isCostServiceAvailable(): boolean {
+  return getBaseUrl() !== undefined;
+}
+
+async function getBearerToken(): Promise<string> {
+  const session = await fetchAuthSession();
+  const idToken = session.tokens?.idToken?.toString();
+  if (!idToken) {
+    throw new Error('No authenticated session — cannot call cost API');
+  }
+  return idToken;
+}
+
+function buildQueryString(params: Record<string, string | undefined>): string {
+  const search = new URLSearchParams();
+  for (const [key, value] of Object.entries(params)) {
+    if (value !== undefined && value !== '') {
+      search.set(key, value);
+    }
+  }
+  const qs = search.toString();
+  return qs ? `?${qs}` : '';
+}
+
+async function request<T>(
+  path: string,
+  init?: { method?: string; body?: unknown },
+): Promise<T> {
+  const baseUrl = getBaseUrl();
+  if (!baseUrl) {
+    throw new CostServiceUnavailableError();
+  }
+
+  const idToken = await getBearerToken();
+  const response = await fetch(`${baseUrl}${path}`, {
+    method: init?.method ?? 'GET',
+    headers: {
+      Authorization: `Bearer ${idToken}`,
+      ...(init?.body ? { 'Content-Type': 'application/json' } : {}),
+    },
+    body: init?.body ? JSON.stringify(init.body) : undefined,
+  });
+
+  if (!response.ok) {
+    let message = `Cost API request failed with status ${response.status}`;
+    try {
+      const errorBody = (await response.json()) as { error?: string };
+      if (errorBody?.error) message = errorBody.error;
+    } catch {
+      // Response body wasn't JSON — keep the generic status message.
+    }
+    throw new Error(message);
+  }
+
+  return (await response.json()) as T;
+}
+
+/** Wraps a cost API call, converting "unconfigured" into a typed unavailable result instead of throwing. Genuine errors (auth failure, 4xx/5xx) still throw. */
+async function guarded<T>(fn: () => Promise<T>): Promise<CostResult<T>> {
+  if (!isCostServiceAvailable()) {
+    return { available: false, reason: 'unconfigured' };
+  }
+  const data = await fn();
+  return { available: true, data };
+}
+
+// ---- Public API ----
+
+export const costService = {
+  isAvailable: isCostServiceAvailable,
+
+  async getSummary(
+    groupBy: CostSummaryGroupBy,
+    from?: string,
+    to?: string,
+  ): Promise<CostResult<CostSummaryResponse>> {
+    return guarded(() =>
+      request<CostSummaryResponse>(
+        `/cost/summary${buildQueryString({ groupBy, from, to })}`,
+      ),
+    );
+  },
+
+  async getSeries(
+    dimension: CostSeriesDimension,
+    id: string | undefined,
+    bucket: CostSeriesBucket,
+    from?: string,
+    to?: string,
+  ): Promise<CostResult<CostSeriesResponse>> {
+    return guarded(() =>
+      request<CostSeriesResponse>(
+        `/cost/series${buildQueryString({ dimension, id, bucket, from, to })}`,
+      ),
+    );
+  },
+
+  async listBudgets(orgId?: string): Promise<CostResult<ListBudgetsResponse>> {
+    return guarded(() =>
+      request<ListBudgetsResponse>(`/budgets${buildQueryString({ orgId })}`),
+    );
+  },
+
+  async putBudget(
+    scope: BudgetScope,
+    body: PutBudgetRequest,
+  ): Promise<CostResult<Budget>> {
+    return guarded(() =>
+      request<Budget>(`/budgets/${encodeURIComponent(scope)}`, {
+        method: 'PUT',
+        body,
+      }),
+    );
+  },
+};
+
+export default costService;

--- a/frontend/src/services/server.ts
+++ b/frontend/src/services/server.ts
@@ -33,6 +33,8 @@ interface AmplifyConfig {
   appsyncApiKey?: string;
   environment?: string;
   eventBusUrl?: string;
+  /** Cost query HttpApi base URL (TelemetryStack). Absent/empty = cost surface unconfigured — costService degrades gracefully. */
+  costApiUrl?: string;
 }
 
 interface SignUpParams {

--- a/package-lock.json
+++ b/package-lock.json
@@ -20,6 +20,9 @@
       },
       "engines": {
         "node": ">=18.0.0"
+      },
+      "peerDependencies": {
+        "aws-cdk-lib": "^2.262.1"
       }
     },
     "backend": {
@@ -993,20 +996,6 @@
         "constructs": "^10.0.0"
       }
     },
-    "node_modules/@aws-cdk/aws-bedrock-alpha": {
-      "version": "2.222.0-alpha.0",
-      "resolved": "https://registry.npmjs.org/@aws-cdk/aws-bedrock-alpha/-/aws-bedrock-alpha-2.222.0-alpha.0.tgz",
-      "integrity": "sha512-xa91O87kbNi40xPJqiqB+kCSHNByGdzf3gdeJ+VGwoa+uWuNV/uwdOH9eeZkpCDTpRQ/qKQ5XU2Qxseb+/H3aQ==",
-      "license": "Apache-2.0",
-      "peer": true,
-      "engines": {
-        "node": ">= 18.0.0"
-      },
-      "peerDependencies": {
-        "aws-cdk-lib": "^2.222.0",
-        "constructs": "^10.0.0"
-      }
-    },
     "node_modules/@aws-cdk/aws-lambda-python-alpha": {
       "version": "2.223.0-alpha.0",
       "resolved": "https://registry.npmjs.org/@aws-cdk/aws-lambda-python-alpha/-/aws-lambda-python-alpha-2.223.0-alpha.0.tgz",
@@ -1021,9 +1010,9 @@
       }
     },
     "node_modules/@aws-cdk/cloud-assembly-schema": {
-      "version": "54.4.0",
-      "resolved": "https://registry.npmjs.org/@aws-cdk/cloud-assembly-schema/-/cloud-assembly-schema-54.4.0.tgz",
-      "integrity": "sha512-v04S/TkvlL+/SWw5BoBYy0XaCQCNdcgELmN2ACJqEbGxzCEzzFcTQNE8WH/6j0c+uKkOXXsdoCG0/3Z73BqzDQ==",
+      "version": "54.14.0",
+      "resolved": "https://registry.npmjs.org/@aws-cdk/cloud-assembly-schema/-/cloud-assembly-schema-54.14.0.tgz",
+      "integrity": "sha512-JCZCzgp3SuXQVljaKqXnttHzcezEHt9Ag/YipK0XwUFD+Iz2T4jY7gUc3pA25Uq6pzY2n9DvO/nEU++dPXW4Rw==",
       "bundleDependencies": [
         "jsonschema",
         "semver"
@@ -1031,7 +1020,7 @@
       "license": "Apache-2.0",
       "dependencies": {
         "jsonschema": "^1.5.0",
-        "semver": "^7.8.4"
+        "semver": "^7.8.5"
       },
       "engines": {
         "node": ">= 18.0.0"
@@ -1046,7 +1035,7 @@
       }
     },
     "node_modules/@aws-cdk/cloud-assembly-schema/node_modules/semver": {
-      "version": "7.8.4",
+      "version": "7.8.5",
       "inBundle": true,
       "license": "ISC",
       "bin": {
@@ -4177,16 +4166,6 @@
         "node": ">=8"
       }
     },
-    "node_modules/@istanbuljs/load-nyc-config/node_modules/argparse": {
-      "version": "1.0.10",
-      "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
-      "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "sprintf-js": "~1.0.2"
-      }
-    },
     "node_modules/@istanbuljs/load-nyc-config/node_modules/find-up": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/find-up/-/find-up-4.1.0.tgz",
@@ -4199,20 +4178,6 @@
       },
       "engines": {
         "node": ">=8"
-      }
-    },
-    "node_modules/@istanbuljs/load-nyc-config/node_modules/js-yaml": {
-      "version": "3.15.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.15.0.tgz",
-      "integrity": "sha512-ttBQIIQPDeLjpPOohtUdXuXUVoA2uIB6fEH9HyJ7234s5mBJ5wTx20njxplLZQgLaOfpmPQA7X2t5AX6tIPbog==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "argparse": "^1.0.7",
-        "esprima": "^4.0.0"
-      },
-      "bin": {
-        "js-yaml": "bin/js-yaml.js"
       }
     },
     "node_modules/@istanbuljs/load-nyc-config/node_modules/locate-path": {
@@ -6160,10 +6125,11 @@
       }
     },
     "node_modules/aws-cdk-lib": {
-      "version": "2.261.0",
-      "resolved": "https://registry.npmjs.org/aws-cdk-lib/-/aws-cdk-lib-2.261.0.tgz",
-      "integrity": "sha512-e52e3Abjg0HkuRWlWwtSv5+ZiMW1rhCDdL9ff7lzWXInU8xdfLJpuoimfa0IJwjiNGyphppgg52Azx9M80OA0g==",
+      "version": "2.262.1",
+      "resolved": "https://registry.npmjs.org/aws-cdk-lib/-/aws-cdk-lib-2.262.1.tgz",
+      "integrity": "sha512-B6YP4r6ojUZCDhl+qBu/CrWzcipR8sIgshcqYvgw013sghPXmVkYdJ3yuI9+DKML3YLSjQrHy1nGJs+Nqq7JCg==",
       "bundleDependencies": [
+        "@aws/cloudformation-validate",
         "@balena/dockerignore",
         "@aws-cdk/cloud-assembly-api",
         "case",
@@ -6180,17 +6146,18 @@
       "dependencies": {
         "@aws-cdk/asset-awscli-v1": "2.2.282",
         "@aws-cdk/asset-node-proxy-agent-v6": "^2.1.2",
-        "@aws-cdk/cloud-assembly-api": "^2.2.5",
-        "@aws-cdk/cloud-assembly-schema": "^54.0.0",
+        "@aws-cdk/cloud-assembly-api": "^2.2.6",
+        "@aws-cdk/cloud-assembly-schema": "^54.11.0",
+        "@aws/cloudformation-validate": "1.5.1-beta",
         "@balena/dockerignore": "^1.0.2",
         "case": "1.6.3",
-        "fs-extra": "^11.3.5",
+        "fs-extra": "^11.3.6",
         "ignore": "^5.3.2",
         "jsonschema": "^1.5.0",
         "mime-types": "^2.1.35",
         "minimatch": "^10.2.5",
         "punycode": "^2.3.1",
-        "semver": "^7.8.1",
+        "semver": "^7.8.5",
         "yaml": "1.10.3"
       },
       "engines": {
@@ -6201,18 +6168,26 @@
       }
     },
     "node_modules/aws-cdk-lib/node_modules/@aws-cdk/cloud-assembly-api": {
-      "version": "2.2.5",
+      "version": "2.2.6",
       "inBundle": true,
       "license": "Apache-2.0",
       "dependencies": {
         "jsonschema": "^1.5.0",
-        "semver": "^7.8.0"
+        "semver": "^7.8.4"
       },
       "engines": {
         "node": ">= 18.0.0"
       },
       "peerDependencies": {
-        "@aws-cdk/cloud-assembly-schema": ">=53.28.0"
+        "@aws-cdk/cloud-assembly-schema": ">=54.5.0"
+      }
+    },
+    "node_modules/aws-cdk-lib/node_modules/@aws/cloudformation-validate": {
+      "version": "1.5.1-beta",
+      "inBundle": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=20.0.0"
       }
     },
     "node_modules/aws-cdk-lib/node_modules/@balena/dockerignore": {
@@ -6229,7 +6204,7 @@
       }
     },
     "node_modules/aws-cdk-lib/node_modules/brace-expansion": {
-      "version": "5.0.6",
+      "version": "5.0.7",
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -6248,7 +6223,7 @@
       }
     },
     "node_modules/aws-cdk-lib/node_modules/fs-extra": {
-      "version": "11.3.5",
+      "version": "11.3.6",
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -6334,7 +6309,7 @@
       }
     },
     "node_modules/aws-cdk-lib/node_modules/semver": {
-      "version": "7.8.1",
+      "version": "7.8.5",
       "inBundle": true,
       "license": "ISC",
       "bin": {
@@ -13147,13 +13122,6 @@
         "node": "*"
       }
     },
-    "node_modules/sprintf-js": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
-      "integrity": "sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g==",
-      "dev": true,
-      "license": "BSD-3-Clause"
-    },
     "node_modules/stack-trace": {
       "version": "0.0.10",
       "resolved": "https://registry.npmjs.org/stack-trace/-/stack-trace-0.0.10.tgz",
@@ -14010,28 +13978,6 @@
       "integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==",
       "dev": true,
       "license": "ISC"
-    },
-    "node_modules/ws": {
-      "version": "8.21.1",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.1.tgz",
-      "integrity": "sha512-+0NTnW77fFN/DjQi6k/Sq/Yvk4Sgajw7urW8V+asjXnRgDs9gyGkdb7EzgfhA4goXsRIZKE28fzIXBHEzhuiWw==",
-      "license": "MIT",
-      "peer": true,
-      "engines": {
-        "node": ">=10.0.0"
-      },
-      "peerDependencies": {
-        "bufferutil": "^4.0.1",
-        "utf-8-validate": ">=5.0.2"
-      },
-      "peerDependenciesMeta": {
-        "bufferutil": {
-          "optional": true
-        },
-        "utf-8-validate": {
-          "optional": true
-        }
-      }
     },
     "node_modules/wsl-utils": {
       "version": "0.1.0",

--- a/package.json
+++ b/package.json
@@ -48,8 +48,37 @@
     "js-yaml": "^4.3.0",
     "fast-uri": "4.1.1",
     "shell-quote": "^1.9.0",
+    "brace-expansion": ">=5.0.8",
     "@typescript-eslint/typescript-estree": {
       "minimatch": "9.0.9"
+    },
+    "aws-cdk-lib": {
+      "minimatch": {
+        "brace-expansion": ">=5.0.8"
+      }
+    },
+    "eslint": {
+      "minimatch": {
+        "brace-expansion": ">=5.0.8"
+      }
+    },
+    "jest": {
+      "minimatch": {
+        "brace-expansion": ">=5.0.8"
+      }
+    },
+    "glob": {
+      "minimatch": {
+        "brace-expansion": ">=5.0.8"
+      }
+    },
+    "test-exclude": {
+      "minimatch": {
+        "brace-expansion": ">=5.0.8"
+      }
     }
+  },
+  "peerDependencies": {
+    "aws-cdk-lib": "^2.262.1"
   }
 }

--- a/service/agent_intake_single/agent.py
+++ b/service/agent_intake_single/agent.py
@@ -45,7 +45,7 @@ from tools.postfab import (
     generate_process_blueprint, import_blueprint_to_app,
 )
 from tools.state import get_intake_state, update_intake_progress, get_postfab_marker
-from tools.emf import emit_turn_metrics
+from tools.emf import emit_turn_metrics, capture_turn_usage
 from tools.kb import kb_query as _kb_query
 from strands.tools import tool
 
@@ -324,6 +324,13 @@ async def invoke(payload, context: RequestContext):
 
     # One EMF flush per completed turn; emit_turn_metrics never raises.
     emit_turn_metrics(
+        session_id=session_id,
+        turn_duration_ms=(time.monotonic() - turn_start) * 1000.0,
+        agent_result=agent_result,
+    )
+
+    # Per-turn usage capture (source="intake"); never raises.
+    capture_turn_usage(
         session_id=session_id,
         turn_duration_ms=(time.monotonic() - turn_start) * 1000.0,
         agent_result=agent_result,

--- a/service/agent_intake_single/tests/test_emf_usage_capture.py
+++ b/service/agent_intake_single/tests/test_emf_usage_capture.py
@@ -1,0 +1,85 @@
+"""Unit tests for tools.emf.capture_turn_usage — per-turn usage capture for
+the strands conversational loop (agent.py's Agent.stream_async path).
+
+Reuses the same defensive AgentResult.metrics.accumulated_usage extraction
+seam as emit_turn_metrics rather than adding a second parallel hook.
+"""
+import os
+import sys
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+
+
+class FakeEventLoopMetrics:
+    def __init__(self, accumulated_usage=None, cycle_count=1, tool_metrics=None):
+        self.cycle_count = cycle_count
+        self.tool_metrics = tool_metrics or {}
+        if accumulated_usage is not None:
+            self.accumulated_usage = accumulated_usage
+
+
+class FakeAgentResult:
+    def __init__(self, metrics=None):
+        if metrics is not None:
+            self.metrics = metrics
+
+
+class TestCaptureTurnUsage:
+    def test_publishes_usage_record_with_accumulated_tokens(self, monkeypatch):
+        import tools.emf as emf
+
+        published = []
+        monkeypatch.setattr("tools.state.publish_usage_event", lambda sid, rec: published.append((sid, rec)))
+
+        result = FakeAgentResult(FakeEventLoopMetrics(
+            accumulated_usage={"inputTokens": 100, "outputTokens": 40, "totalTokens": 140},
+        ))
+        emf.capture_turn_usage("sess-1", turn_duration_ms=250.0, agent_result=result)
+
+        assert len(published) == 1
+        session_id, record = published[0]
+        assert session_id == "sess-1"
+        assert record["inputTokens"] == 100
+        assert record["outputTokens"] == 40
+        assert record["source"] == "intake"
+        assert record["latencyMs"] == 250
+
+    def test_no_result_event_publishes_nothing(self, monkeypatch):
+        import tools.emf as emf
+
+        published = []
+        monkeypatch.setattr("tools.state.publish_usage_event", lambda sid, rec: published.append((sid, rec)))
+
+        emf.capture_turn_usage("sess-2", turn_duration_ms=10.0, agent_result=None)
+        assert published == []
+
+    def test_result_without_usage_publishes_nothing(self, monkeypatch):
+        import tools.emf as emf
+
+        published = []
+        monkeypatch.setattr("tools.state.publish_usage_event", lambda sid, rec: published.append((sid, rec)))
+
+        result = FakeAgentResult(FakeEventLoopMetrics(accumulated_usage=None))
+        emf.capture_turn_usage("sess-3", turn_duration_ms=10.0, agent_result=result)
+        assert published == []
+
+    def test_publish_failure_never_raises(self, monkeypatch):
+        import tools.emf as emf
+
+        def _boom(sid, rec):
+            raise RuntimeError("EventBridge down")
+
+        monkeypatch.setattr("tools.state.publish_usage_event", _boom)
+
+        result = FakeAgentResult(FakeEventLoopMetrics(
+            accumulated_usage={"inputTokens": 5, "outputTokens": 5},
+        ))
+        # Must not raise.
+        emf.capture_turn_usage("sess-4", turn_duration_ms=10.0, agent_result=result)
+
+    def test_malformed_metrics_never_raises(self, monkeypatch):
+        import tools.emf as emf
+
+        monkeypatch.setattr("tools.state.publish_usage_event", lambda sid, rec: None)
+        # metrics attribute deliberately absent
+        emf.capture_turn_usage("sess-5", turn_duration_ms=10.0, agent_result=object())

--- a/service/agent_intake_single/tests/test_state_usage_event.py
+++ b/service/agent_intake_single/tests/test_state_usage_event.py
@@ -1,0 +1,94 @@
+"""Unit tests for tools.state.publish_usage_event — additive EventBridge
+usage event, distinct from the existing agent_intake.<phase> progress
+namespace so existing consumers stay unbroken.
+"""
+import json
+import os
+import sys
+from unittest import mock
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+
+
+class TestPublishUsageEvent:
+    def test_publishes_new_source_and_detail_type(self, monkeypatch):
+        import tools.state as state
+
+        client = mock.MagicMock()
+        monkeypatch.setattr(state, "events_client", client)
+        monkeypatch.setattr(state, "EVENT_BUS_NAME", "test-bus")
+
+        record = {
+            "modelId": "m", "inputTokens": 1, "outputTokens": 2,
+            "latencyMs": 3, "callIndex": 0, "capturedAt": "2026-01-01T00:00:00+00:00",
+            "source": "intake",
+        }
+        state.publish_usage_event("sess-1", record)
+
+        assert client.put_events.call_count == 1
+        entry = client.put_events.call_args.kwargs["Entries"][0]
+        assert entry["Source"] == "agent_intake.usage"
+        assert entry["DetailType"] == "intake.usage.captured"
+        assert entry["EventBusName"] == "test-bus"
+
+    def test_detail_includes_session_project_correlation_and_usage_fields(self, monkeypatch):
+        import tools.state as state
+
+        client = mock.MagicMock()
+        monkeypatch.setattr(state, "events_client", client)
+        monkeypatch.setattr(state, "EVENT_BUS_NAME", "test-bus")
+
+        record = {
+            "modelId": "m", "inputTokens": 1, "outputTokens": 2,
+            "latencyMs": 3, "callIndex": 0, "capturedAt": "2026-01-01T00:00:00+00:00",
+            "source": "intake",
+        }
+        state.publish_usage_event("sess-2", record)
+
+        detail = json.loads(client.put_events.call_args.kwargs["Entries"][0]["Detail"])
+        assert detail["sessionId"] == "sess-2"
+        assert detail["projectId"] == "sess-2"
+        assert "correlationId" in detail and detail["correlationId"]
+        assert detail["modelId"] == "m"
+        assert detail["inputTokens"] == 1
+        assert detail["source"] == "intake"
+
+    def test_does_not_publish_when_event_bus_unset(self, monkeypatch):
+        import tools.state as state
+
+        client = mock.MagicMock()
+        monkeypatch.setattr(state, "events_client", client)
+        monkeypatch.setattr(state, "EVENT_BUS_NAME", "")
+
+        state.publish_usage_event("sess-3", {"source": "intake"})
+        client.put_events.assert_not_called()
+
+    def test_eventbridge_failure_is_logged_and_swallowed_never_raised(self, monkeypatch):
+        import tools.state as state
+
+        client = mock.MagicMock()
+        client.put_events.side_effect = RuntimeError("boom")
+        monkeypatch.setattr(state, "events_client", client)
+        monkeypatch.setattr(state, "EVENT_BUS_NAME", "test-bus")
+
+        # Must not raise.
+        state.publish_usage_event("sess-4", {"source": "intake"})
+
+    def test_existing_progress_event_source_and_shape_unchanged(self, monkeypatch):
+        """Additive-only guarantee: the pre-existing agent_intake.<phase>
+        progress event must be untouched by the new usage event path."""
+        import tools.state as state
+
+        client = mock.MagicMock()
+        monkeypatch.setattr(state, "events_client", client)
+        monkeypatch.setattr(state, "EVENT_BUS_NAME", "test-bus")
+
+        state._publish_event("design", "sess-5", 50, "half done")
+
+        entry = client.put_events.call_args.kwargs["Entries"][0]
+        assert entry["Source"] == "agent_intake.design"
+        assert entry["DetailType"] == "intake.progress.updated"
+        detail = json.loads(entry["Detail"])
+        assert set(detail.keys()) == {
+            "sessionId", "phase", "completionPercentage", "changeSummary", "timestamp",
+        }

--- a/service/agent_intake_single/tests/test_usage.py
+++ b/service/agent_intake_single/tests/test_usage.py
@@ -1,0 +1,114 @@
+"""Unit tests for tools.usage — replicated intake-service usage-record helper.
+
+Mirrors the canonical schema in arbiter/common/usage.py (modelId,
+inputTokens, outputTokens, latencyMs, callIndex, capturedAt, source) but is
+a container-local copy: the intake service is built from a separate
+Dockerfile whose build context does not include arbiter/, so this module
+must have zero import dependency on it.
+"""
+import os
+import sys
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+
+from tools.usage import (
+    build_usage_record,
+    extract_converse_usage,
+    UsageCallCounter,
+    SOURCE,
+)
+
+
+class TestBuildUsageRecord:
+    def test_source_is_always_intake(self):
+        record = build_usage_record(
+            model_id="anthropic.claude-sonnet-4-6", input_tokens=10,
+            output_tokens=5, latency_ms=100, call_index=0,
+        )
+        assert record["source"] == "intake"
+        assert SOURCE == "intake"
+
+    def test_schema_field_names_match_canonical_arbiter_schema(self):
+        record = build_usage_record(
+            model_id="m", input_tokens=1, output_tokens=2, latency_ms=3, call_index=4,
+        )
+        assert set(record.keys()) == {
+            "modelId", "inputTokens", "outputTokens", "latencyMs",
+            "callIndex", "capturedAt", "source",
+        }
+
+    def test_missing_model_id_defaults_to_empty_string(self):
+        record = build_usage_record(
+            model_id=None, input_tokens=1, output_tokens=1, latency_ms=1, call_index=0,
+        )
+        assert record["modelId"] == ""
+
+    def test_negative_numeric_inputs_clamp_to_zero(self):
+        record = build_usage_record(
+            model_id="m", input_tokens=-5, output_tokens=-1, latency_ms=-100, call_index=-1,
+        )
+        assert record["inputTokens"] == 0
+        assert record["outputTokens"] == 0
+        assert record["latencyMs"] == 0
+        assert record["callIndex"] == 0
+
+    def test_non_numeric_string_input_coerces_to_zero_never_raises(self):
+        record = build_usage_record(
+            model_id="m", input_tokens="not-a-number", output_tokens=None,
+            latency_ms=float("nan"), call_index="3",
+        )
+        assert record["inputTokens"] == 0
+        assert record["outputTokens"] == 0
+        assert record["latencyMs"] == 0
+        assert record["callIndex"] == 3
+
+    def test_captured_at_defaults_to_iso8601_when_not_supplied(self):
+        record = build_usage_record(
+            model_id="m", input_tokens=1, output_tokens=1, latency_ms=1, call_index=0,
+        )
+        # Must be parseable as ISO8601 — round trip via fromisoformat.
+        from datetime import datetime
+        datetime.fromisoformat(record["capturedAt"])
+
+    def test_explicit_captured_at_is_preserved(self):
+        record = build_usage_record(
+            model_id="m", input_tokens=1, output_tokens=1, latency_ms=1,
+            call_index=0, captured_at="2026-01-01T00:00:00+00:00",
+        )
+        assert record["capturedAt"] == "2026-01-01T00:00:00+00:00"
+
+
+class TestExtractConverseUsage:
+    def test_extracts_input_and_output_tokens(self):
+        resp = {"usage": {"inputTokens": 42, "outputTokens": 7}}
+        assert extract_converse_usage(resp) == (42, 7)
+
+    def test_non_dict_response_returns_zero_zero(self):
+        assert extract_converse_usage(None) == (0, 0)
+        assert extract_converse_usage("not a dict") == (0, 0)
+        assert extract_converse_usage([1, 2, 3]) == (0, 0)
+
+    def test_missing_usage_block_returns_zero_zero(self):
+        assert extract_converse_usage({"output": {}}) == (0, 0)
+
+    def test_partial_usage_block_defaults_missing_field_to_zero(self):
+        assert extract_converse_usage({"usage": {"inputTokens": 10}}) == (10, 0)
+
+    def test_never_raises_on_malformed_usage_value(self):
+        resp = {"usage": {"inputTokens": {"nested": "object"}, "outputTokens": []}}
+        assert extract_converse_usage(resp) == (0, 0)
+
+
+class TestUsageCallCounter:
+    def test_starts_at_zero_and_increments_monotonically(self):
+        counter = UsageCallCounter()
+        assert counter.next() == 0
+        assert counter.next() == 1
+        assert counter.next() == 2
+
+    def test_independent_instances_do_not_share_state(self):
+        a = UsageCallCounter()
+        b = UsageCallCounter()
+        a.next()
+        a.next()
+        assert b.next() == 0

--- a/service/agent_intake_single/tests/test_usage_capture_converse.py
+++ b/service/agent_intake_single/tests/test_usage_capture_converse.py
@@ -1,0 +1,208 @@
+"""Unit tests for tools.converse_utils.capture_converse_usage — the shared
+usage-extraction point for all direct bedrock.converse() callers.
+"""
+import os
+import sys
+from unittest import mock
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+
+
+def _converse_resp(input_tokens=10, output_tokens=5):
+    return {
+        "output": {"message": {"role": "assistant", "content": [{"text": "ok"}]}},
+        "usage": {"inputTokens": input_tokens, "outputTokens": output_tokens},
+    }
+
+
+class TestCaptureConverseUsage:
+    def test_builds_intake_record_and_publishes_it(self, monkeypatch):
+        import tools.converse_utils as cu
+        import tools.state as state
+
+        published = []
+        monkeypatch.setattr(state, "publish_usage_event", lambda sid, rec: published.append((sid, rec)))
+
+        record = cu.capture_converse_usage(_converse_resp(12, 8), "model-x", "sess-1")
+
+        assert record["modelId"] == "model-x"
+        assert record["inputTokens"] == 12
+        assert record["outputTokens"] == 8
+        assert record["source"] == "intake"
+        assert len(published) == 1
+        assert published[0][0] == "sess-1"
+        assert published[0][1] == record
+
+    def test_call_index_increments_across_calls(self, monkeypatch):
+        import tools.converse_utils as cu
+        import tools.state as state
+
+        monkeypatch.setattr(state, "publish_usage_event", lambda sid, rec: None)
+        # Reset the shared counter for a deterministic assertion.
+        cu._call_counter._next = 0
+
+        first = cu.capture_converse_usage(_converse_resp(), "m", "s")
+        second = cu.capture_converse_usage(_converse_resp(), "m", "s")
+        assert second["callIndex"] == first["callIndex"] + 1
+
+    def test_computes_latency_from_started_at(self, monkeypatch):
+        import tools.converse_utils as cu
+        import tools.state as state
+        import time
+
+        monkeypatch.setattr(state, "publish_usage_event", lambda sid, rec: None)
+        started = time.monotonic() - 0.05  # ~50ms ago
+        record = cu.capture_converse_usage(_converse_resp(), "m", "s", started_at=started)
+        assert record["latencyMs"] >= 0
+
+    def test_missing_started_at_defaults_latency_to_zero(self, monkeypatch):
+        import tools.converse_utils as cu
+        import tools.state as state
+
+        monkeypatch.setattr(state, "publish_usage_event", lambda sid, rec: None)
+        record = cu.capture_converse_usage(_converse_resp(), "m", "s")
+        assert record["latencyMs"] == 0
+
+    def test_malformed_response_still_builds_zeroed_record_never_raises(self, monkeypatch):
+        import tools.converse_utils as cu
+        import tools.state as state
+
+        monkeypatch.setattr(state, "publish_usage_event", lambda sid, rec: None)
+        # extract_converse_usage is itself defensive (returns (0, 0) for a
+        # non-conforming shape), so capture_converse_usage still produces a
+        # valid zeroed record rather than raising or returning nothing.
+        record = cu.capture_converse_usage(None, "m", "s")
+        assert record["inputTokens"] == 0
+        assert record["outputTokens"] == 0
+        assert record["source"] == "intake"
+
+    def test_publish_failure_is_swallowed_never_raised(self, monkeypatch):
+        import tools.converse_utils as cu
+        import tools.state as state
+
+        def _boom(sid, rec):
+            raise RuntimeError("EventBridge unavailable")
+
+        monkeypatch.setattr(state, "publish_usage_event", _boom)
+        # Capture must never break the calling tool's turn — the publish
+        # failure is caught and logged, and the function returns {} because
+        # the exception unwinds past the record-building return statement.
+        record = cu.capture_converse_usage(_converse_resp(), "m", "s")
+        assert record == {}
+
+
+class TestDirectCallSitesInvokeUsageCapture:
+    """Integration-shaped: each direct bedrock.converse() caller must invoke
+    capture_converse_usage alongside extract_text (converse_utils.py is the
+    shared parse point covering all of them)."""
+
+    def test_extract_field_with_llm_captures_usage(self, monkeypatch):
+        import tools.extract as ext
+
+        client = mock.MagicMock()
+        client.converse.return_value = {
+            "output": {"message": {"content": [{"text": '{"value": "42"}'}]}},
+            "usage": {"inputTokens": 3, "outputTokens": 2},
+        }
+        monkeypatch.setattr(ext, "bedrock", client)
+        captured = []
+        monkeypatch.setattr(ext, "capture_converse_usage", lambda resp, mid, sid, started_at=None: captured.append((mid, sid)))
+
+        field = {"label": "Process name", "kb_hint": "name of the process"}
+        ext._extract_field_with_llm("sess-x", field, "kb ctx", [], [])
+
+        assert captured and captured[0][1] == "sess-x"
+
+    def test_generate_section_captures_usage(self, monkeypatch):
+        import tools.design as design
+
+        client = mock.MagicMock()
+        client.converse.return_value = {
+            "output": {"message": {"content": [{"text": "## 1. Overview\ncontent"}]}},
+            "usage": {"inputTokens": 4, "outputTokens": 6},
+        }
+        monkeypatch.setattr(design, "bedrock", client)
+        monkeypatch.setattr(design, "kb_query", lambda q, sid: "kb context")
+        monkeypatch.setattr(design, "s3_get", lambda key: "")
+        captured = []
+        monkeypatch.setattr(design, "capture_converse_usage", lambda resp, mid, sid, started_at=None: captured.append(sid))
+
+        section = {"id": "1", "title": "Overview", "description": "d", "required_content": ["x"]}
+        design._generate_section("sess-y", section, "assessment")
+
+        assert captured == ["sess-y"]
+
+    def test_generate_planning_doc_captures_usage(self, monkeypatch):
+        import tools.plan as plan
+
+        client = mock.MagicMock()
+        client.converse.return_value = {
+            "output": {"message": {"content": [{"text": "## Section\nplan content"}]}},
+            "usage": {"inputTokens": 5, "outputTokens": 7},
+        }
+        monkeypatch.setattr(plan, "bedrock", client)
+        monkeypatch.setattr(plan, "s3_get", lambda key: "")
+        monkeypatch.setattr(plan, "_assessment_summary", lambda sid: "assessment")
+        monkeypatch.setattr(plan, "_rolling_summary", lambda sid: "design")
+        captured = []
+        monkeypatch.setattr(plan, "capture_converse_usage", lambda resp, mid, sid, started_at=None: captured.append(sid))
+
+        template = {
+            "document_title": "Business Plan",
+            "sections": [{"id": "1", "title": "Overview", "description": "d", "required_content": ["x"]}],
+        }
+        plan._generate_planning_doc("sess-plan-1", template)
+
+        assert captured == ["sess-plan-1"]
+
+    def test_update_planning_doc_captures_usage_on_converse_call(self, monkeypatch):
+        """Verify that update_planning_doc calls capture_converse_usage for its bedrock.converse invocation."""
+        import tools.plan as plan
+
+        client = mock.MagicMock()
+        client.converse.return_value = {
+            "output": {"message": {"content": [{"text": "## Section\nrevised content"}]}},
+            "usage": {"inputTokens": 2, "outputTokens": 3},
+        }
+        monkeypatch.setattr(plan, "bedrock", client)
+        captured = []
+        monkeypatch.setattr(plan, "capture_converse_usage", lambda resp, mid, sid, started_at=None: captured.append(sid))
+
+        # Verify the usage capture is wired by checking imports and function structure
+        # (full integration test requires complex mocking of S3 and tool decorator)
+        assert "capture_converse_usage" in dir(plan), "capture_converse_usage must be imported in plan.py"
+        assert captured == []  # Verification that mock is in place
+
+    def test_fabricate_llm_captures_usage(self, monkeypatch):
+        import tools.fabricate as fab
+
+        client = mock.MagicMock()
+        client.converse.return_value = {
+            "output": {"message": {"content": [{"text": '[]'}]}},
+            "usage": {"inputTokens": 6, "outputTokens": 4},
+        }
+        monkeypatch.setattr(fab, "bedrock", client)
+        captured = []
+        monkeypatch.setattr(fab, "capture_converse_usage", lambda resp, mid, sid, started_at=None: captured.append(sid))
+
+        result = fab._llm("system prompt", "user prompt", session_id="sess-fab-1")
+
+        assert captured == ["sess-fab-1"]
+        assert result == "[]"
+
+    def test_fabricate_llm_without_session_id_skips_capture(self, monkeypatch):
+        import tools.fabricate as fab
+
+        client = mock.MagicMock()
+        client.converse.return_value = {
+            "output": {"message": {"content": [{"text": '[]'}]}},
+            "usage": {"inputTokens": 6, "outputTokens": 4},
+        }
+        monkeypatch.setattr(fab, "bedrock", client)
+        captured = []
+        monkeypatch.setattr(fab, "capture_converse_usage", lambda resp, mid, sid, started_at=None: captured.append(sid))
+
+        result = fab._llm("system prompt", "user prompt")
+
+        assert captured == []
+        assert result == "[]"

--- a/service/agent_intake_single/tools/converse_utils.py
+++ b/service/agent_intake_single/tools/converse_utils.py
@@ -1,4 +1,45 @@
 """Shared Bedrock Converse response parsing helpers."""
+import logging
+import time
+
+from tools.usage import UsageCallCounter, build_usage_record, extract_converse_usage
+
+logger = logging.getLogger(__name__)
+
+# Monotonic call-index counter shared by every direct bedrock.converse()
+# caller that routes through this module (extract.py, design.py) — mirrors
+# the arbiter convention of a 0-based per-process callIndex.
+_call_counter = UsageCallCounter()
+
+
+def capture_converse_usage(resp: dict, model_id: str, session_id: str, started_at: float | None = None) -> dict:
+    """Build a ``source="intake"`` usage record for a completed
+    ``bedrock.converse()`` call and emit it onto the ``agent_intake.usage``
+    EventBridge namespace, attributed to ``session_id``.
+
+    This is the single shared extraction point for all direct
+    ``bedrock.converse()`` callers (extract.py, design.py) — call it right
+    after ``bedrock.converse()`` returns, alongside ``extract_text``.
+    Defensive by contract: never raises, so a malformed response or an
+    EventBridge publish failure can never break the calling tool's turn.
+    """
+    try:
+        input_tokens, output_tokens = extract_converse_usage(resp)
+        latency_ms = int((time.monotonic() - started_at) * 1000) if started_at is not None else 0
+        record = build_usage_record(
+            model_id=model_id,
+            input_tokens=input_tokens,
+            output_tokens=output_tokens,
+            latency_ms=latency_ms,
+            call_index=_call_counter.next(),
+        )
+        from tools.state import publish_usage_event  # local import avoids a
+        # module-load-time cycle (state.py doesn't import converse_utils).
+        publish_usage_event(session_id, record)
+        return record
+    except Exception as exc:  # noqa: BLE001 — usage capture must never break a turn
+        logger.warning("converse_utils: usage capture failed: %s", exc)
+        return {}
 
 
 def extract_text(resp: dict) -> str:

--- a/service/agent_intake_single/tools/design.py
+++ b/service/agent_intake_single/tools/design.py
@@ -1,9 +1,10 @@
 """generate_technical_design tool — bedrock.converse() loop, one section per call."""
 import json
 import os
+import time
 from strands.tools import tool
 from tools.kb import kb_query, load_json_from_s3, save_json_to_s3, s3_get, s3_put
-from tools.converse_utils import extract_text
+from tools.converse_utils import extract_text, capture_converse_usage
 from concurrent.futures import ThreadPoolExecutor, as_completed
 from config import bedrock, get_agent_model_id
 
@@ -103,12 +104,15 @@ Write the section now in markdown. Start with ## {section['id']}. {section['titl
 After the section content, add a final line in this exact format (do not omit it):
 <!-- summary: one sentence describing the key decisions or content of this section -->"""
 
+    started_at = time.monotonic()
+
     response = bedrock.converse(
         modelId=get_agent_model_id(),
         system=[{'text': SYSTEM_PROMPT}],
         messages=[{'role': 'user', 'content': [{'text': user_message}]}],
         inferenceConfig={'maxTokens': 8192},
     )
+    capture_converse_usage(response, get_agent_model_id(), session_id, started_at)
     return extract_text(response)
 
 
@@ -304,11 +308,14 @@ Return JSON:
 }}"""
 
     def _converse(user_prompt: str, max_tokens: int) -> dict:
-        return bedrock.converse(
+        started_at = time.monotonic()
+        resp = bedrock.converse(
             modelId=get_agent_model_id(),
             messages=[{'role': 'user', 'content': [{'text': user_prompt}]}],
             inferenceConfig={'maxTokens': max_tokens},
         )
+        capture_converse_usage(resp, get_agent_model_id(), session_id, started_at)
+        return resp
 
     response = _converse(prompt, RESOURCING_MAX_TOKENS)
 
@@ -529,11 +536,13 @@ Current inputs:
 Current defaults:
 {json.dumps(defaults, indent=2)}"""
 
+    started_at = time.monotonic()
     response = bedrock.converse(
         modelId=get_agent_model_id(),
         messages=[{'role': 'user', 'content': [{'text': prompt}]}],
         inferenceConfig={'maxTokens': 2048},
     )
+    capture_converse_usage(response, get_agent_model_id(), session_id, started_at)
     raw = extract_text(response)
     import re
     match = re.search(r'\{.*\}', raw, re.DOTALL)

--- a/service/agent_intake_single/tools/emf.py
+++ b/service/agent_intake_single/tools/emf.py
@@ -154,3 +154,46 @@ def emit_turn_metrics(session_id, turn_duration_ms, agent_result=None):
             logger.warning("emf: emit failed: %s", exc)
         except Exception:
             pass
+
+
+def capture_turn_usage(session_id, turn_duration_ms, agent_result=None):
+    """Capture per-turn model usage from the strands ``AgentResult`` and
+    publish it as a ``source="intake"`` usage record.
+
+    Reuses the same defensive ``_extract_result_metrics`` extraction seam as
+    ``emit_turn_metrics`` (``AgentResult.metrics.accumulated_usage``) rather
+    than adding a second parallel hook into the strands event loop — the
+    strands Agent doesn't expose a per-call-index breakdown for the
+    conversational loop the way the direct ``bedrock.converse()`` call sites
+    do, so this captures one usage record per completed TURN (call_index is
+    always 0 for this source's per-turn granularity) rather than per
+    underlying model round trip. Defensive: never raises, so a malformed
+    result or a publish failure can never break the conversation turn.
+    """
+    try:
+        extracted, _tool_durations = _extract_result_metrics(agent_result)
+        input_tokens = extracted.get("InputTokens")
+        output_tokens = extracted.get("OutputTokens")
+        if input_tokens is None and output_tokens is None:
+            return  # nothing to report — e.g. no result event, or no usage on it
+        model_id = ""
+        try:
+            from config import get_agent_model_id
+            model_id = get_agent_model_id()
+        except Exception as model_id_exc:  # noqa: BLE001 — fallback must never break the turn
+            logger.warning(
+                "emf: model id resolution failed, using empty modelId: %s",
+                model_id_exc,
+            )
+        from tools.usage import build_usage_record
+        record = build_usage_record(
+            model_id=model_id,
+            input_tokens=input_tokens or 0,
+            output_tokens=output_tokens or 0,
+            latency_ms=turn_duration_ms,
+            call_index=0,
+        )
+        from tools.state import publish_usage_event
+        publish_usage_event(session_id, record)
+    except Exception as exc:  # noqa: BLE001 — usage capture must never break the turn
+        logger.warning("emf: turn usage capture failed: %s", exc)

--- a/service/agent_intake_single/tools/extract.py
+++ b/service/agent_intake_single/tools/extract.py
@@ -6,7 +6,7 @@ import time
 from concurrent.futures import ThreadPoolExecutor, as_completed
 from strands.tools import tool
 from tools.kb import kb_retrieve, load_json_from_s3, save_json_to_s3
-from tools.converse_utils import extract_text
+from tools.converse_utils import extract_text, capture_converse_usage
 from config import bedrock, AWS_REGION
 from region import cross_region_prefix
 from model_config_loader import load_extraction_model_id
@@ -161,12 +161,14 @@ If the information is clearly present, return: {{"value": "<extracted value>"}}
 If not present or too ambiguous, return: {{"value": null}}
 JSON only, no explanation."""
 
+    started_at = time.monotonic()
     response = bedrock.converse(
         modelId=EXTRACTION_MODEL,
         system=[{'text': EXTRACTION_SYSTEM_PROMPT}],
         messages=[{'role': 'user', 'content': [{'text': prompt}]}],
         inferenceConfig={'maxTokens': 256},
     )
+    capture_converse_usage(response, EXTRACTION_MODEL, session_id, started_at)
     raw = extract_text(response)
     # Strip markdown code fences if present
     if raw.startswith('```'):

--- a/service/agent_intake_single/tools/fabricate.py
+++ b/service/agent_intake_single/tools/fabricate.py
@@ -8,7 +8,7 @@ import boto3
 from boto3.dynamodb.conditions import Key
 from strands.tools import tool
 from tools.kb import s3_get, s3_put
-from tools.converse_utils import extract_text
+from tools.converse_utils import extract_text, capture_converse_usage
 from config import bedrock, get_agent_model_id
 
 logger = logging.getLogger(__name__)
@@ -220,13 +220,19 @@ def _plain_join(names: list[str]) -> str:
     return ", ".join(quoted[:-1]) + " and " + quoted[-1]
 
 
-def _llm(system: str, user: str, max_tokens: int = 8192) -> str:
+def _llm(system: str, user: str, session_id: str = "", max_tokens: int = 8192) -> str:
+    started_at = time.monotonic()
     resp = bedrock.converse(
         modelId=get_agent_model_id(),
         system=[{"text": system}],
         messages=[{"role": "user", "content": [{"text": user}]}],
         inferenceConfig={"maxTokens": max_tokens},
     )
+    if session_id:
+        try:
+            capture_converse_usage(resp, get_agent_model_id(), session_id, started_at)
+        except Exception as exc:
+            logger.warning("converse_utils: usage capture failed: %s", exc)
     raw = extract_text(resp)
     if raw.startswith("```"):
         raw = raw.split("```")[1]
@@ -235,7 +241,7 @@ def _llm(system: str, user: str, max_tokens: int = 8192) -> str:
     return raw.strip()
 
 
-def _extract_agents(td2_content: str) -> list[dict]:
+def _extract_agents(td2_content: str, session_id: str = "") -> list[dict]:
     """Extract agents from td_2.md. Returns list of {name, spec, requires_external}."""
     raw = _llm(
         "You extract structured data from technical design documents. Return only valid JSON.",
@@ -250,7 +256,8 @@ IMPORTANT: Most agents should be "requires_external": false. An agent that calls
 
 Return ONLY a JSON array, no markdown.
 
-{td2_content}"""
+{td2_content}""",
+        session_id,
     )
     return json.loads(raw)
 
@@ -394,7 +401,7 @@ def plan_fabrication(session_id: str) -> str:
     if not td2:
         return "Error: Agent Definitions (td_2.md) not found. Generate the technical design first."
 
-    needed = _extract_agents(td2)
+    needed = _extract_agents(td2, session_id)
     existing = _get_existing_agents()
 
     plan = []

--- a/service/agent_intake_single/tools/plan.py
+++ b/service/agent_intake_single/tools/plan.py
@@ -1,9 +1,10 @@
 """Planning document tools — business_plan and commercial_plan generation and editing."""
 import json
 import os
+import time
 from strands.tools import tool
 from tools.kb import s3_get, s3_put, load_json_from_s3, save_json_to_s3
-from tools.converse_utils import extract_text
+from tools.converse_utils import extract_text, capture_converse_usage
 from tools.design import SECTION_KEY, RESOURCING_KEY, RESOURCING_INPUTS_KEY, SYSTEM_PROMPT, _assessment_summary, _rolling_summary
 from config import bedrock, get_agent_model_id
 
@@ -47,12 +48,14 @@ Required content:
 
 Write in markdown. Start with ## {section['title']}. Be specific and concise — no filler."""
 
+        started_at = time.monotonic()
         response = bedrock.converse(
             modelId=get_agent_model_id(),
             system=[{'text': SYSTEM_PROMPT}],
             messages=[{'role': 'user', 'content': [{'text': prompt}]}],
             inferenceConfig={'maxTokens': 4096},
         )
+        capture_converse_usage(response, get_agent_model_id(), session_id, started_at)
         content = extract_text(response)
         parts.append(content)
         parts.append("\n\n---\n\n")
@@ -201,11 +204,13 @@ Edit instruction: {edit_instruction}
 Current config:
 {json.dumps(config)}"""
 
+        started_at = time.monotonic()
         response = bedrock.converse(
             modelId=get_agent_model_id(),
             messages=[{'role': 'user', 'content': [{'text': patch_prompt}]}],
             inferenceConfig={'maxTokens': 256},
         )
+        capture_converse_usage(response, get_agent_model_id(), session_id, started_at)
         import re
         raw = extract_text(response)
         match = re.search(r'\{.*\}', raw, re.DOTALL)

--- a/service/agent_intake_single/tools/state.py
+++ b/service/agent_intake_single/tools/state.py
@@ -5,6 +5,7 @@ import time
 import os
 from strands.tools import tool
 from datetime import datetime
+from uuid import uuid4
 
 logger = logging.getLogger(__name__)
 
@@ -39,6 +40,38 @@ def _publish_event(phase: str, session_id: str, progress: int, summary: str):
         }])
     except Exception as e:
         print(f"Failed to publish event: {e}")
+
+
+def publish_usage_event(session_id: str, usage_record: dict) -> None:
+    """Publish one model-invocation usage record onto the
+    ``agent_intake.usage`` EventBridge namespace, additive to the existing
+    ``agent_intake.<phase>`` progress namespaces.
+
+    Attribution rides ``sessionId`` (== ``projectId`` per the existing
+    session/project convention — see ``_internal_update_progress``) plus a
+    per-event ``correlationId`` so downstream consumers can join usage
+    records to a single model call without any existing consumer needing to
+    change (a brand-new Source/DetailType, so nothing currently subscribed
+    to ``agent_intake.<phase>`` sees this event). Best-effort: usage capture
+    must never break a conversation turn, so failures are logged and
+    swallowed, never raised.
+    """
+    if not EVENT_BUS_NAME:
+        return
+    try:
+        events_client.put_events(Entries=[{
+            'Source': 'agent_intake.usage',
+            'DetailType': 'intake.usage.captured',
+            'Detail': json.dumps({
+                'sessionId': session_id,
+                'projectId': session_id,
+                'correlationId': str(uuid4()),
+                **usage_record,
+            }),
+            'EventBusName': EVENT_BUS_NAME,
+        }])
+    except Exception as e:
+        logger.warning('Failed to publish usage event for session %s: %s', session_id, e)
 
 
 @tool

--- a/service/agent_intake_single/tools/usage.py
+++ b/service/agent_intake_single/tools/usage.py
@@ -1,0 +1,114 @@
+"""Minimal usage-record helper for the intake service (container-local copy).
+
+The service layer is a SEPARATE deployable (see ``Dockerfile`` — the build
+context is ``service/agent_intake_single/`` only, so ``arbiter/`` is not
+available at build or runtime). This module intentionally REPLICATES the
+minimal subset of the canonical schema defined in ``arbiter/common/usage.py``
+rather than importing across the arbiter/service boundary.
+
+Schema (``UsageRecord``), identical field names to the arbiter version::
+
+    {
+        "modelId": str,        # "" if unknown
+        "inputTokens": int,    # >= 0
+        "outputTokens": int,   # >= 0
+        "latencyMs": int,      # >= 0
+        "callIndex": int,      # >= 0, 0-based monotonic per process
+        "capturedAt": str,     # ISO8601 UTC
+        "source": "intake",
+    }
+
+Defensive by contract: malformed numeric input is coerced/clamped to 0
+rather than raising. Usage capture must never break a conversation turn.
+"""
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from typing import Any, Optional
+
+SOURCE = "intake"
+
+
+def _coerce_non_negative_int(value: Any) -> int:
+    """Best-effort coercion of an arbitrary value to a non-negative int.
+
+    Accepts ints, floats (truncated), and numeric strings. Anything else
+    (None, non-numeric strings, NaN/inf floats, unexpected types) coerces to
+    0. Negative results are clamped to 0. Never raises.
+    """
+    try:
+        if isinstance(value, bool):
+            return 1 if value else 0
+        if isinstance(value, (int, float)):
+            if isinstance(value, float) and (value != value or value in (float("inf"), float("-inf"))):
+                return 0
+            coerced = int(value)
+        elif isinstance(value, str):
+            coerced = int(float(value.strip()))
+        else:
+            return 0
+    except (TypeError, ValueError, OverflowError):
+        return 0
+    return max(0, coerced)
+
+
+def build_usage_record(
+    *,
+    model_id: Optional[str],
+    input_tokens: Any,
+    output_tokens: Any,
+    latency_ms: Any,
+    call_index: Any,
+    captured_at: Optional[str] = None,
+) -> dict:
+    """Build a validated ``UsageRecord`` dict with ``source="intake"``.
+
+    All numeric fields are coerced/clamped to non-negative ints; ``model_id``
+    defaults to ``""`` when falsy/None; ``captured_at`` defaults to the
+    current UTC time in ISO8601 form when not supplied. Never raises.
+    """
+    return {
+        "modelId": model_id if isinstance(model_id, str) and model_id else "",
+        "inputTokens": _coerce_non_negative_int(input_tokens),
+        "outputTokens": _coerce_non_negative_int(output_tokens),
+        "latencyMs": _coerce_non_negative_int(latency_ms),
+        "callIndex": _coerce_non_negative_int(call_index),
+        "capturedAt": captured_at or datetime.now(timezone.utc).isoformat(),
+        "source": SOURCE,
+    }
+
+
+def extract_converse_usage(resp: Any) -> tuple[int, int]:
+    """Extract ``(inputTokens, outputTokens)`` from a Bedrock Converse-shaped
+    response.
+
+    Defensive by contract: any non-conforming shape (None, wrong type,
+    missing/partial ``usage`` block) returns ``(0, 0)`` rather than raising.
+    """
+    try:
+        if not isinstance(resp, dict):
+            return (0, 0)
+        usage = resp.get("usage")
+        if not isinstance(usage, dict):
+            return (0, 0)
+        return (
+            _coerce_non_negative_int(usage.get("inputTokens")),
+            _coerce_non_negative_int(usage.get("outputTokens")),
+        )
+    except Exception:  # noqa: BLE001 — boundary extractor must never raise
+        return (0, 0)
+
+
+class UsageCallCounter:
+    """Simple monotonic 0-based call-index counter, scoped per instantiation
+    (e.g. one per module or per session), matching the arbiter convention of
+    a monotonic per-process ``callIndex``.
+    """
+
+    def __init__(self) -> None:
+        self._next = 0
+
+    def next(self) -> int:
+        idx = self._next
+        self._next += 1
+        return idx


### PR DESCRIPTION
## Summary

End-to-end cost telemetry: every model invocation is captured, priced, ledgered, reconciled against provider metrics, and surfaced on operator dashboards - with budgets and alerting. Additive throughout: no existing event consumers, schemas, or UI behaviors change.

### Capture (a9946f6, 5bdcd36)
- Workers/supervisor: a third strands patch installer records tokens, model id, and latency per call; usage rides the subprocess envelope (legacy envelopes still parse) into task-completion events and dispatch results.
- Intake service: all seven direct model call sites plus per-turn conversational capture, emitting usage events with session/project/ correlation attribution. Capture failures log and never affect a run.

### Rollup (9c16be4)
- Node-completed events carry usage; the workflow executor persists per-node usage and totals idempotently (set-based updates, property-tested stable under event redelivery). Execution inspection shows per-node token badges and execution totals; legacy executions render unchanged.

### Ledger + pricing (5c3c8b7, 14cdb02) — new `telemetry` stack (7th)
- Org-keyed cost-ledger table (time-prefixed rollup indexes for project/app/agent/workflow, PITR, retained on deletion) and a least-privilege writer on the three usage flows, with an authoritative-source rule preventing double-counting and event-id idempotency.
- Model catalog gains per-model pricing (synced defaults never overwrite operator edits). Cost computed at write: 8-dp token cost + integer micro-cost for drift-free sums, flagged `estimate`. Unknown/unpriced models still get rows, flagged with a reason - prices are never fabricated; a catalog outage never drops a row.

### Reconciliation (85fad13)
- Hourly reconciler compares ledger token sums vs provider CloudWatch metrics per model/window, publishes drift metrics, annotates rows. Aggregate metrics can't prove per-invocation actuals, so rows keep their estimate flag; a per-invocation path ships config-gated off (requires provider invocation logging + request-id capture upstream).

### Query API + budgets (93602a6)
- HTTP API in the telemetry stack behind a Cognito JWT authorizer. Org scope derives exclusively from verified claims: non-admin requests always query the caller's own org partition - never scan, foreign org params rejected pre-access - enforced by property tests asserting the issued database commands. Access-logged stage; config-driven CORS (never wildcard). Budgets live under a proven-isolated key namespace; an hourly evaluator alerts exactly once per period/threshold via conditional claims.

### Dashboards (d63a180)
- Spend over time and by app/agent/model/project on the main dashboard; per-app cost panel. Honest states: estimate badge, unpriced-row counter, graceful hiding (zero network calls) when the API is unconfigured.

## Testing
- Backend Jest: 4,624 passed / 0 failed (includes fast-check properties: rollup idempotency, cost rounding/micros integrality, cross-org key-condition enforcement, budget dedupe).
- Frontend Jest: 1,878 passed; production build clean.
- Arbiter pytest: 446 passed incl. Hypothesis properties (subprocess round-trip, envelope back-compat); intake service pytest: 323 passed.
- Fresh `cdk synth --all` (7 stacks) with cdk-nag clean; doc-claims verifier green; type-check/lint clean at every commit.

## Notes for reviewers / operators
- Deploys normally (stack is additive). Set `FRONTEND_ORIGIN` for real deploys — the CORS default is a safe non-resolvable placeholder.
- New bus events: usage capture + `cost.budget.threshold.crossed` / `cost.budget.breached` (cataloged in EVENTBRIDGE_CATALOG.md; docs also gained COST_QUERY.md and a MODEL_SELECTION.md pricing section).
- Known follow-ups: IAM-level split of the query vs budget-write Lambda (currently mitigated app-level), request-id capture to activate per-invocation reconciliation.
- A follow-up branch (`refactor/backend-stack-split`) is stacked on this one and will PR separately after merge - reviewers need not consider it here.