### PR TITLE
fix(registry): display tool names instead of GUIDs

### DIFF
--- a/backend/src/services/__tests__/registry-service-config-awsjson.test.ts
+++ b/backend/src/services/__tests__/registry-service-config-awsjson.test.ts
@@ -68,11 +68,11 @@ describe("RegistryService — AWSJSON config field invariant", () => {
   // ── Case 1: plain-text description falls back to '{}' ──────────────────
 
   describe("case 1 — plain-text description never leaks into config", () => {
-    it("mapToToolConfig projects {} when description is plain text and meta.config is absent", () => {
+    it("mapToToolConfig injects record.name when description is plain text and meta.config is absent", () => {
       const record = toolRecord({ description: "Fetches weather data" });
       const result = service.mapToToolConfig(record);
-      expect(result.config).toBe("{}");
-      expect(JSON.parse(result.config)).toEqual({});
+      expect(result.config).toBe('{"name":"WeatherTool"}');
+      expect(JSON.parse(result.config)).toEqual({ name: "WeatherTool" });
     });
 
     it("mapToAgentConfig projects {} when description is plain text", () => {
@@ -106,7 +106,7 @@ describe("RegistryService — AWSJSON config field invariant", () => {
       expect(records[0].customDescriptorContent).toBeUndefined();
 
       const projected = service.mapToToolConfig(records[0]);
-      expect(projected.config).toBe("{}");
+      expect(projected.config).toBe('{"name":"WeatherTool"}');
       // Description is NOT lost — it stays out of config only.
       expect(records[0].description).toBe("Fetches weather data");
     });
@@ -151,14 +151,14 @@ describe("RegistryService — AWSJSON config field invariant", () => {
   // ── Case 4: ''/undefined description → '{}' ────────────────────────────
 
   describe("case 4 — ''/undefined description falls back to '{}'", () => {
-    it("mapToToolConfig projects {} when description is ''", () => {
+    it("mapToToolConfig injects record.name when description is ''", () => {
       const record = toolRecord({ description: "" });
-      expect(service.mapToToolConfig(record).config).toBe("{}");
+      expect(service.mapToToolConfig(record).config).toBe('{"name":"WeatherTool"}');
     });
 
-    it("mapToToolConfig projects {} when description is undefined", () => {
+    it("mapToToolConfig injects record.name when description is undefined", () => {
       const record = toolRecord({ description: undefined });
-      expect(service.mapToToolConfig(record).config).toBe("{}");
+      expect(service.mapToToolConfig(record).config).toBe('{"name":"WeatherTool"}');
     });
 
     it("mapToAgentConfig projects {} when description is ''", () => {

--- a/backend/src/services/__tests__/registry-service-mapping.test.ts
+++ b/backend/src/services/__tests__/registry-service-mapping.test.ts
@@ -363,13 +363,13 @@ describe("RegistryService record mapping", () => {
       expect(service.mapToToolConfig(record).categories).toEqual([]);
     });
 
-    it("returns '{}' for config when description is undefined (AWSJSON contract)", () => {
+    it("returns config with injected record.name when description is undefined (AWSJSON contract)", () => {
       const record: RegistryRecord = {
         recordId: "t1",
         name: "T",
         status: RegistryRecordStatusValues.APPROVED,
       };
-      expect(service.mapToToolConfig(record).config).toBe("{}");
+      expect(service.mapToToolConfig(record).config).toBe('{"name":"T"}');
     });
 
     it("returns undefined timestamps when dates are missing", () => {

--- a/backend/src/services/registry-service.ts
+++ b/backend/src/services/registry-service.ts
@@ -1560,6 +1560,32 @@ export class RegistryService {
   }
 
   /**
+   * Inject `name` into a config JSON string when it is missing or empty.
+   * This ensures the frontend ToolCard always has a human-readable name
+   * to display instead of falling back to the raw record GUID.
+   */
+  private static ensureConfigName(configJson: string, recordName: string): string {
+    if (!recordName) return configJson;
+    try {
+      const parsed = JSON.parse(configJson);
+      if (
+        typeof parsed === "object" &&
+        parsed !== null &&
+        !Array.isArray(parsed)
+      ) {
+        if (!parsed.name || (typeof parsed.name === "string" && parsed.name.trim() === "")) {
+          parsed.name = recordName;
+          return JSON.stringify(parsed);
+        }
+      }
+    } catch {
+      // If configJson is unparseable, wrap the name in a minimal config.
+      return JSON.stringify({ name: recordName });
+    }
+    return configJson;
+  }
+
+  /**
    * Maps a Registry record to the AgentConfig GraphQL response shape.
    */
   mapToAgentConfig(record: RegistryRecord): AgentConfig {
@@ -1605,17 +1631,23 @@ export class RegistryService {
       RegistryService.TOOL_METADATA_DEFAULTS,
     );
 
+    // Ensure the config JSON always carries a human-readable `name`.
+    // Registry records store the tool name at the record level
+    // (record.name), but the frontend ToolCard reads it from
+    // `config.name`. When the persisted config payload lacks a name
+    // (legacy records, fabricator-created records whose
+    // customDescriptorContent.config was never populated), inject
+    // record.name so the UI never falls back to displaying the raw GUID.
+    const rawConfig = RegistryService.toValidConfigJson(
+      meta.config,
+      record.description,
+    );
+    const config = RegistryService.ensureConfigName(rawConfig, record.name);
+
     return {
       toolId: record.recordId,
       orgId: meta.orgId ?? "",
-      // New records: config comes from custom_metadata.config (see tool-config-resolver createToolConfigRegistry).
-      // Legacy records: fall back to record.description which previously carried the full JSON blob.
-      // AWSJSON contract: whichever candidate wins must be a JSON object —
-      // plain text or '' falls back to '{}' (see toValidConfigJson).
-      config: RegistryService.toValidConfigJson(
-        meta.config,
-        record.description,
-      ),
+      config,
       state: this.toInternalState(record.status),
       categories: meta.categories,
       integrationBindings: RegistryService.sanitizeIntegrationBindings(


### PR DESCRIPTION
## Problem

Agent Tools page displayed raw registry record IDs (GUIDs) instead of human-readable tool names. This happened because:

1. Tools created by the fabricator or registry sync had no `config.name` populated in their `customDescriptorContent`
2. The frontend ToolCard falls back to `tool.toolId` (the GUID) when `config.name` is missing

## Fix

Added `ensureConfigName()` to `RegistryService.mapToToolConfig()` — when the parsed config JSON lacks a `name` field, it injects `record.name` (the human-readable name stored at the registry level).

## Also fixed in this deploy

- `citadel-projects-prod` and `citadel-registry-prod` stacks were stuck in `REVIEW_IN_PROGRESS` from the stack-split refactor deploy — now `CREATE_COMPLETE`
- This resolved: "Failed to load projects" and "can't access property 'items', b is null" in Agent Apps

## Testing

- 172 registry-service tests pass (14 suites)
- 4,797 backend tests pass
- 1,926 frontend tests pass
- Fix deployed and verified live