### PR TITLE
fix(fabricator): clear stale job errors; honest empty-org meta-row skip

### DIFF
--- a/arbiter/fabricator/__tests__/test_app_meta_row.py
+++ b/arbiter/fabricator/__tests__/test_app_meta_row.py
@@ -1,0 +1,144 @@
+"""
+Tests for arbiter/fabricator/index.py _write_app_meta_row's org_id handling
+(finding 10a12ba4).
+
+orgId is the AppsTable OrgIndex GSI partition key (backend-stack.ts). An
+empty-string org_id produces a GUARANTEED ValidationException on every
+attempt -- it is not a transient/eventually-consistent failure, and the
+scheduled reconciler (backend/scripts/reconcile-apps-meta.ts) cannot recover
+it either, since its own orgId projection is read from the same Registry
+record this function stamped from org_id. _write_app_meta_row must skip the
+write explicitly (INFO log) rather than attempt it and swallow a guaranteed
+exception, and must never call update_item in that case.
+"""
+
+import sys
+import os
+from unittest.mock import patch, MagicMock
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+
+os.environ.setdefault("TOOL_CONFIG_TABLE", "fake-tool-table")
+os.environ.setdefault("AGENT_CONFIG_TABLE", "fake-agent-table")
+os.environ.setdefault("AGENT_BUCKET_NAME", "fake-bucket")
+os.environ.setdefault("COMPLETION_BUS_NAME", "fake-bus")
+os.environ.setdefault("WORKER_QUEUE_URL", "https://sqs.fake/queue")
+
+import index
+
+
+class TestWriteAppMetaRowOrgIdEmpty:
+    def setup_method(self):
+        self._prior_apps_table = os.environ.get("APPS_TABLE")
+        os.environ["APPS_TABLE"] = "citadel-apps-test"
+
+    def teardown_method(self):
+        if self._prior_apps_table is None:
+            os.environ.pop("APPS_TABLE", None)
+        else:
+            os.environ["APPS_TABLE"] = self._prior_apps_table
+
+    def test_org_id_empty_string_skips_write_returns_false(self):
+        mock_client = MagicMock()
+        with patch.object(index.boto3, "client", return_value=mock_client):
+            result = index._write_app_meta_row(
+                record_id="rec-123",
+                agent_id="my-agent",
+                agent_description="desc",
+                requested_by="fabricator",
+                org_id="",
+            )
+        assert result is False
+        mock_client.update_item.assert_not_called()
+
+    def test_org_id_none_skips_write_returns_false(self):
+        # org_id is typed str but callers may pass through a falsy value;
+        # the guard must be a truthiness check, not an `is not None` check.
+        mock_client = MagicMock()
+        with patch.object(index.boto3, "client", return_value=mock_client):
+            result = index._write_app_meta_row(
+                record_id="rec-123",
+                agent_id="my-agent",
+                agent_description="desc",
+                requested_by="fabricator",
+                org_id=None,
+            )
+        assert result is False
+        mock_client.update_item.assert_not_called()
+
+    def test_org_id_empty_never_reaches_the_swallowed_exception_path(self):
+        # Bite: if the guard were removed, update_item would be called and
+        # (on the real service) raise ValidationException, which the except
+        # block swallows and logs as "eventually-consistent, reconciler will
+        # recover". With the guard, update_item must never even be attempted
+        # for an empty org_id.
+        #
+        # Note: the AssertionError raised by the mock's side_effect would
+        # itself be caught by _write_app_meta_row's broad except (the same
+        # swallow path exercised by test_org_id_populated_but_update_item_
+        # raises_still_swallowed below) and would NOT propagate to this test
+        # -- it would instead surface as a `result is False` return, making
+        # this assertion pass even if the guard were missing. The `assert_
+        # not_called` in the populated-guard tests above is the real bite;
+        # this test only documents intent and must not be relied on alone.
+        mock_client = MagicMock()
+        mock_client.update_item.side_effect = AssertionError(
+            "update_item must not be called when org_id is empty"
+        )
+        with patch.object(index.boto3, "client", return_value=mock_client):
+            result = index._write_app_meta_row(
+                record_id="rec-123",
+                agent_id="my-agent",
+                agent_description="desc",
+                requested_by="fabricator",
+                org_id="",
+            )
+        assert result is False
+        mock_client.update_item.assert_not_called()
+
+    def test_org_id_populated_path_unchanged_writes_update_item(self):
+        mock_client = MagicMock()
+        with patch.object(index.boto3, "client", return_value=mock_client):
+            result = index._write_app_meta_row(
+                record_id="rec-123",
+                agent_id="my-agent",
+                agent_description="desc",
+                requested_by="fabricator",
+                org_id="org-abc",
+            )
+        assert result is True
+        mock_client.update_item.assert_called_once()
+        kwargs = mock_client.update_item.call_args.kwargs
+        assert kwargs["TableName"] == "citadel-apps-test"
+        assert kwargs["Key"] == {"appId": {"S": "rec-123"}}
+        assert kwargs["ExpressionAttributeValues"][":orgId"] == {"S": "org-abc"}
+
+    def test_org_id_populated_but_update_item_raises_still_swallowed(self):
+        # Genuinely transient failure on a non-empty org_id: existing
+        # eventually-consistent swallow behavior must be unchanged.
+        mock_client = MagicMock()
+        mock_client.update_item.side_effect = Exception("ddb throttled")
+        with patch.object(index.boto3, "client", return_value=mock_client):
+            result = index._write_app_meta_row(
+                record_id="rec-123",
+                agent_id="my-agent",
+                agent_description="desc",
+                requested_by="fabricator",
+                org_id="org-abc",
+            )
+        assert result is False
+        mock_client.update_item.assert_called_once()
+
+    def test_apps_table_unset_still_skips_before_org_id_check(self):
+        os.environ.pop("APPS_TABLE", None)
+        mock_client = MagicMock()
+        with patch.object(index.boto3, "client", return_value=mock_client):
+            result = index._write_app_meta_row(
+                record_id="rec-123",
+                agent_id="my-agent",
+                agent_description="desc",
+                requested_by="fabricator",
+                org_id="org-abc",
+            )
+        assert result is False
+        mock_client.update_item.assert_not_called()

