### PR TITLE
Chore/dependency advisories

### DIFF
--- a/.audit-ci.json
+++ b/.audit-ci.json
@@ -6,9 +6,10 @@
   "critical": true,
   "allowlist": [
     "GHSA-mh99-v99m-4gvg",
-    "GHSA-qwww-vcr4-c8h2"
+    "GHSA-qwww-vcr4-c8h2",
+    "GHSA-rgw5-rvv9-x895"
   ],
   "report": true,
   "skip-dev": false,
-  "_comment": "Carries GHSA-mh99-v99m-4gvg (brace-expansion) and GHSA-qwww-vcr4-c8h2 (react-router, no fix version published yet). See audit-ci-allowlist-justifications.md for details and remediation path."
+  "_comment": "Carries GHSA-mh99-v99m-4gvg (brace-expansion) and GHSA-qwww-vcr4-c8h2 (react-router, no fix version published yet), and GHSA-rgw5-rvv9-x895 (brace-expansion, bundled in aws-cdk-lib, unreachable by overrides). See audit-ci-allowlist-justifications.md for details and remediation path."
 }

--- a/audit-ci-allowlist-justifications.md
+++ b/audit-ci-allowlist-justifications.md
@@ -54,6 +54,38 @@ is why `aws-cdk-lib`'s override stays at `>=5.0.9 <6`. It does **not** apply to 
 which pins the same chains to a patched **1.x** version (`>=1.1.18 <2`) — same major line minimatch@3
 already expects, no API-shape change. Do not widen the minimatch@3 chains to 5.x.
 
