### PR TITLE
fix(fabricator): legal registry approve; recovery without recreate

### DIFF
--- a/arbiter/fabricator/__tests__/test_creating_conflict_recovery.py
+++ b/arbiter/fabricator/__tests__/test_creating_conflict_recovery.py
@@ -114,45 +114,92 @@ def run_state():
 # ---------------------------------------------------------------------------
 
 class TestCreatingConflictRecoveryWiring:
+    def test_happy_path_approve_is_legal_two_step_sequence(self, run_state):
+        # Root-cause regression guard: approve must NEVER be a single
+        # DRAFT->APPROVED call (the live service rejects that with
+        # ValidationException) — it must always be the two-step
+        # DRAFT->PENDING_APPROVAL->APPROVED sequence, on the ordinary happy
+        # path (no CREATING conflict at all).
+        client = MagicMock()
+        client.create_registry_record.return_value = _arn("rec-1")
+
+        with patch.object(index, "_get_registry_client", return_value=client), \
+                patch.object(index, "publish_fabrication_event") as pub:
+            assert _call_store_tool() is True
+
+        calls = client.update_registry_record_status.call_args_list
+        assert len(calls) == 2
+        assert calls[0].kwargs["status"] == "PENDING_APPROVAL"
+        assert calls[0].kwargs["recordId"] == "rec-1"
+        assert calls[1].kwargs["status"] == "APPROVED"
+        assert calls[1].kwargs["recordId"] == "rec-1"
+        pub.assert_not_called()
+
     def test_in_flight_creating_recovers_and_returns_true(self, run_state):
         client = MagicMock()
         client.create_registry_record.return_value = _arn("rec-1")
-        client.update_registry_record_status.side_effect = [_conflict(), None]
+        # First approve attempt: PENDING_APPROVAL step hits the CREATING
+        # conflict. Recovery polls to DRAFT, then approve-in-place runs the
+        # full two-step sequence (PENDING_APPROVAL, APPROVED) again.
+        client.update_registry_record_status.side_effect = [
+            _conflict(), None, None,
+        ]
         client.get_registry_record.side_effect = [{"status": "DRAFT"}]
 
         with patch.object(index, "_get_registry_client", return_value=client), \
                 patch.object(index, "publish_fabrication_event") as pub:
             assert _call_store_tool() is True
 
-        # Recovery approved the SAME record after CREATING settled.
-        assert client.update_registry_record_status.call_count == 2
+        # 1 failed PENDING_APPROVAL (conflict) + 2 recovered steps = 3 calls.
+        assert client.update_registry_record_status.call_count == 3
         client.delete_registry_record.assert_not_called()
+        client.create_registry_record.assert_called_once()
         # A recovered registration is a SUCCESS — no failure event.
         pub.assert_not_called()
 
-    def test_stuck_creating_deletes_recreates_and_returns_true(self, run_state):
+    def test_seeded_creating_orphan_yields_one_usable_record_zero_net_new(
+        self, run_state
+    ):
+        # Integration-style seed of a CREATING orphan: recovery must yield
+        # exactly one usable record and create/delete NOTHING in the
+        # process (structural zero-net-new-orphans invariant).
         client = MagicMock()
-        client.create_registry_record.side_effect = [_arn("rec-1"), _arn("rec-2")]
-        client.update_registry_record_status.side_effect = [_conflict(), None]
+        client.create_registry_record.return_value = _arn("rec-1")
+        client.update_registry_record_status.side_effect = [_conflict(), None, None]
         client.get_registry_record.side_effect = [
             {"status": "CREATING"},
-            {"status": "CREATING"},
-            _not_found(),
+            {"status": "DRAFT"},
         ]
 
         with patch.object(index, "_get_registry_client", return_value=client), \
                 patch.object(index, "publish_fabrication_event") as pub:
             assert _call_store_tool() is True
 
-        client.delete_registry_record.assert_called_once()
-        assert client.delete_registry_record.call_args.kwargs["recordId"] == "rec-1"
-        assert client.create_registry_record.call_count == 2
-        approved_ids = [
-            c.kwargs["recordId"]
-            for c in client.update_registry_record_status.call_args_list
-        ]
-        assert approved_ids == ["rec-1", "rec-2"]
+        # Exactly one create call (the original registration) — recovery
+        # never calls create_registry_record or delete_registry_record.
+        client.create_registry_record.assert_called_once()
+        client.delete_registry_record.assert_not_called()
         pub.assert_not_called()
+
+    def test_stuck_creating_beyond_budget_is_single_terminal_no_recreate(
+        self, run_state
+    ):
+        # Replaces the old delete-and-recreate scenario: past the poll
+        # budget, recovery raises ONE terminal error — no delete, no
+        # recreate, no second attempt.
+        client = MagicMock()
+        client.create_registry_record.return_value = _arn("rec-1")
+        client.update_registry_record_status.side_effect = _conflict()
+        client.get_registry_record.return_value = {"status": "CREATING"}
+
+        with patch.object(index, "_get_registry_client", return_value=client), \
+                patch.object(index, "publish_fabrication_event") as pub:
+            with pytest.raises(OrphanedRegistryRecordError):
+                _call_store_tool()
+
+        client.delete_registry_record.assert_not_called()
+        client.create_registry_record.assert_called_once()
+        assert pub.call_count == 1
 
     def test_non_creating_conflict_is_not_recovered(self, run_state):
         client = MagicMock()
@@ -297,7 +344,10 @@ class TestRegistrationDeadlineCheckpoints:
             with pytest.raises(FabricationDeadlineExceeded):
                 _call_store_tool()
         client.create_registry_record.assert_called_once()
-        client.update_registry_record_status.assert_called_once()
+        # Approve is now the legal two-step DRAFT->PENDING_APPROVAL->APPROVED
+        # sequence (root-cause fix), so a completed registration makes two
+        # update_registry_record_status calls, not one.
+        assert client.update_registry_record_status.call_count == 2
 
     def test_agent_registration_refuses_to_start_inside_margin(self):
         set_fabrication_deadline(FabricationDeadline(lambda: 10_000))

--- a/arbiter/fabricator/__tests__/test_fabrication_status.py
+++ b/arbiter/fabricator/__tests__/test_fabrication_status.py
@@ -181,6 +181,94 @@ class TestFabricationStatusWrites:
         assert processing_kwargs.get("agent_name") == "MyAgent"
 
 