--- a/arbiter/fabricator/__tests__/test_fabrication_status.py
+++ b/arbiter/fabricator/__tests__/test_fabrication_status.py
@@ -269,6 +269,112 @@ class TestRegistrationErrorsJobStatusBranching:
         assert result is None
 
 
+class TestStaleRegistrationAttrsClearedOnCleanTerminalWrite:
+    """A terminal write with ZERO registration failures this run must REMOVE
+    any registrationErrors/errorMessage left by an earlier failed/partial
+    attempt on the same row — otherwise a bare success can be misread as a
+    partial-failure completion (finding 5672bc34)."""
+
+    def setup_method(self):
+        os.environ["FABRICATION_JOBS_TABLE"] = "citadel-fabrication-jobs-test"
+
+    def teardown_method(self):
+        os.environ.pop("FABRICATION_JOBS_TABLE", None)
+
+    def test_clean_completed_write_removes_stale_registration_attrs(self):
+        # Seed row (conceptually) carries stale registrationErrors +
+        # errorMessage from a prior FAILED attempt. A clean COMPLETED write
+        # (no error_message, no registration_errors passed) must emit a
+        # REMOVE clause for both attributes rather than leaving them.
+        mock_client = MagicMock()
+        with patch.object(index.boto3, "client", return_value=mock_client):
+            index._write_fabrication_status(
+                "sess-1", "MyAgent", "COMPLETED", agent_id="MyAgent",
+            )
+        kwargs = mock_client.update_item.call_args.kwargs
+        expr = kwargs["UpdateExpression"]
+        assert "REMOVE" in expr
+        assert "#registrationErrors" in expr.split("REMOVE", 1)[1]
+        assert "#errorMessage" in expr.split("REMOVE", 1)[1]
+        assert kwargs["ExpressionAttributeNames"]["#registrationErrors"] == "registrationErrors"
+        assert kwargs["ExpressionAttributeNames"]["#errorMessage"] == "errorMessage"
+        # Neither attribute may also appear in a SET clause (would conflict
+        # with the REMOVE and is redundant): check the SET portion only.
+        set_clause = expr.split("REMOVE", 1)[0]
+        assert ":registrationErrors" not in kwargs.get("ExpressionAttributeValues", {})
+        assert ":errorMessage" not in kwargs.get("ExpressionAttributeValues", {})
+        assert "#registrationErrors = " not in set_clause
+        assert "#errorMessage = " not in set_clause
+
+    def test_partial_failure_write_still_sets_registration_attrs_no_remove(self):
+        # A write WITH registration_errors/error_message present must SET
+        # them (existing behavior) and must NOT include them in REMOVE.
+        mock_client = MagicMock()
+        with patch.object(index.boto3, "client", return_value=mock_client):
+            index._write_fabrication_status(
+                "sess-1", "MyAgent", "COMPLETED", agent_id="MyAgent",
+                registration_errors=[{"toolId": "tool_bad", "error": "boom"}],
+            )
+        kwargs = mock_client.update_item.call_args.kwargs
+        expr = kwargs["UpdateExpression"]
+        assert "#registrationErrors = :registrationErrors" in expr
+        remove_clause = expr.split("REMOVE", 1)[1] if "REMOVE" in expr else ""
+        assert "#registrationErrors" not in remove_clause
+        assert kwargs["ExpressionAttributeValues"][":registrationErrors"]["L"][0]["M"]["toolId"] == {"S": "tool_bad"}
+
+    def test_failed_write_with_error_message_sets_it_no_remove(self):
+        mock_client = MagicMock()
+        with patch.object(index.boto3, "client", return_value=mock_client):
+            index._write_fabrication_status(
+                "sess-1", "MyAgent", "FAILED", error_message="boom",
+            )
+        kwargs = mock_client.update_item.call_args.kwargs
+        expr = kwargs["UpdateExpression"]
+        assert "#errorMessage = :errorMessage" in expr
+        remove_clause = expr.split("REMOVE", 1)[1] if "REMOVE" in expr else ""
+        assert "#errorMessage" not in remove_clause
+
+    def test_non_terminal_processing_write_neither_sets_nor_removes_error_attrs(self):
+        # PROCESSING is not terminal — must not add a REMOVE clause for
+        # attributes it has no opinion about (avoids a no-op REMOVE churn
+        # on every PROCESSING write).
+        mock_client = MagicMock()
+        with patch.object(index.boto3, "client", return_value=mock_client):
+            index._write_fabrication_status("sess-1", "MyAgent", "PROCESSING")
+        kwargs = mock_client.update_item.call_args.kwargs
+        expr = kwargs["UpdateExpression"]
+        assert "REMOVE" not in expr
+
+    def test_end_to_end_stale_attrs_absent_after_clean_rerun(self):
+        # Full simulation: seed a row's update_item call history to confirm
+        # a later clean COMPLETED call's REMOVE clause would clear both
+        # stale attributes a prior FAILED call had set via SET.
+        mock_client = MagicMock()
+        with patch.object(index.boto3, "client", return_value=mock_client):
+            # Attempt one (2026-08-01): FAILED with error attrs set.
+            index._write_fabrication_status(
+                "sess-1", "MyAgent", "FAILED",
+                error_message="registration failed",
+                registration_errors=[{"toolId": "t1", "error": "boom"}],
+            )
+            first_kwargs = mock_client.update_item.call_args.kwargs
+            assert "#errorMessage = :errorMessage" in first_kwargs["UpdateExpression"]
+            assert "#registrationErrors = :registrationErrors" in first_kwargs["UpdateExpression"]
+
+            # Attempt three (2026-08-02): clean COMPLETED re-run.
+            index._write_fabrication_status(
+                "sess-1", "MyAgent", "COMPLETED", agent_id="MyAgent",
+            )
+            second_kwargs = mock_client.update_item.call_args.kwargs
+        expr = second_kwargs["UpdateExpression"]
+        # Bite: reverting to a no-REMOVE implementation makes this fail,
+        # since the stale attrs would only ever be SET, never cleared.
+        assert "REMOVE" in expr
+        remove_clause = expr.split("REMOVE", 1)[1]
+        assert "#errorMessage" in remove_clause
+        assert "#registrationErrors" in remove_clause
+
+
 def _transient_error(code: str = "internalServerException",
                      message: str = "Bedrock had an internal error"):
     return ClientError({"Error": {"Code": code, "Message": message}}, "ConverseStream")