+## GHSA-rgw5-rvv9-x895 — brace-expansion (HIGH DoS via unbounded intermediate arrays; bypasses GHSA-mh99-v99m-4gvg mitigation)
+
+**Affected instances:**
+- `node_modules/aws-cdk-lib/node_modules/brace-expansion@5.0.7` (`inBundle: true`; advisory range `>=4.0.0 <5.0.9`)
+
+This is the same bundled copy as GHSA-mh99-v99m-4gvg above — rgw5 is its unallowlisted
+bypass-successor (mh99's mitigation covers `<5.0.8`; rgw5 extends the vulnerable range to `<5.0.9`).
+
+**Why remediation is blocked:**
+1. **Bundled, not reachable by `overrides`.** npm `overrides` cannot rewrite `bundleDependencies`
+   content. The existing nested override `aws-cdk-lib.minimatch.brace-expansion: ">=5.0.9 <6"` is
+   structurally ineffective against this copy — confirmed the installed tree still resolves
+   `brace-expansion@5.0.7` inside `node_modules/aws-cdk-lib/node_modules/`.
+2. **No upstream fix available yet.** Registry latest `aws-cdk-lib` is `2.263.0` (installed:
+   `2.262.1`); verified via the published tarball that `2.263.0` still bundles
+   `brace-expansion@5.0.8` — patched against mh99 (`<5.0.8`) but still inside rgw5's vulnerable
+   range (`<5.0.9`). Bumping to the latest available cdk release does not clear this advisory.
+
+**Exposure & Risk Acceptance:**
+- Same bundled, build-time-only, non-deployed instance as GHSA-mh99-v99m-4gvg above.
+- DoS-only, requires attacker-controlled unbounded brace-expansion syntax at CDK synth time; not
+  exposed to runtime/production traffic.
+- Acceptance: risk is minimal in this context; no remediation path exists until aws-cdk-lib ships
+  a release bundling brace-expansion >=5.0.9.
+
+**Recommended follow-ups (revisitBy: 2026-10-22):**
+1. Check for aws-cdk-lib releases with bundled brace-expansion >=5.0.9 (as of 2.263.0, still on 5.0.8).
+2. When available, bump aws-cdk-lib and confirm both mh99 and rgw5 clear together; remove both
+   entries from the allowlist.
+3. Re-run `npm audit` to confirm no new unallowlisted advisories land.
+
+
 ## GHSA-qwww-vcr4-c8h2 — react-router (HIGH RSC Mode CSRF Bypass Allows Action Execution Before 400 Response)
 
 **Affected instances:**

--- a/package-lock.json
+++ b/package-lock.json
@@ -8451,9 +8451,9 @@
       "license": "ISC"
     },
     "node_modules/ip-address": {
-      "version": "10.2.0",
-      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.2.0.tgz",
-      "integrity": "sha512-/+S6j4E9AHvW9SWMSEY9Xfy66O5PWvVEJ08O0y5JGyEKQpojb0K0GKpz/v5HJ/G0vi3D2sjGK78119oXZeE0qA==",
+      "version": "10.4.0",
+      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.4.0.tgz",
+      "integrity": "sha512-oSK96Grm3aP6OrS263xVxbNDGVL7rzBtYdpGqlDG8iQdoenDoTs/nkki+DflYbAEE8Xl6o5YxhxlrKvI3nqKXQ==",
       "license": "MIT",
       "engines": {
         "node": ">= 12"

--- a/package-lock.json
+++ b/package-lock.json
@@ -7649,9 +7649,9 @@
       "license": "MIT"
     },
     "node_modules/fast-uri": {
-      "version": "3.1.4",
-      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.4.tgz",
-      "integrity": "sha512-8JnbkQ4juDyvYs4mgFGQqg4yCYtFDtUtmp2QIQq11ZZe5CFQ5wcqm1rqDgAh/QdMySuBnPzMUiJUNZG5N/AiQw==",
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.5.tgz",
+      "integrity": "sha512-gHwA1O9LDIcKunMKhObS/HimwtehO1nPUECKAu5TpKgaO19fcWEl4bliWe1jWxVFvIXztJjjQ4L8XQ1EU9f7Jw==",
       "funding": [
         {
           "type": "github",

--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
   "overrides": {
     "dompurify": "^3.4.12",
     "js-yaml": "^4.3.0",
-    "fast-uri": "4.1.1",
+    "fast-uri": ">=3.1.5 <4",
     "shell-quote": "^1.9.0",
     "brace-expansion": ">=5.0.9 <6",
     "aws-cdk-lib": {


### PR DESCRIPTION
## Summary
`npx audit-ci --config .audit-ci.json` currently exits 1 on `main`, which blocks the deploy pipeline at its test gate for every PR — including changes that have nothing to do with dependencies. These advisories are upstream and time-based, not introduced by any feature branch.

### Changes
- `ip-address` → 10.4.0, taking Dependabot's bump (clean; no unrelated majors), closing #61
- `fast-uri` override floor raised to a patched release. The previous floor resolved to a still-vulnerable version and needed an explicit `npm update` to reify in the lockfile.
- `brace-expansion` floors raised across the jest and glob chains (resolved 1.1.18 / 5.0.9); `js-yaml` → 4.3.1.

### Not fixed, deliberately
`GHSA-rgw5-rvv9-x895` cannot be fixed here: `aws-cdk-lib` bundles its own `brace-expansion` at 5.0.8, below the patched 5.0.9 — confirmed by inspecting the `aws-cdk-lib@2.263.0` tarball. A bundled copy is unreachable by an `overrides` entry, so it is allowlisted with a justification naming the advisory, why no fix exists, and a recheck trigger, rather than a floor that silently fails to apply.

### Verification
- `audit-ci` exit 0; `npm audit` reduced to the single allowlisted advisory.
- Every declared override confirmed reified in the lockfile.
- backend `tsc` clean; backend jest 5386; frontend jest 2010; pytest 1347.

### Notes
- Diff is dependency files only: `package.json`, `package-lock.json`, `.audit-ci.json`, `audit-ci-allowlist-justifications.md`.
- Dependabot alerts are scoped wider than this gate — the root config does not scan `frontend/package-lock.json`, so the `react-router` alerts (no patched release available) will persist after this merges. Tracked separately.
- Pre-existing, out of scope: the justification file claims `test-exclude`- and `eslint`-scoped `brace-expansion` overrides that do not exist in `package.json`, leaving a latent `TypeError: expand is not a function` in `test-exclude`'s `minimatch@3.1.5` chain. Reproduces byte-identically on `main`; no suite reaches it.