### PR TITLE
chore(frontend): clear TS6133 unused declarations in test files

### DIFF
--- a/frontend/src/pages/__tests__/AgenticStudio.regression.test.tsx
+++ b/frontend/src/pages/__tests__/AgenticStudio.regression.test.tsx
@@ -5,7 +5,7 @@
  * workflowId deep link behavior, error boundary wrapping.
  */
 import React from 'react';
-import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { render, screen } from '@testing-library/react';
 import '@testing-library/jest-dom';
 
 jest.mock('@/components/ui/tabs', () => ({

--- a/frontend/src/pages/__tests__/AppBuilderWizard.regression.test.tsx
+++ b/frontend/src/pages/__tests__/AppBuilderWizard.regression.test.tsx
@@ -4,7 +4,6 @@
  * Covers: step indicator rendering, step navigation (next/back), form inputs,
  * validation (name required), agent/workflow selection, review and submit.
  */
-import React from 'react';
 import { render, screen, fireEvent, waitFor } from '@testing-library/react';
 import '@testing-library/jest-dom';
 

--- a/frontend/src/pages/__tests__/Dashboard.regression.test.tsx
+++ b/frontend/src/pages/__tests__/Dashboard.regression.test.tsx
@@ -4,7 +4,6 @@
  * Covers: metric cards render, loading/error states, lazy sections,
  * chart data computation, weekly data display, growth data computation.
  */
-import React from 'react';
 import { render, screen, waitFor } from '@testing-library/react';
 import '@testing-library/jest-dom';
 
@@ -21,7 +20,7 @@ jest.mock('@/components/PageContainer', () => ({
   PageContainer: ({ children, className }: any) => <div className={className}>{children}</div>,
 }));
 jest.mock('@/components/LazyLoadSection', () => ({
-  LazyLoadSection: ({ children, fallback }: any) => <div data-testid="lazy-section">{children}</div>,
+  LazyLoadSection: ({ children, fallback: _fallback }: any) => <div data-testid="lazy-section">{children}</div>,
 }));
 jest.mock('@/components/ErrorBoundary', () => ({
   ErrorBoundary: ({ children }: any) => <>{children}</>,

--- a/frontend/src/pages/__tests__/DataStores.regression.test.tsx
+++ b/frontend/src/pages/__tests__/DataStores.regression.test.tsx
@@ -4,8 +4,7 @@
  * Covers: renders list, category filter tabs, search input, status icons,
  * create wizard trigger, loading/error/empty states.
  */
-import React from 'react';
-import { render, screen, fireEvent, waitFor, act } from '@testing-library/react';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
 import '@testing-library/jest-dom';
 
 jest.mock('@/components/ui/card', () => ({
@@ -17,7 +16,7 @@ jest.mock('@/components/ui/button', () => ({
   ),
 }));
 jest.mock('@/components/ui/tabs', () => ({
-  Tabs: ({ children, value, onValueChange }: any) => <div data-value={value}>{children}</div>,
+  Tabs: ({ children, value, onValueChange: _onValueChange }: any) => <div data-value={value}>{children}</div>,
   TabsContent: ({ children, value }: any) => <div data-tabcontent={value}>{children}</div>,
   TabsList: ({ children }: any) => <div role="tablist">{children}</div>,
   TabsTrigger: ({ children, value, onClick }: any) => (

--- a/frontend/src/pages/__tests__/ImplementationPage.regression.test.tsx
+++ b/frontend/src/pages/__tests__/ImplementationPage.regression.test.tsx
@@ -4,7 +4,6 @@
  * Covers: loading state, document rendering (markdown), error state with
  * retry, empty state, back button, refresh button.
  */
-import React from 'react';
 import { render, screen, fireEvent, waitFor } from '@testing-library/react';
 import '@testing-library/jest-dom';
 

--- a/frontend/src/pages/__tests__/IntakeRequests.regression.test.tsx
+++ b/frontend/src/pages/__tests__/IntakeRequests.regression.test.tsx
@@ -4,7 +4,6 @@
  * Covers: project list rendering, filter tabs, new project button,
  * loading/error states, subscription setup, polling, project card navigation.
  */
-import React from 'react';
 import { render, screen, fireEvent, waitFor } from '@testing-library/react';
 import '@testing-library/jest-dom';
 

--- a/frontend/src/pages/__tests__/Team.regression.test.tsx
+++ b/frontend/src/pages/__tests__/Team.regression.test.tsx
@@ -4,7 +4,6 @@
  * Covers: user list rendering, role badges, invite user button/modal,
  * admin-only actions, organization management, loading/error states.
  */
-import React from 'react';
 import { render, screen, fireEvent, waitFor } from '@testing-library/react';
 import '@testing-library/jest-dom';
 
@@ -36,7 +35,7 @@ jest.mock('@/components/ui/accordion', () => ({
   AccordionContent: ({ children }: any) => <div>{children}</div>,
 }));
 jest.mock('@/components/ui/select', () => ({
-  Select: ({ children, onValueChange }: any) => <div>{children}</div>,
+  Select: ({ children, onValueChange: _onValueChange }: any) => <div>{children}</div>,
   SelectContent: ({ children }: any) => <div>{children}</div>,
   SelectItem: ({ children, value }: any) => <option value={value}>{children}</option>,
   SelectTrigger: ({ children }: any) => <button>{children}</button>,


### PR DESCRIPTION
## Summary

Follow-up to #57. Fixes the 12 pre-existing TS6133 errors ("declared but never read") across 7 frontend regression test files: unused `React`/`fireEvent`/`waitFor`/`act` imports removed, intentional destructure placeholders underscore-prefixed. Zero logic changes (+5/−11). Frontend `tsc --noEmit` now exits 0, unblocking type-check gating for the frontend later if wanted.

Also investigated but deliberately untouched: the react-router allowlist entry (GHSA-qwww-vcr4-c8h2) — verified "no fix exists" remains true (latest 7.18.2 is inside the vulnerable range `<8.3.0`; no 8.x published). Filed a low finding for the real gap found along the way: the CI audit gate only scans the root lockfile, so frontend advisories are invisible to it.

## Testing

Frontend jest 2,010 passed / 0 failed; `npm run build` green; every hunk reviewed as mechanical.