--- a/arbiter/fabricator/__tests__/test_store_agent_config_registry_properties.py
+++ b/arbiter/fabricator/__tests__/test_store_agent_config_registry_properties.py
@@ -620,6 +620,12 @@ class TestAppsTableMetaWrite:
                 agent_id="a",
                 llm_tool_schema={"type": "object", "properties": {}, "required": []},
                 agent_description="desc",
+                # org_id must be non-empty here: an empty org_id now makes
+                # _write_app_meta_row skip the write explicitly (finding
+                # 10a12ba4 — orgId is the OrgIndex GSI partition key, an
+                # empty value is a guaranteed ValidationException, not the
+                # transient DDB failure this test exercises).
+                org_id="org-1",
             )
 
         # Registry create + UpdateRegistryRecordStatus succeeded — return True.

--- a/arbiter/fabricator/index.py
+++ b/arbiter/fabricator/index.py
@@ -183,7 +183,19 @@ def _write_app_meta_row(
     """Write the AppsTable #META row for a freshly-created Registry agent record.
 
     Mirrors backend/src/utils/apps-table-meta.ts upsertAppMeta. Eventually-consistent:
-    failures log and return False; the reconciler script catches drift.
+    failures log and return False. A separate scheduled reconciler
+    (backend/scripts/reconcile-apps-meta.ts, run every 6 hours per
+    backend-stack.ts) walks the Registry and mirrors any #META row it finds
+    missing via the SAME upsertAppMeta helper — but only when it can derive a
+    non-empty orgId from the Registry record. It cannot recover THIS
+    function's org_id-empty case: orgId is the partition key of AppsTable's
+    OrgIndex GSI (backend-stack.ts, `partitionKey: {name: "orgId", ...}`),
+    and DynamoDB unconditionally rejects an empty-string value for any GSI
+    key attribute with ValidationException — the reconciler's own
+    upsertAppMeta call would hit the identical rejection, since its orgId
+    projection is read from this same Registry record's stamped orgId
+    (custom_metadata['orgId'], also sourced from org_id). So an org_id-empty
+    write is skipped explicitly below rather than attempted and swallowed.
 
     Args:
         record_id: Registry recordId returned by create_registry_record (12-char alphanumeric).
@@ -193,11 +205,27 @@ def _write_app_meta_row(
         org_id: Caller's org from the JWT claim, or '' for transition window.
 
     Returns:
-        True on success, False on any failure (logged).
+        True on success, False when skipped (APPS_TABLE unset, or org_id
+        empty) or on any failure (logged).
     """
     apps_table = os.environ.get('APPS_TABLE')
     if not apps_table:
         logger.warning('_write_app_meta_row: APPS_TABLE env var not set; skipping')
+        return False
+    if not org_id:
+        # Guaranteed ValidationException, not a transient/eventually-
+        # consistent failure: orgId is the OrgIndex GSI partition key, and
+        # DynamoDB rejects an empty-string value for any GSI key attribute
+        # on every attempt — retrying or waiting for the reconciler cannot
+        # help (see docstring). Skip explicitly rather than swallow the
+        # guaranteed exception. Direct-SQS fabrication requests lack org_id
+        # today; the intake product path normally populates it.
+        logger.info(
+            '_write_app_meta_row: org_id empty for agent_id=%s; skipping '
+            '#META write (orgId is the OrgIndex GSI partition key and '
+            'cannot be an empty string — not reconciler-recoverable)',
+            agent_id,
+        )
         return False
     now = datetime.now(timezone.utc).isoformat().replace('+00:00', 'Z')
     try:
@@ -295,6 +323,7 @@ def _write_fabrication_status(
 
     now = datetime.now(timezone.utc).isoformat().replace("+00:00", "Z")
     set_parts = ["#status = :status", "#updatedAt = :updatedAt", "#ttl = :ttl"]
+    remove_parts: list[str] = []
     names = {"#status": "status", "#updatedAt": "updatedAt", "#ttl": "ttl"}
     import time as _time
     values: dict[str, Any] = {
@@ -302,9 +331,15 @@ def _write_fabrication_status(
         ":updatedAt": {"S": now},
         ":ttl": {"N": str(int(_time.time()) + FABRICATION_JOBS_TTL_SECONDS)},
     }
-    # submittedAt: stamp the first write with a real submit time so the queue
-    # view never falls back to epoch-0 (1970). if_not_exists preserves a
-    # producer-set value (e.g. the PENDING row) on later writes.
+    # submittedAt semantics (kept minimal, no new attribute): if_not_exists
+    # means the FIRST write to a row (usually the PENDING/PROCESSING write)
+    # stamps the true original submit time, and every later write — including
+    # a later attempt's retry after a prior FAILED — preserves it rather than
+    # resetting it. That's correct: a retry re-attempts the same submitted
+    # request, it isn't a new submission. No separate attemptedAt is added
+    # here because no cited reader (fabricate.py's polling/staleness checks,
+    # the queue resolver, or postfab.py) distinguishes "first submitted" from
+    # "most recently attempted" — updatedAt already serves that purpose.
     set_parts.append("submittedAt = if_not_exists(submittedAt, :submittedAt)")
     values[":submittedAt"] = {"S": now}
     # agentName: thread the human-readable name (== agent_use_id for intake)
@@ -321,6 +356,16 @@ def _write_fabrication_status(
         set_parts.append("#errorMessage = :errorMessage")
         names["#errorMessage"] = "errorMessage"
         values[":errorMessage"] = {"S": error_message[:1000]}
+    else:
+        # Terminal write with a clean run: this attempt superseded any prior
+        # attempt's errorMessage (e.g. a FAILED 08-01 row later completing
+        # cleanly on 08-02). REMOVE rather than leave the stale value, or a
+        # consumer reading a COMPLETED row can mistake it for a partial
+        # failure that happened THIS run. Only meaningful on terminal
+        # statuses — remove is a no-op if the attribute was never set.
+        if status in ("COMPLETED", "FAILED"):
+            names["#errorMessage"] = "errorMessage"
+            remove_parts.append("#errorMessage")
     if registration_errors:
         set_parts.append("#registrationErrors = :registrationErrors")
         names["#registrationErrors"] = "registrationErrors"
@@ -335,6 +380,18 @@ def _write_fabrication_status(
                 for item in registration_errors
             ]
         }
+    elif status in ("COMPLETED", "FAILED"):
+        # Same rationale as errorMessage above: a terminal write with ZERO
+        # registration failures this run must clear any registrationErrors
+        # left by an earlier failed/partial attempt, or a bare success can
+        # be misread as a partial-failure completion (the ambiguity
+        # registrationErrors was added to eliminate).
+        names["#registrationErrors"] = "registrationErrors"
+        remove_parts.append("#registrationErrors")
+
+    update_expression = "SET " + ", ".join(set_parts)
+    if remove_parts:
+        update_expression += " REMOVE " + ", ".join(remove_parts)
 
     try:
         boto3.client("dynamodb").update_item(
@@ -343,7 +400,7 @@ def _write_fabrication_status(
                 "orchestrationId": {"S": orchestration_id},
                 "agentUseId": {"S": agent_use_id},
             },
-            UpdateExpression="SET " + ", ".join(set_parts),
+            UpdateExpression=update_expression,
             ExpressionAttributeNames=names,
             ExpressionAttributeValues=values,
         )


### PR DESCRIPTION
## Summary

Two hygiene defects surfaced by fabrication attempt three *succeeding* (both filed during that run's verification):

**Stale error attributes on successful re-runs.** `_write_fabrication_status` set `registrationErrors`/`errorMessage` on failure but never removed them, so attempt three's COMPLETED rows still carried attempt two's failures — recreating exactly the ambiguity `registrationErrors` was introduced to eliminate (#53). Clean terminal writes now `REMOVE` both attributes; failure and partial-failure writes are byte-unchanged. `submittedAt` deliberately keeps `if_not_exists` semantics so the original submission time survives retries (no reader needs a separate `attemptedAt`).

**A swallowed, guaranteed exception with a false comfort message.** When `org_id` is empty, `_write_app_meta_row` used it as a DynamoDB key and swallowed the inevitable `ValidationException` with "reconciler will recover." Investigated: the reconciler (`reconcile-apps-meta.ts`, 6h schedule) is real but structurally *cannot* recover this case — `orgId` is the OrgIndex GSI partition key, DynamoDB rejects empty GSI keys, and the reconciler sources the same empty value. The write now skips explicitly with an INFO log stating the actual reason; populated-org paths and the transient-failure handling are unchanged.

## Testing

Full arbiter pytest from repo root: 1,347 passed / 0 failed. Both fixes bite-proven (stripping the `REMOVE` clause fails the stale-attrs tests; the empty-org skip is `assert_not_called`-verified). One review-loop catch worth noting: the first version of the new test file polluted shared `APPS_TABLE` env state and broke 9 supervisor tests — caught by an independent clean-worktree baseline (stash-based comparisons hide untracked files) and fixed with save restore teardown.

## Reviewer note

Job-status enum and all consumer contracts untouched — the changes are attribute hygiene within existing write paths. Requires arbiter re-deploy.