+class TestRegistrationErrorsJobStatusBranching:
+    """process_event's post-agent-loop terminal write branches on this run's
+    tool-registration bookkeeping (_registration_run_state), additive only
+    — no new status enum value:
+      - zero registration failures -> bare COMPLETED (no registrationErrors)
+      - some succeeded, some failed (partial) -> COMPLETED + registrationErrors
+      - every registration failed (none succeeded) -> FAILED + errorMessage +
+        registrationErrors, then a CLEAN RETURN (no raise / no redelivery).
+    """
+
+    def setup_method(self):
+        os.environ["FABRICATION_JOBS_TABLE"] = "citadel-fabrication-jobs-test"
+
+    def teardown_method(self):
+        os.environ.pop("FABRICATION_JOBS_TABLE", None)
+
+    def _run_tool_creation(self, agent_side_effect):
+        statuses = []
+
+        def record(orchestration_id, agent_use_id, status, **kwargs):
+            statuses.append((status, kwargs))
+
+        with patch.object(index, "_write_fabrication_status", side_effect=record), \
+                patch.object(index, "check_design_assessment"), \
+                patch.object(index, "create_tool_fabricator") as mk, \
+                patch.object(index, "publish_intake_progress"), \
+                patch.object(index, "publish_fabrication_event"):
+            mk.return_value = MagicMock(side_effect=agent_side_effect)
+            result = index.process_event(
+                _base_event(), {}, request_type="tool-creation"
+            )
+        return statuses, result
+
+    def test_zero_registration_failures_writes_bare_completed(self):
+        # No tool_fabricator call ever touches run_state.failed/succeeded ->
+        # registration_errors stays None -> bare COMPLETED, no attribute.
+        def fake_fabricator(task):
+            return "done"
+
+        statuses, result = self._run_tool_creation(fake_fabricator)
+
+        seq = [s for s, _ in statuses]
+        assert seq == ["PROCESSING", "COMPLETED"]
+        completed_kwargs = next(kw for s, kw in statuses if s == "COMPLETED")
+        assert completed_kwargs.get("registration_errors") is None
+        assert result is None
+
+    def test_partial_registration_failure_writes_completed_with_errors(self):
+        # One tool succeeded, one failed this run -> still COMPLETED (the
+        # agent has usable tools) but registrationErrors must be present.
+        def fake_fabricator(task):
+            run_state = index._registration_run_state
+            run_state.succeeded.add("tool_ok")
+            run_state.failed["tool_bad"] = "orphaned CREATING record"
+            return "done"
+
+        statuses, result = self._run_tool_creation(fake_fabricator)
+
+        seq = [s for s, _ in statuses]
+        assert seq == ["PROCESSING", "COMPLETED"]
+        completed_kwargs = next(kw for s, kw in statuses if s == "COMPLETED")
+        errors = completed_kwargs.get("registration_errors")
+        assert errors == [{"toolId": "tool_bad", "error": "orphaned CREATING record"}]
+        assert result is None
+
+    def test_all_registrations_failed_writes_failed_and_returns_cleanly(self):
+        # Every tool registration failed this run (succeeded stays empty) ->
+        # terminal FAILED + errorMessage + registrationErrors, and the
+        # handler returns cleanly (no raise -> no SQS redelivery).
+        def fake_fabricator(task):
+            run_state = index._registration_run_state
+            run_state.failed["tool_a"] = "orphaned CREATING record"
+            run_state.failed["tool_b"] = "orphaned CREATING record"
+            return "done"
+
+        statuses, result = self._run_tool_creation(fake_fabricator)
+
+        seq = [s for s, _ in statuses]
+        assert seq == ["PROCESSING", "FAILED"]
+        failed_kwargs = next(kw for s, kw in statuses if s == "FAILED")
+        assert failed_kwargs.get("error_message")
+        errors = failed_kwargs.get("registration_errors")
+        assert {"toolId": "tool_a", "error": "orphaned CREATING record"} in errors
+        assert {"toolId": "tool_b", "error": "orphaned CREATING record"} in errors
+        # Clean return: no exception propagates from process_event.
+        assert result is None
+
+
 def _transient_error(code: str = "internalServerException",
                      message: str = "Bedrock had an internal error"):
     return ClientError({"Error": {"Code": code, "Message": message}}, "ConverseStream")

--- a/arbiter/fabricator/__tests__/test_registry_recovery.py
+++ b/arbiter/fabricator/__tests__/test_registry_recovery.py
@@ -6,21 +6,22 @@ Live evidence (2026-07-23): a 900s SIGKILL mid tool-registration orphaned
 Registry tool records in CREATING; every subsequent
 UpdateRegistryRecordStatus raised ConflictException 'Registry record cannot
 be modified while in CREATING state' and the fabricator LLM retried the
-tool 92-110× (~825-834s of the 900s budget). The record never leaves
+tool 92-110× per run (~825-834s of the 900s budget). The record never leaves
 CREATING without intervention — the condition is NON-RETRYABLE within a run.
 
-Contract under test:
+Revised contract (post-incident-2, 2026-08-01) under test:
   - ``is_creating_conflict`` matches ONLY the poison shape: a botocore-style
     ConflictException whose message mentions the CREATING state.
-  - ``recover_creating_record`` follows the documented recovery path,
-    strictly bounded (never spins):
-      (a) poll GetRegistryRecord ≤2 checks, seconds apart, in case CREATING
-          is genuinely in-flight → approve and return the same recordId;
-      (b) delete-and-recreate: DeleteRegistryRecord (supported by the
-          bedrock-agentcore-control SDK; deletion is asynchronous), wait ≤2
-          checks for the record to disappear, recreate, approve;
-      (d) any recovery step failing → OrphanedRegistryRecordError — a
-          terminal, user-actionable error naming the orphaned record.
+  - ``recover_creating_record`` approve-in-place is the PRIMARY and ONLY
+    recovery mechanism — it NEVER creates or deletes a Registry record:
+      (a) poll GetRegistryRecord ≤``POLL_ATTEMPTS`` (5) checks, seconds
+          apart, in case CREATING is genuinely in-flight;
+      (b) if the record settles to a non-CREATING, non-``*_FAILED`` status,
+          approve it IN PLACE and return the SAME recordId;
+      (c) if the record settles to CREATE_FAILED/UPDATE_FAILED, or never
+          settles within the poll budget, or approve itself raises: raise
+          the terminal, NON-RETRYABLE ``OrphanedRegistryRecordError`` — a
+          single attempt, zero net-new orphans (no delete, no recreate).
   - ``OrphanedRegistryRecordError`` is an ordinary Exception (it must reach
     the LLM as a tool error) whose message says NON-RETRYABLE / DO NOT
     retry, so the model does not re-enter the retry spiral.
