### PR TITLE
fix(deps): resolve brace-expansion to 5.0.9 across reachable copies

### DIFF
--- a/audit-ci-allowlist-justifications.md
+++ b/audit-ci-allowlist-justifications.md
@@ -8,7 +8,6 @@ renew the justification by the listed `revisitBy` date.
 ## GHSA-mh99-v99m-4gvg — brace-expansion (HIGH DoS via unbounded expansion)
 
 **Affected instances:**
-- `backend/node_modules/brace-expansion@5.0.7` (direct; advisory range <=5.0.7)
 - `node_modules/aws-cdk-lib/node_modules/brace-expansion@5.0.7` (bundled; advisory range <=5.0.7)
 - `node_modules/@eslint/eslintrc/node_modules/brace-expansion@1.1.16` (transitive via eslint→minimatch@3.1.5→brace-expansion; audit flags all)
 - `node_modules/@humanwhocodes/config-array/node_modules/brace-expansion@1.1.16` (transitive via minimatch@3.1.5)
@@ -16,10 +15,17 @@ renew the justification by the listed `revisitBy` date.
 - `node_modules/glob/node_modules/brace-expansion@1.1.16` (transitive via minimatch@3.1.5)
 - `node_modules/test-exclude/node_modules/brace-expansion@1.1.16` (transitive via minimatch@3.1.5)
 
+**Resolved (2026-08-01):** the backend/root direct-edge copy (previously listed above as
+"backend direct copy", `backend/node_modules/brace-expansion@5.0.7`) is fixed — both root
+and backend `overrides.brace-expansion` floors were raised to `>=5.0.9 <6` and re-resolved
+via `npm update brace-expansion`. It now hoists to a single `node_modules/brace-expansion@5.0.9`
+satisfying both workspaces; no separate `backend/node_modules/brace-expansion` entry remains.
+Residual allowlist scope is now exactly the two categories below (bundled + minimatch@3.1.5
+chain) — both correctly labeled as *not* a direct dependency in this codebase.
+
 **Why remediation is blocked:**
-1. **backend direct copy**: brace-expansion@5.0.7 is locked directly in backend/package.json; upgrade requires explicit change.
-2. **aws-cdk-lib bundled copy**: npm `overrides` cannot rewrite `bundleDependencies` entries. Only an upstream `aws-cdk-lib` release bumping its bundled `brace-expansion` to >=5.0.8 will fix this.
-3. **eslint chain (1.1.16 instances via minimatch@3.1.5)**: These resolve via eslint→minimatch@3.1.5→brace-expansion@^1.1. Minimatch v3.1.5 *requires* brace-expansion@^1.1, not v5.x. To remediate, minimatch must be upgraded (which requires eslint major upgrade). No in-range npm overrides floor can force v5 without breaking minimatch.
+1. **aws-cdk-lib bundled copy**: npm `overrides` cannot rewrite `bundleDependencies` entries. Only an upstream `aws-cdk-lib` release bumping its bundled `brace-expansion` to >=5.0.8 will fix this.
+2. **eslint chain (1.1.16 instances via minimatch@3.1.5)**: These resolve via eslint→minimatch@3.1.5→brace-expansion@^1.1. Minimatch v3.1.5 *requires* brace-expansion@^1.1, not v5.x. To remediate, minimatch must be upgraded (which requires eslint major upgrade). No in-range npm overrides floor can force v5 without breaking minimatch.
 
 **Exposure & Risk Acceptance:**
 - All instances are in root devDependencies (build-time only, not deployed).

--- a/backend/package.json
+++ b/backend/package.json
@@ -105,6 +105,6 @@
     "node": ">=24.0.0"
   },
   "overrides": {
-    "brace-expansion": ">=5.0.8"
+    "brace-expansion": ">=5.0.9 <6"
   }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -517,29 +517,6 @@
         "url": "https://github.com/sponsors/epoberezkin"
       }
     },