@@ -87,12 +88,11 @@ class TestIsCreatingConflict:
 # ---------------------------------------------------------------------------
 
 class _Recorder:
-    """Records sleep durations and approve/recreate invocations."""
+    """Records sleep durations and approve invocations."""
 
     def __init__(self):
         self.sleeps = []
         self.approved = []
-        self.recreated = 0
 
     def sleep(self, seconds):
         self.sleeps.append(seconds)
@@ -100,17 +100,12 @@ class _Recorder:
     def approve(self, record_id):
         self.approved.append(record_id)
 
-    def recreate(self):
-        self.recreated += 1
-        return f"rec-new-{self.recreated}"
-
 
 def _recover(client, rec, **overrides):
     kwargs = dict(
         registry_id="reg-1",
         record_id="rec-old",
         name="my_tool",
-        recreate=rec.recreate,
         approve=rec.approve,
         sleep=rec.sleep,
     )
@@ -120,8 +115,8 @@ def _recover(client, rec, **overrides):
 
 class TestPollResolvesInFlightCreating:
     def test_status_settles_then_approves_same_record(self):
-        # (a) CREATING was genuinely in-flight: first check still CREATING,
-        # second check DRAFT → approve the SAME record; no delete/recreate.
+        # CREATING was genuinely in-flight: first check still CREATING,
+        # second check DRAFT → approve the SAME record; zero net-new.
         rec = _Recorder()
         client = MagicMock()
         client.get_registry_record.side_effect = [
@@ -133,8 +128,8 @@ class TestPollResolvesInFlightCreating:
 
         assert result == "rec-old"
         assert rec.approved == ["rec-old"]
-        assert rec.recreated == 0
         client.delete_registry_record.assert_not_called()
+        client.create_registry_record.assert_not_called()
 
     def test_poll_checks_are_seconds_apart_and_bounded(self):
         rec = _Recorder()
@@ -147,7 +142,7 @@ class TestPollResolvesInFlightCreating:
         _recover(client, rec)
 
         assert rec.sleeps == [POLL_INTERVAL_SECONDS, POLL_INTERVAL_SECONDS]
-        assert client.get_registry_record.call_count == POLL_ATTEMPTS
+        assert client.get_registry_record.call_count == 2
 
     def test_settles_on_first_check_uses_single_poll(self):
         rec = _Recorder()
@@ -160,71 +155,35 @@ class TestPollResolvesInFlightCreating:
         assert client.get_registry_record.call_count == 1
         assert rec.sleeps == [POLL_INTERVAL_SECONDS]
 
-
-class TestDeleteAndRecreate:
-    def test_stuck_creating_is_deleted_and_recreated_then_approved(self):
-        # (b) record never leaves CREATING → delete (async) → gone on the
-        # first deletion check → recreate → approve the NEW record.
+    def test_longer_budget_settles_on_fifth_poll(self):
+        # Raised poll budget (POLL_ATTEMPTS=5): CREATING for the first 4
+        # checks then DRAFT on the 5th → approve in place, no failure.
         rec = _Recorder()
         client = MagicMock()
         client.get_registry_record.side_effect = [
-            {"status": "CREATING"},   # poll 1
-            {"status": "CREATING"},   # poll 2 — still stuck: orphaned
-            _not_found(),             # deletion check: record gone
+            {"status": "CREATING"},
+            {"status": "CREATING"},
+            {"status": "CREATING"},
+            {"status": "CREATING"},
+            {"status": "DRAFT"},
         ]
 
         result = _recover(client, rec)
 
-        assert result == "rec-new-1"
-        client.delete_registry_record.assert_called_once_with(
-            registryId="reg-1", recordId="rec-old"
-        )
-        assert rec.recreated == 1
-        assert rec.approved == ["rec-new-1"]
-
-    def test_deletion_wait_tolerates_deleting_status(self):
-        rec = _Recorder()
-        client = MagicMock()
-        client.get_registry_record.side_effect = [
-            {"status": "CREATING"},   # poll 1
-            {"status": "CREATING"},   # poll 2
-            {"status": "DELETING"},   # deletion check 1: async delete running
-            _not_found(),             # deletion check 2: gone
-        ]
-
-        result = _recover(client, rec)
-
-        assert result == "rec-new-1"
-        # 2 poll sleeps + 2 deletion-wait sleeps, all bounded.
-        assert rec.sleeps == [POLL_INTERVAL_SECONDS] * 4
-
-    def test_record_already_gone_when_polled_skips_delete(self):
-        # The orphan vanished between the conflict and our poll (e.g. an
-        # operator deleted it): go straight to recreate + approve.
-        rec = _Recorder()
-        client = MagicMock()
-        client.get_registry_record.side_effect = [_not_found()]
-
-        result = _recover(client, rec)
-
-        assert result == "rec-new-1"
-        client.delete_registry_record.assert_not_called()
-        assert rec.approved == ["rec-new-1"]
+        assert result == "rec-old"
+        assert rec.approved == ["rec-old"]
+        assert client.get_registry_record.call_count == 5
+        assert POLL_ATTEMPTS == 5
 
 
 class TestFailFastTerminal:
-    def test_delete_refused_raises_terminal_orphaned_error(self):
+    def test_never_settles_raises_terminal_with_zero_net_new(self):
+        # Stuck in CREATING for the entire poll budget → terminal error;
+        # NO delete, NO recreate, NO approve attempted — the original
+        # record is the only record that exists, unmodified.
         rec = _Recorder()
         client = MagicMock()
-        client.get_registry_record.side_effect = [
-            {"status": "CREATING"},
-            {"status": "CREATING"},
-        ]
-        client.delete_registry_record.side_effect = _client_error(
-            "ConflictException",
-            "Registry record cannot be deleted while in CREATING state.",
-            "DeleteRegistryRecord",
-        )
+        client.get_registry_record.return_value = {"status": "CREATING"}
 
         with pytest.raises(OrphanedRegistryRecordError) as exc_info:
             _recover(client, rec)
@@ -234,64 +193,56 @@ class TestFailFastTerminal:
         assert "rec-old" in message
         assert "NON-RETRYABLE" in message
         assert "DO NOT retry" in message
-        assert rec.recreated == 0
+        assert client.get_registry_record.call_count == POLL_ATTEMPTS
+        client.delete_registry_record.assert_not_called()
+        client.create_registry_record.assert_not_called()
+        assert rec.approved == []
 
-    def test_record_never_disappears_after_delete_raises_terminal(self):
+    def test_settles_to_create_failed_raises_terminal_without_approving(self):
+        # Creation genuinely failed service-side: PENDING_APPROVAL is
+        # unreachable from CREATE_FAILED, so approve must NOT be attempted.
         rec = _Recorder()
         client = MagicMock()
-        client.get_registry_record.side_effect = [
-            {"status": "CREATING"},   # poll 1
-            {"status": "CREATING"},   # poll 2
-            {"status": "DELETING"},   # deletion check 1
-            {"status": "DELETING"},   # deletion check 2 — still there
-        ]
-
-        with pytest.raises(OrphanedRegistryRecordError):
-            _recover(client, rec)
-
-        assert rec.recreated == 0
-        # Strictly bounded: no further get calls beyond 2 polls + 2 checks.
-        assert client.get_registry_record.call_count == 4
-
-    def test_recreate_failure_raises_terminal(self):
-        rec = _Recorder()
-        client = MagicMock()
-        client.get_registry_record.side_effect = [
-            {"status": "CREATING"},
-            {"status": "CREATING"},
-            _not_found(),
-        ]
-
-        def failing_recreate():
-            raise _client_error(
-                "ConflictException", "name already exists", "CreateRegistryRecord"
-            )
+        client.get_registry_record.side_effect = [{"status": "CREATE_FAILED"}]
 
         with pytest.raises(OrphanedRegistryRecordError) as exc_info:
-            _recover(client, rec, recreate=failing_recreate)
+            _recover(client, rec)
 
-        assert "my_tool" in str(exc_info.value)
+        assert "CREATE_FAILED" in str(exc_info.value)
+        assert rec.approved == []
+        client.delete_registry_record.assert_not_called()
+        client.create_registry_record.assert_not_called()
 
-    def test_approve_after_recreate_failing_cleans_up_and_raises_terminal(self):
-        # Never leave a FRESH orphan behind: if the recreated record can't be
-        # approved either, best-effort delete it before failing terminally.
+    def test_settles_to_update_failed_raises_terminal_without_approving(self):
         rec = _Recorder()
         client = MagicMock()
-        client.get_registry_record.side_effect = [
-            {"status": "CREATING"},
-            {"status": "CREATING"},
-            _not_found(),
-        ]
+        client.get_registry_record.side_effect = [{"status": "UPDATE_FAILED"}]
+
+        with pytest.raises(OrphanedRegistryRecordError) as exc_info:
+            _recover(client, rec)
+
+        assert "UPDATE_FAILED" in str(exc_info.value)
+        assert rec.approved == []
+
+    def test_approve_raises_after_settle_is_terminal_single_attempt(self):
+        # Settled to a usable-looking status but approve itself raises
+        # (e.g. an unexpected settled status or a raced-back conflict):
+        # terminal immediately — no fallback, no second attempt.
+        client = MagicMock()
+        client.get_registry_record.side_effect = [{"status": "DRAFT"}]
 
         def failing_approve(record_id):
-            raise _creating_conflict()
+            raise _client_error(
+                "ValidationException", "Invalid source status"
+            )
 
-        with pytest.raises(OrphanedRegistryRecordError):
+        rec = _Recorder()
+        with pytest.raises(OrphanedRegistryRecordError) as exc_info:
             _recover(client, rec, approve=failing_approve)
 
-        client.delete_registry_record.assert_any_call(
-            registryId="reg-1", recordId="rec-new-1"
-        )
+        assert "my_tool" in str(exc_info.value)
+        client.delete_registry_record.assert_not_called()
+        client.create_registry_record.assert_not_called()
 
     def test_poll_infrastructure_error_raises_terminal(self):
         rec = _Recorder()
@@ -303,31 +254,5 @@ class TestFailFastTerminal:
         with pytest.raises(OrphanedRegistryRecordError):
             _recover(client, rec)
 
-
-class TestApproveAfterSettleFallsBackToRecreate:
-    def test_settled_but_unusable_record_falls_back_to_delete_recreate(self):
-        # The record left CREATING but landed somewhere unusable
-        # (e.g. CREATE_FAILED) — approve fails → delete-and-recreate.
-        client = MagicMock()
-        client.get_registry_record.side_effect = [
-            {"status": "CREATE_FAILED"},  # poll 1: settled but broken
-            _not_found(),                  # deletion check: gone
-        ]
-        rec = _Recorder()
-        calls = {"n": 0}
-
-        def approve_first_fails(record_id):
-            calls["n"] += 1
-            if record_id == "rec-old":
-                raise _client_error(
-                    "ValidationException", "Invalid source status", "UpdateRegistryRecordStatus"
-                )
-            rec.approve(record_id)
-
-        result = _recover(client, rec, approve=approve_first_fails)
-
-        assert result == "rec-new-1"
-        client.delete_registry_record.assert_called_once_with(
-            registryId="reg-1", recordId="rec-old"
-        )
-        assert rec.approved == ["rec-new-1"]
+        client.delete_registry_record.assert_not_called()
+        client.create_registry_record.assert_not_called()

--- a/arbiter/fabricator/index.py
+++ b/arbiter/fabricator/index.py
@@ -87,6 +87,15 @@ class _RegistrationRunState:
     - ``published`` dedupes tool.fabrication.failed to ONE event per
       (tool_id, error type) per run — once per tool failure, never once per
       retry iteration.
+    - ``succeeded`` is the set of tool_ids that completed registration this
+      run — used to distinguish "all failed" from "partial" when the run
+      terminates.
+    - ``failed`` maps tool_id -> short error string for EVERY registration
+      failure this run (a superset of ``latched``, which only tracks the
+      NON-RETRYABLE orphaned-record case) — threaded into the job status
+      row as the additive ``registrationErrors`` attribute so a run that
+      completes with some or all tool registrations failing is never
+      reported as a bare, silent COMPLETED.
 
     Scoped to a run on purpose: process_event begins/ends it around each
     SQS record (Lambda containers are REUSED, so module state must never
@@ -97,6 +106,8 @@ class _RegistrationRunState:
     def __init__(self):
         self.latched = {}
         self.published = set()
+        self.succeeded = set()
+        self.failed = {}
 
 
 _registration_run_state = None
@@ -235,6 +246,7 @@ def _write_fabrication_status(
     agent_id: str | None = None,
     error_message: str | None = None,
     agent_name: str | None = None,
+    registration_errors: list | None = None,
 ) -> bool:
     """Upsert a per-agent fabrication status row in the durable jobs table.
 
@@ -242,6 +254,15 @@ def _write_fabrication_status(
     (``citadel-fabrication-jobs-${env}``) is keyed by orchestrationId (PK) /
     agentUseId (SK). process_event calls this at the START (PROCESSING), on
     SUCCESS (COMPLETED + agentId) and on EXCEPTION (FAILED + errorMessage).
+
+    ``registration_errors`` is an ADDITIVE attribute (no new status enum
+    value — the 4-value {PENDING, PROCESSING, COMPLETED, FAILED} contract is
+    a hard constraint of downstream consumers, see queue resolver / intake
+    terminal-status checks): a list of ``{"toolId": ..., "error": ...}``
+    dicts describing tool registrations that failed during the run. Written
+    whenever a run had any registration failures (partial COMPLETED or
+    all-failed FAILED); omitted (never a bare empty list) when there were
+    none, so existing bare-COMPLETED consumers see no shape change.
 
     Backward-compatible and best-effort: when ``FABRICATION_JOBS_TABLE`` is
     unset the write is skipped (logged); any failure is logged and swallowed
@@ -290,6 +311,20 @@ def _write_fabrication_status(
         set_parts.append("#errorMessage = :errorMessage")
         names["#errorMessage"] = "errorMessage"
         values[":errorMessage"] = {"S": error_message[:1000]}
+    if registration_errors:
+        set_parts.append("#registrationErrors = :registrationErrors")
+        names["#registrationErrors"] = "registrationErrors"
+        values[":registrationErrors"] = {
+            "L": [
+                {
+                    "M": {
+                        "toolId": {"S": str(item.get("toolId", ""))},
+                        "error": {"S": str(item.get("error", ""))[:500]},
+                    }
+                }
+                for item in registration_errors
+            ]
+        }
 
     try:
         boto3.client("dynamodb").update_item(
@@ -1655,9 +1690,7 @@ def store_tool_config_registry(
 
         # CreateRegistryRecord does NOT accept a recordId — the service generates
         # one. We use the toolId as the record name so records can be located
-        # by name in subsequent operations. The kwargs are shared with the
-        # CREATING-conflict recovery below, which may need to recreate the
-        # record with exactly the same shape.
+        # by name in subsequent operations.
         create_kwargs = {
             "registryId": registry_id,
             "name": tool_id,
@@ -1692,16 +1725,27 @@ def store_tool_config_registry(
         # value both the intake catalog (_registry_state_from_status) and the
         # backend (toInternalState) map to "active".
         def _approve(rid: str) -> None:
-            _get_registry_client().update_registry_record_status(
+            # Legal two-step transition: the live bedrock-agentcore-control
+            # service rejects a direct DRAFT->APPROVED with ValidationException
+            # ("Invalid status transition from DRAFT to APPROVED. Valid
+            # transitions from DRAFT: PENDING_APPROVAL, DEPRECATED, DRAFT,
+            # UPDATING") — the legal path is DRAFT->PENDING_APPROVAL->APPROVED
+            # (two calls). This callable is shared by the happy path and both
+            # registry-recovery approve-in-place call sites, so fixing it
+            # here repairs approval everywhere at once. Status updates are
+            # synchronous (unlike create), so no inter-step wait is needed.
+            client = _get_registry_client()
+            client.update_registry_record_status(
+                registryId=registry_id,
+                recordId=rid,
+                status="PENDING_APPROVAL",
+                statusReason="Fabricator submit for approval",
+            )
+            client.update_registry_record_status(
                 registryId=registry_id,
                 recordId=rid,
                 status="APPROVED",
                 statusReason="Initial status set by Fabricator",
-            )
-
-        def _recreate() -> str:
-            return _record_id_from(
-                _get_registry_client().create_registry_record(**create_kwargs)
             )
 
         try:
@@ -1717,22 +1761,21 @@ def store_tool_config_registry(
             # within this run — the record never leaves CREATING on its own —
             # so it must never be blindly retried (the LLM previously retried
             # it 92-110×, burning ~92% of the 900s Lambda budget). Run the
-            # bounded, SDK-documented recovery instead: poll briefly in case
-            # CREATING is genuinely in-flight, then delete-and-recreate the
-            # orphan (DeleteRegistryRecord is supported; deletion is async),
-            # else fail FAST with a terminal, user-actionable error. See
-            # registry_recovery.py for the full justification.
+            # bounded, SDK-documented recovery instead: poll briefly for the
+            # record to settle, then approve it IN PLACE, else fail FAST with
+            # a terminal, user-actionable error. Recovery never creates or
+            # deletes a Registry record — see registry_recovery.py for the
+            # full justification (zero-net-new-orphans is structural).
             print(
                 f"[store_tool_config_registry] ConflictException on CREATING "
                 f"for '{tool_id}' (recordId {record_id}) — entering bounded "
-                f"recovery (poll -> delete-and-recreate -> fail fast)"
+                f"recovery (poll -> approve in place -> fail fast)"
             )
             record_id = recover_creating_record(
                 _get_registry_client(),
                 registry_id,
                 record_id,
                 tool_id,
-                recreate=_recreate,
                 approve=_approve,
             )
 
@@ -1743,6 +1786,9 @@ def store_tool_config_registry(
         registration_checkpoint(f"after tool registration '{tool_id}'")
 
         print(f"[store_tool_config_registry] SUCCESS - Registry response: {response}")
+        run_state = _registration_run_state
+        if run_state is not None:
+            run_state.succeeded.add(tool_id)
         return True
 
     except Exception as e:
@@ -1762,6 +1808,8 @@ def store_tool_config_registry(
         # check at the top). Direct calls outside a run keep the legacy
         # one-event-per-call behavior.
         run_state = _registration_run_state
+        if run_state is not None:
+            run_state.failed[tool_id] = str(e)[:500]
         if run_state is not None and isinstance(e, OrphanedRegistryRecordError):
             run_state.latched.setdefault(tool_id, str(e))
         publish_key = (tool_id, type(e).__name__)
@@ -2224,11 +2272,45 @@ def process_event(event, context, request_type=None):
                 f"fabrication run"
             )
 
-        # Durable status: fabrication dispatch completed without raising — mark
-        # COMPLETED and stamp the agent name/recordId. Best-effort.
+        # Durable status: fabrication dispatch completed without raising.
+        # Branch on this run's registration bookkeeping (ADDITIVE signal
+        # only — the {PENDING, PROCESSING, COMPLETED, FAILED} enum contract
+        # is unchanged; see _RegistrationRunState / registrationErrors):
+        #   - no registration failures         -> bare COMPLETED (unchanged)
+        #   - some succeeded, some failed       -> COMPLETED + registrationErrors
+        #   - every registration failed         -> FAILED + errorMessage +
+        #     registrationErrors, then RETURN CLEANLY (no re-raise) so the
+        #     SQS message is consumed rather than redelivered into a run
+        #     that will fail identically (mirrors the deadline-guard
+        #     philosophy: durable FAILED row + clean return).
+        run_state = _registration_run_state
+        registration_errors = None
+        if run_state is not None and run_state.failed:
+            registration_errors = [
+                {"toolId": tool_id, "error": err}
+                for tool_id, err in run_state.failed.items()
+            ]
+
+        if run_state is not None and run_state.failed and not run_state.succeeded:
+            all_failed_message = (
+                "All tool registrations failed for this agent: "
+                + "; ".join(
+                    f"{tool_id}: {err}" for tool_id, err in run_state.failed.items()
+                )
+            )
+            print(f"All tool registrations failed: {all_failed_message}")
+            _write_fabrication_status(
+                orchestration_id, agent_use_id, "FAILED",
+                error_message=all_failed_message[:1000],
+                agent_name=agent_use_id,
+                registration_errors=registration_errors,
+            )
+            return
+
         _write_fabrication_status(
             orchestration_id, agent_use_id, "COMPLETED",
-            agent_id=agent_use_id, agent_name=agent_use_id
+            agent_id=agent_use_id, agent_name=agent_use_id,
+            registration_errors=registration_errors,
         )
 
     except FabricationDeadlineExceeded as deadline_exc:

--- a/arbiter/fabricator/registry_recovery.py
+++ b/arbiter/fabricator/registry_recovery.py
@@ -11,37 +11,52 @@ leaves CREATING without intervention, so this ConflictException is
 NON-RETRYABLE from within a run and must be either recovered or failed
 terminally — never silently spun on.
 
-Chosen recovery path, in order of preference, justified against the
-bedrock-agentcore-control SDK surface (botocore 1.43.36):
+Chosen recovery path (revised post-incident-2, 2026-08-01 — see
+OrphanedRegistryRecordError call sites below), justified against the
+bedrock-agentcore-control SDK surface (botocore 1.43.36) AND the live
+registry transition table (backend REGISTRY_TRANSITIONS; CREATING is not a
+key — no client-side API legally transitions a record OUT of CREATING):
 
 (a) POLL briefly — ``GetRegistryRecord(registryId, recordId)`` returns the
     record ``status`` (enum includes CREATING). Creation is asynchronous,
-    so CREATING may be genuinely in-flight: check ≤``POLL_ATTEMPTS`` (2)
-    times, ``POLL_INTERVAL_SECONDS`` apart. If the record settles, approve
-    it and we are done.
+    so CREATING may be genuinely in-flight: check ≤``POLL_ATTEMPTS`` (5)
+    times, ``POLL_INTERVAL_SECONDS`` apart (total budget ≤15s, comfortably
+    exceeding the backend's own ≤10s ``waitForStableState`` wait). If the
+    record settles to a status other than CREATING, approve it IN PLACE and
+    we are done.
 
-(b) DELETE-AND-RECREATE — the SDK DOES support
-    ``DeleteRegistryRecord(registryId, recordId)``: "Deletes a registry
-    record. The record's status transitions to DELETING and the record is
-    removed asynchronously." No CREATING restriction is documented, so
-    deleting the orphan is the sanctioned cleanup. Because deletion is
-    asynchronous, wait ≤2 checks for the record to disappear
-    (ResourceNotFoundException), then recreate it and approve the fresh
-    record. If approving the recreated record fails too, best-effort delete
-    it so we never leave a FRESH orphan behind.
+(b) If the record settles to CREATE_FAILED (or any other ``*_FAILED``
+    status), creation genuinely failed service-side — the record is not
+    approvable (PENDING_APPROVAL is unreachable from a FAILED status) — so
+    approve is never attempted; fail fast, terminally.
 
-(c) versioned/suffixed record name — REJECTED: the record NAME is the
+(c) If approve-in-place itself raises for any other reason, fail fast,
+    terminally. There is no fallback.
+
+(d) delete-and-recreate — REMOVED. While a record is CREATING the service
+    permits neither approve nor delete (both raise ConflictException), so a
+    delete-and-recreate arm can never run cleanly: recreating produces a
+    SECOND record that is itself CREATING (the approve on it hits the same
+    conflict), and the best-effort cleanup-delete on that fresh CREATING
+    record also fails and is swallowed — the recreated record survives as a
+    NEW orphan. Recovery therefore never creates or deletes anything: this
+    makes "zero net-new orphans" a STRUCTURAL invariant of this module, not
+    a best-effort.
+
+(e) versioned/suffixed record name — REJECTED: the record NAME is the
     tool's resolution key (records are located by tool_id name by every
     downstream consumer), so a suffixed record would register a tool that
     is invisible to the system. Failing fast is strictly better.
 
-(d) FAIL FAST — any recovery step failing raises
+(f) FAIL FAST — any recovery step failing raises
     ``OrphanedRegistryRecordError``: terminal, user-actionable, naming the
     orphaned record, and explicitly marked NON-RETRYABLE so the fabricator
     LLM does not re-enter the retry spiral.
 
-The whole path is strictly bounded: ≤ ~8 registry API calls and ≤4 short
-sleeps (~12s) — versus the observed ~825-834s retry burn.
+The whole path is strictly bounded: ≤``POLL_ATTEMPTS`` (5) GetRegistryRecord
+calls + ≤1 approve call, ≤5 short sleeps (~15s) — versus the observed
+~825-834s retry burn. Recovery never calls CreateRegistryRecord or
+DeleteRegistryRecord.
 """
 
 import logging
@@ -51,11 +66,18 @@ from transient_retry import bedrock_error_code
 
 logger = logging.getLogger(__name__)
 
-# ≤2 checks, seconds apart, per bounded-recovery contract — never spins.
-POLL_ATTEMPTS = 2
+# Bounded poll, seconds apart, per bounded-recovery contract — never spins.
+# 5 × 3.0s = 15s total budget, comfortably exceeding the backend's own
+# waitForStableState wait (≤10s, registry-service.ts:890-903).
+POLL_ATTEMPTS = 5
 POLL_INTERVAL_SECONDS = 3.0
 
 CREATING_STATUS = "CREATING"
+
+# Statuses the record can settle into where creation genuinely failed
+# service-side: the record is not approvable (PENDING_APPROVAL is
+# unreachable from any *_FAILED status), so approve must not be attempted.
+_FAILED_STATUSES = ("CREATE_FAILED", "UPDATE_FAILED")
 
 # Test seam: recovery sleeps go through this module-level hook so tests can
 # neutralize them without patching the global ``time`` module.
@@ -92,7 +114,7 @@ def _orphaned(name, record_id, registry_id, detail):
     return OrphanedRegistryRecordError(
         f"NON-RETRYABLE: Registry record '{name}' (recordId {record_id}, "
         f"registryId {registry_id}) is orphaned in CREATING state and the "
-        f"automatic recovery (poll -> delete -> recreate) failed: {detail} "
+        f"automatic recovery (poll -> approve in place) failed: {detail} "
         f"DO NOT retry this registration - it cannot succeed until the "
         f"orphaned record is removed. Ask an operator to delete the record "
         f"from the AgentCore Registry, then re-queue this agent."
@@ -104,7 +126,6 @@ def recover_creating_record(
     registry_id,
     record_id,
     name,
-    recreate,
     approve,
     *,
     sleep=None,
@@ -113,24 +134,35 @@ def recover_creating_record(
 ):
     """Recover a registration blocked by a record stuck in CREATING.
 
+    Approve-in-place is the PRIMARY and ONLY recovery mechanism: this
+    function never creates or deletes a Registry record. On any non-success
+    outcome (record never settles within the poll budget, settles to a
+    ``*_FAILED`` status, or the approve call itself raises) it raises the
+    terminal, NON-RETRYABLE ``OrphanedRegistryRecordError`` — leaving the
+    single original record in place for operator cleanup. Zero net-new
+    orphans is therefore a structural property of this function, not a
+    best-effort.
+
     Args:
-        client: bedrock-agentcore-control client (get/delete record used).
+        client: bedrock-agentcore-control client (get_registry_record used).
         registry_id: Registry containing the record.
         record_id: The recordId whose approve raised the CREATING conflict.
         name: Record name (the tool_id) — for logs and terminal messages.
-        recreate: Zero-arg callable re-issuing the original
-            CreateRegistryRecord; returns the NEW recordId.
-        approve: One-arg callable moving a recordId to its usable status.
+        approve: One-arg callable moving a recordId to its usable status
+            (the legal two-step DRAFT->PENDING_APPROVAL->APPROVED sequence
+            lives in the caller's ``approve`` implementation).
         sleep: Injectable sleep for tests; defaults to the module hook.
         poll_attempts / poll_interval_seconds: Bounded-poll knobs.
 
     Returns:
-        The recordId that ended up approved (original or recreated).
+        The recordId that ended up approved (always ``record_id`` — this
+        function never recreates the record).
 
     Raises:
         OrphanedRegistryRecordError: Terminal, NON-RETRYABLE — any recovery
             step failed; the message names the orphaned record and the
-            operator action. This function NEVER silently spins.
+            operator action. This function NEVER silently spins and NEVER
+            creates or deletes a Registry record.
     """
     sleep_fn = _sleep if sleep is None else sleep
 
@@ -140,19 +172,13 @@ def recover_creating_record(
         )
         return (response or {}).get("status")
 
-    # --- (a) brief bounded poll: CREATING may be genuinely in-flight -------
+    # --- bounded poll: CREATING may be genuinely in-flight ------------------
     status = CREATING_STATUS
-    record_exists = True
     for _ in range(poll_attempts):
         sleep_fn(poll_interval_seconds)
         try:
             status = _status()
-        except Exception as poll_err:  # noqa: BLE001 — classified below
-            if _is_not_found(poll_err):
-                # The orphan vanished (e.g. an operator already deleted it):
-                # skip the delete and go straight to recreate.
-                record_exists = False
-                break
+        except Exception as poll_err:  # noqa: BLE001 — terminal by contract
             raise _orphaned(
                 name, record_id, registry_id,
                 f"status poll failed with {type(poll_err).__name__}: {poll_err}.",
@@ -160,92 +186,34 @@ def recover_creating_record(
         if status != CREATING_STATUS:
             break
 
-    if record_exists and status != CREATING_STATUS:
-        logger.warning(
-            "Registry record '%s' (%s) settled to %s after CREATING conflict; "
-            "approving in place", name, record_id, status,
-        )
-        try:
-            approve(record_id)
-            return record_id
-        except Exception as approve_err:  # noqa: BLE001 — fall through to (b)
-            # Settled somewhere unusable (e.g. CREATE_FAILED) or raced back
-            # into a conflict — the record is not salvageable in place;
-            # continue to delete-and-recreate.
-            logger.warning(
-                "Approving settled record '%s' (%s, status %s) failed with "
-                "%s: %s — falling back to delete-and-recreate",
-                name, record_id, status, type(approve_err).__name__, approve_err,
-            )
-
-    # --- (b) delete-and-recreate the orphaned record ------------------------
-    if record_exists:
-        try:
-            client.delete_registry_record(
-                registryId=registry_id, recordId=record_id
-            )
-        except Exception as delete_err:  # noqa: BLE001 — classified below
-            if not _is_not_found(delete_err):
-                raise _orphaned(
-                    name, record_id, registry_id,
-                    f"DeleteRegistryRecord failed with "
-                    f"{type(delete_err).__name__}: {delete_err}.",
-                )
-
-        # Deletion is asynchronous (status -> DELETING, removed async): wait
-        # for the record to actually disappear before recreating the name.
-        gone = False
-        for _ in range(poll_attempts):
-            sleep_fn(poll_interval_seconds)
-            try:
-                _status()
-            except Exception as check_err:  # noqa: BLE001 — classified below
-                if _is_not_found(check_err):
-                    gone = True
-                    break
-                raise _orphaned(
-                    name, record_id, registry_id,
-                    f"deletion check failed with "
-                    f"{type(check_err).__name__}: {check_err}.",
-                )
-        if not gone:
-            raise _orphaned(
-                name, record_id, registry_id,
-                "the record was still present after the asynchronous delete "
-                f"({poll_attempts} checks, {poll_interval_seconds:.0f}s apart).",
-            )
-
-    try:
-        new_record_id = recreate()
-    except Exception as create_err:  # noqa: BLE001 — terminal by contract
+    if status == CREATING_STATUS:
         raise _orphaned(
             name, record_id, registry_id,
-            f"recreating the record failed with "
-            f"{type(create_err).__name__}: {create_err}.",
+            "the record was still in CREATING state after "
+            f"{poll_attempts} checks, {poll_interval_seconds:.0f}s apart.",
         )
 
-    try:
-        approve(new_record_id)
-    except Exception as approve_err:  # noqa: BLE001 — terminal by contract
-        # Never leave a FRESH orphan behind: best-effort cleanup of the
-        # record we just recreated but could not approve.
-        try:
-            client.delete_registry_record(
-                registryId=registry_id, recordId=new_record_id
-            )
-        except Exception as cleanup_err:  # noqa: BLE001 — best-effort only
-            logger.warning(
-                "Best-effort cleanup of recreated record '%s' (%s) failed: %s",
-                name, new_record_id, cleanup_err,
-            )
+    if status in _FAILED_STATUSES:
+        # Creation failed service-side; PENDING_APPROVAL is unreachable from
+        # a *_FAILED status, so the approve call is doomed — do not attempt
+        # it (that would just be a second, differently-shaped failure).
         raise _orphaned(
-            name, new_record_id, registry_id,
-            f"approving the recreated record failed with "
-            f"{type(approve_err).__name__}: {approve_err}.",
+            name, record_id, registry_id,
+            f"the record settled to {status}; creation failed service-side "
+            "and the record is not approvable.",
         )
 
     logger.warning(
-        "Recovered orphaned CREATING record '%s': deleted %s, recreated as %s "
-        "and approved", name, record_id, new_record_id,
+        "Registry record '%s' (%s) settled to %s after CREATING conflict; "
+        "approving in place", name, record_id, status,
     )
-    return new_record_id
+    try:
+        approve(record_id)
+    except Exception as approve_err:  # noqa: BLE001 — terminal by contract
+        raise _orphaned(
+            name, record_id, registry_id,
+            f"approving the settled record (status {status}) failed with "
+            f"{type(approve_err).__name__}: {approve_err}.",
+        )
+
+    return record_id


### PR DESCRIPTION
## Summary

Field-found by the observability epic: the DLQ alarm fired minutes after first deploy, flagging two fabrication messages parked since July 23. Redriving them validated the earlier deadline-guard fix (no retry spiral, clean fast-fail) but exposed that registry recovery couldn't recover — and each attempt *added* orphans (12 accumulated on the dev registry).

**Root cause was deeper than the recovery module.** The shared `_approve` primitive issued a single direct DRAFT→APPROVED status update — an illegal transition the control plane rejects (`Valid transitions from DRAFT: PENDING_APPROVAL, DEPRECATED, DRAFT, UPDATING`). The happy path was exactly as broken as recovery; that is how orphans accumulated. `_approve` now performs the legal two-step DRAFT→PENDING_APPROVAL→APPROVED, fixing both paths with one change.

**Recovery is redesigned around a structural invariant.** Approve-in-place is the only arm: wait-for-stable raised to 15s (above the backend's own 10s budget), a CREATE_FAILED/UPDATE_FAILED guard that fails terminally instead of attempting a doomed approve, single attempt, no fallback. The delete-and-recreate arm is removed entirely — a CREATING record can be neither approved nor deleted, so recreation was self-defeating and orphan-doubling. Recovery now makes zero create/delete calls: "zero net-new orphans" is not a tested behavior but a capability the code no longer has (and is mutant-proven in tests anyway).

**Fabrication jobs stop lying about partial failure.** Jobs previously wrote bare COMPLETED even when every tool registration failed. The status enum is a hard four-value consumer contract (queue resolver normalizes unknown values to FAILED), so the signal is additive: `registrationErrors` (`[{toolId, error}]`); zero failures → COMPLETED; partial → COMPLETED + registrationErrors; all failed → FAILED + errorMessage with a clean return so SQS does not redeliver. Read-side surfacing in the UI is deliberately deferred.

## Testing

Full arbiter pytest, CI-equivalent from repo root: 1,330 passed / 0 failed. Bite proofs: a single-call `_approve` mutant fails the two-step sequence test; an all-failed→COMPLETED mutant fails the job-status test; both pass on restore. mypy: zero new errors vs base. Diff confined to `arbiter/fabricator/**` — no backend, service, or frontend changes; consumers verified untouched.

## Reviewer note

- Integration tests seed a CREATING orphan and assert exactly one usable record with zero net-new (asserting zero create/delete calls inside recovery).