-    "backend/node_modules/balanced-match": {
-      "version": "4.0.4",
-      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
-      "integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": "18 || 20 || >=22"
-      }
-    },
-    "backend/node_modules/brace-expansion": {
-      "version": "5.0.7",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.7.tgz",
-      "integrity": "sha512-7oFy703dxfY3/NLxC1fh2SUCQ0H9rmAY+5EpDVfXjUTTs+HEwR2nYaqLv+GWcTsumwxPfiz6CzCNkwXwBUwqCA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "balanced-match": "^4.0.2"
-      },
-      "engines": {
-        "node": "18 || 20 || >=22"
-      }
-    },
     "backend/node_modules/eslint-visitor-keys": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-5.0.1.tgz",
@@ -6670,6 +6647,29 @@
       "resolved": "https://registry.npmjs.org/bowser/-/bowser-2.14.1.tgz",
       "integrity": "sha512-tzPjzCxygAKWFOJP011oxFHs57HzIhOEracIgAePE4pqB3LikALKnSzUyU4MGs9/iCEUuHlAJTjTc5M+u7YEGg==",
       "license": "MIT"
+    },
+    "node_modules/brace-expansion": {
+      "version": "5.0.9",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.9.tgz",
+      "integrity": "sha512-ScQ4IuvIEF1TMlP7Zt+vjJ//9zlPb2SDcxWxM3bk8s6t6GGdJ7KO1dCcTidOPJKePW30LE/2cT7wCyPho9/Wxg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^4.0.2"
+      },
+      "engines": {
+        "node": "20 || >=22"
+      }
+    },
+    "node_modules/brace-expansion/node_modules/balanced-match": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
+      "integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "18 || 20 || >=22"
+      }
     },
     "node_modules/braces": {
       "version": "3.0.3",

--- a/package.json
+++ b/package.json
@@ -48,33 +48,33 @@
     "js-yaml": "^4.3.0",
     "fast-uri": "4.1.1",
     "shell-quote": "^1.9.0",
-    "brace-expansion": ">=5.0.8",
+    "brace-expansion": ">=5.0.9 <6",
     "@typescript-eslint/typescript-estree": {
       "minimatch": "9.0.9"
     },
     "aws-cdk-lib": {
       "minimatch": {
-        "brace-expansion": ">=5.0.8"
+        "brace-expansion": ">=5.0.9 <6"
       }
     },
     "eslint": {
       "minimatch": {
-        "brace-expansion": ">=5.0.8"
+        "brace-expansion": ">=5.0.9 <6"
       }
     },
     "jest": {
       "minimatch": {
-        "brace-expansion": ">=5.0.8"
+        "brace-expansion": ">=5.0.9 <6"
       }
     },
     "glob": {
       "minimatch": {
-        "brace-expansion": ">=5.0.8"
+        "brace-expansion": ">=5.0.9 <6"
       }
     },
     "test-exclude": {
       "minimatch": {
-        "brace-expansion": ">=5.0.8"
+        "brace-expansion": ">=5.0.9 <6"
       }
     }
   },


### PR DESCRIPTION
- Dependabot alert #88 (CVE-2026-14257, HIGH DoS) — lockfile resolved 5.0.7 below the existing >=5.0.8 override floor
- Floors raised to >=5.0.9 <6 (root + backend, actual latest) and lockfile re-resolved via npm — pure hoist, version+resolved+integrity changed together, zero unrelated packages
- aws-cdk-lib BUNDLED copy stays 5.0.7 — npm overrides cannot reach bundleDependencies; allowlisted with rationale, clears via upstream cdk bump
- Allowlist justification corrected (backend copy is transitive via minimatch, not direct)
- Supersedes Dependabot PRs #45/#52 — #52 bundled eslint 8→10 + jest 29→30 majors and eslint 10 flat-config breaks backend lint (migration deferred to its own story)
- Verified: eslint 8 lint clean, jest --listTests 355, scoped suite green, tsc clean, audit residual = documented allowlisted set only

Dependabot-Alert: 88 