### PR TITLE
Feat/agent releases

### DIFF
--- a/arbiter/common/metrics_constants.py
+++ b/arbiter/common/metrics_constants.py
@@ -61,3 +61,27 @@ UNIT_COUNT = 'Count'
 
 DIMENSION_WORKFLOW_ID = 'WorkflowId'
 DIMENSION_AGENT_ID = 'AgentId'
+
+# Release-aware dispatch (this story): per-mode dispatch outcome counters
+# so the release-gate rollout can be measured before strict is flipped.
+# Mirrors the TS backend tier's METRIC_RELEASE_DISPATCH_EVALUATED /
+# METRIC_RELEASE_DISPATCH_WOULD_BLOCK / METRIC_RELEASE_DISPATCH_REFUSED in
+# backend/src/utils/metrics-constants.ts. Dimensions: WorkflowId (existing,
+# above) plus DIMENSION_RELEASE_MODE and DIMENSION_RELEASE_OUTCOME (both
+# low-cardinality — 3 modes x 4 status literals).
+
+# Emitted on every governed dispatch once RELEASE_DISPATCH_ENVIRONMENT is
+# set, in every mode — the baseline "the gate ran" counter.
+METRIC_RELEASE_DISPATCH_EVALUATED = 'ReleaseDispatchEvaluated'
+
+# Emitted in shadow mode (and, informationally, permissive) whenever the
+# resolution would have caused a refusal had the mode been strict. Never
+# emitted in strict mode itself — strict either proceeds or refuses, it
+# does not also "would-block".
+METRIC_RELEASE_DISPATCH_WOULD_BLOCK = 'ReleaseDispatchWouldBlock'
+
+# Emitted only in strict mode, only when dispatch is actually refused.
+METRIC_RELEASE_DISPATCH_REFUSED = 'ReleaseDispatchRefused'
+
+DIMENSION_RELEASE_MODE = 'ReleaseDispatchMode'
+DIMENSION_RELEASE_OUTCOME = 'ReleaseDispatchOutcome'

--- a/arbiter/governance/__tests__/test_grandfathering.py
+++ b/arbiter/governance/__tests__/test_grandfathering.py
@@ -1,0 +1,76 @@
+"""Tests for the pure grandfathering rule (release-aware dispatch).
+
+Byte-for-byte port of the deterministic branches in
+``backend/src/utils/is-grandfathered.ts``'s ``isGrandfatheredPure`` — same
+rule, same branch order, same conservative-bypass posture on malformed
+input. This is the ONLY grandfathering rule in the codebase; Python does
+not invent a second one, it applies the same one the TS side already
+owns, using whatever created-at signal is actually available to a caller
+(see release_resolution.py, which has none today and always passes
+``created_at=None``).
+"""
+from __future__ import annotations
+
+import os
+import sys
+
+_PROJECT_ROOT = os.path.abspath(
+    os.path.join(os.path.dirname(__file__), "..", "..", "..")
+)
+if _PROJECT_ROOT not in sys.path:
+    sys.path.insert(0, _PROJECT_ROOT)
+
+from arbiter.governance.grandfathering import is_grandfathered_pure  # noqa: E402
+
+
+# ---------------------------------------------------------------------------
+# Pre-shadow-flip (no cutoff) -> everyone grandfathered
+# ---------------------------------------------------------------------------
+
+
+def test_none_effective_at_with_normal_created_at_is_true() -> None:
+    assert is_grandfathered_pure("2026-05-10T00:00:00Z", None) is True
+
+
+def test_empty_string_effective_at_with_normal_created_at_is_true() -> None:
+    assert is_grandfathered_pure("2026-05-10T00:00:00Z", "") is True
+
+
+def test_distant_future_created_at_with_none_cutoff_still_grandfathered() -> None:
+    assert is_grandfathered_pure("9999-12-31T23:59:59Z", None) is True
+
+
+# ---------------------------------------------------------------------------
+# ISO-8601 lexicographic comparison
+# ---------------------------------------------------------------------------
+
+
+def test_created_at_before_effective_at_is_true() -> None:
+    assert is_grandfathered_pure("2026-05-10T00:00:00Z", "2026-05-15T00:00:00Z") is True
+
+
+def test_created_at_equal_to_effective_at_is_false() -> None:
+    assert is_grandfathered_pure("2026-05-15T00:00:00Z", "2026-05-15T00:00:00Z") is False
+
+
+def test_created_at_after_effective_at_is_false() -> None:
+    assert is_grandfathered_pure("2026-05-20T00:00:00Z", "2026-05-15T00:00:00Z") is False
+
+
+# ---------------------------------------------------------------------------
+# Malformed created_at -> conservative bypass (True)
+# ---------------------------------------------------------------------------
+
+
+def test_none_created_at_is_true() -> None:
+    assert is_grandfathered_pure(None, "2026-05-15T00:00:00Z") is True
+
+
+def test_empty_string_created_at_is_true() -> None:
+    assert is_grandfathered_pure("", "2026-05-15T00:00:00Z") is True
+
+
+def test_non_string_created_at_is_true() -> None:
+    # Defensive: a caller could pass a non-string by mistake (e.g. an int
+    # epoch); this must bypass conservatively, not raise or misbehave.
+    assert is_grandfathered_pure(12345, "2026-05-15T00:00:00Z") is True  # type: ignore[arg-type]

--- a/arbiter/governance/__tests__/test_hierarchy_effective_at.py
+++ b/arbiter/governance/__tests__/test_hierarchy_effective_at.py
@@ -1,0 +1,143 @@
+"""Tests for governance effective_at resolution in hierarchy.py.
+
+Covers the SSM-backed ``_resolve_effective_at`` helper and its wiring into
+``GovernanceState.effective_at`` via ``load_governance_state``. Mirrors
+``_resolve_enforcement_mode``'s existing test shape and cache discipline —
+this is the second of the two parameters ``backend/src/utils/
+governance-flag.ts`` reads (``enforce`` was ported first; this ports
+``effective_at``), read from the same parameter path
+(``/citadel/governance/effective_at/{ENVIRONMENT}``).
+"""
+from __future__ import annotations
+
+import os
+import sys
+from typing import Any
+from unittest.mock import MagicMock
+
+import pytest
+
+_PROJECT_ROOT = os.path.abspath(
+    os.path.join(os.path.dirname(__file__), "..", "..", "..")
+)
+if _PROJECT_ROOT not in sys.path:
+    sys.path.insert(0, _PROJECT_ROOT)
+
+from arbiter.governance import hierarchy  # noqa: E402
+from arbiter.governance.hierarchy import (  # noqa: E402
+    load_governance_state,
+    __reset_hierarchy_cache_for_test,
+    __reset_mode_cache_for_test,
+)
+
+
+@pytest.fixture(autouse=True)
+def _reset_caches() -> None:
+    __reset_hierarchy_cache_for_test()
+    __reset_mode_cache_for_test()
+    yield
+    __reset_hierarchy_cache_for_test()
+    __reset_mode_cache_for_test()
+
+
+def _install_fake_ssm(
+    monkeypatch: pytest.MonkeyPatch,
+    enforce_value: str | None,
+    effective_at_value: str | None,
+    *,
+    effective_at_raises: bool = False,
+) -> MagicMock:
+    """Patch boto3.client('ssm') to answer both GetParameter calls."""
+    fake_client = MagicMock()
+
+    def _get_parameter(Name: str, **_kw: Any) -> Any:
+        if Name.startswith("/citadel/governance/enforce/"):
+            if enforce_value is None:
+                raise Exception("ParameterNotFound (simulated)")
+            return {"Parameter": {"Value": enforce_value}}
+        if Name.startswith("/citadel/governance/effective_at/"):
+            if effective_at_raises:
+                raise Exception("ParameterNotFound (simulated)")
+            return {"Parameter": {"Value": effective_at_value}}
+        raise AssertionError(f"unexpected parameter name: {Name}")
+
+    fake_client.get_parameter.side_effect = _get_parameter
+
+    def _client(service_name: str, *a: Any, **kw: Any) -> Any:
+        assert service_name == "ssm"
+        return fake_client
+
+    monkeypatch.setattr(hierarchy.boto3, "client", _client)
+    return fake_client
+
+
+def _stub_ddb_empty(monkeypatch: pytest.MonkeyPatch) -> None:
+    for name in (
+        "AUTHORITY_UNITS_TABLE",
+        "COMPOSITION_CONTRACTS_TABLE",
+        "CASE_LAW_TABLE",
+        "CONSTITUTIONAL_LAYERS_TABLE",
+    ):
+        monkeypatch.delenv(name, raising=False)
+
+
+def test_no_environment_var_skips_ssm_and_defaults_none(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.delenv("ENVIRONMENT", raising=False)
+    _stub_ddb_empty(monkeypatch)
+
+    def _should_not_call(service_name: str, *a: Any, **kw: Any) -> Any:
+        raise AssertionError("boto3.client('ssm') must not be called when ENVIRONMENT is unset")
+
+    monkeypatch.setattr(hierarchy.boto3, "client", _should_not_call)
+
+    state = load_governance_state()
+
+    assert state.effective_at is None
+
+
+def test_valid_effective_at_value_is_used_directly(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("ENVIRONMENT", "test-env")
+    _stub_ddb_empty(monkeypatch)
+    fake_client = _install_fake_ssm(monkeypatch, "shadow", "2026-05-15T00:00:00Z")
+
+    state = load_governance_state()
+
+    assert state.effective_at == "2026-05-15T00:00:00Z"
+    fake_client.get_parameter.assert_any_call(
+        Name="/citadel/governance/effective_at/test-env"
+    )
+
+
+def test_empty_string_effective_at_normalizes_to_none(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("ENVIRONMENT", "test-env")
+    _stub_ddb_empty(monkeypatch)
+    _install_fake_ssm(monkeypatch, "shadow", "")
+
+    state = load_governance_state()
+
+    assert state.effective_at is None
+
+
+def test_missing_effective_at_param_defaults_to_none(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("ENVIRONMENT", "test-env")
+    _stub_ddb_empty(monkeypatch)
+    _install_fake_ssm(monkeypatch, "shadow", None, effective_at_raises=True)
+
+    state = load_governance_state()
+
+    assert state.effective_at is None
+
+
+def test_effective_at_is_cached_within_ttl(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("ENVIRONMENT", "test-env")
+    _stub_ddb_empty(monkeypatch)
+    fake_client = _install_fake_ssm(monkeypatch, "strict", "2026-05-15T00:00:00Z")
+
+    load_governance_state()
+    load_governance_state()
+
+    # One enforce + one effective_at call per resolution, cached on the
+    # second load_governance_state() call.
+    assert fake_client.get_parameter.call_count == 2

--- a/arbiter/governance/__tests__/test_hierarchy_enforcement_mode.py
+++ b/arbiter/governance/__tests__/test_hierarchy_enforcement_mode.py
@@ -40,12 +40,23 @@ def _reset_caches() -> None:
 
 
 def _install_fake_ssm(monkeypatch: pytest.MonkeyPatch, value: str | None) -> MagicMock:
-    """Patch boto3.client('ssm') to return ``value`` for GetParameter."""
+    """Patch boto3.client('ssm') to return ``value`` for the enforce-mode
+    GetParameter call. The sibling effective_at parameter (also read by
+    load_governance_state -> _resolve_effective_at) is answered with an
+    empty value so it never affects these enforcement-mode-focused
+    assertions; effective_at has its own dedicated test module
+    (test_hierarchy_effective_at.py).
+    """
     fake_client = MagicMock()
-    if value is None:
-        fake_client.get_parameter.side_effect = Exception("ParameterNotFound (simulated)")
-    else:
-        fake_client.get_parameter.return_value = {"Parameter": {"Value": value}}
+
+    def _get_parameter(Name: str, **_kw: Any) -> Any:
+        if Name.startswith("/citadel/governance/effective_at/"):
+            return {"Parameter": {"Value": ""}}
+        if value is None:
+            raise Exception("ParameterNotFound (simulated)")
+        return {"Parameter": {"Value": value}}
+
+    fake_client.get_parameter.side_effect = _get_parameter
 
     def _client(service_name: str, *a: Any, **kw: Any) -> Any:
         assert service_name == "ssm"
@@ -53,6 +64,17 @@ def _install_fake_ssm(monkeypatch: pytest.MonkeyPatch, value: str | None) -> Mag
 
     monkeypatch.setattr(hierarchy.boto3, "client", _client)
     return fake_client
+
+
+def _enforce_calls(fake_client: MagicMock) -> list[Any]:
+    """Filter the fake client's recorded calls to just the enforce-mode
+    parameter, so effective_at's sibling call (added alongside this test
+    module) never perturbs these mode-focused call-count assertions."""
+    return [
+        call
+        for call in fake_client.get_parameter.call_args_list
+        if call.kwargs.get("Name", "").startswith("/citadel/governance/enforce/")
+    ]
 
 
 def _stub_ddb_empty(monkeypatch: pytest.MonkeyPatch) -> None:
@@ -103,9 +125,7 @@ def test_valid_ssm_value_is_used_directly(
     state = load_governance_state()
 
     assert state.enforcement_mode == mode
-    fake_client.get_parameter.assert_called_once_with(
-        Name="/citadel/governance/enforce/test-env"
-    )
+    assert len(_enforce_calls(fake_client)) == 1
 
 
 # ---------------------------------------------------------------------------
@@ -158,7 +178,7 @@ def test_mode_is_cached_within_ttl(monkeypatch: pytest.MonkeyPatch) -> None:
     load_governance_state()
     load_governance_state()  # cache hit on both DDB state and mode
 
-    assert fake_client.get_parameter.call_count == 1
+    assert len(_enforce_calls(fake_client)) == 1
 
 
 def test_explicit_force_reload_also_refreshes_mode(monkeypatch: pytest.MonkeyPatch) -> None:
@@ -171,7 +191,7 @@ def test_explicit_force_reload_also_refreshes_mode(monkeypatch: pytest.MonkeyPat
     load_governance_state(force_reload=True)
     load_governance_state(force_reload=True)
 
-    assert fake_client.get_parameter.call_count == 2
+    assert len(_enforce_calls(fake_client)) == 2
 
 
 def test_force_reload_refreshes_mode_after_ttl(monkeypatch: pytest.MonkeyPatch) -> None:
@@ -183,8 +203,8 @@ def test_force_reload_refreshes_mode_after_ttl(monkeypatch: pytest.MonkeyPatch) 
     monkeypatch.setattr(hierarchy.time, "time", lambda: fake_now[0])
 
     load_governance_state()
-    assert fake_client.get_parameter.call_count == 1
+    assert len(_enforce_calls(fake_client)) == 1
 
     fake_now[0] = 1000.0 + hierarchy._MODE_CACHE_TTL_SECONDS + 1
     load_governance_state(force_reload=True)
-    assert fake_client.get_parameter.call_count == 2
+    assert len(_enforce_calls(fake_client)) == 2

--- a/arbiter/governance/__tests__/test_release_resolution.py
+++ b/arbiter/governance/__tests__/test_release_resolution.py
@@ -1,0 +1,307 @@
+"""Tests for arbiter/governance/release_resolution.py.
+
+Covers the read-only (GetItem-only) pointer -> release resolution used by
+the release-aware dispatch gate. Three distinct outcomes are asserted
+throughout, per the module's fail-closed doctrine:
+
+  * RESOLVED       — pointer + release both found.
+  * NO_POINTER     — clean "not configured yet" (table unset, or a GetItem
+                      that returns no Item). This is the backward-
+                      compatible case: an existing deployment with no
+                      pointers/releases must land here, not in
+                      LOOKUP_FAILED.
+  * LOOKUP_FAILED  — the lookup itself raised (throttle, network,
+                      permissions, or a resolved table name that does not
+                      exist). Distinct from NO_POINTER because the
+                      established doctrine (this codebase's governance
+                      layer: design_assessment_gate's env-unset no-op vs.
+                      hierarchy.py's SSM-failure-vs-missing-param split) is
+                      assert-or-refuse in strict mode: a failed lookup must
+                      never be silently treated as "no release, proceed".
+"""
+from __future__ import annotations
+
+import os
+import sys
+from typing import Any
+from unittest.mock import MagicMock
+
+import pytest
+from botocore.exceptions import ClientError
+
+_PROJECT_ROOT = os.path.abspath(
+    os.path.join(os.path.dirname(__file__), "..", "..", "..")
+)
+if _PROJECT_ROOT not in sys.path:
+    sys.path.insert(0, _PROJECT_ROOT)
+
+from arbiter.governance import release_resolution as rr  # noqa: E402
+from arbiter.governance.release_resolution import (  # noqa: E402
+    ReleaseResolutionStatus,
+    resolve_release,
+    __reset_clients_for_test,
+)
+
+
+@pytest.fixture(autouse=True)
+def _reset() -> None:
+    __reset_clients_for_test()
+    yield
+    __reset_clients_for_test()
+
+
+def _client_error(code: str) -> ClientError:
+    return ClientError(
+        {"Error": {"Code": code, "Message": "simulated"}},
+        "GetItem",
+    )
+
+
+# ---------------------------------------------------------------------------
+# Tables unset -> clean NO_POINTER, zero AWS calls (mirrors
+# design_assessment_gate's AGENT_DESIGN_ASSESSMENTS_TABLE-unset no-op).
+# ---------------------------------------------------------------------------
+
+
+def test_no_pointer_table_env_unset_is_no_pointer_with_zero_calls(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.delenv("ENVIRONMENT_RELEASE_POINTERS_TABLE", raising=False)
+    monkeypatch.delenv("AGENT_RELEASES_TABLE", raising=False)
+
+    should_not_be_called = MagicMock()
+    monkeypatch.setattr(rr.boto3, "resource", should_not_be_called)
+
+    result = resolve_release(org_id="org-1", agent_target_id="agent-1", environment="PROD")
+
+    assert result.status == ReleaseResolutionStatus.NO_POINTER
+    assert result.release is None
+    should_not_be_called.assert_not_called()
+
+
+def test_release_table_env_unset_is_no_pointer_even_if_pointer_table_set(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Backward-compat: a partially-provisioned environment (pointer table
+    exists, releases table doesn't — or vice versa) must still degrade to
+    NO_POINTER, not crash or fabricate a release."""
+    monkeypatch.setenv("ENVIRONMENT_RELEASE_POINTERS_TABLE", "pointers-table")
+    monkeypatch.delenv("AGENT_RELEASES_TABLE", raising=False)
+
+    result = resolve_release(org_id="org-1", agent_target_id="agent-1", environment="PROD")
+
+    assert result.status == ReleaseResolutionStatus.NO_POINTER
+    assert result.release is None
+
+
+# ---------------------------------------------------------------------------
+# Pointer GetItem returns no Item -> clean NO_POINTER (never queries the
+# releases table — nothing to look up).
+# ---------------------------------------------------------------------------
+
+
+def test_pointer_missing_is_no_pointer(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("ENVIRONMENT_RELEASE_POINTERS_TABLE", "pointers-table")
+    monkeypatch.setenv("AGENT_RELEASES_TABLE", "releases-table")
+
+    pointers_table = MagicMock()
+    pointers_table.get_item.return_value = {}  # no 'Item' key
+    releases_table = MagicMock()
+
+    def _fake_resource(service_name: str, *a: Any, **kw: Any) -> Any:
+        assert service_name == "dynamodb"
+        fake = MagicMock()
+        fake.Table.side_effect = lambda name: (
+            pointers_table if name == "pointers-table" else releases_table
+        )
+        return fake
+
+    monkeypatch.setattr(rr.boto3, "resource", _fake_resource)
+
+    result = resolve_release(org_id="org-1", agent_target_id="agent-1", environment="PROD")
+
+    assert result.status == ReleaseResolutionStatus.NO_POINTER
+    assert result.release is None
+    releases_table.get_item.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# Pointer found, release found -> RESOLVED.
+# ---------------------------------------------------------------------------
+
+
+def test_pointer_and_release_found_is_resolved(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("ENVIRONMENT_RELEASE_POINTERS_TABLE", "pointers-table")
+    monkeypatch.setenv("AGENT_RELEASES_TABLE", "releases-table")
+
+    pointer_item = {
+        "orgId": "org-1",
+        "agentTargetId_environment": "agent-1#PROD",
+        "releaseId": "sha256-abc",
+        "version": 3,
+    }
+    release_item = {"releaseId": "sha256-abc", "orgId": "org-1", "agentTargetId": "agent-1"}
+
+    pointers_table = MagicMock()
+    pointers_table.get_item.return_value = {"Item": pointer_item}
+    releases_table = MagicMock()
+    releases_table.get_item.return_value = {"Item": release_item}
+
+    def _fake_resource(service_name: str, *a: Any, **kw: Any) -> Any:
+        fake = MagicMock()
+        fake.Table.side_effect = lambda name: (
+            pointers_table if name == "pointers-table" else releases_table
+        )
+        return fake
+
+    monkeypatch.setattr(rr.boto3, "resource", _fake_resource)
+
+    result = resolve_release(org_id="org-1", agent_target_id="agent-1", environment="PROD")
+
+    assert result.status == ReleaseResolutionStatus.RESOLVED
+    assert result.release == release_item
+    pointers_table.get_item.assert_called_once_with(
+        Key={"orgId": "org-1", "agentTargetId_environment": "agent-1#PROD"}
+    )
+    releases_table.get_item.assert_called_once_with(Key={"releaseId": "sha256-abc"})
+
+
+# ---------------------------------------------------------------------------
+# Pointer found but release row itself missing (dangling pointer) ->
+# LOOKUP_FAILED. A pointer that resolves to no release is NOT the clean
+# "no release" case (that's NO_POINTER when the POINTER itself is absent);
+# it is a data-integrity failure the same way any other lookup failure is
+# — the promise of the immutable-release table (release-store.ts: rows are
+# create-only, never deleted) means a dangling pointer indicates something
+# is wrong with the read path, not a normal "not yet promoted" state.
+# ---------------------------------------------------------------------------
+
+
+def test_pointer_found_but_release_row_missing_is_lookup_failed(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("ENVIRONMENT_RELEASE_POINTERS_TABLE", "pointers-table")
+    monkeypatch.setenv("AGENT_RELEASES_TABLE", "releases-table")
+
+    pointer_item = {
+        "orgId": "org-1",
+        "agentTargetId_environment": "agent-1#PROD",
+        "releaseId": "sha256-abc",
+        "version": 1,
+    }
+    pointers_table = MagicMock()
+    pointers_table.get_item.return_value = {"Item": pointer_item}
+    releases_table = MagicMock()
+    releases_table.get_item.return_value = {}  # dangling pointer
+
+    def _fake_resource(service_name: str, *a: Any, **kw: Any) -> Any:
+        fake = MagicMock()
+        fake.Table.side_effect = lambda name: (
+            pointers_table if name == "pointers-table" else releases_table
+        )
+        return fake
+
+    monkeypatch.setattr(rr.boto3, "resource", _fake_resource)
+
+    result = resolve_release(org_id="org-1", agent_target_id="agent-1", environment="PROD")
+
+    assert result.status == ReleaseResolutionStatus.LOOKUP_FAILED
+    assert result.release is None
+    assert "dangling" in (result.error or "").lower()
+
+
+# ---------------------------------------------------------------------------
+# The lookup ITSELF fails (throttle / network / missing table) ->
+# LOOKUP_FAILED, distinct from a clean NO_POINTER. This is the doctrine
+# this task requires: assert-or-refuse, not warn-and-proceed.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "error_code",
+    ["ProvisionedThroughputExceededException", "ResourceNotFoundException", "ThrottlingException"],
+)
+def test_pointer_lookup_raising_is_lookup_failed(
+    monkeypatch: pytest.MonkeyPatch, error_code: str
+) -> None:
+    monkeypatch.setenv("ENVIRONMENT_RELEASE_POINTERS_TABLE", "pointers-table")
+    monkeypatch.setenv("AGENT_RELEASES_TABLE", "releases-table")
+
+    pointers_table = MagicMock()
+    pointers_table.get_item.side_effect = _client_error(error_code)
+    releases_table = MagicMock()
+
+    def _fake_resource(service_name: str, *a: Any, **kw: Any) -> Any:
+        fake = MagicMock()
+        fake.Table.side_effect = lambda name: (
+            pointers_table if name == "pointers-table" else releases_table
+        )
+        return fake
+
+    monkeypatch.setattr(rr.boto3, "resource", _fake_resource)
+
+    result = resolve_release(org_id="org-1", agent_target_id="agent-1", environment="PROD")
+
+    assert result.status == ReleaseResolutionStatus.LOOKUP_FAILED
+    assert result.release is None
+    assert result.error is not None
+    releases_table.get_item.assert_not_called()
+
+
+def test_release_lookup_raising_after_pointer_found_is_lookup_failed(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("ENVIRONMENT_RELEASE_POINTERS_TABLE", "pointers-table")
+    monkeypatch.setenv("AGENT_RELEASES_TABLE", "releases-table")
+
+    pointer_item = {
+        "orgId": "org-1",
+        "agentTargetId_environment": "agent-1#PROD",
+        "releaseId": "sha256-abc",
+        "version": 1,
+    }
+    pointers_table = MagicMock()
+    pointers_table.get_item.return_value = {"Item": pointer_item}
+    releases_table = MagicMock()
+    releases_table.get_item.side_effect = _client_error("InternalServerError")
+
+    def _fake_resource(service_name: str, *a: Any, **kw: Any) -> Any:
+        fake = MagicMock()
+        fake.Table.side_effect = lambda name: (
+            pointers_table if name == "pointers-table" else releases_table
+        )
+        return fake
+
+    monkeypatch.setattr(rr.boto3, "resource", _fake_resource)
+
+    result = resolve_release(org_id="org-1", agent_target_id="agent-1", environment="PROD")
+
+    assert result.status == ReleaseResolutionStatus.LOOKUP_FAILED
+    assert result.release is None
+
+
+def test_unexpected_exception_type_is_also_lookup_failed(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Not just ClientError — any exception from the lookup path (e.g. a
+    malformed response causing a KeyError/TypeError) must resolve to
+    LOOKUP_FAILED, never propagate and never silently become NO_POINTER."""
+    monkeypatch.setenv("ENVIRONMENT_RELEASE_POINTERS_TABLE", "pointers-table")
+    monkeypatch.setenv("AGENT_RELEASES_TABLE", "releases-table")
+
+    pointers_table = MagicMock()
+    pointers_table.get_item.side_effect = TypeError("simulated malformed response")
+    releases_table = MagicMock()
+
+    def _fake_resource(service_name: str, *a: Any, **kw: Any) -> Any:
+        fake = MagicMock()
+        fake.Table.side_effect = lambda name: (
+            pointers_table if name == "pointers-table" else releases_table
+        )
+        return fake
+
+    monkeypatch.setattr(rr.boto3, "resource", _fake_resource)
+
+    result = resolve_release(org_id="org-1", agent_target_id="agent-1", environment="PROD")
+
+    assert result.status == ReleaseResolutionStatus.LOOKUP_FAILED

--- a/arbiter/governance/grandfathering.py
+++ b/arbiter/governance/grandfathering.py
@@ -1,0 +1,65 @@
+"""Grandfathering rule (release-aware dispatch) — Python port.
+
+Byte-for-byte port of the deterministic branches in
+``backend/src/utils/is-grandfathered.ts``'s ``isGrandfatheredPure``. This
+is deliberately a PORT of the existing rule, not a second rule: the two
+functions must always agree given the same two arguments, so any change
+to one's branch logic must be mirrored in the other.
+
+Why a port instead of a cross-language call: the TS helper's I/O wrapper
+(``isGrandfathered``) reads SSM via a Lambda-only in-process cache and is
+not reachable from the long-running Python arbiter processes (supervisor
+Lambda and stepRunner Lambda run in a different runtime with their own
+SSM-backed mode cache in ``hierarchy.py``). The PURE rule below has no I/O
+and is safe to duplicate verbatim; the I/O-bound SSM read for
+``effective_at`` lives in ``hierarchy.py`` (see ``_resolve_effective_at``),
+mirroring the same parameter path
+(``/citadel/governance/effective_at/{ENVIRONMENT}``) the TS
+``governance-flag.ts`` reader uses, exactly the same way
+``_resolve_enforcement_mode`` already mirrors ``governance-flag.ts``'s
+``enforce`` parameter.
+
+Callers supply whatever ``created_at`` signal they actually have. The
+release-dispatch gate (``release_resolution.py`` / the supervisor and
+stepRunner dispatch call sites) has no reliable per-agent creation
+timestamp today — the arbiter's agent config and workflow node dicts carry
+no ``createdAt`` field, and org/agent registry lookups are optional
+(``REGISTRY_ENABLED``) — so it always calls this with ``created_at=None``.
+That is not a special case here: ``created_at=None`` already falls into
+the "malformed input -> conservative bypass" branch the TS rule defines
+for exactly this situation (missing/absent data must never harden into a
+block), so no additional branching is needed to accommodate it.
+"""
+from __future__ import annotations
+
+from typing import Any
+
+
+def is_grandfathered_pure(
+    created_at: Any,
+    effective_at: str | None,
+) -> bool:
+    """Pure implementation of the grandfathering rule.
+
+    Rule (mirrors ``isGrandfatheredPure`` in ``is-grandfathered.ts``):
+      - ``effective_at`` is ``None`` or ``''`` -> True (pre-shadow-flip;
+        everyone grandfathered).
+      - malformed ``created_at`` (not a non-empty string) -> True
+        (conservative bypass — a data defect must not become a hard
+        failure).
+      - ``created_at < effective_at`` (ISO-8601 lexicographic
+        comparison) -> True.
+      - ``created_at == effective_at`` -> False (the exact cutoff is NOT
+        grandfathered).
+      - ``created_at > effective_at`` -> False.
+    """
+    # Pre-shadow-flip (no cutoff set): everyone is grandfathered.
+    if effective_at is None or effective_at == "":
+        return True
+    # Conservative fallback for malformed/absent created_at data: bypass
+    # rather than block.
+    if not isinstance(created_at, str) or created_at == "":
+        return True
+    # ISO-8601 strings compare correctly lexicographically when
+    # timezone-normalized, matching the TS side's string comparison.
+    return created_at < effective_at

--- a/arbiter/governance/hierarchy.py
+++ b/arbiter/governance/hierarchy.py
@@ -58,6 +58,19 @@ _DEFAULT_ENFORCEMENT_MODE = "shadow"
 # Maps env name to (mode, loaded_at).
 _mode_cache: dict[str, tuple[str, float]] = {}
 
+# effective_at cache — same TTL/cache shape as the enforcement-mode cache
+# above (independent SSM parameter, same env-scoped cache key). Mirrors the
+# second parameter ``backend/src/utils/governance-flag.ts`` reads
+# (``getGovernanceEffectiveAt``). ``None`` means "no cutoff set" (pre-flip),
+# which is the value the grandfathering rule
+# (``arbiter/governance/grandfathering.py``) treats as "grandfather
+# everyone" — same semantics as the TS reader's ``effectiveAt: string |
+# null``.
+_EFFECTIVE_AT_CACHE_TTL_SECONDS = 300
+
+# Maps env name to (effective_at, loaded_at).
+_effective_at_cache: dict[str, tuple[str | None, float]] = {}
+
 
 # ---------------------------------------------------------------------------
 # Public dataclass
@@ -89,6 +102,14 @@ class GovernanceState:
     loaded_at: float = 0.0
     registry_id: str | None = None
     enforcement_mode: str = _DEFAULT_ENFORCEMENT_MODE
+    # The persisted grandfathering cutoff (``/citadel/governance/
+    # effective_at/{env}``), resolved from the same SSM-backed control
+    # surface as ``enforcement_mode`` — see ``_resolve_effective_at``.
+    # ``None`` means no cutoff has been written yet (pre-shadow-flip);
+    # every grandfathering check for that state treats every subject as
+    # grandfathered, matching ``is_grandfathered_pure``'s ``None``/``''``
+    # branch and the TS reader's ``effectiveAt: string | null`` contract.
+    effective_at: str | None = None
 
 
 # ---------------------------------------------------------------------------
@@ -476,6 +497,72 @@ def __reset_mode_cache_for_test() -> None:
     _mode_cache.clear()
 
 
+def _resolve_effective_at(force_reload: bool = False) -> str | None:
+    """Resolve the persisted grandfathering cutoff.
+
+    Reads the SSM parameter ``/citadel/governance/effective_at/{ENVIRONMENT}``
+    — the second parameter the TypeScript governance-flag reader
+    (``getGovernanceEffectiveAt`` in ``backend/src/utils/
+    governance-flag.ts``) consults, alongside ``enforce`` (see
+    ``_resolve_enforcement_mode`` above, which this function mirrors
+    structurally: same cache shape, same env-unset short-circuit, same
+    fail-soft posture on any SSM error).
+
+    Returns ``None`` when: ``ENVIRONMENT`` is unset, the parameter does not
+    exist, the value is empty, or the SSM call raises for any reason
+    (permissions, throttling, network). ``None`` is itself a meaningful,
+    valid value here (not a degraded fallback like
+    ``_DEFAULT_ENFORCEMENT_MODE``) — it means "no cutoff has been written
+    yet", which the grandfathering rule (``grandfathering.py``) already
+    treats as "grandfather everyone". There is deliberately no
+    default-to-a-literal-string fallback the way enforcement mode falls
+    back to ``'shadow'``: an unresolvable cutoff must never manufacture a
+    real-looking date that could accidentally un-grandfather a subject.
+
+    Cached in-process for ``_EFFECTIVE_AT_CACHE_TTL_SECONDS`` per
+    environment name, independently of the enforcement-mode cache.
+    """
+    env_name = os.environ.get("ENVIRONMENT")
+    if not env_name:
+        return None
+
+    now = time.time()
+
+    if not force_reload:
+        cached = _effective_at_cache.get(env_name)
+        if cached is not None:
+            effective_at, loaded_at = cached
+            if now - loaded_at < _EFFECTIVE_AT_CACHE_TTL_SECONDS:
+                return effective_at
+
+    resolved: str | None = None
+    try:
+        response = _get_ssm_client().get_parameter(
+            Name=f"/citadel/governance/effective_at/{env_name}"
+        )
+        raw_value = response.get("Parameter", {}).get("Value")
+        if raw_value:
+            resolved = raw_value
+    except Exception as e:
+        # Any SSM failure (missing param, permissions, throttling, network)
+        # resolves to None (no cutoff), same fail-soft posture as
+        # _resolve_enforcement_mode's SSM-failure branch, logged the same
+        # way for operator visibility.
+        logger.warning(
+            "Failed to resolve governance effective_at from SSM for "
+            "env=%s; defaulting to no cutoff (None). Error: %s",
+            env_name, e,
+        )
+
+    _effective_at_cache[env_name] = (resolved, now)
+    return resolved
+
+
+def __reset_effective_at_cache_for_test() -> None:
+    """Clear the process-local effective_at cache. Test-only helper."""
+    _effective_at_cache.clear()
+
+
 # ---------------------------------------------------------------------------
 # Public entry points
 # ---------------------------------------------------------------------------
@@ -517,6 +604,7 @@ def load_governance_state(
     case_law = _load_case_law()
     constitutional_layers = _load_constitutional_layers()
     enforcement_mode = _resolve_enforcement_mode(force_reload=force_reload)
+    effective_at = _resolve_effective_at(force_reload=force_reload)
 
     loaded_at = time.time()
     state = GovernanceState(
@@ -527,6 +615,7 @@ def load_governance_state(
         loaded_at=loaded_at,
         registry_id=registry_id,
         enforcement_mode=enforcement_mode,
+        effective_at=effective_at,
     )
     _cache[cache_key] = (state, loaded_at)
 
@@ -551,3 +640,4 @@ def __reset_hierarchy_cache_for_test() -> None:
     """
     _cache.clear()
     _mode_cache.clear()
+    _effective_at_cache.clear()

--- a/arbiter/governance/release_resolution.py
+++ b/arbiter/governance/release_resolution.py
@@ -1,0 +1,190 @@
+"""Read-only pointer -> release resolution for release-aware dispatch.
+
+Resolves an (org_id, agent_target_id, environment) triple to the
+AgentRelease it currently points at, by reading (never writing)
+EnvironmentReleasePointersTable then AgentReleasesTable. Mirrors
+``environment-release-pointer-store.ts``'s key schema exactly:
+  - pointer PK/SK: ``orgId`` / ``agentTargetId_environment`` =
+    ``f"{agent_target_id}#{environment}"`` (see
+    ``environment-release-pointer-store.ts``'s ``sortKey``).
+  - release PK: ``releaseId`` (see ``release-store.ts``).
+
+IAM floor (enforced at the CDK layer, not here): GetItem/Query only on
+both tables. This module never issues Put/Update/Delete against either —
+mirrors the fabricator's design-assessment gate
+(``arbiter/fabricator/design_assessment_gate.py``), which is the
+established pattern in this codebase for a Python read-only precondition
+gate against a table it does not own.
+
+Three-way outcome (ReleaseResolutionStatus), not a boolean, because the
+release-dispatch gate's strict-mode doctrine depends on distinguishing
+"cleanly resolved to no release" from "the lookup itself failed":
+
+  * RESOLVED      — pointer row found, release row found. ``release`` set.
+  * NO_POINTER    — no pointer row exists (either table's env var is
+                    unset — table not provisioned in this deployment,
+                    same forward-compatible convention as
+                    ``design_assessment_gate.py``'s
+                    ``AGENT_DESIGN_ASSESSMENTS_TABLE``-unset no-op — or the
+                    pointer GetItem returned no Item). This is the
+                    BACKWARD-COMPATIBILITY case: an existing deployment
+                    with no releases/pointers must land here on every
+                    dispatch, indistinguishable from "not using releases
+                    yet".
+  * LOOKUP_FAILED — the lookup itself could not be completed: a DynamoDB
+                    exception (throttle, permissions, network, a
+                    misconfigured table name that does not exist), OR a
+                    pointer that resolves to a releaseId with no matching
+                    row in AgentReleasesTable (a "dangling pointer" —
+                    since releases are create-only and never deleted
+                    (release-store.ts), a pointer whose releaseId doesn't
+                    resolve is a data-integrity failure, not a normal "not
+                    yet promoted" state, and must be treated the same as
+                    any other lookup failure).
+
+Why LOOKUP_FAILED is not silently folded into NO_POINTER: this codebase's
+established doctrine (see hierarchy.py's SSM-failure handling and the
+class-level guidance this task follows) is assert-or-refuse, not
+warn-and-proceed, for a failed control-surface read in strict mode. A
+throttled/broken lookup and a clean "nothing configured yet" state must
+remain observably distinct all the way up to the dispatch gate, so strict
+mode can refuse on the former while still being backward-compatible with
+the latter.
+"""
+from __future__ import annotations
+
+import os
+from dataclasses import dataclass
+from enum import Enum
+from typing import Any
+
+import boto3
+from botocore.exceptions import ClientError
+
+_dynamodb = None
+
+
+def _get_resource() -> Any:
+    """Lazy boto3 resource construction (mirrors design_assessment_gate.py
+    and registry_client.py's QB-013-1 pattern: constructing the resource
+    at import time triggers credential resolution, which fails in
+    credential-less test/local-dev environments)."""
+    global _dynamodb
+    if _dynamodb is None:
+        _dynamodb = boto3.resource("dynamodb")
+    return _dynamodb
+
+
+def __reset_clients_for_test() -> None:
+    """Test-only hook — forces the next call to rebuild the cached resource."""
+    global _dynamodb
+    _dynamodb = None
+
+
+def _pointer_table_name() -> str | None:
+    return os.environ.get("ENVIRONMENT_RELEASE_POINTERS_TABLE") or None
+
+
+def _release_table_name() -> str | None:
+    return os.environ.get("AGENT_RELEASES_TABLE") or None
+
+
+def _pointer_sort_key(agent_target_id: str, environment: str) -> str:
+    """Mirrors environment-release-pointer-store.ts's ``sortKey`` helper."""
+    return f"{agent_target_id}#{environment}"
+
+
+class ReleaseResolutionStatus(str, Enum):
+    RESOLVED = "resolved"
+    NO_POINTER = "no_pointer"
+    LOOKUP_FAILED = "lookup_failed"
+
+
+@dataclass
+class ReleaseResolution:
+    status: ReleaseResolutionStatus
+    release: dict | None = None
+    error: str | None = None
+
+
+def resolve_release(
+    org_id: str,
+    agent_target_id: str,
+    environment: str,
+) -> ReleaseResolution:
+    """Resolve the release currently pointed at for (org_id,
+    agent_target_id, environment). Read-only: issues at most one GetItem
+    against each of EnvironmentReleasePointersTable and AgentReleasesTable.
+    Never raises — every failure mode is captured in the returned
+    ``ReleaseResolution.status``.
+    """
+    pointer_table_name = _pointer_table_name()
+    release_table_name = _release_table_name()
+
+    # Forward-compatible no-op: either table not provisioned in this
+    # deployment. This is the exact backward-compatibility case — an
+    # existing deployment predating this feature has neither table, so
+    # every dispatch resolves here with zero AWS calls, identical to
+    # today's ungoverned-by-release behaviour.
+    if not pointer_table_name or not release_table_name:
+        return ReleaseResolution(status=ReleaseResolutionStatus.NO_POINTER)
+
+    try:
+        resource = _get_resource()
+        pointer_table = resource.Table(pointer_table_name)
+        pointer_response = pointer_table.get_item(
+            Key={
+                "orgId": org_id,
+                "agentTargetId_environment": _pointer_sort_key(
+                    agent_target_id, environment
+                ),
+            }
+        )
+    except Exception as exc:  # noqa: BLE001 — any lookup failure is LOOKUP_FAILED
+        return ReleaseResolution(
+            status=ReleaseResolutionStatus.LOOKUP_FAILED,
+            error=f"pointer lookup failed: {type(exc).__name__}: {exc}",
+        )
+
+    pointer_item = pointer_response.get("Item")
+    if not pointer_item:
+        # Clean, expected state: no promotion has ever happened for this
+        # (org, agent, environment) triple. Not a failure.
+        return ReleaseResolution(status=ReleaseResolutionStatus.NO_POINTER)
+
+    release_id = pointer_item.get("releaseId")
+    if not release_id:
+        # Malformed pointer row (should be unreachable given the write
+        # boundary in environment-release-pointer-store.ts, which always
+        # sets releaseId) — treat the same as a lookup failure rather than
+        # guessing at a release.
+        return ReleaseResolution(
+            status=ReleaseResolutionStatus.LOOKUP_FAILED,
+            error="pointer row is missing its releaseId field",
+        )
+
+    try:
+        release_response = resource.Table(release_table_name).get_item(
+            Key={"releaseId": release_id}
+        )
+    except Exception as exc:  # noqa: BLE001 — any lookup failure is LOOKUP_FAILED
+        return ReleaseResolution(
+            status=ReleaseResolutionStatus.LOOKUP_FAILED,
+            error=f"release lookup failed: {type(exc).__name__}: {exc}",
+        )
+
+    release_item = release_response.get("Item")
+    if not release_item:
+        # Dangling pointer: the release table is create-only and rows are
+        # never deleted (release-store.ts), so a pointer whose releaseId
+        # does not resolve indicates a data-integrity problem, not a
+        # normal state. Refuse-worthy, same as any other lookup failure.
+        return ReleaseResolution(
+            status=ReleaseResolutionStatus.LOOKUP_FAILED,
+            error=f"dangling pointer: releaseId {release_id!r} has no matching release row",
+        )
+
+    return ReleaseResolution(
+        status=ReleaseResolutionStatus.RESOLVED,
+        release=release_item,
+    )

--- a/arbiter/stepRunner/__tests__/test_release_aware_dispatch.py
+++ b/arbiter/stepRunner/__tests__/test_release_aware_dispatch.py
@@ -1,0 +1,215 @@
+"""Release-aware dispatch tests for ``executor.invoke_node`` (stepRunner).
+
+Mirrors the supervisor's release-gate semantics
+(arbiter/supervisor/__tests__/test_release_aware_dispatch.py) applied at
+the stepRunner's dispatch choke point. executor.py has no pre-existing
+authority-graph governance gate (unlike supervisor/index.py's
+governed_process_agent_call) — this story adds ONLY the release
+resolution + mode + grandfathering + telemetry seam here, per scope
+(the full authority DENY/ESCALATE engine is out of scope for this choke
+point).
+
+Backward compatibility: RELEASE_DISPATCH_ENVIRONMENT unset -> the gate is
+a complete no-op (resolve_release never called), so an existing workflow
+node dispatch is byte-identical to pre-feature behaviour — asserted first,
+then permissive/shadow/strict branch semantics.
+"""
+import os
+import sys
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..'))
+
+from unittest.mock import patch, MagicMock
+
+import pytest
+
+
+NODE = {'id': 'n0', 'agentId': 'agent-A', 'data': {}}
+
+
+@pytest.fixture(autouse=True)
+def _clean_env():
+    saved = {}
+    for key in (
+        'RELEASE_DISPATCH_ENVIRONMENT',
+        'RELEASE_DEFAULT_ORG_ID',
+        'WORKER_QUEUE_URL',
+    ):
+        saved[key] = os.environ.pop(key, None)
+    os.environ['WORKER_QUEUE_URL'] = 'https://sqs.fake/worker-queue'
+    yield
+    for key, value in saved.items():
+        if value is not None:
+            os.environ[key] = value
+        else:
+            os.environ.pop(key, None)
+
+
+def _patched_executor():
+    """Returns (executor module, patch context tuple) with tables/events/sqs
+    neutralised, mirroring test_node_dispatch.py's _patch_tables fixture."""
+    import executor
+    fake_sqs = MagicMock()
+    ctx = (
+        patch.object(executor, '_executions_table', MagicMock()),
+        patch.object(executor, 'events', MagicMock()),
+        patch.object(executor, '_get_sqs_client', return_value=fake_sqs),
+    )
+    return executor, ctx, fake_sqs
+
+
+# ---------------------------------------------------------------------------
+# Backward-compat: feature switch unset -> resolve_release never called.
+# ---------------------------------------------------------------------------
+
+
+def test_release_gate_noop_when_dispatch_environment_unset():
+    executor, ctx, fake_sqs = _patched_executor()
+    with ctx[0], ctx[1], ctx[2], \
+         patch.object(executor, 'resolve_release') as mock_resolve:
+        executor.invoke_node('exec-1', 'wf-1', NODE, {'k': 'v'}, {'cfg': 1})
+
+    mock_resolve.assert_not_called()
+    fake_sqs.send_message.assert_called_once()
+
+
+# ---------------------------------------------------------------------------
+# permissive/shadow — always dispatch, telemetry only.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("mode", ["permissive", "shadow"])
+def test_no_release_resolvable_still_dispatches_in_permissive_and_shadow(mode):
+    executor, ctx, fake_sqs = _patched_executor()
+    fake_state = MagicMock(enforcement_mode=mode, effective_at=None)
+    fake_resolution = MagicMock(status=executor.ReleaseResolutionStatus.NO_POINTER, error=None)
+
+    with ctx[0], ctx[1], ctx[2], \
+         patch.object(executor, 'load_governance_state', return_value=fake_state), \
+         patch.object(executor, 'resolve_release', return_value=fake_resolution), \
+         patch.object(executor, '_emit_release_dispatch_metric') as mock_metric:
+        os.environ['RELEASE_DISPATCH_ENVIRONMENT'] = 'PROD'
+        executor.invoke_node('exec-1', 'wf-1', NODE, {'k': 'v'}, {'cfg': 1})
+
+    fake_sqs.send_message.assert_called_once()
+    assert mock_metric.call_args.kwargs['mode'] == mode
+    assert mock_metric.call_args.kwargs['would_block'] is True
+
+
+# ---------------------------------------------------------------------------
+# strict — refuses when unresolvable and not grandfathered.
+# ---------------------------------------------------------------------------
+
+
+def test_strict_no_release_and_not_grandfathered_refuses_dispatch():
+    executor, ctx, fake_sqs = _patched_executor()
+    fake_state = MagicMock(enforcement_mode='strict', effective_at='2026-05-15T00:00:00Z')
+    fake_resolution = MagicMock(status=executor.ReleaseResolutionStatus.NO_POINTER, error=None)
+
+    with ctx[0], ctx[1], ctx[2], \
+         patch.object(executor, 'load_governance_state', return_value=fake_state), \
+         patch.object(executor, 'resolve_release', return_value=fake_resolution), \
+         patch.object(executor, '_resolve_agent_created_at', return_value='2026-06-01T00:00:00Z'):
+        os.environ['RELEASE_DISPATCH_ENVIRONMENT'] = 'PROD'
+        executor.invoke_node('exec-1', 'wf-1', NODE, {'k': 'v'}, {'cfg': 1})
+
+    fake_sqs.send_message.assert_not_called()
+
+
+def test_strict_no_release_but_grandfathered_dispatches():
+    executor, ctx, fake_sqs = _patched_executor()
+    # No created_at signal available (the honest default) -> conservative
+    # bypass -> grandfathered=True even with a cutoff set.
+    fake_state = MagicMock(enforcement_mode='strict', effective_at='2026-05-15T00:00:00Z')
+    fake_resolution = MagicMock(status=executor.ReleaseResolutionStatus.NO_POINTER, error=None)
+
+    with ctx[0], ctx[1], ctx[2], \
+         patch.object(executor, 'load_governance_state', return_value=fake_state), \
+         patch.object(executor, 'resolve_release', return_value=fake_resolution):
+        os.environ['RELEASE_DISPATCH_ENVIRONMENT'] = 'PROD'
+        executor.invoke_node('exec-1', 'wf-1', NODE, {'k': 'v'}, {'cfg': 1})
+
+    fake_sqs.send_message.assert_called_once()
+
+
+def test_strict_resolved_release_dispatches():
+    executor, ctx, fake_sqs = _patched_executor()
+    fake_state = MagicMock(enforcement_mode='strict', effective_at=None)
+    fake_resolution = MagicMock(
+        status=executor.ReleaseResolutionStatus.RESOLVED,
+        release={'releaseId': 'r1'},
+        error=None,
+    )
+
+    with ctx[0], ctx[1], ctx[2], \
+         patch.object(executor, 'load_governance_state', return_value=fake_state), \
+         patch.object(executor, 'resolve_release', return_value=fake_resolution):
+        os.environ['RELEASE_DISPATCH_ENVIRONMENT'] = 'PROD'
+        executor.invoke_node('exec-1', 'wf-1', NODE, {'k': 'v'}, {'cfg': 1})
+
+    fake_sqs.send_message.assert_called_once()
+
+
+def test_strict_lookup_failed_always_refuses_even_pre_flip():
+    """Assert-or-refuse: LOOKUP_FAILED refuses in strict mode regardless of
+    effective_at/grandfathering — same doctrine as the supervisor gate."""
+    executor, ctx, fake_sqs = _patched_executor()
+    fake_state = MagicMock(enforcement_mode='strict', effective_at=None)
+    fake_resolution = MagicMock(
+        status=executor.ReleaseResolutionStatus.LOOKUP_FAILED,
+        error='throttled',
+    )
+
+    with ctx[0], ctx[1], ctx[2], \
+         patch.object(executor, 'load_governance_state', return_value=fake_state), \
+         patch.object(executor, 'resolve_release', return_value=fake_resolution):
+        os.environ['RELEASE_DISPATCH_ENVIRONMENT'] = 'PROD'
+        executor.invoke_node('exec-1', 'wf-1', NODE, {'k': 'v'}, {'cfg': 1})
+
+    fake_sqs.send_message.assert_not_called()
+
+
+def test_strict_lookup_failed_in_shadow_mode_still_dispatches_with_would_block():
+    executor, ctx, fake_sqs = _patched_executor()
+    fake_state = MagicMock(enforcement_mode='shadow', effective_at=None)
+    fake_resolution = MagicMock(
+        status=executor.ReleaseResolutionStatus.LOOKUP_FAILED,
+        error='throttled',
+    )
+
+    with ctx[0], ctx[1], ctx[2], \
+         patch.object(executor, 'load_governance_state', return_value=fake_state), \
+         patch.object(executor, 'resolve_release', return_value=fake_resolution), \
+         patch.object(executor, '_emit_release_dispatch_metric') as mock_metric:
+        os.environ['RELEASE_DISPATCH_ENVIRONMENT'] = 'PROD'
+        executor.invoke_node('exec-1', 'wf-1', NODE, {'k': 'v'}, {'cfg': 1})
+
+    fake_sqs.send_message.assert_called_once()
+    assert mock_metric.call_args.kwargs['would_block'] is True
+
+
+def test_no_agent_id_on_node_resolves_release_with_empty_target_id():
+    """A node with no agentId (agent_id='' per executor's own
+    node.get('agentId', '') default) must not crash the release gate —
+    resolve_release is still called with an empty agent_target_id. (The
+    subsequent SQS dispatch for an agentId-less node already fails its own
+    pre-existing, unrelated validation in workflow_contract.py — out of
+    scope here; this test only asserts the release gate itself tolerates
+    the empty id.)"""
+    executor, ctx, fake_sqs = _patched_executor()
+    fake_state = MagicMock(enforcement_mode='permissive', effective_at=None)
+    fake_resolution = MagicMock(status=executor.ReleaseResolutionStatus.NO_POINTER, error=None)
+
+    node_without_agent = {'id': 'n0', 'data': {}}
+
+    with ctx[0], ctx[1], ctx[2], \
+         patch.object(executor, 'load_governance_state', return_value=fake_state), \
+         patch.object(executor, 'resolve_release', return_value=fake_resolution) as mock_resolve:
+        os.environ['RELEASE_DISPATCH_ENVIRONMENT'] = 'PROD'
+        try:
+            executor.invoke_node('exec-1', 'wf-1', node_without_agent, {'k': 'v'}, {'cfg': 1})
+        except ValueError:
+            pass  # pre-existing, unrelated workflow_contract validation
+
+    mock_resolve.assert_called_once()
+    assert mock_resolve.call_args.kwargs['agent_target_id'] == ''

--- a/arbiter/stepRunner/executor.py
+++ b/arbiter/stepRunner/executor.py
@@ -12,6 +12,7 @@ import boto3
 import json
 import logging
 import os
+import sys
 from datetime import datetime, timezone
 
 # Tracing foundation (architect task 5459301e-1e7b-4bfd-bccb-b106aba2748c):
@@ -39,10 +40,111 @@ from common.metrics_constants import (
     METRIC_NODE_FAILURE,
     METRIC_NODE_QUEUE_WAIT_MS,
     METRIC_UNSTAMPED_DISPATCH,
+    METRIC_RELEASE_DISPATCH_EVALUATED,
+    METRIC_RELEASE_DISPATCH_WOULD_BLOCK,
+    METRIC_RELEASE_DISPATCH_REFUSED,
     UNIT_MILLISECONDS,
     UNIT_COUNT,
     DIMENSION_WORKFLOW_ID,
+    DIMENSION_RELEASE_MODE,
+    DIMENSION_RELEASE_OUTCOME,
 )
+
+# ---------------------------------------------------------------------------
+# Release-aware dispatch (this story) — governance package import.
+#
+# Mirrors supervisor/index.py's ``_load_governance_package`` exactly (same
+# private-namespace loading technique, same fail-closed contract), but
+# loads only the three submodules this choke point needs: ``hierarchy``
+# (mode + effective_at resolution), ``release_resolution`` (pointer/release
+# lookup), and ``grandfathering`` (the ported pure rule). The full
+# authority-graph engine (``engine``, ``ledger``, ``models``) is
+# deliberately NOT loaded here — this choke point gains ONLY the release
+# gate, not the DENY/ESCALATE authority machinery supervisor/index.py's
+# ``governed_process_agent_call`` already has (out of scope for this
+# story; see task scope).
+#
+# Deployment note: the Step Runner Lambda's asset is
+# `code.fromAsset(ARBITER_ROOT/stepRunner)` only (backend/lib/
+# arbiter-stack.ts's StepRunnerFunction) — unlike the Supervisor, which
+# widens its own `entry` to the arbiter/ root. governance/ is instead
+# staged into the shared `catalogLayer` (see arbiter-stack.ts's
+# ArbiterCatalogLayer bundling command) at /opt/python/governance/, so it
+# is loaded from the layer path rather than a sibling directory.
+_stepRunner_dir = os.path.dirname(os.path.abspath(__file__))
+_arbiter_dir = os.path.dirname(_stepRunner_dir)
+
+
+def _load_release_governance_modules():
+    """Load hierarchy/release_resolution/grandfathering from either the
+    sibling arbiter/governance/ directory (pytest / local dev, where
+    conftest.py puts arbiter/ on sys.path the same way it does for
+    supervisor) or the Lambda layer path /opt/python/governance/
+    (deployed Step Runner Lambda). Returns None if neither is available.
+    """
+    import importlib.util as _ilu
+
+    candidates = [
+        os.path.join(_arbiter_dir, 'governance'),
+        '/opt/python/governance',
+    ]
+    pkg_dir = next((c for c in candidates if os.path.isfile(os.path.join(c, '__init__.py'))), None)
+    if pkg_dir is None:
+        return None
+
+    pkg_name = '_citadel_governance_stepRunner'
+    if pkg_name in sys.modules:
+        return sys.modules[pkg_name]
+
+    spec = _ilu.spec_from_file_location(
+        pkg_name, os.path.join(pkg_dir, '__init__.py'),
+        submodule_search_locations=[pkg_dir],
+    )
+    pkg = _ilu.module_from_spec(spec)
+    sys.modules[pkg_name] = pkg
+    spec.loader.exec_module(pkg)
+
+    for submod in ('hierarchy', 'release_resolution', 'grandfathering'):
+        sub_file = os.path.join(pkg_dir, f'{submod}.py')
+        if not os.path.isfile(sub_file):
+            continue
+        sub_spec = _ilu.spec_from_file_location(f'{pkg_name}.{submod}', sub_file)
+        sub_mod = _ilu.module_from_spec(sub_spec)
+        sys.modules[f'{pkg_name}.{submod}'] = sub_mod
+        sub_spec.loader.exec_module(sub_mod)
+        setattr(pkg, submod, sub_mod)
+
+    return pkg
+
+
+try:
+    _gov_pkg = _load_release_governance_modules()
+    if _gov_pkg is None:
+        raise ImportError("governance package files not found for stepRunner")
+    load_governance_state = _gov_pkg.hierarchy.load_governance_state
+    resolve_release = _gov_pkg.release_resolution.resolve_release
+    ReleaseResolutionStatus = _gov_pkg.release_resolution.ReleaseResolutionStatus
+    is_grandfathered_pure = _gov_pkg.grandfathering.is_grandfathered_pure
+    _RELEASE_GOVERNANCE_AVAILABLE = True
+    _RELEASE_GOVERNANCE_IMPORT_ERROR: str | None = None
+except ImportError as e:
+    # Fail-closed (same doctrine as supervisor/index.py's
+    # _GOVERNANCE_AVAILABLE gate): if the release-governance modules are
+    # not present in the deployed asset/layer, the release gate refuses
+    # every dispatch WHEN ACTIVE (RELEASE_DISPATCH_ENVIRONMENT set) rather
+    # than silently skipping the check — see invoke_node below. When
+    # RELEASE_DISPATCH_ENVIRONMENT is unset, this deployment hasn't opted
+    # into the gate at all, so the missing-package state is irrelevant and
+    # invoke_node's own feature-switch check short-circuits before ever
+    # consulting this flag.
+    _RELEASE_GOVERNANCE_AVAILABLE = False
+    _RELEASE_GOVERNANCE_IMPORT_ERROR = str(e)
+    _logger_bootstrap = logging.getLogger(__name__)
+    _logger_bootstrap.warning(
+        "release-governance package unavailable (%s); release-aware "
+        "dispatch will refuse if RELEASE_DISPATCH_ENVIRONMENT is set. "
+        "This is not a bypass.", e,
+    )
 
 # DynamoDB table names from environment
 WORKFLOWS_TABLE = os.environ.get('WORKFLOWS_TABLE', 'citadel-workflows-dev')
@@ -147,6 +249,157 @@ def _emit_metric(metric_name: str, value: float, unit: str, *, workflow_id: str 
         )
     except Exception as exc:  # noqa: BLE001 — telemetry must never raise
         _logger.warning('cloudwatch metric emit failed metric=%s: %s', metric_name, exc)
+
+
+# ---------------------------------------------------------------------------
+# Release-aware dispatch (this story)
+# ---------------------------------------------------------------------------
+
+
+def _resolve_agent_created_at(agent_id: str) -> str | None:
+    """Best-effort per-agent creation timestamp for the grandfathering
+    check. Mirrors supervisor/index.py's identical helper: returns None
+    when no signal is available, which is the honest default in this
+    codebase today (see release_resolution.py's module docstring) — the
+    Step Runner's workflow node dict carries no createdAt either, and the
+    AgentCore Registry lookup that DOES expose one requires
+    REGISTRY_ENABLED + a resolvable recordId, neither of which is
+    guaranteed. A None return routes through grandfathering.py's
+    conservative-bypass branch, not a special case here.
+    """
+    if os.environ.get('REGISTRY_ENABLED') != 'true':
+        return None
+    registry_id = os.environ.get('REGISTRY_ID')
+    if not registry_id or not agent_id:
+        return None
+    try:
+        from catalog.registry_client import get_agent_record
+        record = get_agent_record(registry_id, agent_id)
+    except Exception:
+        return None
+    if record is None:
+        return None
+    created_at = record.get('createdAt')
+    return created_at if isinstance(created_at, str) and created_at else None
+
+
+def _emit_release_dispatch_metric(
+    *, mode: str, outcome: str, would_block: bool, workflow_id: str = '',
+) -> None:
+    """Best-effort CloudWatch telemetry for the release-aware dispatch
+    gate. Mirrors supervisor/index.py's identical helper exactly (same
+    metric names/dimensions, same never-raises discipline) so a downstream
+    dashboard can aggregate across both dispatch choke points without a
+    branch per producer.
+    """
+    try:
+        cw = _get_cloudwatch_client()
+        dimensions = [{'Name': DIMENSION_RELEASE_MODE, 'Value': mode}]
+        if workflow_id:
+            dimensions.append({'Name': DIMENSION_WORKFLOW_ID, 'Value': workflow_id})
+        outcome_dimensions = dimensions + [
+            {'Name': DIMENSION_RELEASE_OUTCOME, 'Value': outcome},
+        ]
+        metric_data = [{
+            'MetricName': METRIC_RELEASE_DISPATCH_EVALUATED,
+            'Value': 1.0,
+            'Unit': UNIT_COUNT,
+            'Dimensions': outcome_dimensions,
+        }]
+        if would_block:
+            metric_data.append({
+                'MetricName': METRIC_RELEASE_DISPATCH_WOULD_BLOCK,
+                'Value': 1.0,
+                'Unit': UNIT_COUNT,
+                'Dimensions': dimensions,
+            })
+        if outcome == 'refused':
+            metric_data.append({
+                'MetricName': METRIC_RELEASE_DISPATCH_REFUSED,
+                'Value': 1.0,
+                'Unit': UNIT_COUNT,
+                'Dimensions': dimensions,
+            })
+        cw.put_metric_data(Namespace=METRIC_NAMESPACE, MetricData=metric_data)
+    except Exception as exc:  # noqa: BLE001 — telemetry must never raise
+        _logger.warning('release-dispatch metric emit failed: %s', exc)
+
+
+def _check_release_gate(agent_id: str, workflow_id: str) -> tuple[bool, str | None]:
+    """Evaluates the release-aware dispatch gate for one node dispatch.
+
+    Returns ``(refused, refusal_reason)``. ``refused`` is always False
+    when ``RELEASE_DISPATCH_ENVIRONMENT`` is unset (the gate's own feature
+    switch — backward-compat no-op, see module docstring above) or when
+    the release-governance modules failed to load AND the switch is unset
+    (irrelevant in that case). When the switch IS set but the modules
+    failed to load, this refuses unconditionally — the same fail-closed
+    contract as supervisor/index.py's package-unavailable gate: a missing
+    package means there is nothing to evaluate against, so dispatch must
+    be refused, never silently ungoverned.
+
+    Telemetry is emitted for every mode via
+    ``_emit_release_dispatch_metric`` before returning, so the rollout can
+    be measured before strict is flipped, in every branch including the
+    package-unavailable one.
+    """
+    release_dispatch_environment = os.environ.get('RELEASE_DISPATCH_ENVIRONMENT')
+    if not release_dispatch_environment:
+        return False, None
+
+    if not _RELEASE_GOVERNANCE_AVAILABLE:
+        _logger.error(
+            "release dispatch refused: release-governance package "
+            "unavailable (%s); workflow_id=%s target_agent=%s",
+            _RELEASE_GOVERNANCE_IMPORT_ERROR, workflow_id, agent_id,
+        )
+        return True, 'release_governance_package_unavailable'
+
+    state = load_governance_state()
+    enforcement_mode = getattr(state, 'enforcement_mode', 'shadow')
+
+    release_result = resolve_release(
+        org_id=os.environ.get('RELEASE_DEFAULT_ORG_ID') or '',
+        agent_target_id=agent_id,
+        environment=release_dispatch_environment,
+    )
+
+    if release_result.status == ReleaseResolutionStatus.RESOLVED:
+        outcome, would_block = 'proceed', False
+    elif release_result.status == ReleaseResolutionStatus.LOOKUP_FAILED:
+        # Assert-or-refuse doctrine — see release_resolution.py's module
+        # docstring and supervisor/index.py's identical branch. Never
+        # excused by grandfathering.
+        outcome = 'refused' if enforcement_mode == 'strict' else 'proceed'
+        would_block = enforcement_mode != 'strict'
+    else:
+        # NO_POINTER — clean backward-compat state. Strict refuses unless
+        # grandfathered via the ported pure rule.
+        created_at = _resolve_agent_created_at(agent_id)
+        grandfathered = is_grandfathered_pure(created_at, getattr(state, 'effective_at', None))
+        outcome = 'refused' if (enforcement_mode == 'strict' and not grandfathered) else 'proceed'
+        would_block = enforcement_mode != 'strict'
+
+    _emit_release_dispatch_metric(
+        mode=enforcement_mode, outcome=outcome, would_block=would_block,
+        workflow_id=workflow_id,
+    )
+
+    if outcome == 'refused':
+        refusal_reason = (
+            'release_lookup_failed'
+            if release_result.status == ReleaseResolutionStatus.LOOKUP_FAILED
+            else 'no_release_resolvable'
+        )
+        _logger.error(
+            "release dispatch refused: %s; workflow_id=%s target_agent=%s "
+            "environment=%s detail=%s",
+            refusal_reason, workflow_id, agent_id, release_dispatch_environment,
+            release_result.error,
+        )
+        return True, refusal_reason
+
+    return False, None
 
 
 def _load_workflow(workflow_id: str) -> dict:
@@ -293,6 +546,18 @@ def invoke_node(
     # validator (workflow-resolver.validateDefinition) use the top-level
     # shape, so executor must read top-level too.
     agent_id = node.get('agentId', '')
+
+    # Release-aware dispatch (this story). Evaluated before any state
+    # mutation (node status update, node.started event, SQS send) so a
+    # strict-mode refusal leaves no partial/inconsistent trace of a
+    # dispatch that never actually happened — the node simply stays in
+    # whatever state DAG scheduling left it, and the refusal is observable
+    # via the ERROR-level log line and the ReleaseDispatchRefused metric
+    # emitted inside _check_release_gate.
+    _release_refused, _release_refusal_reason = _check_release_gate(agent_id, workflow_id)
+    if _release_refused:
+        return
+
     now = _now_iso()
 
     # Correlation log: one line per node dispatch, tagged with the ids a log

--- a/arbiter/supervisor/__tests__/test_release_aware_dispatch.py
+++ b/arbiter/supervisor/__tests__/test_release_aware_dispatch.py
@@ -1,0 +1,418 @@
+"""Release-aware dispatch tests for ``governed_process_agent_call``.
+
+Covers the release resolution seam layered on top of the existing US-ARB-008
+mode/decision gate (test_supervisor_governed_dispatch.py):
+
+  * permissive — telemetry only, always proceeds (existing dispatch
+    behaviour, unaffected by whether a release resolves).
+  * shadow — resolves the release and records a would-block telemetry
+    event when none is resolvable, but always proceeds.
+  * strict — refuses dispatch when no release is resolvable UNLESS the
+    (org, agent, environment) triple is grandfathered; a LOOKUP_FAILED
+    resolution always refuses regardless of grandfathering (assert-or-
+    refuse doctrine, distinct from the clean NO_POINTER case).
+
+Backward-compatibility invariant asserted throughout: an existing
+deployment with RELEASE_DISPATCH_ENVIRONMENT unset (or with the release
+tables unset, covered in test_release_resolution.py) must dispatch
+byte-identically to pre-feature behaviour — this is asserted here via the
+"release gate is a no-op unless RELEASE_DISPATCH_ENVIRONMENT is set"
+tests, which is the seam's own backward-compat switch, separate from (and
+in addition to) the table-unset seam release_resolution.py already
+guarantees.
+"""
+from __future__ import annotations
+
+import logging
+import os
+import sys
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+
+os.environ.setdefault("AGENT_CONFIG_TABLE", "fake-table")
+os.environ.setdefault("EVENT_BUS_NAME", "fake-bus")
+os.environ.setdefault("ORCHESTRATION_TABLE", "fake-orch-table")
+os.environ.setdefault("WORKER_STATE_TABLE", "fake-worker-table")
+
+_mock_dynamodb = MagicMock()
+_mock_sqs = MagicMock()
+_mock_bedrock = MagicMock()
+_mock_events = MagicMock()
+_mock_sns = MagicMock()
+
+with patch.multiple(
+    "boto3",
+    resource=MagicMock(return_value=_mock_dynamodb),
+    client=MagicMock(
+        side_effect=lambda svc, **kw: {
+            "sqs": _mock_sqs,
+            "bedrock-runtime": _mock_bedrock,
+            "events": _mock_events,
+            "sns": _mock_sns,
+        }.get(svc, MagicMock())
+    ),
+):
+    import index as supervisor_mod  # noqa: E402
+
+ArbitrationDecision = supervisor_mod.ArbitrationDecision
+GovernanceFinding = supervisor_mod.GovernanceFinding
+ReleaseResolutionStatus = supervisor_mod.ReleaseResolutionStatus
+ReleaseResolution = supervisor_mod.ReleaseResolution
+
+
+@pytest.fixture(autouse=True)
+def _clean_env():
+    saved_bypass = os.environ.pop("ARBITER_GOVERNANCE_BYPASS", None)
+    saved_env_lit = os.environ.pop("RELEASE_DISPATCH_ENVIRONMENT", None)
+    saved_org = os.environ.pop("RELEASE_DEFAULT_ORG_ID", None)
+    prev_available = supervisor_mod._GOVERNANCE_AVAILABLE
+    yield
+    if saved_bypass is not None:
+        os.environ["ARBITER_GOVERNANCE_BYPASS"] = saved_bypass
+    if saved_env_lit is not None:
+        os.environ["RELEASE_DISPATCH_ENVIRONMENT"] = saved_env_lit
+    else:
+        os.environ.pop("RELEASE_DISPATCH_ENVIRONMENT", None)
+    if saved_org is not None:
+        os.environ["RELEASE_DEFAULT_ORG_ID"] = saved_org
+    else:
+        os.environ.pop("RELEASE_DEFAULT_ORG_ID", None)
+    supervisor_mod._GOVERNANCE_AVAILABLE = prev_available
+
+
+def _make_finding(decision, scope_evaluated="u-1", reason="test-reason"):
+    return GovernanceFinding.create(
+        workflow_id="wf-1",
+        decision=decision,
+        requesting_agent="supervisor",
+        target_agent="agent-a",
+        reason=reason,
+        scope_evaluated=scope_evaluated,
+    )
+
+
+def _make_state(enforcement_mode="shadow", effective_at=None):
+    state = MagicMock()
+    state.authority_units = []
+    state.composition_contracts = []
+    state.case_law = []
+    state.constitutional_layers = []
+    state.enforcement_mode = enforcement_mode
+    state.effective_at = effective_at
+    return state
+
+
+_AGENTS_CONFIG = {"agents": [{"name": "agent-a", "domain": "billing"}]}
+_ORCH = {"orchestrationId": "orch-123"}
+
+
+def _common_patches(mode, finding, resolve_return):
+    """Returns a context-manager-friendly tuple of patches shared by every
+    test below: load_governance_state, GovernanceEngine.evaluate,
+    write_finding, resolve_release, process_agent_call."""
+    return (
+        patch.object(supervisor_mod, "load_governance_state", return_value=_make_state(mode)),
+        patch.object(supervisor_mod, "GovernanceEngine"),
+        patch.object(supervisor_mod, "write_finding"),
+        patch.object(supervisor_mod, "resolve_release", return_value=resolve_return),
+        patch.object(supervisor_mod, "process_agent_call", return_value={"dispatched": True}),
+    )
+
+
+# ---------------------------------------------------------------------------
+# Backward-compat: feature switch (RELEASE_DISPATCH_ENVIRONMENT) unset ->
+# resolve_release is never even called, byte-identical to pre-feature
+# dispatch.
+# ---------------------------------------------------------------------------
+
+
+def test_release_gate_is_noop_when_dispatch_environment_unset(monkeypatch):
+    monkeypatch.setattr(supervisor_mod, "_GOVERNANCE_AVAILABLE", True)
+    monkeypatch.delenv("RELEASE_DISPATCH_ENVIRONMENT", raising=False)
+    finding = _make_finding(ArbitrationDecision.PERMIT)
+
+    with patch.object(supervisor_mod, "load_governance_state",
+                      return_value=_make_state("strict")), \
+         patch.object(supervisor_mod, "GovernanceEngine") as MockEngine, \
+         patch.object(supervisor_mod, "write_finding"), \
+         patch.object(supervisor_mod, "resolve_release") as mock_resolve, \
+         patch.object(supervisor_mod, "process_agent_call",
+                      return_value={"dispatched": True}) as mock_dispatch:
+        MockEngine.return_value.evaluate.return_value = finding
+
+        result = supervisor_mod.governed_process_agent_call(
+            _AGENTS_CONFIG, _ORCH, "agent-a", {"x": 1}, "use-1",
+        )
+
+    mock_resolve.assert_not_called()
+    mock_dispatch.assert_called_once()
+    assert result == {"dispatched": True}
+
+
+# ---------------------------------------------------------------------------
+# permissive — telemetry only, always proceeds regardless of resolution.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "resolve_return",
+    [
+        ReleaseResolution(status=ReleaseResolutionStatus.RESOLVED, release={"releaseId": "r1"}),
+        ReleaseResolution(status=ReleaseResolutionStatus.NO_POINTER),
+        ReleaseResolution(status=ReleaseResolutionStatus.LOOKUP_FAILED, error="boom"),
+    ],
+)
+def test_permissive_always_proceeds_and_emits_telemetry(monkeypatch, resolve_return):
+    monkeypatch.setattr(supervisor_mod, "_GOVERNANCE_AVAILABLE", True)
+    monkeypatch.setenv("RELEASE_DISPATCH_ENVIRONMENT", "PROD")
+    finding = _make_finding(ArbitrationDecision.PERMIT)
+
+    patches = _common_patches("permissive", finding, resolve_return)
+    with patches[0], patches[1] as MockEngine, patches[2], patches[3] as mock_resolve, \
+         patches[4] as mock_dispatch, \
+         patch.object(supervisor_mod, "_emit_release_dispatch_metric") as mock_metric:
+        MockEngine.return_value.evaluate.return_value = finding
+
+        result = supervisor_mod.governed_process_agent_call(
+            _AGENTS_CONFIG, _ORCH, "agent-a", {"x": 1}, "use-1",
+        )
+
+    mock_resolve.assert_called_once()
+    mock_dispatch.assert_called_once()
+    mock_metric.assert_called_once()
+    assert mock_metric.call_args.kwargs["mode"] == "permissive"
+    assert result == {"dispatched": True}
+
+
+# ---------------------------------------------------------------------------
+# shadow — would-block recorded, dispatch still proceeds.
+# ---------------------------------------------------------------------------
+
+
+def test_shadow_no_release_records_would_block_but_proceeds(monkeypatch):
+    monkeypatch.setattr(supervisor_mod, "_GOVERNANCE_AVAILABLE", True)
+    monkeypatch.setenv("RELEASE_DISPATCH_ENVIRONMENT", "PROD")
+    finding = _make_finding(ArbitrationDecision.PERMIT)
+    resolve_return = ReleaseResolution(status=ReleaseResolutionStatus.NO_POINTER)
+
+    patches = _common_patches("shadow", finding, resolve_return)
+    with patches[0], patches[1] as MockEngine, patches[2], patches[3], \
+         patches[4] as mock_dispatch, \
+         patch.object(supervisor_mod, "_emit_release_dispatch_metric") as mock_metric:
+        MockEngine.return_value.evaluate.return_value = finding
+
+        result = supervisor_mod.governed_process_agent_call(
+            _AGENTS_CONFIG, _ORCH, "agent-a", {"x": 1}, "use-1",
+        )
+
+    mock_dispatch.assert_called_once()
+    assert mock_metric.call_args.kwargs["mode"] == "shadow"
+    assert mock_metric.call_args.kwargs["would_block"] is True
+    assert result == {"dispatched": True}
+
+
+def test_shadow_release_resolved_proceeds_without_would_block(monkeypatch):
+    monkeypatch.setattr(supervisor_mod, "_GOVERNANCE_AVAILABLE", True)
+    monkeypatch.setenv("RELEASE_DISPATCH_ENVIRONMENT", "PROD")
+    finding = _make_finding(ArbitrationDecision.PERMIT)
+    resolve_return = ReleaseResolution(
+        status=ReleaseResolutionStatus.RESOLVED, release={"releaseId": "r1"},
+    )
+
+    patches = _common_patches("shadow", finding, resolve_return)
+    with patches[0], patches[1] as MockEngine, patches[2], patches[3], \
+         patches[4] as mock_dispatch, \
+         patch.object(supervisor_mod, "_emit_release_dispatch_metric") as mock_metric:
+        MockEngine.return_value.evaluate.return_value = finding
+
+        result = supervisor_mod.governed_process_agent_call(
+            _AGENTS_CONFIG, _ORCH, "agent-a", {"x": 1}, "use-1",
+        )
+
+    mock_dispatch.assert_called_once()
+    assert mock_metric.call_args.kwargs["would_block"] is False
+    assert result == {"dispatched": True}
+
+
+# ---------------------------------------------------------------------------
+# strict — the core refusal semantics.
+# ---------------------------------------------------------------------------
+
+
+class TestStrictReleaseGate:
+    def test_resolved_release_proceeds(self, monkeypatch):
+        monkeypatch.setattr(supervisor_mod, "_GOVERNANCE_AVAILABLE", True)
+        monkeypatch.setenv("RELEASE_DISPATCH_ENVIRONMENT", "PROD")
+        finding = _make_finding(ArbitrationDecision.PERMIT)
+        resolve_return = ReleaseResolution(
+            status=ReleaseResolutionStatus.RESOLVED, release={"releaseId": "r1"},
+        )
+
+        patches = _common_patches("strict", finding, resolve_return)
+        with patches[0], patches[1] as MockEngine, patches[2], patches[3], patches[4] as mock_dispatch:
+            MockEngine.return_value.evaluate.return_value = finding
+            result = supervisor_mod.governed_process_agent_call(
+                _AGENTS_CONFIG, _ORCH, "agent-a", {"x": 1}, "use-1",
+            )
+
+        mock_dispatch.assert_called_once()
+        assert result == {"dispatched": True}
+
+    def test_no_pointer_and_not_grandfathered_refuses(self, monkeypatch):
+        monkeypatch.setattr(supervisor_mod, "_GOVERNANCE_AVAILABLE", True)
+        monkeypatch.setenv("RELEASE_DISPATCH_ENVIRONMENT", "PROD")
+        # effective_at set (cutoff has been flipped) + no per-agent
+        # created_at signal available -> is_grandfathered_pure(None,
+        # effective_at) is actually True (conservative bypass on missing
+        # created_at) per the ported rule. To exercise the "refuses"
+        # branch we must simulate a resolvable created_at signal that is
+        # AFTER the cutoff, which the gate reads via
+        # _resolve_agent_created_at (patched here).
+        finding = _make_finding(ArbitrationDecision.PERMIT)
+        resolve_return = ReleaseResolution(status=ReleaseResolutionStatus.NO_POINTER)
+
+        patches = _common_patches("strict", finding, resolve_return)
+        with patches[0] as mock_load, patches[1] as MockEngine, patches[2], patches[3], \
+             patches[4] as mock_dispatch, \
+             patch.object(supervisor_mod, "_resolve_agent_created_at",
+                          return_value="2026-06-01T00:00:00Z"):
+            mock_load.return_value = _make_state("strict", effective_at="2026-05-15T00:00:00Z")
+            MockEngine.return_value.evaluate.return_value = finding
+
+            result = supervisor_mod.governed_process_agent_call(
+                _AGENTS_CONFIG, _ORCH, "agent-a", {"x": 1}, "use-1",
+            )
+
+        mock_dispatch.assert_not_called()
+        assert result["denied"] is True
+        assert result["reason"] == "no_release_resolvable"
+
+    def test_no_pointer_and_grandfathered_proceeds(self, monkeypatch):
+        """No created_at signal available (the honest default for this
+        codebase today — see release_resolution.py's module docstring) ->
+        is_grandfathered_pure(None, effective_at) is True -> proceeds even
+        in strict mode with no release resolvable."""
+        monkeypatch.setattr(supervisor_mod, "_GOVERNANCE_AVAILABLE", True)
+        monkeypatch.setenv("RELEASE_DISPATCH_ENVIRONMENT", "PROD")
+        finding = _make_finding(ArbitrationDecision.PERMIT)
+        resolve_return = ReleaseResolution(status=ReleaseResolutionStatus.NO_POINTER)
+
+        patches = _common_patches("strict", finding, resolve_return)
+        with patches[0] as mock_load, patches[1] as MockEngine, patches[2], patches[3], \
+             patches[4] as mock_dispatch:
+            mock_load.return_value = _make_state("strict", effective_at="2026-05-15T00:00:00Z")
+            MockEngine.return_value.evaluate.return_value = finding
+
+            result = supervisor_mod.governed_process_agent_call(
+                _AGENTS_CONFIG, _ORCH, "agent-a", {"x": 1}, "use-1",
+            )
+
+        mock_dispatch.assert_called_once()
+        assert result == {"dispatched": True}
+
+    def test_no_pointer_pre_flip_effective_at_none_proceeds(self, monkeypatch):
+        """effective_at unset (pre-shadow-flip) -> everyone grandfathered
+        regardless of created_at -> proceeds."""
+        monkeypatch.setattr(supervisor_mod, "_GOVERNANCE_AVAILABLE", True)
+        monkeypatch.setenv("RELEASE_DISPATCH_ENVIRONMENT", "PROD")
+        finding = _make_finding(ArbitrationDecision.PERMIT)
+        resolve_return = ReleaseResolution(status=ReleaseResolutionStatus.NO_POINTER)
+
+        patches = _common_patches("strict", finding, resolve_return)
+        with patches[0] as mock_load, patches[1] as MockEngine, patches[2], patches[3], \
+             patches[4] as mock_dispatch, \
+             patch.object(supervisor_mod, "_resolve_agent_created_at",
+                          return_value="2026-06-01T00:00:00Z"):
+            mock_load.return_value = _make_state("strict", effective_at=None)
+            MockEngine.return_value.evaluate.return_value = finding
+
+            result = supervisor_mod.governed_process_agent_call(
+                _AGENTS_CONFIG, _ORCH, "agent-a", {"x": 1}, "use-1",
+            )
+
+        mock_dispatch.assert_called_once()
+        assert result == {"dispatched": True}
+
+    def test_lookup_failed_always_refuses_even_if_would_be_grandfathered(self, monkeypatch):
+        """Assert-or-refuse doctrine: a LOOKUP_FAILED resolution refuses
+        regardless of grandfathering — distinct from the clean NO_POINTER
+        case, which grandfathering can excuse."""
+        monkeypatch.setattr(supervisor_mod, "_GOVERNANCE_AVAILABLE", True)
+        monkeypatch.setenv("RELEASE_DISPATCH_ENVIRONMENT", "PROD")
+        finding = _make_finding(ArbitrationDecision.PERMIT)
+        resolve_return = ReleaseResolution(
+            status=ReleaseResolutionStatus.LOOKUP_FAILED, error="throttled",
+        )
+
+        patches = _common_patches("strict", finding, resolve_return)
+        with patches[0] as mock_load, patches[1] as MockEngine, patches[2], patches[3], \
+             patches[4] as mock_dispatch:
+            # No effective_at at all (pre-flip) — normally this would
+            # grandfather a NO_POINTER resolution, but LOOKUP_FAILED must
+            # refuse unconditionally.
+            mock_load.return_value = _make_state("strict", effective_at=None)
+            MockEngine.return_value.evaluate.return_value = finding
+
+            result = supervisor_mod.governed_process_agent_call(
+                _AGENTS_CONFIG, _ORCH, "agent-a", {"x": 1}, "use-1",
+            )
+
+        mock_dispatch.assert_not_called()
+        assert result["denied"] is True
+        assert result["reason"] == "release_lookup_failed"
+
+    def test_lookup_failed_refusal_takes_precedence_over_authority_permit(self, monkeypatch):
+        """Even when the authority-graph decision is PERMIT, a
+        LOOKUP_FAILED release resolution still refuses in strict mode —
+        the release gate and the authority gate are independent AND'd
+        conditions, not an either/or."""
+        monkeypatch.setattr(supervisor_mod, "_GOVERNANCE_AVAILABLE", True)
+        monkeypatch.setenv("RELEASE_DISPATCH_ENVIRONMENT", "PROD")
+        finding = _make_finding(ArbitrationDecision.PERMIT)
+        resolve_return = ReleaseResolution(
+            status=ReleaseResolutionStatus.LOOKUP_FAILED, error="network",
+        )
+
+        patches = _common_patches("strict", finding, resolve_return)
+        with patches[0] as mock_load, patches[1] as MockEngine, patches[2] as mock_write, \
+             patches[3], patches[4] as mock_dispatch:
+            mock_load.return_value = _make_state("strict", effective_at=None)
+            MockEngine.return_value.evaluate.return_value = finding
+
+            result = supervisor_mod.governed_process_agent_call(
+                _AGENTS_CONFIG, _ORCH, "agent-a", {"x": 1}, "use-1",
+            )
+
+        # The authority finding is still written (existing D9 ledger
+        # behaviour is unaffected by the release gate).
+        mock_write.assert_called_once_with(finding)
+        mock_dispatch.assert_not_called()
+        assert result["denied"] is True
+
+
+# ---------------------------------------------------------------------------
+# Package-unavailable / bypass interactions — the release gate must never
+# run when governance itself is unavailable (same fail-closed contract as
+# the authority gate).
+# ---------------------------------------------------------------------------
+
+
+def test_release_gate_never_runs_when_governance_package_unavailable(monkeypatch, caplog):
+    monkeypatch.setattr(supervisor_mod, "_GOVERNANCE_AVAILABLE", False)
+    monkeypatch.setattr(supervisor_mod, "_GOVERNANCE_IMPORT_ERROR", "boom")
+    monkeypatch.setenv("RELEASE_DISPATCH_ENVIRONMENT", "PROD")
+
+    with patch.object(supervisor_mod, "resolve_release") as mock_resolve, \
+         patch.object(supervisor_mod, "process_agent_call") as mock_dispatch, \
+         caplog.at_level(logging.ERROR, logger=supervisor_mod.logger.name):
+        result = supervisor_mod.governed_process_agent_call(
+            _AGENTS_CONFIG, _ORCH, "agent-a", {"x": 1}, "use-1",
+        )
+
+    mock_resolve.assert_not_called()
+    mock_dispatch.assert_not_called()
+    assert result["denied"] is True
+    assert result["reason"] == "governance_package_unavailable"

--- a/arbiter/supervisor/index.py
+++ b/arbiter/supervisor/index.py
@@ -89,6 +89,16 @@ from model_config_loader import load_model_id
 # today — unlike workerWrapper's deferred-bundling situation for
 # ``tools_config``/``workflow_contract``.
 from common.usage import build_usage_record, extract_converse_usage, extract_request_id
+from common.metrics_constants import (
+    METRIC_NAMESPACE,
+    METRIC_RELEASE_DISPATCH_EVALUATED,
+    METRIC_RELEASE_DISPATCH_WOULD_BLOCK,
+    METRIC_RELEASE_DISPATCH_REFUSED,
+    UNIT_COUNT,
+    DIMENSION_WORKFLOW_ID,
+    DIMENSION_RELEASE_MODE,
+    DIMENSION_RELEASE_OUTCOME,
+)
 
 # Tracing foundation (architect task 5459301e-1e7b-4bfd-bccb-b106aba2748c):
 # import BEFORE the sqs/dynamodb/bedrock-runtime/events boto3 clients are
@@ -132,7 +142,7 @@ def _load_governance_package():
     # Explicitly load the submodules the supervisor needs. They use relative
     # imports (``from .models import ...``) which need the parent package
     # (``_citadel_governance``) to already be registered — done above.
-    for submod in ('models', 'hierarchy', 'engine', 'ledger'):
+    for submod in ('models', 'hierarchy', 'engine', 'ledger', 'release_resolution', 'grandfathering'):
         sub_file = os.path.join(pkg_dir, f'{submod}.py')
         if not os.path.isfile(sub_file):
             continue
@@ -158,6 +168,18 @@ try:
     DispatchRequest = _gov_pkg.models.DispatchRequest
     ArbitrationDecision = _gov_pkg.models.ArbitrationDecision
     GovernanceFinding = _gov_pkg.models.GovernanceFinding
+    # Release-aware dispatch: read-only pointer/release resolution + the
+    # ported pure grandfathering rule. Loaded the same way as the four
+    # symbols above — no code path exists where these load but the
+    # authority-gate symbols don't (a single try/except covers both), so a
+    # packaging regression that drops release_resolution.py or
+    # grandfathering.py surfaces as the SAME fail-closed
+    # governance_package_unavailable refusal the authority gate already
+    # has, not a silent release-gate bypass.
+    resolve_release = _gov_pkg.release_resolution.resolve_release
+    ReleaseResolution = _gov_pkg.release_resolution.ReleaseResolution
+    ReleaseResolutionStatus = _gov_pkg.release_resolution.ReleaseResolutionStatus
+    is_grandfathered_pure = _gov_pkg.grandfathering.is_grandfathered_pure
     _GOVERNANCE_AVAILABLE = True
     _GOVERNANCE_IMPORT_ERROR: str | None = None
 except ImportError as e:
@@ -380,6 +402,139 @@ def _get_sns():
 
 ESCALATION_TOPIC_ARN = os.environ.get('ESCALATION_TOPIC_ARN')
 
+# ---------------------------------------------------------------------------
+# Release-aware dispatch (this story)
+# ---------------------------------------------------------------------------
+#
+# RELEASE_DISPATCH_ENVIRONMENT is the feature switch: when unset, the
+# release gate is a complete no-op (resolve_release is never called) so an
+# existing deployment with no releases/pointers dispatches byte-identically
+# to pre-feature behaviour. When set, it names which EnvironmentLiteral
+# ("DEV" | "STAGING" | "PROD") this deployment's dispatch path checks
+# pointers for — the same literal set environment-release-pointer-store.ts
+# keys rows by (see backend/src/types/index.ts's EnvironmentLiteral).
+#
+# Read live (os.environ.get(...) at call time, in
+# governed_process_agent_call below) rather than snapshotted once at module
+# import — mirrors ARBITER_GOVERNANCE_BYPASS's own read-live pattern a few
+# lines below, and lets an operator flip this without a redeploy the same
+# way the emergency bypass can be flipped.
+
+# Named seam, not a fabricated multi-tenancy layer: the arbiter's dispatch
+# path (agent_config.py's load_config_from_dynamodb / load_app_scoped_agents,
+# and the orchestration dict itself) carries no orgId anywhere today —
+# org resolution in this codebase happens exclusively at the AppSync/
+# resolver layer from an authenticated Cognito caller (see
+# intake-orchestration-resolver.ts's resolveOrgId), which the arbiter's
+# EventBridge/SQS-driven dispatch has no equivalent of. Rather than
+# fabricate a per-request caller identity that doesn't exist, this env var
+# is the explicit, documented seam: a single org id the deployment's
+# release pointers are scoped under, until a future story threads real
+# per-request org identity into the arbiter. Unset -> the release gate
+# treats every environment as NO_POINTER (see governed_process_agent_call),
+# which is the same safe, backward-compatible outcome as the release
+# tables themselves being unprovisioned. Read live, same rationale as
+# RELEASE_DISPATCH_ENVIRONMENT above.
+
+
+def _resolve_agent_created_at(agent_name: str) -> str | None:
+    """Best-effort per-agent creation timestamp for the grandfathering
+    check. Returns None when no signal is available — which is the honest
+    default in this codebase today (see release_resolution.py's module
+    docstring and RELEASE_DEFAULT_ORG_ID's comment above): the arbiter's
+    agent config rows (agent_config.py) carry no createdAt field, and the
+    AgentCore Registry lookup that DOES expose one
+    (catalog.registry_client.get_agent_record) requires REGISTRY_ENABLED +
+    a resolvable recordId, which is optional and not guaranteed present.
+
+    A None return is not a special case for the grandfathering rule — see
+    grandfathering.py's module docstring: is_grandfathered_pure(None, ...)
+    already resolves via the same conservative-bypass branch defined for
+    any malformed/absent created_at, so no additional logic is needed here
+    to accommodate "the arbiter doesn't have this data yet".
+
+    This function is a single, named seam for a future story to fill in
+    (e.g. once REGISTRY_ENABLED + a resolvable recordId are available for
+    every agent) without touching the call site in
+    governed_process_agent_call.
+    """
+    if os.environ.get('REGISTRY_ENABLED') != 'true':
+        return None
+    registry_id = os.environ.get('REGISTRY_ID')
+    if not registry_id:
+        return None
+    try:
+        from catalog.registry_client import get_agent_record
+        record = get_agent_record(registry_id, agent_name)
+    except Exception:
+        return None
+    if record is None:
+        return None
+    created_at = record.get('createdAt')
+    return created_at if isinstance(created_at, str) and created_at else None
+
+
+_cloudwatch_client = None
+
+
+def _get_cloudwatch():
+    global _cloudwatch_client
+    if _cloudwatch_client is None:
+        _cloudwatch_client = boto3.client('cloudwatch')
+    return _cloudwatch_client
+
+
+def _emit_release_dispatch_metric(
+    *,
+    mode: str,
+    outcome: str,
+    would_block: bool,
+    workflow_id: str = '',
+) -> None:
+    """Best-effort CloudWatch telemetry for the release-aware dispatch
+    gate, emitted for every mode so the rollout can be measured before
+    strict is flipped (Req 5). Never raises — a telemetry backend failure
+    must not affect dispatch, same discipline as executor.py's
+    ``_emit_metric``.
+
+    Always emits METRIC_RELEASE_DISPATCH_EVALUATED (the gate ran).
+    Additionally emits METRIC_RELEASE_DISPATCH_WOULD_BLOCK when
+    ``would_block`` is True (permissive/shadow: what strict WOULD have
+    done), or METRIC_RELEASE_DISPATCH_REFUSED when ``outcome`` is
+    'refused' (strict: what actually happened).
+    """
+    try:
+        cw = _get_cloudwatch()
+        dimensions = [{'Name': DIMENSION_RELEASE_MODE, 'Value': mode}]
+        if workflow_id:
+            dimensions.append({'Name': DIMENSION_WORKFLOW_ID, 'Value': workflow_id})
+        outcome_dimensions = dimensions + [
+            {'Name': DIMENSION_RELEASE_OUTCOME, 'Value': outcome},
+        ]
+        metric_data = [{
+            'MetricName': METRIC_RELEASE_DISPATCH_EVALUATED,
+            'Value': 1.0,
+            'Unit': UNIT_COUNT,
+            'Dimensions': outcome_dimensions,
+        }]
+        if would_block:
+            metric_data.append({
+                'MetricName': METRIC_RELEASE_DISPATCH_WOULD_BLOCK,
+                'Value': 1.0,
+                'Unit': UNIT_COUNT,
+                'Dimensions': dimensions,
+            })
+        if outcome == 'refused':
+            metric_data.append({
+                'MetricName': METRIC_RELEASE_DISPATCH_REFUSED,
+                'Value': 1.0,
+                'Unit': UNIT_COUNT,
+                'Dimensions': dimensions,
+            })
+        cw.put_metric_data(Namespace=METRIC_NAMESPACE, MetricData=metric_data)
+    except Exception as exc:  # noqa: BLE001 — telemetry must never raise
+        logger.warning('release-dispatch metric emit failed: %s', exc)
+
 
 def governed_process_agent_call(
     agents_config: dict,
@@ -434,6 +589,17 @@ def governed_process_agent_call(
 
     ``app_id`` scopes the authority graph (D2). ``None`` means no app
     filter.
+
+    Release-aware dispatch (additive, this story): after the authority
+    finding is written (step 5), a second and fully independent gate
+    resolves the (org, agent, environment) release pointer — see step 5b
+    below and ``arbiter/governance/release_resolution.py`` /
+    ``arbiter/governance/grandfathering.py``. It reuses this same
+    ``enforcement_mode`` (permissive/shadow telemetry-only,
+    strict-refuses-on-no-release-with-grandfathering) rather than a
+    parallel mode system, and is a no-op end to end when
+    ``RELEASE_DISPATCH_ENVIRONMENT`` is unset — the backward-compatibility
+    floor this story's top constraint requires.
     """
     # Gate 1 — package availability. Fail-closed: refuse, never fall through
     # to ungoverned dispatch. This is intentionally unconditional; it must
@@ -569,6 +735,92 @@ def governed_process_agent_call(
     # 5. Write finding (fail-closed per D9). Any exception halts dispatch,
     # in every mode.
     write_finding(finding)
+
+    # 5b. Release-aware dispatch (this story). A completely separate,
+    # additive gate from the authority-graph decision above — the two are
+    # AND'd, not either/or: a PERMIT from the authority engine can still be
+    # refused here, and vice versa is impossible (the authority gate's own
+    # DENY/ESCALATE/HALT branches return before reaching this point in
+    # strict mode; in permissive/shadow they fall through to here exactly
+    # like a PERMIT would).
+    #
+    # Backward-compatible no-op: RELEASE_DISPATCH_ENVIRONMENT unset means
+    # this deployment has not opted into release-aware dispatch at all —
+    # resolve_release is never called, so an existing deployment with no
+    # releases/pointers/env-var dispatches byte-identically to pre-feature
+    # behaviour, in every mode including strict.
+    if os.environ.get('RELEASE_DISPATCH_ENVIRONMENT'):
+        release_dispatch_environment = os.environ['RELEASE_DISPATCH_ENVIRONMENT']
+        release_result = resolve_release(
+            org_id=os.environ.get('RELEASE_DEFAULT_ORG_ID') or '',
+            agent_target_id=agent_name,
+            environment=release_dispatch_environment,
+        )
+
+        if release_result.status == ReleaseResolutionStatus.RESOLVED:
+            release_gate_outcome = 'proceed'
+            release_would_block = False
+        elif release_result.status == ReleaseResolutionStatus.LOOKUP_FAILED:
+            # Assert-or-refuse doctrine (this codebase's established
+            # posture — see hierarchy.py's SSM-failure handling and
+            # release_resolution.py's module docstring): the lookup itself
+            # failing (throttle, network, missing table, a dangling
+            # pointer) is NEVER treated the same as a clean "no release
+            # configured yet". Grandfathering does not apply here — a
+            # broken control-surface read is not the same class of thing
+            # as "this agent predates the gate", so bypassing it on
+            # grandfathering grounds would defeat the whole point of
+            # distinguishing LOOKUP_FAILED from NO_POINTER.
+            release_gate_outcome = 'refused' if enforcement_mode == 'strict' else 'proceed'
+            release_would_block = enforcement_mode != 'strict'
+        else:
+            # NO_POINTER — the clean, expected backward-compat state. In
+            # strict mode this refuses UNLESS the (org, agent, environment)
+            # triple is grandfathered, via the same ported pure rule the
+            # TS side owns (grandfathering.py's is_grandfathered_pure).
+            # _resolve_agent_created_at's honest None default (see its
+            # docstring) already routes through that rule's conservative-
+            # bypass branch, so an arbiter with no per-agent creation
+            # signal available today grandfathers by default rather than
+            # hardening into a block.
+            created_at = _resolve_agent_created_at(agent_name)
+            grandfathered = is_grandfathered_pure(created_at, state.effective_at)
+            if enforcement_mode == 'strict' and not grandfathered:
+                release_gate_outcome = 'refused'
+            else:
+                release_gate_outcome = 'proceed'
+            release_would_block = enforcement_mode != 'strict'
+
+        _emit_release_dispatch_metric(
+            mode=enforcement_mode,
+            outcome=release_gate_outcome,
+            would_block=release_would_block,
+            workflow_id=workflow_id,
+        )
+
+        if release_gate_outcome == 'refused':
+            refusal_reason = (
+                'release_lookup_failed'
+                if release_result.status == ReleaseResolutionStatus.LOOKUP_FAILED
+                else 'no_release_resolvable'
+            )
+            logger.error(
+                "release dispatch refused: %s; workflow_id=%s target_agent=%s "
+                "environment=%s detail=%s",
+                refusal_reason,
+                workflow_id,
+                agent_name,
+                release_dispatch_environment,
+                release_result.error,
+            )
+            return {
+                'denied': True,
+                'reason': refusal_reason,
+                'detail': release_result.error,
+                'workflow_id': workflow_id,
+                'target_agent': agent_name,
+                'agent_use_id': agent_use_id,
+            }
 
     # 6. Branch on mode + decision.
     #    permissive/shadow (or the emergency bypass override): evaluate +

--- a/backend/bin/app.ts
+++ b/backend/bin/app.ts
@@ -206,6 +206,15 @@ const arbiterStack = new ArbiterStack(app, `citadel-arbiter-${environment}`, {
   // API + user pool ARN here keeps that wiring centralised in app.ts.
   appSyncApi: backendStack.appSyncApi,
   userPoolArn: backendStack.userPool.userPoolArn,
+  // Release-aware dispatch (this story): read-only handles on the two
+  // release tables so the Supervisor and Step Runner can resolve the
+  // (org, agent, environment) pointer at dispatch time. Same tables
+  // GovernanceStack's release resolver already reads from — passed here
+  // too since ArbiterStack's Lambdas are a distinct set of principals with
+  // their own, narrower (GetItem/Query-only) grant (see ArbiterStack's
+  // agentReleasesTable/environmentReleasePointersTable prop doc comment).
+  agentReleasesTable: backendStack.agentReleasesTable,
+  environmentReleasePointersTable: backendStack.environmentReleasePointersTable,
 });
 
 // Telemetry stack — invocation cost ledger + cost query API/budgets

--- a/backend/bin/app.ts
+++ b/backend/bin/app.ts
@@ -170,6 +170,14 @@ const governanceStack = new GovernanceStack(
     agentReleaseWriterRole: backendStack.agentReleaseWriterRole,
     registryArn: backendStack.registryArn,
     registryId: backendStack.registryId,
+    // Environment release pointer (follow-on to slices 1-2): separate
+    // table + separate writer role from AgentReleasesTable above — see
+    // backend-stack.ts's EnvironmentReleasePointersTable construction
+    // site for why these must never share a grant.
+    environmentReleasePointersTable:
+      backendStack.environmentReleasePointersTable,
+    environmentReleasePointerWriterRole:
+      backendStack.environmentReleasePointerWriterRole,
   },
 );
 

--- a/backend/bin/app.ts
+++ b/backend/bin/app.ts
@@ -162,6 +162,14 @@ const governanceStack = new GovernanceStack(
     evalComparisonConfigTable: backendStack.evalComparisonConfigTable,
     executionsTable: backendStack.executionsTable,
     conversationsTable: backendStack.conversationsTable,
+    // Agent release bundles (slices 1-2, wiring in this slice): the
+    // resolver ASSUMES the existing AgentReleaseWriterRole rather than
+    // being granted grantReadWriteData — see governance-stack.ts's
+    // AgentRelease Resolver section.
+    agentReleasesTable: backendStack.agentReleasesTable,
+    agentReleaseWriterRole: backendStack.agentReleaseWriterRole,
+    registryArn: backendStack.registryArn,
+    registryId: backendStack.registryId,
   },
 );
 
@@ -882,6 +890,12 @@ if (app.node.tryGetContext("nag") !== "false") {
       servicesStack,
       "IntakeOrchestrationResolverFunction/ServiceRole/DefaultPolicy/Resource",
     ],
+    // AgentReleaseWriterRole (backend-stack.ts): assumed by
+    // AgentReleaseResolverFunction (governance-stack.ts) to read the
+    // AgentCore registry record being released via GetRegistryRecord
+    // only. Not a fresh per-function ServiceRole — the shared, hand-named
+    // writer role — so its DefaultPolicy lives under backendStack.
+    [backendStack, "AgentReleaseWriterRole/DefaultPolicy/Resource"],
   ];
   for (const [stack, path] of registryArnPaths) {
     NagSuppressions.addResourceSuppressionsByPath(

--- a/backend/lib/arbiter-stack.ts
+++ b/backend/lib/arbiter-stack.ts
@@ -85,6 +85,23 @@ interface ArbiterStackProps extends cdk.StackProps {
   // the broader `userpool/*` ARN scope (with a TODO comment in the
   // attaching code).
   userPoolArn?: string;
+  // Release-aware dispatch (this story): optional read-only handles on the
+  // two release tables (both owned by BackendStack — see
+  // backend-stack.ts's AgentReleasesTable / EnvironmentReleasePointersTable
+  // construction sites) so the Supervisor and Step Runner Lambdas can
+  // resolve the (org, agent, environment) pointer at dispatch time.
+  // Optional because the release-resolution gate is forward-compatible —
+  // when either table/prop is absent, the corresponding env var is simply
+  // omitted and release_resolution.py's own table-name-unset check
+  // resolves every lookup to NO_POINTER (see that module's docstring),
+  // never a crash. GetItem/Query ONLY — see the grantReadData calls below;
+  // neither Lambda is ever granted PutItem/UpdateItem/DeleteItem on either
+  // table (the releases table must never gain a write grant beyond its
+  // sole writer role in backend-stack.ts/governance-stack.ts, and the
+  // pointer table's write grant is confined to the promotion resolver
+  // there too).
+  agentReleasesTable?: dynamodb.Table;
+  environmentReleasePointersTable?: dynamodb.Table;
 }
 
 export class ArbiterStack extends cdk.Stack {
@@ -136,8 +153,26 @@ export class ArbiterStack extends cdk.Stack {
 
     // Shared layer for arbiter root packages so all arbiter PythonFunctions
     // can `from catalog.registry_client import ...` and `from common.region
-    // import ...`. The layer structures catalog/ at /opt/python/catalog/ and
-    // common/ at /opt/python/common/ per the Python Lambda layer convention.
+    // import ...`. The layer structures catalog/ at /opt/python/catalog/,
+    // common/ at /opt/python/common/, and governance/ at
+    // /opt/python/governance/ per the Python Lambda layer convention.
+    //
+    // governance/ was added for release-aware dispatch (this story): the
+    // Step Runner's Lambda asset is `code.fromAsset(ARBITER_ROOT/stepRunner)`
+    // ONLY (see StepRunnerFunction below) — unlike the Supervisor, which
+    // widens `entry` to the arbiter/ root specifically so its own
+    // `_load_governance_package()` can reach the sibling governance/
+    // directory. Without this layer addition, executor.py's equivalent
+    // dynamic governance-package loader would have nothing to load in a
+    // deployed stepRunner Lambda, and its own fail-closed refusal (mirrors
+    // the Supervisor's _GOVERNANCE_AVAILABLE gate) would fire on every
+    // dispatch once RELEASE_DISPATCH_ENVIRONMENT is set. Bundled here
+    // (rather than widening the Step Runner's own `code.fromAsset` root the
+    // way the Supervisor does) because the layer is already the
+    // established sharing mechanism between the Step Runner and the
+    // catalog/common packages, and staging governance/ alongside them
+    // keeps a single copy shared by every governance-aware Python Lambda
+    // rather than duplicating the package per-function asset.
     const catalogLayer = new lambda.LayerVersion(this, "ArbiterCatalogLayer", {
       layerVersionName: `citadel-arbiter-catalog-${props.environment}`,
       code: lambda.Code.fromAsset(ARBITER_ROOT, {
@@ -146,14 +181,15 @@ export class ArbiterStack extends cdk.Stack {
           command: [
             "bash",
             "-c",
-            "mkdir -p /asset-output/python && cp -r /asset-input/catalog /asset-output/python/catalog && cp -r /asset-input/common /asset-output/python/common",
+            "mkdir -p /asset-output/python && cp -r /asset-input/catalog /asset-output/python/catalog && cp -r /asset-input/common /asset-output/python/common && cp -r /asset-input/governance /asset-output/python/governance",
           ],
         },
       }),
       compatibleRuntimes: [lambda.Runtime.PYTHON_3_14],
       description:
         "Shared arbiter Python packages (catalog: registry_client and utilities; " +
-        "common: cross-region prefix helper).",
+        "common: cross-region prefix helper; governance: release resolution + " +
+        "grandfathering for release-aware dispatch).",
     });
 
     const supervisorLambda = new PythonFunction(this, "SupervisorAgent", {
@@ -207,6 +243,22 @@ export class ArbiterStack extends cdk.Stack {
         ...(props.appsTable && { APPS_TABLE: props.appsTable.tableName }),
         ...(props.registryId && { REGISTRY_ID: props.registryId }),
         ...(props.registryId && { REGISTRY_ENABLED: "true" }),
+        // Release-aware dispatch (this story): table names only, omitted
+        // entirely when the tables aren't provisioned (forward-compatible
+        // no-op — see ArbiterStackProps's agentReleasesTable/
+        // environmentReleasePointersTable doc comment). RELEASE_DISPATCH_
+        // ENVIRONMENT / RELEASE_DEFAULT_ORG_ID are deliberately NOT set
+        // here — they are the feature switch and the named org seam
+        // respectively, both operator-provisioned per-deployment rather
+        // than CDK-derived, so an operator opts a deployment into the gate
+        // explicitly instead of it turning on the moment the tables exist.
+        ...(props.agentReleasesTable && {
+          AGENT_RELEASES_TABLE: props.agentReleasesTable.tableName,
+        }),
+        ...(props.environmentReleasePointersTable && {
+          ENVIRONMENT_RELEASE_POINTERS_TABLE:
+            props.environmentReleasePointersTable.tableName,
+        }),
       },
       initialPolicy: [
         new PolicyStatement({
@@ -230,6 +282,16 @@ export class ArbiterStack extends cdk.Stack {
     props.agentConfigTable.grantReadData(supervisorLambda);
     if (props.appsTable) {
       props.appsTable.grantReadData(supervisorLambda);
+    }
+    // Release-aware dispatch (this story): GetItem/Query ONLY. This floor
+    // has been broken twice already in this story — grantReadData() never
+    // grants Put/Update/Delete, and no other statement below adds them.
+    // Do not widen this beyond grantReadData for either table.
+    if (props.agentReleasesTable) {
+      props.agentReleasesTable.grantReadData(supervisorLambda);
+    }
+    if (props.environmentReleasePointersTable) {
+      props.environmentReleasePointersTable.grantReadData(supervisorLambda);
     }
 
     // Configurable model selection (read-only). The supervisor reads the
@@ -869,6 +931,19 @@ export class ArbiterStack extends cdk.Stack {
             // this SQS queue; the worker runs the agent and emits the node
             // completed/failed events the rules below consume.
             WORKER_QUEUE_URL: workerAgentQueue.queueUrl,
+            // Release-aware dispatch (this story): mirrors the Supervisor's
+            // env var wiring above — table names only, omitted when the
+            // tables aren't provisioned. See ArbiterStackProps's doc
+            // comment and the Supervisor's identical block for the
+            // rationale (RELEASE_DISPATCH_ENVIRONMENT / RELEASE_DEFAULT_
+            // ORG_ID are operator-set, not derived here).
+            ...(props.agentReleasesTable && {
+              AGENT_RELEASES_TABLE: props.agentReleasesTable.tableName,
+            }),
+            ...(props.environmentReleasePointersTable && {
+              ENVIRONMENT_RELEASE_POINTERS_TABLE:
+                props.environmentReleasePointersTable.tableName,
+            }),
           },
         },
       );
@@ -878,6 +953,15 @@ export class ArbiterStack extends cdk.Stack {
       props.workflowsTable.grantReadData(stepRunnerFunction);
       props.agentConfigTable.grantReadData(stepRunnerFunction);
       toolsConfigTable.grantReadData(stepRunnerFunction);
+      // Release-aware dispatch (this story): GetItem/Query ONLY, mirrors
+      // the Supervisor's identical grant above. Never widen beyond
+      // grantReadData for either table.
+      if (props.agentReleasesTable) {
+        props.agentReleasesTable.grantReadData(stepRunnerFunction);
+      }
+      if (props.environmentReleasePointersTable) {
+        props.environmentReleasePointersTable.grantReadData(stepRunnerFunction);
+      }
       props.agentEventBus.grantPutEventsTo(stepRunnerFunction);
       // SendMessage only, on the single worker agent queue — the Step Runner
       // dispatches node execution to the worker via SQS and never receives or

--- a/backend/lib/backend-stack.ts
+++ b/backend/lib/backend-stack.ts
@@ -59,6 +59,21 @@ export class BackendStack extends cdk.Stack {
   // eval-run-resolver/eval-runner/eval-conversation-worker.
   public readonly evalRunsTable: dynamodb.Table;
   public readonly evalRunCaseResultsTable: dynamodb.Table;
+  // Agent release bundles (slice 1) — content-addressed, immutable audit
+  // record pinning an agent's full constituent set (config, prompts,
+  // exec spec, model config, tools, policy) plus its non-nullable eval
+  // evidence at cut time. Placed here, sibling to EvalRuns/
+  // EvalRunCaseResults above, because a release's eval evidence is a
+  // pointer into those exact tables — same file, same construction
+  // order, same RETAIN + deletionProtection + PITR governance posture.
+  // The sole writer is release-store.ts (see
+  // release-store-choke-point.guard.test.ts); IAM below grants
+  // PutItem/GetItem/Query only — no UpdateItem, no DeleteItem, to any
+  // principal.
+  public readonly agentReleasesTable: dynamodb.Table;
+  /** IAM floor for AgentReleasesTable — PutItem/GetItem/Query only, see
+   * construction site below for the full rationale. */
+  public readonly agentReleaseWriterRole: iam.Role;
   // Phase 2 (production sampling) — admin-authored per-org sampling
   // config (small, not release evidence — no RETAIN/deletionProtection
   // needed, but PITR kept for consistency) and the captured+scored
@@ -3261,6 +3276,63 @@ export class BackendStack extends cdk.Stack {
         pointInTimeRecoverySpecification: { pointInTimeRecoveryEnabled: true },
       },
     );
+
+    // AgentReleases (slice 1) — content-addressed, immutable release
+    // bundle. Simple PK (releaseId = sha256 content hash, computed by
+    // release-hash.ts — see release-store.ts, the sole writer). Same
+    // RETAIN + deletionProtection + PITR posture as EvalRunsTable/
+    // EvalRunCaseResultsTable directly above, since this table's eval
+    // evidence fields are pointers into those exact tables. One GSI
+    // (org-index) mirrors EvalRunsTable's org-scoped listing convention.
+    // NO update/delete IAM is granted on this table to any principal —
+    // see the narrow addToRolePolicy grant below (Put/Get/Query only),
+    // the layer EvalSuites/EvalRuns lacked at first ship.
+    this.agentReleasesTable = new dynamodb.Table(this, "AgentReleasesTable", {
+      tableName: `citadel-agent-releases-${props.environment}`,
+      partitionKey: {
+        name: "releaseId",
+        type: dynamodb.AttributeType.STRING,
+      },
+      billingMode: dynamodb.BillingMode.PAY_PER_REQUEST,
+      removalPolicy: cdk.RemovalPolicy.RETAIN,
+      deletionProtection: true,
+      pointInTimeRecoverySpecification: { pointInTimeRecoveryEnabled: true },
+    });
+    this.agentReleasesTable.addGlobalSecondaryIndex({
+      indexName: "org-index",
+      partitionKey: { name: "orgId", type: dynamodb.AttributeType.STRING },
+      sortKey: { name: "createdAt", type: dynamodb.AttributeType.STRING },
+      projectionType: dynamodb.ProjectionType.ALL,
+    });
+
+    // IAM floor (design §2, L3) — the layer EvalSuites/EvalRuns lacked at
+    // first ship (the bypass incident: a seed writer's role held
+    // UpdateItem/PutItem). This role is the ONLY principal granted write
+    // access to AgentReleasesTable, and it carries PutItem + GetItem +
+    // Query ONLY — no UpdateItem, no DeleteItem, granted here or anywhere
+    // else. Slice 2's cut-release Lambda (release-resolver.ts, deferred)
+    // assumes this role rather than being granted broader
+    // grantReadWriteData; any future consumer needing read-only access
+    // must be granted a SEPARATE, narrower Query/GetItem-only statement,
+    // never this role.
+    const agentReleaseWriterRole = new iam.Role(
+      this,
+      "AgentReleaseWriterRole",
+      {
+        assumedBy: new iam.ServicePrincipal("lambda.amazonaws.com"),
+      },
+    );
+    agentReleaseWriterRole.addToPolicy(
+      new iam.PolicyStatement({
+        effect: iam.Effect.ALLOW,
+        actions: ["dynamodb:PutItem", "dynamodb:GetItem", "dynamodb:Query"],
+        resources: [
+          this.agentReleasesTable.tableArn,
+          `${this.agentReleasesTable.tableArn}/index/*`,
+        ],
+      }),
+    );
+    this.agentReleaseWriterRole = agentReleaseWriterRole;
 
     // Phase 2 (production sampling) — EvalSamplingConfig: admin-authored,
     // one row per org (PK=orgId). Small config table, DESTROY on stack

--- a/backend/lib/backend-stack.ts
+++ b/backend/lib/backend-stack.ts
@@ -74,6 +74,23 @@ export class BackendStack extends cdk.Stack {
   /** IAM floor for AgentReleasesTable — PutItem/GetItem/Query only, see
    * construction site below for the full rationale. */
   public readonly agentReleaseWriterRole: iam.Role;
+  // Environment release pointer (follow-on to slices 1-2) — the MUTABLE
+  // cursor saying which AgentRelease an (org, agentTargetId, environment)
+  // triple currently runs. Deliberately separate table AND separate
+  // writer role from AgentReleasesTable above: this table needs
+  // UpdateItem-equivalent write capability (a Put that moves the pointer,
+  // optimistic-locked via a version ConditionExpression at the write
+  // boundary — see environment-release-pointer-store.ts), and that
+  // capability must never be co-granted on AgentReleasesTable, which
+  // Slice 1 guarantees carries zero UpdateItem/DeleteItem from any
+  // principal. See backend-stack-environment-release-pointer-table.test.ts
+  // for the assertion that no single IAM statement names both tables.
+  public readonly environmentReleasePointersTable: dynamodb.Table;
+  /** IAM floor for EnvironmentReleasePointersTable — PutItem/GetItem/Query
+   * only (the Put IS the mutation; there is no separate UpdateItem call —
+   * see environment-release-pointer-store.ts). No DeleteItem anywhere:
+   * deleting a pointer would erase deployment history. */
+  public readonly environmentReleasePointerWriterRole: iam.Role;
   // Phase 2 (production sampling) — admin-authored per-org sampling
   // config (small, not release evidence — no RETAIN/deletionProtection
   // needed, but PITR kept for consistency) and the captured+scored
@@ -3333,6 +3350,64 @@ export class BackendStack extends cdk.Stack {
       }),
     );
     this.agentReleaseWriterRole = agentReleaseWriterRole;
+
+    // Environment release pointer — MUTABLE cursor, deliberately the
+    // opposite governance posture from AgentReleasesTable's immutability.
+    // PK orgId, SK `agentTargetId_environment` (composite, mirroring
+    // EvalBaselinesTable's `agentTargetId_suiteId` sort-key convention)
+    // so a point-get is exact for one (agent, environment) and a Query on
+    // orgId + begins_with(agentTargetId_environment, `${agentTargetId}#`)
+    // lists every environment's pointer for one agent. Still RETAIN +
+    // deletionProtection + PITR: even though the row's CONTENT changes on
+    // every promotion, the row's non-existence-to-existence-to-history is
+    // itself deployment history that must survive stack updates and be
+    // recoverable — mutability of content is not a reason to relax
+    // durability of the table.
+    this.environmentReleasePointersTable = new dynamodb.Table(
+      this,
+      "EnvironmentReleasePointersTable",
+      {
+        tableName: `citadel-environment-release-pointers-${props.environment}`,
+        partitionKey: { name: "orgId", type: dynamodb.AttributeType.STRING },
+        sortKey: {
+          name: "agentTargetId_environment",
+          type: dynamodb.AttributeType.STRING,
+        },
+        billingMode: dynamodb.BillingMode.PAY_PER_REQUEST,
+        removalPolicy: cdk.RemovalPolicy.RETAIN,
+        deletionProtection: true,
+        pointInTimeRecoverySpecification: { pointInTimeRecoveryEnabled: true },
+      },
+    );
+
+    // IAM floor — a SEPARATE role from agentReleaseWriterRole above, on
+    // purpose (see the invariant called out on the table's own doc
+    // comment and on the class field declaration). PutItem/GetItem/Query
+    // ONLY, granted against ONLY this table's ARN + index ARNs — never
+    // co-listed as a resource alongside AgentReleasesTable in the same
+    // statement, and never DeleteItem, anywhere. There is no UpdateItem
+    // grant either: the pointer's "move" operation is a conditional Put
+    // (environment-release-pointer-store.ts), not an UpdateCommand, so
+    // PutItem is the only write action this role needs.
+    const environmentReleasePointerWriterRole = new iam.Role(
+      this,
+      "EnvironmentReleasePointerWriterRole",
+      {
+        assumedBy: new iam.ServicePrincipal("lambda.amazonaws.com"),
+      },
+    );
+    environmentReleasePointerWriterRole.addToPolicy(
+      new iam.PolicyStatement({
+        effect: iam.Effect.ALLOW,
+        actions: ["dynamodb:PutItem", "dynamodb:GetItem", "dynamodb:Query"],
+        resources: [
+          this.environmentReleasePointersTable.tableArn,
+          `${this.environmentReleasePointersTable.tableArn}/index/*`,
+        ],
+      }),
+    );
+    this.environmentReleasePointerWriterRole =
+      environmentReleasePointerWriterRole;
 
     // Phase 2 (production sampling) — EvalSamplingConfig: admin-authored,
     // one row per org (PK=orgId). Small config table, DESTROY on stack

--- a/backend/lib/governance-stack.ts
+++ b/backend/lib/governance-stack.ts
@@ -77,6 +77,18 @@ export interface GovernanceStackProps extends cdk.StackProps {
   executionsTable: dynamodb.ITable;
   /** Adapter B dispatch target — conversation transcript rows for CONVERSATION-kind cases. */
   conversationsTable: dynamodb.ITable;
+  // Agent release bundles (slices 1-2) — owned by BackendStack. The
+  // release-resolver Lambda ASSUMES agentReleaseWriterRole (the sole
+  // Put/Get/Query-only IAM floor for this table, see backend-stack.ts's
+  // AgentReleasesTable construction site) rather than being granted
+  // grantReadWriteData — no principal may hold UpdateItem/DeleteItem on
+  // this table, by design.
+  agentReleasesTable: dynamodb.ITable;
+  agentReleaseWriterRole: iam.IRole;
+  /** AgentCore Registry handles — release-resolver reads the registry
+   * record (agent config) being released via GetRegistryRecord only. */
+  registryArn: string;
+  registryId: string;
 }
 
 export class GovernanceStack extends cdk.Stack {
@@ -1028,6 +1040,123 @@ exports.handler = async (event) => {
       });
       resolver.addResourceDependency(evalRunLambdaDataSource);
     }
+
+    // ============================================================
+    // AgentRelease Resolver (cutAgentRelease reachability, wiring only)
+    // ============================================================
+    //
+    // release-resolver.ts (slice 2, already implemented/tested) is wired
+    // here rather than created in BackendStack, mirroring the eval-run
+    // resolver's home: governance-grade audit records live in
+    // GovernanceStack alongside their AppSync wiring. Two invariants:
+    //  - This function's execution role IS agentReleaseWriterRole
+    //    (`role:` prop below), ASSUMED rather than granted via
+    //    grantReadWriteData — the sole Put/Get/Query-only IAM floor for
+    //    AgentReleasesTable (backend-stack.ts). No additional grant is
+    //    issued against that table from this stack.
+    //  - Every other table this resolver reads for cross-validation
+    //    (execution specs, eval runs, eval suites, projects) receives a
+    //    SEPARATE, narrower read-side grant. Eval suites additionally
+    //    need write access for the suite-reference freeze step
+    //    (markEvalSuiteReferencedForRelease), but this MUST NOT be a
+    //    grantReadWriteData call: the function's role is the SHARED
+    //    AgentReleaseWriterRole, so a table-level grantReadWriteData
+    //    would hand DeleteItem/BatchWriteItem/UpdateItem on that table
+    //    to every principal that assumes the role. Instead: a plain
+    //    read-only grant plus one hand-written UpdateItem-only
+    //    PolicyStatement, scoped to exactly the action the resolver
+    //    issues (a single UpdateCommand by primary key).
+    const agentReleaseResolverFunction = new lambda.Function(
+      this,
+      "AgentReleaseResolverFunction",
+      {
+        runtime: lambda.Runtime.NODEJS_24_X,
+        handler: "release-resolver.handler",
+        code: lambda.Code.fromAsset("dist/lambda"),
+        role: props.agentReleaseWriterRole,
+        environment: {
+          AGENT_RELEASES_TABLE: props.agentReleasesTable.tableName,
+          EXECUTION_SPECS_TABLE: props.executionSpecificationsTable.tableName,
+          EVAL_RUNS_TABLE: props.evalRunsTable.tableName,
+          EVAL_SUITES_TABLE: props.evalSuitesTable.tableName,
+          PROJECTS_TABLE: props.projectsTable.tableName,
+          REGISTRY_ID: props.registryId,
+        },
+        timeout: cdk.Duration.seconds(30),
+        logGroup: new logs.LogGroup(this, "AgentReleaseResolverFunctionLogs", {
+          retention: logs.RetentionDays.ONE_WEEK,
+          removalPolicy: cdk.RemovalPolicy.DESTROY,
+        }),
+      },
+    );
+
+    props.executionSpecificationsTable.grantReadData(
+      agentReleaseResolverFunction,
+    );
+    props.evalRunsTable.grantReadData(agentReleaseResolverFunction);
+    // Read: general suite lookups performed by the resolver.
+    props.evalSuitesTable.grantReadData(agentReleaseResolverFunction);
+    // Write: markEvalSuiteReferencedForRelease issues a single UpdateCommand
+    // (by primary key) against EvalSuitesTable to freeze the referenced
+    // suite's `references` attribute. A scoped UpdateItem-only statement is
+    // used deliberately instead of grantReadWriteData — this function's
+    // role is the SHARED AgentReleaseWriterRole (assumed, not a fresh
+    // per-function role), so a grantReadWriteData call here would also
+    // hand that role dynamodb:DeleteItem/BatchWriteItem/UpdateItem on
+    // EvalSuitesTable, widening every principal that can assume the role.
+    // This statement only ever needs UpdateItem.
+    agentReleaseResolverFunction.addToRolePolicy(
+      new iam.PolicyStatement({
+        effect: iam.Effect.ALLOW,
+        actions: ["dynamodb:UpdateItem"],
+        resources: [props.evalSuitesTable.tableArn],
+      }),
+    );
+    props.projectsTable.grantReadData(agentReleaseResolverFunction);
+    agentReleaseResolverFunction.addToRolePolicy(
+      new iam.PolicyStatement({
+        effect: iam.Effect.ALLOW,
+        actions: ["bedrock-agentcore:GetRegistryRecord"],
+        resources: [props.registryArn, `${props.registryArn}/*`],
+      }),
+    );
+
+    const agentReleaseDataSourceRole = new iam.Role(
+      this,
+      "AgentReleaseDataSourceRole",
+      {
+        assumedBy: new iam.ServicePrincipal("appsync.amazonaws.com"),
+      },
+    );
+    agentReleaseResolverFunction.grantInvoke(agentReleaseDataSourceRole);
+
+    const agentReleaseLambdaDataSource = new appsyncCfn.CfnDataSource(
+      this,
+      "AgentReleaseLambdaDataSource",
+      {
+        apiId: props.appSyncApi.apiId,
+        name: "AgentReleaseLambdaDataSource",
+        type: "AWS_LAMBDA",
+        serviceRoleArn: agentReleaseDataSourceRole.roleArn,
+        lambdaConfig: {
+          lambdaFunctionArn: agentReleaseResolverFunction.functionArn,
+        },
+      },
+    );
+
+    const cutAgentReleaseResolver = new appsyncCfn.CfnResolver(
+      this,
+      "CutAgentReleaseResolver",
+      {
+        apiId: props.appSyncApi.apiId,
+        typeName: "Mutation",
+        fieldName: "cutAgentRelease",
+        dataSourceName: agentReleaseLambdaDataSource.attrName,
+        requestMappingTemplate: LAMBDA_REQUEST_MAPPING,
+        responseMappingTemplate: LAMBDA_RESPONSE_MAPPING,
+      },
+    );
+    cutAgentReleaseResolver.addResourceDependency(agentReleaseLambdaDataSource);
 
     // ============================================================
     // EvalBaseline / EvalComparison Resolver (CIT-105)

--- a/backend/lib/governance-stack.ts
+++ b/backend/lib/governance-stack.ts
@@ -89,6 +89,15 @@ export interface GovernanceStackProps extends cdk.StackProps {
    * record (agent config) being released via GetRegistryRecord only. */
   registryArn: string;
   registryId: string;
+  // Environment release pointer (follow-on to slices 1-2) — owned by
+  // BackendStack, consumed here by environment-release-pointer-resolver.
+  // Deliberately a SEPARATE table AND a SEPARATE role from
+  // agentReleasesTable/agentReleaseWriterRole above — see the invariant
+  // documented on backend-stack.ts's EnvironmentReleasePointersTable
+  // construction site: this role's write capability must never be
+  // co-granted on AgentReleasesTable.
+  environmentReleasePointersTable: dynamodb.ITable;
+  environmentReleasePointerWriterRole: iam.IRole;
 }
 
 export class GovernanceStack extends cdk.Stack {
@@ -1157,6 +1166,131 @@ exports.handler = async (event) => {
       },
     );
     cutAgentReleaseResolver.addResourceDependency(agentReleaseLambdaDataSource);
+
+    // ============================================================
+    // Environment Release Pointer Resolver (mutable per-environment cursor)
+    // ============================================================
+    //
+    // Own function, own AppSync data source, and — the invariant this
+    // slice is delicate about — its OWN, SEPARATE execution role
+    // (environmentReleasePointerWriterRole), never
+    // agentReleaseWriterRole. This function's role is granted
+    // PutItem/GetItem/Query on EnvironmentReleasePointersTable ONLY (see
+    // backend-stack.ts's construction site); AgentReleasesTable access
+    // (to validate the target release exists and belongs to the caller's
+    // org) is a SEPARATE, narrower grantReadData call below —
+    // grantReadData only ever adds GetItem/Query/BatchGetItem, never a
+    // write action, so it cannot widen either table's write floor. No
+    // statement anywhere names both tables, which
+    // backend-stack-environment-release-pointer-table.test.ts asserts
+    // directly.
+    const environmentReleasePointerResolverFunction = new lambda.Function(
+      this,
+      "EnvironmentReleasePointerResolverFunction",
+      {
+        runtime: lambda.Runtime.NODEJS_24_X,
+        handler: "environment-release-pointer-resolver.handler",
+        code: lambda.Code.fromAsset("dist/lambda"),
+        role: props.environmentReleasePointerWriterRole,
+        environment: {
+          ENVIRONMENT_RELEASE_POINTERS_TABLE:
+            props.environmentReleasePointersTable.tableName,
+          AGENT_RELEASES_TABLE: props.agentReleasesTable.tableName,
+        },
+        timeout: cdk.Duration.seconds(30),
+        logGroup: new logs.LogGroup(
+          this,
+          "EnvironmentReleasePointerResolverFunctionLogs",
+          {
+            retention: logs.RetentionDays.ONE_WEEK,
+            removalPolicy: cdk.RemovalPolicy.DESTROY,
+          },
+        ),
+      },
+    );
+
+    // Read-only: existence + org-ownership check against the target
+    // release, via a single GetCommand by primary key (never a batch or
+    // scan). A hand-scoped PolicyStatement is used here instead of
+    // grantReadData deliberately — grantReadData's standard action set
+    // includes BatchGetItem, which would violate this table's
+    // established narrow allowlist (PutItem/GetItem/Query only, enforced
+    // by backend-stack-agent-releases-table.test.ts /
+    // governance-stack-agent-release.test.ts) even though BatchGetItem is
+    // itself a read-only action. GetItem is all this resolver's
+    // getAgentRelease() ever issues.
+    environmentReleasePointerResolverFunction.addToRolePolicy(
+      new iam.PolicyStatement({
+        effect: iam.Effect.ALLOW,
+        actions: ["dynamodb:GetItem"],
+        resources: [props.agentReleasesTable.tableArn],
+      }),
+    );
+
+    const environmentReleasePointerDataSourceRole = new iam.Role(
+      this,
+      "EnvironmentReleasePointerDataSourceRole",
+      {
+        assumedBy: new iam.ServicePrincipal("appsync.amazonaws.com"),
+      },
+    );
+    environmentReleasePointerResolverFunction.grantInvoke(
+      environmentReleasePointerDataSourceRole,
+    );
+
+    const environmentReleasePointerLambdaDataSource =
+      new appsyncCfn.CfnDataSource(
+        this,
+        "EnvironmentReleasePointerLambdaDataSource",
+        {
+          apiId: props.appSyncApi.apiId,
+          name: "EnvironmentReleasePointerLambdaDataSource",
+          type: "AWS_LAMBDA",
+          serviceRoleArn: environmentReleasePointerDataSourceRole.roleArn,
+          lambdaConfig: {
+            lambdaFunctionArn:
+              environmentReleasePointerResolverFunction.functionArn,
+          },
+        },
+      );
+
+    const promoteEnvironmentReleasePointerResolver = new appsyncCfn.CfnResolver(
+      this,
+      "PromoteEnvironmentReleasePointerResolver",
+      {
+        apiId: props.appSyncApi.apiId,
+        typeName: "Mutation",
+        fieldName: "promoteEnvironmentReleasePointer",
+        dataSourceName: environmentReleasePointerLambdaDataSource.attrName,
+        requestMappingTemplate: LAMBDA_REQUEST_MAPPING,
+        responseMappingTemplate: LAMBDA_RESPONSE_MAPPING,
+      },
+    );
+    promoteEnvironmentReleasePointerResolver.addResourceDependency(
+      environmentReleasePointerLambdaDataSource,
+    );
+
+    const environmentReleasePointerQueryFields = [
+      {
+        id: "GetCurrentEnvironmentReleasePointerResolver",
+        fieldName: "getCurrentEnvironmentReleasePointer",
+      },
+      {
+        id: "ListEnvironmentReleasePointersResolver",
+        fieldName: "listEnvironmentReleasePointers",
+      },
+    ];
+    for (const { id, fieldName } of environmentReleasePointerQueryFields) {
+      const resolver = new appsyncCfn.CfnResolver(this, id, {
+        apiId: props.appSyncApi.apiId,
+        typeName: "Query",
+        fieldName,
+        dataSourceName: environmentReleasePointerLambdaDataSource.attrName,
+        requestMappingTemplate: LAMBDA_REQUEST_MAPPING,
+        responseMappingTemplate: LAMBDA_RESPONSE_MAPPING,
+      });
+      resolver.addResourceDependency(environmentReleasePointerLambdaDataSource);
+    }
 
     // ============================================================
     // EvalBaseline / EvalComparison Resolver (CIT-105)

--- a/backend/src/lambda/__tests__/environment-release-pointer-resolver.test.ts
+++ b/backend/src/lambda/__tests__/environment-release-pointer-resolver.test.ts
@@ -1,0 +1,420 @@
+/**
+ * environment-release-pointer-resolver.test.ts — promoteEnvironmentReleasePointer
+ * mutation and the two read queries.
+ *
+ * Structural mirror of release-resolver.test.ts's conventions: mocked DDB
+ * client, authContext fixtures per role, direct function calls (not the
+ * AppSync `handler` dispatch, except where explicitly noted).
+ *
+ * The store module (environment-release-pointer-store.ts) is exercised
+ * through its real, unmocked exports — this suite never mocks
+ * setEnvironmentReleasePointer/getEnvironmentReleasePointer directly, only
+ * the DynamoDB client underneath, so the optimistic-locking guarantee
+ * stays load-bearing for these tests too.
+ */
+import {
+  DynamoDBDocumentClient,
+  GetCommand,
+  PutCommand,
+  QueryCommand,
+} from "@aws-sdk/lib-dynamodb";
+import { mockClient } from "aws-sdk-client-mock";
+import type { AuthContext, AgentRelease } from "../../types";
+
+process.env.AGENT_RELEASES_TABLE = "citadel-agent-releases-test";
+process.env.ENVIRONMENT_RELEASE_POINTERS_TABLE =
+  "citadel-environment-release-pointers-test";
+
+const ddbMock = mockClient(DynamoDBDocumentClient);
+
+import {
+  promoteEnvironmentReleasePointer,
+  getCurrentEnvironmentReleasePointer,
+  listEnvironmentReleasePointers,
+  validateReleaseGate,
+  handler,
+} from "../environment-release-pointer-resolver";
+
+function authContextFor(role: string): AuthContext {
+  return {
+    userId: `user-${role}`,
+    username: role,
+    groups: [],
+    roles: [role],
+  };
+}
+
+function release(overrides: Partial<AgentRelease> = {}): AgentRelease {
+  return {
+    releaseId: "release-1",
+    orgId: "org-1",
+    agentTargetId: "agent-1",
+    semver: "1.0.0",
+    agentConfig: { sourceId: "rec-1", content: "{}", digest: "d" },
+    promptVersions: {},
+    execSpecId: "spec-1",
+    execSpecVersion: 1,
+    modelConfigSnapshots: [],
+    toolConfigs: [],
+    policySnapshot: {
+      enforcementMode: "strict",
+      ruleSetVersion: "1",
+      authorityUnitGrantIds: [],
+    },
+    evalEvidence: {
+      evalRunId: "run-1",
+      evalSuiteId: "suite-1",
+      evalSuiteVersion: 1,
+    },
+    createdAt: "2026-01-01T00:00:00.000Z",
+    createdBy: "architect-1",
+    gitSha: "abc123",
+    region: "us-east-1",
+    runId: "runid-1",
+    ...overrides,
+  };
+}
+
+beforeEach(() => {
+  ddbMock.reset();
+});
+
+describe("validateReleaseGate", () => {
+  test("is an explicit no-op seam — never enforces, never throws", () => {
+    expect(() => validateReleaseGate()).not.toThrow();
+    expect(validateReleaseGate()).toBeUndefined();
+  });
+});
+
+describe("promoteEnvironmentReleasePointer — permission gate", () => {
+  test("rejects a caller without release:promote before touching DynamoDB", async () => {
+    await expect(
+      promoteEnvironmentReleasePointer(
+        {
+          agentTargetId: "agent-1",
+          environment: "STAGING",
+          releaseId: "release-1",
+        },
+        authContextFor("developer"),
+        "org-1",
+      ),
+    ).rejects.toThrow(/UnauthorizedError/);
+
+    expect(ddbMock.commandCalls(GetCommand)).toHaveLength(0);
+    expect(ddbMock.commandCalls(PutCommand)).toHaveLength(0);
+  });
+
+  test("architect role (release:promote) is allowed through the gate", async () => {
+    ddbMock
+      .on(GetCommand, { TableName: "citadel-agent-releases-test" })
+      .resolves({
+        Item: release(),
+      });
+    ddbMock
+      .on(GetCommand, {
+        TableName: "citadel-environment-release-pointers-test",
+      })
+      .resolves({ Item: undefined });
+    ddbMock.on(PutCommand).resolves({});
+
+    const result = await promoteEnvironmentReleasePointer(
+      {
+        agentTargetId: "agent-1",
+        environment: "STAGING",
+        releaseId: "release-1",
+      },
+      authContextFor("architect"),
+      "org-1",
+    );
+
+    expect(result.releaseId).toBe("release-1");
+  });
+});
+
+describe("promoteEnvironmentReleasePointer — release existence + org validation", () => {
+  const architect = authContextFor("architect");
+
+  test("rejects when the target release does not exist", async () => {
+    ddbMock
+      .on(GetCommand, { TableName: "citadel-agent-releases-test" })
+      .resolves({
+        Item: undefined,
+      });
+
+    await expect(
+      promoteEnvironmentReleasePointer(
+        {
+          agentTargetId: "agent-1",
+          environment: "STAGING",
+          releaseId: "release-missing",
+        },
+        architect,
+        "org-1",
+      ),
+    ).rejects.toThrow(/ValidationError/);
+
+    expect(ddbMock.commandCalls(PutCommand)).toHaveLength(0);
+  });
+
+  test("rejects when the target release belongs to a different org", async () => {
+    ddbMock
+      .on(GetCommand, { TableName: "citadel-agent-releases-test" })
+      .resolves({
+        Item: release({ orgId: "org-OTHER" }),
+      });
+
+    await expect(
+      promoteEnvironmentReleasePointer(
+        {
+          agentTargetId: "agent-1",
+          environment: "STAGING",
+          releaseId: "release-1",
+        },
+        architect,
+        "org-1",
+      ),
+    ).rejects.toThrow(/SecurityError/);
+
+    expect(ddbMock.commandCalls(PutCommand)).toHaveLength(0);
+  });
+
+  test("accepts a same-org, existing release and writes the pointer", async () => {
+    ddbMock
+      .on(GetCommand, { TableName: "citadel-agent-releases-test" })
+      .resolves({
+        Item: release({ orgId: "org-1" }),
+      });
+    ddbMock
+      .on(GetCommand, {
+        TableName: "citadel-environment-release-pointers-test",
+      })
+      .resolves({ Item: undefined });
+    ddbMock.on(PutCommand).resolves({});
+
+    const result = await promoteEnvironmentReleasePointer(
+      { agentTargetId: "agent-1", environment: "PROD", releaseId: "release-1" },
+      architect,
+      "org-1",
+    );
+
+    expect(result.orgId).toBe("org-1");
+    expect(result.environment).toBe("PROD");
+    expect(result.releaseId).toBe("release-1");
+    expect(result.previousReleaseId).toBeNull();
+    expect(result.version).toBe(1);
+  });
+});
+
+describe("promoteEnvironmentReleasePointer — moving an existing pointer", () => {
+  const architect = authContextFor("architect");
+
+  test("retains previousReleaseId from the current pointer and bumps version", async () => {
+    ddbMock
+      .on(GetCommand, { TableName: "citadel-agent-releases-test" })
+      .resolves({
+        Item: release({ orgId: "org-1", releaseId: "release-2" }),
+      });
+    ddbMock
+      .on(GetCommand, {
+        TableName: "citadel-environment-release-pointers-test",
+      })
+      .resolves({
+        Item: {
+          orgId: "org-1",
+          agentTargetId: "agent-1",
+          environment: "STAGING",
+          releaseId: "release-1",
+          previousReleaseId: null,
+          promotedAt: "2026-01-01T00:00:00.000Z",
+          promotedBy: "user-architect-old",
+          version: 1,
+        },
+      });
+    ddbMock.on(PutCommand).resolves({});
+
+    const result = await promoteEnvironmentReleasePointer(
+      {
+        agentTargetId: "agent-1",
+        environment: "STAGING",
+        releaseId: "release-2",
+      },
+      architect,
+      "org-1",
+    );
+
+    expect(result.previousReleaseId).toBe("release-1");
+    expect(result.releaseId).toBe("release-2");
+    expect(result.version).toBe(2);
+
+    const putCall = ddbMock.commandCalls(PutCommand)[0].args[0].input;
+    expect(putCall.ConditionExpression).toBe(
+      "attribute_not_exists(orgId) OR #version = :expectedVersion",
+    );
+    expect(putCall.ExpressionAttributeValues).toMatchObject({
+      ":expectedVersion": 1,
+    });
+  });
+
+  test("surfaces ConcurrentPromotionError as a distinct, catchable error when two promotions race", async () => {
+    ddbMock
+      .on(GetCommand, { TableName: "citadel-agent-releases-test" })
+      .resolves({
+        Item: release({ orgId: "org-1", releaseId: "release-2" }),
+      });
+    ddbMock
+      .on(GetCommand, {
+        TableName: "citadel-environment-release-pointers-test",
+      })
+      .resolves({
+        Item: {
+          orgId: "org-1",
+          agentTargetId: "agent-1",
+          environment: "STAGING",
+          releaseId: "release-1",
+          previousReleaseId: null,
+          promotedAt: "2026-01-01T00:00:00.000Z",
+          promotedBy: "user-architect-old",
+          version: 1,
+        },
+      });
+    const conditionalError = Object.assign(
+      new Error("The conditional request failed"),
+      { name: "ConditionalCheckFailedException" },
+    );
+    ddbMock.on(PutCommand).rejects(conditionalError);
+
+    await expect(
+      promoteEnvironmentReleasePointer(
+        {
+          agentTargetId: "agent-1",
+          environment: "STAGING",
+          releaseId: "release-2",
+        },
+        architect,
+        "org-1",
+      ),
+    ).rejects.toThrow(/ConcurrentPromotionError/);
+  });
+});
+
+describe("getCurrentEnvironmentReleasePointer", () => {
+  test("returns null when nothing has been promoted yet", async () => {
+    ddbMock.on(GetCommand).resolves({ Item: undefined });
+
+    const result = await getCurrentEnvironmentReleasePointer(
+      "org-1",
+      "agent-1",
+      "PROD",
+    );
+
+    expect(result).toBeNull();
+  });
+
+  test("returns the current pointer row for an agent+environment", async () => {
+    const pointer = {
+      orgId: "org-1",
+      agentTargetId: "agent-1",
+      environment: "PROD" as const,
+      releaseId: "release-9",
+      previousReleaseId: "release-8",
+      promotedAt: "2026-01-01T00:00:00.000Z",
+      promotedBy: "user-architect",
+      version: 4,
+    };
+    ddbMock.on(GetCommand).resolves({ Item: pointer });
+
+    const result = await getCurrentEnvironmentReleasePointer(
+      "org-1",
+      "agent-1",
+      "PROD",
+    );
+
+    expect(result).toEqual(pointer);
+  });
+});
+
+describe("listEnvironmentReleasePointers", () => {
+  test("returns every environment's pointer for the agent", async () => {
+    const staging = {
+      orgId: "org-1",
+      agentTargetId: "agent-1",
+      environment: "STAGING" as const,
+      releaseId: "release-5",
+      previousReleaseId: null,
+      promotedAt: "2026-01-01T00:00:00.000Z",
+      promotedBy: "user-architect",
+      version: 1,
+    };
+    const prod = {
+      ...staging,
+      environment: "PROD" as const,
+      releaseId: "release-3",
+      version: 2,
+    };
+    ddbMock.on(QueryCommand).resolves({ Items: [staging, prod] });
+
+    const result = await listEnvironmentReleasePointers("org-1", "agent-1");
+
+    expect(result).toEqual([staging, prod]);
+  });
+});
+
+describe("handler — AppSync dispatch", () => {
+  test("routes promoteEnvironmentReleasePointer through the custom:organization claim", async () => {
+    ddbMock
+      .on(GetCommand, { TableName: "citadel-agent-releases-test" })
+      .resolves({
+        Item: release({ orgId: "org-1" }),
+      });
+    ddbMock
+      .on(GetCommand, {
+        TableName: "citadel-environment-release-pointers-test",
+      })
+      .resolves({ Item: undefined });
+    ddbMock.on(PutCommand).resolves({});
+
+    const event = {
+      info: { fieldName: "promoteEnvironmentReleasePointer" },
+      identity: {
+        sub: "user-1",
+        "custom:role": "architect",
+        "custom:organization": "org-1",
+      },
+      arguments: {
+        input: {
+          agentTargetId: "agent-1",
+          environment: "STAGING",
+          releaseId: "release-1",
+        },
+      },
+    };
+
+    const result = (await handler(event as never)) as { releaseId: string };
+    expect(result.releaseId).toBe("release-1");
+  });
+
+  test("rejects when the caller organization cannot be determined", async () => {
+    const event = {
+      info: { fieldName: "promoteEnvironmentReleasePointer" },
+      identity: { sub: "user-1", "custom:role": "architect" },
+      arguments: {
+        input: {
+          agentTargetId: "agent-1",
+          environment: "STAGING",
+          releaseId: "release-1",
+        },
+      },
+    };
+
+    await expect(handler(event as never)).rejects.toThrow(/ValidationError/);
+  });
+
+  test("throws for an unsupported field name", async () => {
+    const event = {
+      info: { fieldName: "somethingElse" },
+      identity: {},
+      arguments: {},
+    };
+    await expect(handler(event as never)).rejects.toThrow(/Unsupported field/);
+  });
+});

--- a/backend/src/lambda/__tests__/environment-release-pointer-store.test.ts
+++ b/backend/src/lambda/__tests__/environment-release-pointer-store.test.ts
@@ -1,0 +1,243 @@
+/**
+ * environment-release-pointer-store.ts — the SOLE write choke point for
+ * EnvironmentReleasePointersTable.
+ *
+ * Structural mirror of release-store.test.ts's conventions: mocked DDB
+ * client, direct function calls against the real (unmocked) store logic.
+ *
+ * Unlike AgentRelease, this record is deliberately MUTABLE — these tests
+ * assert the OPPOSITE property of release-store.test.ts: a second write
+ * to the same (orgId, agentTargetId, environment) key succeeds and moves
+ * the pointer, but ONLY when its ConditionExpression on the `version`
+ * attribute matches what the caller last read. A concurrent promotion
+ * racing against a stale read must be rejected by DynamoDB itself, not by
+ * application logic re-checking after the fact.
+ */
+import {
+  DynamoDBDocumentClient,
+  GetCommand,
+  PutCommand,
+  QueryCommand,
+} from "@aws-sdk/lib-dynamodb";
+import { mockClient } from "aws-sdk-client-mock";
+import type { EnvironmentReleasePointer } from "../../types";
+
+process.env.ENVIRONMENT_RELEASE_POINTERS_TABLE =
+  "citadel-environment-release-pointers-test";
+
+const ddbMock = mockClient(DynamoDBDocumentClient);
+
+import {
+  getEnvironmentReleasePointer,
+  listEnvironmentReleasePointersForAgent,
+  setEnvironmentReleasePointer,
+  ConcurrentPromotionError,
+} from "../environment-release-pointer-store";
+
+function existingPointer(
+  overrides: Partial<EnvironmentReleasePointer> = {},
+): EnvironmentReleasePointer {
+  return {
+    orgId: "org-1",
+    agentTargetId: "agent-1",
+    environment: "STAGING",
+    releaseId: "release-old",
+    previousReleaseId: null,
+    promotedAt: "2026-01-01T00:00:00.000Z",
+    promotedBy: "user-architect",
+    version: 1,
+    ...overrides,
+  };
+}
+
+beforeEach(() => {
+  ddbMock.reset();
+});
+
+describe("getEnvironmentReleasePointer", () => {
+  test("returns the pointer row when it exists", async () => {
+    const pointer = existingPointer();
+    ddbMock.on(GetCommand).resolves({ Item: pointer });
+
+    const result = await getEnvironmentReleasePointer(
+      "org-1",
+      "agent-1",
+      "STAGING",
+    );
+
+    expect(result).toEqual(pointer);
+    const call = ddbMock.commandCalls(GetCommand)[0].args[0].input;
+    expect(call.TableName).toBe("citadel-environment-release-pointers-test");
+    expect(call.Key).toEqual({
+      orgId: "org-1",
+      agentTargetId_environment: "agent-1#STAGING",
+    });
+  });
+
+  test("returns null when no pointer exists yet for that key", async () => {
+    ddbMock.on(GetCommand).resolves({ Item: undefined });
+
+    const result = await getEnvironmentReleasePointer(
+      "org-1",
+      "agent-1",
+      "PROD",
+    );
+
+    expect(result).toBeNull();
+  });
+});
+
+describe("listEnvironmentReleasePointersForAgent", () => {
+  test("queries across every environment for one agent within the org", async () => {
+    const staging = existingPointer({ environment: "STAGING" });
+    const prod = existingPointer({
+      environment: "PROD",
+      releaseId: "release-prod",
+      version: 3,
+    });
+    ddbMock.on(QueryCommand).resolves({ Items: [staging, prod] });
+
+    const result = await listEnvironmentReleasePointersForAgent(
+      "org-1",
+      "agent-1",
+    );
+
+    expect(result).toEqual([staging, prod]);
+    const call = ddbMock.commandCalls(QueryCommand)[0].args[0].input;
+    expect(call.TableName).toBe("citadel-environment-release-pointers-test");
+    expect(call.KeyConditionExpression).toContain("orgId");
+    expect(call.KeyConditionExpression).toContain(
+      "begins_with(agentTargetId_environment",
+    );
+    expect(call.ExpressionAttributeValues).toMatchObject({
+      ":oid": "org-1",
+      ":prefix": "agent-1#",
+    });
+  });
+
+  test("returns an empty array when the agent has no pointers yet", async () => {
+    ddbMock.on(QueryCommand).resolves({ Items: [] });
+
+    const result = await listEnvironmentReleasePointersForAgent(
+      "org-1",
+      "agent-2",
+    );
+
+    expect(result).toEqual([]);
+  });
+});
+
+describe("setEnvironmentReleasePointer — first promotion (no existing row)", () => {
+  test("Puts a new row at version 1 with previousReleaseId null, guarded by attribute_not_exists", async () => {
+    ddbMock.on(PutCommand).resolves({});
+
+    const result = await setEnvironmentReleasePointer({
+      orgId: "org-1",
+      agentTargetId: "agent-1",
+      environment: "DEV",
+      releaseId: "release-new",
+      expectedVersion: null,
+      promotedBy: "user-architect",
+    });
+
+    expect(result.version).toBe(1);
+    expect(result.previousReleaseId).toBeNull();
+    expect(result.releaseId).toBe("release-new");
+
+    const call = ddbMock.commandCalls(PutCommand)[0].args[0].input;
+    expect(call.TableName).toBe("citadel-environment-release-pointers-test");
+    expect(call.ConditionExpression).toBe("attribute_not_exists(orgId)");
+    expect(call.Item).toMatchObject({
+      orgId: "org-1",
+      agentTargetId_environment: "agent-1#DEV",
+      environment: "DEV",
+      releaseId: "release-new",
+      previousReleaseId: null,
+      version: 1,
+      promotedBy: "user-architect",
+    });
+  });
+});
+
+describe("setEnvironmentReleasePointer — subsequent promotion (existing row)", () => {
+  test("moves the pointer, retaining the prior releaseId as previousReleaseId, bumping version, guarded by a version-match ConditionExpression", async () => {
+    ddbMock.on(PutCommand).resolves({});
+
+    const result = await setEnvironmentReleasePointer({
+      orgId: "org-1",
+      agentTargetId: "agent-1",
+      environment: "STAGING",
+      releaseId: "release-new",
+      expectedVersion: 1,
+      promotedBy: "user-architect-2",
+    });
+
+    expect(result.version).toBe(2);
+    expect(result.previousReleaseId).toBe(null);
+    expect(result.releaseId).toBe("release-new");
+
+    const call = ddbMock.commandCalls(PutCommand)[0].args[0].input;
+    expect(call.ConditionExpression).toBe(
+      "attribute_not_exists(orgId) OR #version = :expectedVersion",
+    );
+    expect(call.ExpressionAttributeNames).toEqual({ "#version": "version" });
+    expect(call.ExpressionAttributeValues).toMatchObject({
+      ":expectedVersion": 1,
+    });
+  });
+
+  test("carries the CALLER-SUPPLIED prior releaseId forward as previousReleaseId when moving from a known current release", async () => {
+    ddbMock.on(PutCommand).resolves({});
+
+    const result = await setEnvironmentReleasePointer({
+      orgId: "org-1",
+      agentTargetId: "agent-1",
+      environment: "STAGING",
+      releaseId: "release-new",
+      expectedVersion: 1,
+      currentReleaseId: "release-old",
+      promotedBy: "user-architect-2",
+    });
+
+    expect(result.previousReleaseId).toBe("release-old");
+    const call = ddbMock.commandCalls(PutCommand)[0].args[0].input;
+    expect(call.Item).toMatchObject({ previousReleaseId: "release-old" });
+  });
+
+  test("throws ConcurrentPromotionError (not a generic error) when the ConditionExpression fails — two concurrent promotions must not silently lose one", async () => {
+    const conditionalError = Object.assign(
+      new Error("The conditional request failed"),
+      { name: "ConditionalCheckFailedException" },
+    );
+    ddbMock.on(PutCommand).rejects(conditionalError);
+
+    await expect(
+      setEnvironmentReleasePointer({
+        orgId: "org-1",
+        agentTargetId: "agent-1",
+        environment: "STAGING",
+        releaseId: "release-new",
+        expectedVersion: 1,
+        promotedBy: "user-architect-2",
+      }),
+    ).rejects.toThrow(ConcurrentPromotionError);
+  });
+
+  test("propagates any OTHER DynamoDB error unchanged (not wrapped as ConcurrentPromotionError)", async () => {
+    const otherError = Object.assign(new Error("throttled"), {
+      name: "ProvisionedThroughputExceededException",
+    });
+    ddbMock.on(PutCommand).rejects(otherError);
+
+    await expect(
+      setEnvironmentReleasePointer({
+        orgId: "org-1",
+        agentTargetId: "agent-1",
+        environment: "STAGING",
+        releaseId: "release-new",
+        expectedVersion: 1,
+        promotedBy: "user-architect-2",
+      }),
+    ).rejects.toThrow("throttled");
+  });
+});

--- a/backend/src/lambda/__tests__/release-resolver.test.ts
+++ b/backend/src/lambda/__tests__/release-resolver.test.ts
@@ -1,0 +1,857 @@
+/**
+ * release-resolver.test.ts — cutAgentRelease assembly operation (slice 2).
+ *
+ * Structural mirror of eval-run-resolver.test.ts's conventions: mocked DDB
+ * client, authContext fixtures per role, direct function calls (not the
+ * AppSync `handler` dispatch, except where explicitly noted).
+ *
+ * Slice 1 (release-store.ts / release-hash.ts) is exercised through its
+ * real, unmocked exports — this suite never mocks putRelease/getRelease
+ * directly, only the DynamoDB client underneath them, so the create-only
+ * and idempotency guarantees stay load-bearing for these tests too.
+ */
+import {
+  DynamoDBDocumentClient,
+  GetCommand,
+  PutCommand,
+  UpdateCommand,
+} from "@aws-sdk/lib-dynamodb";
+import {
+  CognitoIdentityProviderClient,
+  AdminGetUserCommand,
+} from "@aws-sdk/client-cognito-identity-provider";
+import { mockClient } from "aws-sdk-client-mock";
+import type {
+  AuthContext,
+  EvalRun,
+  EvalSuite,
+  ExecutionSpecification,
+} from "../../types";
+import type { RegistryRecord } from "../../services/registry-service";
+
+process.env.AGENT_RELEASES_TABLE = "citadel-agent-releases-test";
+process.env.EXECUTION_SPECS_TABLE = "citadel-execution-specifications-test";
+process.env.EVAL_RUNS_TABLE = "citadel-eval-runs-test";
+process.env.EVAL_SUITES_TABLE = "citadel-eval-suites-test";
+process.env.PROJECTS_TABLE = "citadel-projects-test";
+process.env.USER_POOL_ID = "us-west-2_testpool";
+process.env.REGISTRY_ENABLED = "true";
+process.env.REGISTRY_ID = "test-registry";
+
+const ddbMock = mockClient(DynamoDBDocumentClient);
+const cognitoMock = mockClient(CognitoIdentityProviderClient);
+
+// registry-service is mocked at module level: cutAgentRelease only needs
+// getResource(type, id), the same surface agent-config-resolver.ts uses.
+const mockGetResource = jest.fn();
+jest.mock("../../services/registry-service", () => ({
+  RegistryService: jest.fn().mockImplementation(() => ({
+    getResource: mockGetResource,
+  })),
+}));
+
+import {
+  cutAgentRelease,
+  validateReleaseGate,
+  handler,
+} from "../release-resolver";
+
+function authContextFor(role: string): AuthContext {
+  return {
+    userId: `user-${role}`,
+    username: role,
+    groups: [],
+    roles: [role],
+  };
+}
+
+function approvedRegistryRecord(
+  overrides: Partial<RegistryRecord> = {},
+  metaOverrides: Record<string, unknown> = {},
+): RegistryRecord {
+  return {
+    recordId: "agent-1",
+    name: "intake-agent",
+    status: "APPROVED",
+    customDescriptorContent: JSON.stringify({
+      orgId: "org-1",
+      manifest: { name: "intake-agent" },
+      ...metaOverrides,
+    }),
+    ...overrides,
+  };
+}
+
+function approvedExecSpec(
+  overrides: Partial<ExecutionSpecification> = {},
+): ExecutionSpecification {
+  return {
+    specId: "spec-123",
+    projectId: "project-1",
+    sourceAdrIds: ["adr-1"],
+    structuredPayload: "{}",
+    narrativeS3Uri:
+      "s3://citadel-governance-transcripts-dev-123456789012-us-east-1/projects/project-1/n.md",
+    status: "APPROVED",
+    version: 3,
+    createdAt: "2026-08-01T00:00:00.000Z",
+    createdBy: "architect-1",
+    ...overrides,
+  };
+}
+
+function completedEvalRun(overrides: Partial<EvalRun> = {}): EvalRun {
+  return {
+    evalRunId: "run-1",
+    orgId: "org-1",
+    suiteId: "suite-1",
+    suiteVersion: 2,
+    agentTargetId: "agent-1",
+    agentTargetVersion: "v1",
+    status: "COMPLETED",
+    caseCount: 3,
+    pendingCases: 0,
+    startedAt: "2026-08-01T00:00:00.000Z",
+    startedBy: "architect-1",
+    idempotencyKey: "key-1",
+    ...overrides,
+  };
+}
+
+function frozenSuite(overrides: Partial<EvalSuite> = {}): EvalSuite {
+  return {
+    suiteId: "suite-1",
+    orgId: "org-1",
+    agentTargetId: "agent-1",
+    name: "Suite One",
+    description: "",
+    semver: "1.0.0",
+    status: "FROZEN",
+    version: 2,
+    references: [],
+    createdAt: "2026-01-01T00:00:00.000Z",
+    createdBy: "architect-1",
+    updatedAt: "2026-01-01T00:00:00.000Z",
+    ...overrides,
+  };
+}
+
+function baseCutInput() {
+  return {
+    orgId: "org-1",
+    agentTargetId: "agent-1",
+    semver: "1.0.0",
+    registryRecordId: "agent-1",
+    execSpecId: "spec-123",
+    evalRunId: "run-1",
+    promptVersions: {
+      supervisor: { sourceId: "p1", content: "you are...", digest: "d1" },
+    },
+    modelConfigSnapshots: [
+      { slot: "supervisor", content: "claude-x", digest: "m1" },
+    ],
+    toolConfigs: [{ sourceId: "tool-a", content: "{}", digest: "t1" }],
+    policySnapshot: {
+      enforcementMode: "strict",
+      ruleSetVersion: "v3",
+      authorityUnitGrantIds: ["grant-1"],
+    },
+    gitSha: "abc123",
+    region: "us-east-1",
+    runId: "run-abc",
+  };
+}
+
+/** Wires the three GetCommand-backed lookups (execSpec, evalRun, evalSuite)
+ * plus registry getResource to the "everything is valid" fixtures, and the
+ * two write paths (release PutCommand, suite UpdateCommand) to success.
+ * Also wires the exec spec's Project (PROJECTS_TABLE) and its Cognito
+ * owner-org lookup to resolve to the caller's own org ("org-1"), so
+ * existing happy-path tests exercise the exec-spec org check without
+ * having to know about it. */
+function mockHappyPath(): void {
+  mockGetResource.mockResolvedValue(approvedRegistryRecord());
+  ddbMock.on(GetCommand).callsFake((input) => {
+    if (input.TableName === process.env.EXECUTION_SPECS_TABLE) {
+      return { Item: approvedExecSpec() };
+    }
+    if (input.TableName === process.env.EVAL_RUNS_TABLE) {
+      return { Item: completedEvalRun() };
+    }
+    if (input.TableName === process.env.EVAL_SUITES_TABLE) {
+      return { Item: frozenSuite() };
+    }
+    if (input.TableName === process.env.PROJECTS_TABLE) {
+      return { Item: { id: "project-1", owner: "owner-in-org-1" } };
+    }
+    return {};
+  });
+  ddbMock.on(PutCommand).resolves({});
+  ddbMock
+    .on(UpdateCommand)
+    .resolves({ Attributes: frozenSuite({ references: ["run-1"] }) });
+  cognitoMock.on(AdminGetUserCommand).resolves({
+    UserAttributes: [{ Name: "custom:organization", Value: "org-1" }],
+  });
+}
+
+function mockAdminGetUserResolves(
+  attributes: { Name: string; Value: string }[],
+): void {
+  cognitoMock.on(AdminGetUserCommand).resolves({ UserAttributes: attributes });
+}
+
+beforeEach(() => {
+  ddbMock.reset();
+  cognitoMock.reset();
+  jest.clearAllMocks();
+});
+
+describe("cutAgentRelease — authorization", () => {
+  test("throws UnauthorizedError without release:cut permission", async () => {
+    mockHappyPath();
+    await expect(
+      cutAgentRelease(baseCutInput(), authContextFor("developer"), "org-1"),
+    ).rejects.toThrow(/UnauthorizedError/);
+  });
+
+  test("allows architect", async () => {
+    mockHappyPath();
+    const release = await cutAgentRelease(
+      baseCutInput(),
+      authContextFor("architect"),
+      "org-1",
+    );
+    expect(release.releaseId).toMatch(/^[0-9a-f]{64}$/);
+  });
+
+  test("permission check happens before any DDB lookup", async () => {
+    // No mocks wired at all — if the permission check were skipped or
+    // deferred, the very first unmocked call would throw a jest-mock
+    // "not implemented" style rejection instead of UnauthorizedError.
+    await expect(
+      cutAgentRelease(baseCutInput(), authContextFor("developer"), "org-1"),
+    ).rejects.toThrow(/UnauthorizedError/);
+    expect(mockGetResource).not.toHaveBeenCalled();
+    expect(ddbMock.commandCalls(GetCommand)).toHaveLength(0);
+  });
+});
+
+describe("cutAgentRelease — registry record validation", () => {
+  test("rejects when the registry record does not exist", async () => {
+    mockHappyPath();
+    mockGetResource.mockResolvedValue(null);
+    await expect(
+      cutAgentRelease(baseCutInput(), authContextFor("architect"), "org-1"),
+    ).rejects.toThrow(/ValidationError.*registry/i);
+  });
+
+  test("rejects when the registry record is not APPROVED", async () => {
+    mockHappyPath();
+    mockGetResource.mockResolvedValue(
+      approvedRegistryRecord({ status: "DRAFT" }),
+    );
+    await expect(
+      cutAgentRelease(baseCutInput(), authContextFor("architect"), "org-1"),
+    ).rejects.toThrow(/ValidationError.*APPROVED/);
+  });
+
+  test("rejects (security) when the registry record belongs to a different org", async () => {
+    mockHappyPath();
+    mockGetResource.mockResolvedValue(
+      approvedRegistryRecord({}, { orgId: "org-OTHER" }),
+    );
+    await expect(
+      cutAgentRelease(baseCutInput(), authContextFor("architect"), "org-1"),
+    ).rejects.toThrow(/cross-org|different org/i);
+  });
+
+  test("rejects (fail-closed) when the registry record's descriptor lacks an orgId entirely", async () => {
+    mockHappyPath();
+    mockGetResource.mockResolvedValue(
+      approvedRegistryRecord({
+        customDescriptorContent: JSON.stringify({
+          manifest: { name: "intake-agent" },
+        }),
+      }),
+    );
+    await expect(
+      cutAgentRelease(baseCutInput(), authContextFor("architect"), "org-1"),
+    ).rejects.toThrow(/SecurityError.*org/i);
+    expect(ddbMock.commandCalls(PutCommand)).toHaveLength(0);
+  });
+
+  test("no DDB write occurs when registry validation fails", async () => {
+    mockHappyPath();
+    mockGetResource.mockResolvedValue(
+      approvedRegistryRecord({ status: "DRAFT" }),
+    );
+    await expect(
+      cutAgentRelease(baseCutInput(), authContextFor("architect"), "org-1"),
+    ).rejects.toThrow();
+    expect(ddbMock.commandCalls(PutCommand)).toHaveLength(0);
+    expect(ddbMock.commandCalls(UpdateCommand)).toHaveLength(0);
+  });
+});
+
+describe("cutAgentRelease — exec spec validation", () => {
+  test("rejects when the exec spec does not exist", async () => {
+    mockHappyPath();
+    ddbMock.on(GetCommand).callsFake((input) => {
+      if (input.TableName === process.env.EXECUTION_SPECS_TABLE) return {};
+      if (input.TableName === process.env.EVAL_RUNS_TABLE)
+        return { Item: completedEvalRun() };
+      if (input.TableName === process.env.EVAL_SUITES_TABLE)
+        return { Item: frozenSuite() };
+      if (input.TableName === process.env.PROJECTS_TABLE) {
+        return { Item: { id: "project-1", owner: "owner-in-org-1" } };
+      }
+      return {};
+    });
+    await expect(
+      cutAgentRelease(baseCutInput(), authContextFor("architect"), "org-1"),
+    ).rejects.toThrow(/ValidationError.*exec/i);
+  });
+
+  test("rejects when the exec spec is not APPROVED", async () => {
+    mockHappyPath();
+    ddbMock.on(GetCommand).callsFake((input) => {
+      if (input.TableName === process.env.EXECUTION_SPECS_TABLE) {
+        return { Item: approvedExecSpec({ status: "DRAFT" }) };
+      }
+      if (input.TableName === process.env.EVAL_RUNS_TABLE)
+        return { Item: completedEvalRun() };
+      if (input.TableName === process.env.EVAL_SUITES_TABLE)
+        return { Item: frozenSuite() };
+      if (input.TableName === process.env.PROJECTS_TABLE) {
+        return { Item: { id: "project-1", owner: "owner-in-org-1" } };
+      }
+      return {};
+    });
+    await expect(
+      cutAgentRelease(baseCutInput(), authContextFor("architect"), "org-1"),
+    ).rejects.toThrow(/ValidationError.*APPROVED/);
+  });
+
+  test("rejects (security) when the exec spec's project is owned by a different org (via Project.owner -> lookupUserOrganization)", async () => {
+    mockHappyPath();
+    ddbMock.on(GetCommand).callsFake((input) => {
+      if (input.TableName === process.env.EXECUTION_SPECS_TABLE)
+        return { Item: approvedExecSpec() };
+      if (input.TableName === process.env.EVAL_RUNS_TABLE)
+        return { Item: completedEvalRun() };
+      if (input.TableName === process.env.EVAL_SUITES_TABLE)
+        return { Item: frozenSuite() };
+      if (input.TableName === process.env.PROJECTS_TABLE) {
+        return { Item: { id: "project-1", owner: "owner-in-org-OTHER" } };
+      }
+      return {};
+    });
+    mockAdminGetUserResolves([
+      { Name: "custom:organization", Value: "org-OTHER" },
+    ]);
+    await expect(
+      cutAgentRelease(baseCutInput(), authContextFor("architect"), "org-1"),
+    ).rejects.toThrow(/SecurityError.*exec spec/i);
+    expect(ddbMock.commandCalls(PutCommand)).toHaveLength(0);
+  });
+
+  test("allows when the exec spec's project owner resolves to the caller's own org", async () => {
+    mockHappyPath();
+    ddbMock.on(GetCommand).callsFake((input) => {
+      if (input.TableName === process.env.EXECUTION_SPECS_TABLE)
+        return { Item: approvedExecSpec() };
+      if (input.TableName === process.env.EVAL_RUNS_TABLE)
+        return { Item: completedEvalRun() };
+      if (input.TableName === process.env.EVAL_SUITES_TABLE)
+        return { Item: frozenSuite() };
+      if (input.TableName === process.env.PROJECTS_TABLE) {
+        return { Item: { id: "project-1", owner: "owner-in-org-1" } };
+      }
+      return {};
+    });
+    mockAdminGetUserResolves([{ Name: "custom:organization", Value: "org-1" }]);
+    const release = await cutAgentRelease(
+      baseCutInput(),
+      authContextFor("architect"),
+      "org-1",
+    );
+    expect(release.releaseId).toMatch(/^[0-9a-f]{64}$/);
+  });
+
+  test("rejects (fail-closed) when the exec spec's project cannot be found", async () => {
+    mockHappyPath();
+    ddbMock.on(GetCommand).callsFake((input) => {
+      if (input.TableName === process.env.EXECUTION_SPECS_TABLE)
+        return { Item: approvedExecSpec() };
+      if (input.TableName === process.env.EVAL_RUNS_TABLE)
+        return { Item: completedEvalRun() };
+      if (input.TableName === process.env.EVAL_SUITES_TABLE)
+        return { Item: frozenSuite() };
+      if (input.TableName === process.env.PROJECTS_TABLE) return {};
+      return {};
+    });
+    await expect(
+      cutAgentRelease(baseCutInput(), authContextFor("architect"), "org-1"),
+    ).rejects.toThrow(/SecurityError.*exec spec/i);
+    expect(ddbMock.commandCalls(PutCommand)).toHaveLength(0);
+  });
+
+  test("rejects (fail-closed) when the exec spec's project owner's org cannot be resolved (Cognito lookup returns nothing)", async () => {
+    mockHappyPath();
+    ddbMock.on(GetCommand).callsFake((input) => {
+      if (input.TableName === process.env.EXECUTION_SPECS_TABLE)
+        return { Item: approvedExecSpec() };
+      if (input.TableName === process.env.EVAL_RUNS_TABLE)
+        return { Item: completedEvalRun() };
+      if (input.TableName === process.env.EVAL_SUITES_TABLE)
+        return { Item: frozenSuite() };
+      if (input.TableName === process.env.PROJECTS_TABLE) {
+        return { Item: { id: "project-1", owner: "owner-unknown" } };
+      }
+      return {};
+    });
+    mockAdminGetUserResolves([]);
+    await expect(
+      cutAgentRelease(baseCutInput(), authContextFor("architect"), "org-1"),
+    ).rejects.toThrow(/SecurityError.*exec spec/i);
+    expect(ddbMock.commandCalls(PutCommand)).toHaveLength(0);
+  });
+});
+
+describe("cutAgentRelease — eval run validation", () => {
+  test("rejects when the eval run does not exist", async () => {
+    mockHappyPath();
+    ddbMock.on(GetCommand).callsFake((input) => {
+      if (input.TableName === process.env.EXECUTION_SPECS_TABLE)
+        return { Item: approvedExecSpec() };
+      if (input.TableName === process.env.EVAL_RUNS_TABLE) return {};
+      if (input.TableName === process.env.EVAL_SUITES_TABLE)
+        return { Item: frozenSuite() };
+      if (input.TableName === process.env.PROJECTS_TABLE) {
+        return { Item: { id: "project-1", owner: "owner-in-org-1" } };
+      }
+      return {};
+    });
+    await expect(
+      cutAgentRelease(baseCutInput(), authContextFor("architect"), "org-1"),
+    ).rejects.toThrow(/ValidationError.*eval run/i);
+  });
+
+  test("rejects when the eval run is not COMPLETED", async () => {
+    mockHappyPath();
+    ddbMock.on(GetCommand).callsFake((input) => {
+      if (input.TableName === process.env.EXECUTION_SPECS_TABLE)
+        return { Item: approvedExecSpec() };
+      if (input.TableName === process.env.EVAL_RUNS_TABLE) {
+        return { Item: completedEvalRun({ status: "RUNNING" }) };
+      }
+      if (input.TableName === process.env.EVAL_SUITES_TABLE)
+        return { Item: frozenSuite() };
+      if (input.TableName === process.env.PROJECTS_TABLE) {
+        return { Item: { id: "project-1", owner: "owner-in-org-1" } };
+      }
+      return {};
+    });
+    await expect(
+      cutAgentRelease(baseCutInput(), authContextFor("architect"), "org-1"),
+    ).rejects.toThrow(/ValidationError.*COMPLETED/);
+  });
+
+  test("rejects (security) when the eval run belongs to a different org", async () => {
+    mockHappyPath();
+    ddbMock.on(GetCommand).callsFake((input) => {
+      if (input.TableName === process.env.EXECUTION_SPECS_TABLE)
+        return { Item: approvedExecSpec() };
+      if (input.TableName === process.env.EVAL_RUNS_TABLE) {
+        return { Item: completedEvalRun({ orgId: "org-OTHER" }) };
+      }
+      if (input.TableName === process.env.EVAL_SUITES_TABLE)
+        return { Item: frozenSuite() };
+      if (input.TableName === process.env.PROJECTS_TABLE) {
+        return { Item: { id: "project-1", owner: "owner-in-org-1" } };
+      }
+      return {};
+    });
+    await expect(
+      cutAgentRelease(baseCutInput(), authContextFor("architect"), "org-1"),
+    ).rejects.toThrow(/cross-org|different org/i);
+  });
+
+  test("rejects when the pinned suite version does not match the eval run's suiteVersion", async () => {
+    mockHappyPath();
+    ddbMock.on(GetCommand).callsFake((input) => {
+      if (input.TableName === process.env.EXECUTION_SPECS_TABLE)
+        return { Item: approvedExecSpec() };
+      if (input.TableName === process.env.EVAL_RUNS_TABLE) {
+        return { Item: completedEvalRun({ suiteVersion: 5 }) };
+      }
+      if (input.TableName === process.env.EVAL_SUITES_TABLE) {
+        return { Item: frozenSuite({ version: 2 }) };
+      }
+      if (input.TableName === process.env.PROJECTS_TABLE) {
+        return { Item: { id: "project-1", owner: "owner-in-org-1" } };
+      }
+      return {};
+    });
+    await expect(
+      cutAgentRelease(baseCutInput(), authContextFor("architect"), "org-1"),
+    ).rejects.toThrow(/ValidationError.*suiteVersion/i);
+  });
+
+  test("rejects (security) when the eval suite belongs to a different org than the caller", async () => {
+    mockHappyPath();
+    ddbMock.on(GetCommand).callsFake((input) => {
+      if (input.TableName === process.env.EXECUTION_SPECS_TABLE)
+        return { Item: approvedExecSpec() };
+      if (input.TableName === process.env.EVAL_RUNS_TABLE)
+        return { Item: completedEvalRun() };
+      if (input.TableName === process.env.EVAL_SUITES_TABLE) {
+        return { Item: frozenSuite({ orgId: "org-OTHER" }) };
+      }
+      if (input.TableName === process.env.PROJECTS_TABLE) {
+        return { Item: { id: "project-1", owner: "owner-in-org-1" } };
+      }
+      return {};
+    });
+    await expect(
+      cutAgentRelease(baseCutInput(), authContextFor("architect"), "org-1"),
+    ).rejects.toThrow(/SecurityError.*suite/i);
+    expect(ddbMock.commandCalls(UpdateCommand)).toHaveLength(0);
+    expect(ddbMock.commandCalls(PutCommand)).toHaveLength(0);
+  });
+});
+
+describe("cutAgentRelease — release orgId is derived from callerOrgId, not trusted from input", () => {
+  test("the stored release's orgId is the caller's org even when input.orgId claims a different org", async () => {
+    mockHappyPath();
+    const release = await cutAgentRelease(
+      { ...baseCutInput(), orgId: "org-EVIL" },
+      authContextFor("architect"),
+      "org-1",
+    );
+    expect(release.orgId).toBe("org-1");
+  });
+});
+
+describe("cutAgentRelease — validation happens before hashing/storing", () => {
+  test("a validation failure never calls putRelease or markEvalSuiteReferenced", async () => {
+    mockHappyPath();
+    mockGetResource.mockResolvedValue(
+      approvedRegistryRecord({ status: "REJECTED" }),
+    );
+    await expect(
+      cutAgentRelease(baseCutInput(), authContextFor("architect"), "org-1"),
+    ).rejects.toThrow();
+    expect(ddbMock.commandCalls(PutCommand)).toHaveLength(0);
+    expect(ddbMock.commandCalls(UpdateCommand)).toHaveLength(0);
+  });
+});
+
+describe("cutAgentRelease — successful cut", () => {
+  test("stores the release and freezes the eval suite by marking it referenced", async () => {
+    mockHappyPath();
+    const release = await cutAgentRelease(
+      baseCutInput(),
+      authContextFor("architect"),
+      "org-1",
+    );
+
+    expect(release.orgId).toBe("org-1");
+    expect(release.evalEvidence).toEqual({
+      evalRunId: "run-1",
+      evalSuiteId: "suite-1",
+      evalSuiteVersion: 2,
+    });
+    expect(release.execSpecId).toBe("spec-123");
+    expect(release.execSpecVersion).toBe(3);
+
+    const putCalls = ddbMock.commandCalls(PutCommand);
+    expect(putCalls).toHaveLength(1);
+    expect(putCalls[0].args[0].input.TableName).toBe(
+      process.env.AGENT_RELEASES_TABLE,
+    );
+
+    const updateCalls = ddbMock.commandCalls(UpdateCommand);
+    expect(updateCalls).toHaveLength(1);
+    expect(updateCalls[0].args[0].input.TableName).toBe(
+      process.env.EVAL_SUITES_TABLE,
+    );
+  });
+
+  test("the release store write (PutCommand) happens BEFORE the suite-freeze write (UpdateCommand)", async () => {
+    mockHappyPath();
+    const callOrder: string[] = [];
+    ddbMock.on(PutCommand).callsFake(() => {
+      callOrder.push("put-release");
+      return {};
+    });
+    ddbMock.on(UpdateCommand).callsFake(() => {
+      callOrder.push("mark-referenced");
+      return { Attributes: frozenSuite({ references: ["run-1"] }) };
+    });
+
+    await cutAgentRelease(baseCutInput(), authContextFor("architect"), "org-1");
+
+    expect(callOrder).toEqual(["put-release", "mark-referenced"]);
+  });
+
+  test("cutting identical content twice is idempotent: second call does not overwrite and returns the same releaseId", async () => {
+    mockHappyPath();
+    const first = await cutAgentRelease(
+      baseCutInput(),
+      authContextFor("architect"),
+      "org-1",
+    );
+
+    // Second attempt: the conditional Put now collides on the identical
+    // content hash, exactly like release-store.test.ts's duplicate-content
+    // scenario.
+    ddbMock.on(PutCommand).rejects(
+      Object.assign(new Error("The conditional request failed"), {
+        name: "ConditionalCheckFailedException",
+      }),
+    );
+    ddbMock.on(GetCommand).callsFake((input) => {
+      if (input.TableName === process.env.AGENT_RELEASES_TABLE) {
+        return { Item: { ...first } };
+      }
+      if (input.TableName === process.env.EXECUTION_SPECS_TABLE)
+        return { Item: approvedExecSpec() };
+      if (input.TableName === process.env.EVAL_RUNS_TABLE)
+        return { Item: completedEvalRun() };
+      if (input.TableName === process.env.EVAL_SUITES_TABLE)
+        return { Item: frozenSuite() };
+      if (input.TableName === process.env.PROJECTS_TABLE) {
+        return { Item: { id: "project-1", owner: "owner-in-org-1" } };
+      }
+      return {};
+    });
+
+    const second = await cutAgentRelease(
+      baseCutInput(),
+      authContextFor("architect"),
+      "org-1",
+    );
+
+    expect(second.releaseId).toBe(first.releaseId);
+  });
+
+  test("real retry across wall-clock time is idempotent WITHOUT mocking ConditionalCheckFailedException: two cuts of identical constituents at different createdAt produce the SAME releaseId and a single stored row", async () => {
+    mockHappyPath();
+    jest.useFakeTimers({ now: new Date("2026-08-07T00:00:00.000Z") });
+
+    // A genuine simulation of DynamoDB's attribute_not_exists(releaseId)
+    // conditional Put — NOT a pre-canned ConditionalCheckFailedException.
+    // The releaseId key space is backed by a real in-memory map keyed on
+    // the Item's own releaseId, so the SAME releaseId on a second Put
+    // naturally collides, and a DIFFERENT releaseId naturally does not.
+    // This is what actually exercises whether computeReleaseHash excludes
+    // createdAt — a canned rejection would mask the bug instead.
+    const releasesTable = new Map<string, unknown>();
+    ddbMock.on(PutCommand).callsFake((input) => {
+      if (input.TableName !== process.env.AGENT_RELEASES_TABLE) return {};
+      const item = input.Item as { releaseId: string };
+      if (releasesTable.has(item.releaseId)) {
+        throw Object.assign(new Error("The conditional request failed"), {
+          name: "ConditionalCheckFailedException",
+        });
+      }
+      releasesTable.set(item.releaseId, item);
+      return {};
+    });
+    ddbMock.on(GetCommand).callsFake((input) => {
+      if (input.TableName === process.env.AGENT_RELEASES_TABLE) {
+        const releaseId = (input.Key as { releaseId: string }).releaseId;
+        const item = releasesTable.get(releaseId);
+        return item ? { Item: item } : {};
+      }
+      if (input.TableName === process.env.EXECUTION_SPECS_TABLE)
+        return { Item: approvedExecSpec() };
+      if (input.TableName === process.env.EVAL_RUNS_TABLE)
+        return { Item: completedEvalRun() };
+      if (input.TableName === process.env.EVAL_SUITES_TABLE)
+        return { Item: frozenSuite() };
+      if (input.TableName === process.env.PROJECTS_TABLE) {
+        return { Item: { id: "project-1", owner: "owner-in-org-1" } };
+      }
+      return {};
+    });
+
+    try {
+      const first = await cutAgentRelease(
+        baseCutInput(),
+        authContextFor("architect"),
+        "org-1",
+      );
+
+      // Advance the clock so a fresh createdAt is minted on the retry —
+      // the real conditional Put must collide on its own because the
+      // hash must depend only on the constituents, not on createdAt.
+      jest.setSystemTime(new Date("2026-08-07T00:00:00.123Z"));
+
+      const second = await cutAgentRelease(
+        baseCutInput(),
+        authContextFor("architect"),
+        "org-1",
+      );
+
+      expect(second.releaseId).toBe(first.releaseId);
+      expect(releasesTable.size).toBe(1);
+    } finally {
+      jest.useRealTimers();
+    }
+  });
+});
+
+describe("cutAgentRelease — ordering / partial failure (store succeeds, freeze fails)", () => {
+  /**
+   * If putRelease succeeds but markEvalSuiteReferenced then throws, the
+   * release row now durably exists while its evalEvidence's suite is still
+   * mutable (not yet frozen-by-reference) — the exact guarantee the release
+   * exists to make. We deliberately do NOT swallow this: the error must
+   * propagate to the caller (observable, e.g. surfaced to an on-call
+   * dashboard or a retry queue) rather than returning a release object that
+   * looks successful. See the ordering comment in release-resolver.ts for
+   * the full fail-safe-ordering rationale (store-then-freeze, never the
+   * reverse, because an over-frozen suite is harmless but a release with
+   * mutable evidence is not).
+   */
+  test("propagates the markEvalSuiteReferenced failure rather than swallowing it", async () => {
+    mockHappyPath();
+    ddbMock
+      .on(UpdateCommand)
+      .rejects(new Error("ProvisionedThroughputExceeded"));
+
+    await expect(
+      cutAgentRelease(baseCutInput(), authContextFor("architect"), "org-1"),
+    ).rejects.toThrow(/ProvisionedThroughputExceeded/);
+
+    // The release WAS durably stored — this is the fail-safe half of the
+    // ordering choice: an already-put release row is not itself harmful,
+    // only its as-yet-unfrozen evidence is a residual risk (surfaced above
+    // by not swallowing the error).
+    expect(ddbMock.commandCalls(PutCommand)).toHaveLength(1);
+  });
+
+  test("retrying the identical cut after a freeze failure is safe: the store half is idempotent and the freeze half is re-attempted", async () => {
+    mockHappyPath();
+    ddbMock.on(UpdateCommand).rejectsOnce(new Error("transient failure"));
+
+    await expect(
+      cutAgentRelease(baseCutInput(), authContextFor("architect"), "org-1"),
+    ).rejects.toThrow(/transient failure/);
+
+    // Retry: PutCommand will now hit the conditional-check-failed path
+    // (content already stored) and UpdateCommand succeeds this time.
+    ddbMock.on(PutCommand).rejects(
+      Object.assign(new Error("The conditional request failed"), {
+        name: "ConditionalCheckFailedException",
+      }),
+    );
+    ddbMock.on(GetCommand).callsFake((input) => {
+      if (input.TableName === process.env.AGENT_RELEASES_TABLE) {
+        // releaseId is content-derived and deterministic across retries
+        // with identical input — recomputed by the resolver itself, so we
+        // just need SOME stored row to be returned; the resolver supplies
+        // the actual releaseId it computed when it calls getRelease.
+        return {};
+      }
+      if (input.TableName === process.env.EXECUTION_SPECS_TABLE)
+        return { Item: approvedExecSpec() };
+      if (input.TableName === process.env.EVAL_RUNS_TABLE)
+        return { Item: completedEvalRun() };
+      if (input.TableName === process.env.EVAL_SUITES_TABLE)
+        return { Item: frozenSuite() };
+      if (input.TableName === process.env.PROJECTS_TABLE) {
+        return { Item: { id: "project-1", owner: "owner-in-org-1" } };
+      }
+      return {};
+    });
+    ddbMock
+      .on(UpdateCommand)
+      .resolves({ Attributes: frozenSuite({ references: ["run-1"] }) });
+
+    // getRelease on the conditional-check-failed path needs the exact
+    // stored item back; re-wire GetCommand for AGENT_RELEASES_TABLE once we
+    // know what the first attempt would have stored (same input -> same
+    // hash), by capturing the Put item from the first PutCommand call.
+    const firstPutItem =
+      ddbMock.commandCalls(PutCommand)[0]?.args[0].input.Item;
+    ddbMock.on(GetCommand).callsFake((input) => {
+      if (input.TableName === process.env.AGENT_RELEASES_TABLE) {
+        return { Item: firstPutItem };
+      }
+      if (input.TableName === process.env.EXECUTION_SPECS_TABLE)
+        return { Item: approvedExecSpec() };
+      if (input.TableName === process.env.EVAL_RUNS_TABLE)
+        return { Item: completedEvalRun() };
+      if (input.TableName === process.env.EVAL_SUITES_TABLE)
+        return { Item: frozenSuite() };
+      if (input.TableName === process.env.PROJECTS_TABLE) {
+        return { Item: { id: "project-1", owner: "owner-in-org-1" } };
+      }
+      return {};
+    });
+
+    const retried = await cutAgentRelease(
+      baseCutInput(),
+      authContextFor("architect"),
+      "org-1",
+    );
+    expect(retried.releaseId).toBe(
+      (firstPutItem as { releaseId: string }).releaseId,
+    );
+  });
+});
+
+describe("validateReleaseGate — deferred seam", () => {
+  test("exists as a no-op stub, not wired into cutAgentRelease", () => {
+    expect(typeof validateReleaseGate).toBe("function");
+    expect(validateReleaseGate()).toBeUndefined();
+  });
+});
+
+describe("handler — AppSync dispatch", () => {
+  test("cutAgentRelease field extracts orgId from the identity claim and delegates to cutAgentRelease", async () => {
+    mockHappyPath();
+    const result = await handler({
+      info: { fieldName: "cutAgentRelease" },
+      identity: {
+        sub: "architect-1",
+        "custom:role": "architect",
+        claims: { "custom:organization": "org-1" },
+      },
+      arguments: { input: baseCutInput() } as never,
+    } as never);
+    expect((result as { releaseId: string }).releaseId).toMatch(
+      /^[0-9a-f]{64}$/,
+    );
+  });
+
+  test("rejects when the caller's organization cannot be determined", async () => {
+    mockHappyPath();
+    // mockHappyPath wires Cognito AdminGetUser to resolve org-1 (for the
+    // exec-spec org check's happy path) — override it here so the
+    // identity-claim-less caller genuinely cannot resolve an org via
+    // either extractOrgFromEvent's claim or Cognito-fallback path.
+    cognitoMock.on(AdminGetUserCommand).resolves({ UserAttributes: [] });
+    await expect(
+      handler({
+        info: { fieldName: "cutAgentRelease" },
+        identity: { sub: "architect-1", "custom:role": "architect" },
+        arguments: { input: baseCutInput() } as never,
+      } as never),
+    ).rejects.toThrow(/ValidationError.*organization/i);
+  });
+
+  test("throws for an unsupported field name", async () => {
+    await expect(
+      handler({
+        info: { fieldName: "deleteAgentRelease" },
+        identity: {},
+        arguments: {} as never,
+      } as never),
+    ).rejects.toThrow(/Unsupported field/);
+  });
+});

--- a/backend/src/lambda/__tests__/release-store-choke-point.guard.test.ts
+++ b/backend/src/lambda/__tests__/release-store-choke-point.guard.test.ts
@@ -1,0 +1,159 @@
+/**
+ * release-store-choke-point.guard.test.ts — mechanical guard enforcing
+ * that release-store.ts is the SOLE write choke point for
+ * AgentReleasesTable (design §2, L1). Modeled on
+ * eval-no-composite.guard.test.ts's scanning precedent (steering: "Never
+ * use empty catch{} around DB writes" — same technique, different
+ * forbidden pattern), which closes the exact bypass class the eval
+ * tables suffered from: a seeder/healer/migration issuing a raw
+ * Put/Update/Delete against the table outside its owning resolver.
+ *
+ * Scope note: CDK infrastructure (lib/*.ts) legitimately DEFINES the
+ * table and its IAM floor — that is not a write-path bypass, it is the
+ * resource declaration. The guard therefore scans APPLICATION code only
+ * (src/lambda/**, excluding release-store.ts itself and __tests__), for
+ * two independent bypass signatures:
+ *  (a) STATIC SCAN — any file that both (i) imports
+ *      PutCommand/UpdateCommand/DeleteCommand from
+ *      @aws-sdk/lib-dynamodb (or the low-level @aws-sdk/client-dynamodb
+ *      equivalents) AND (ii) references the AGENT_RELEASES_TABLE env var
+ *      or the literal table name prefix. Either signal alone is not
+ *      proof of a raw write (e.g. a file might read the env var to pass
+ *      it elsewhere), but the combination is the exact shape of a bypass
+ *      write.
+ *  (b) BEHAVIORAL/bite-proof — a scratch file combining both signatures
+ *      must be flagged by the scanner, proving it is not a no-op.
+ *
+ * release-store.ts itself is required to export ONLY putRelease and
+ * getRelease — no update, no delete — asserted directly (belt-and-
+ * suspenders with release-store.test.ts's module-surface test).
+ */
+import * as fs from "fs";
+import * as os from "os";
+import * as path from "path";
+import * as releaseStore from "../release-store";
+
+const REPO_ROOT = path.resolve(__dirname, "../../..");
+const OWNING_FILE = path.join("src", "lambda", "release-store.ts");
+const TABLE_ENV_VAR = "AGENT_RELEASES_TABLE";
+const TABLE_NAME_LITERAL_RE = /citadel-agent-releases-/;
+const WRITE_COMMAND_RE =
+  /\b(PutCommand|UpdateCommand|DeleteCommand|PutItemCommand|UpdateItemCommand|DeleteItemCommand)\b/;
+
+/** Only application code under src/lambda is scanned — CDK infra
+ * (lib/*.ts) legitimately defines the table/IAM and is out of scope. */
+const SCAN_DIR = path.join("src", "lambda");
+
+function listSourceFiles(dir: string): string[] {
+  const abs = path.join(REPO_ROOT, dir);
+  if (!fs.existsSync(abs)) return [];
+  const out: string[] = [];
+  const stack = [abs];
+  while (stack.length > 0) {
+    const current = stack.pop()!;
+    for (const entry of fs.readdirSync(current, { withFileTypes: true })) {
+      if (entry.name === "node_modules" || entry.name === "__tests__") {
+        continue;
+      }
+      const full = path.join(current, entry.name);
+      if (entry.isDirectory()) {
+        stack.push(full);
+      } else if (entry.isFile() && /\.tsx?$/.test(entry.name)) {
+        out.push(full);
+      }
+    }
+  }
+  return out;
+}
+
+/** Returns the list of files (relative to repo root) that combine a raw
+ * write-command import/usage with a reference to the AgentReleasesTable
+ * name/env var — the exact signature of a bypass write — EXCLUDING the
+ * one legitimate owning file. */
+function findChokePointViolations(): string[] {
+  const violations: string[] = [];
+  for (const file of listSourceFiles(SCAN_DIR)) {
+    const relPath = path.relative(REPO_ROOT, file);
+    if (relPath === OWNING_FILE) continue;
+
+    const content = fs.readFileSync(file, "utf-8");
+    const referencesTable =
+      content.includes(TABLE_ENV_VAR) || TABLE_NAME_LITERAL_RE.test(content);
+    const issuesWriteCommand = WRITE_COMMAND_RE.test(content);
+
+    if (referencesTable && issuesWriteCommand) {
+      violations.push(relPath);
+    }
+  }
+  return violations;
+}
+
+describe("release-store choke-point guard — static scan", () => {
+  it("no application file other than release-store.ts combines a raw write command with a reference to AgentReleasesTable", () => {
+    const violations = findChokePointViolations();
+    expect(violations).toEqual([]);
+  });
+
+  it("bites: the scanner FAILS when a bypass (write command + table reference) is planted in a scratch file", () => {
+    const scratchDir = fs.mkdtempSync(
+      path.join(os.tmpdir(), "release-choke-point-guard-"),
+    );
+    const scratchFile = path.join(scratchDir, "planted-bypass.ts");
+    try {
+      fs.writeFileSync(
+        scratchFile,
+        [
+          "// simulated seeder/healer bypass",
+          'import { PutCommand } from "@aws-sdk/lib-dynamodb";',
+          "const TABLE = process.env.AGENT_RELEASES_TABLE!;",
+          "docClient.send(new PutCommand({ TableName: TABLE, Item: {} }));",
+        ].join("\n"),
+      );
+
+      const content = fs.readFileSync(scratchFile, "utf-8");
+      const referencesTable =
+        content.includes(TABLE_ENV_VAR) || TABLE_NAME_LITERAL_RE.test(content);
+      const issuesWriteCommand = WRITE_COMMAND_RE.test(content);
+
+      // The bite-proof: this scratch file WOULD be flagged if it lived
+      // inside the scanned directory. If this assertion ever fails, the
+      // detection predicate itself is broken and the guard is a no-op.
+      expect(referencesTable && issuesWriteCommand).toBe(true);
+    } finally {
+      fs.rmSync(scratchDir, { recursive: true, force: true });
+    }
+  });
+
+  it("a file that only references the table name without a raw write command is NOT flagged (e.g. a Lambda receiving the table name as an env var to pass through)", () => {
+    const scratchDir = fs.mkdtempSync(
+      path.join(os.tmpdir(), "release-choke-point-guard-safe-"),
+    );
+    const scratchFile = path.join(scratchDir, "safe-reference.ts");
+    try {
+      fs.writeFileSync(
+        scratchFile,
+        [
+          "// legitimate: reads the env var to log it, issues no DDB command",
+          "const TABLE = process.env.AGENT_RELEASES_TABLE!;",
+          "console.log(TABLE);",
+        ].join("\n"),
+      );
+
+      const content = fs.readFileSync(scratchFile, "utf-8");
+      const referencesTable =
+        content.includes(TABLE_ENV_VAR) || TABLE_NAME_LITERAL_RE.test(content);
+      const issuesWriteCommand = WRITE_COMMAND_RE.test(content);
+
+      expect(referencesTable && issuesWriteCommand).toBe(false);
+    } finally {
+      fs.rmSync(scratchDir, { recursive: true, force: true });
+    }
+  });
+});
+
+describe("release-store choke-point guard — module surface", () => {
+  it("release-store.ts exports ONLY putRelease and getRelease (create + read) — no update, no delete", () => {
+    const exported = Object.keys(releaseStore).sort();
+    expect(exported).toEqual(["getRelease", "putRelease"]);
+  });
+});

--- a/backend/src/lambda/__tests__/release-store.test.ts
+++ b/backend/src/lambda/__tests__/release-store.test.ts
@@ -1,0 +1,184 @@
+/**
+ * release-store.test.ts — the SOLE write choke point for AgentReleases.
+ *
+ * Binding invariants (design §2, L1+L2):
+ *   - putRelease is create-only: ConditionExpression
+ *     attribute_not_exists(releaseId).
+ *   - Putting identical content twice is an idempotent no-op — the
+ *     second call must NOT overwrite the row and must return the
+ *     already-stored release (same releaseId, same fields).
+ *   - Differing content produces a distinct row (different releaseId)
+ *     and never overwrites the first row.
+ *   - The module exports create + read only — no update, no delete.
+ */
+import {
+  DynamoDBDocumentClient,
+  PutCommand,
+  GetCommand,
+} from "@aws-sdk/lib-dynamodb";
+import { mockClient } from "aws-sdk-client-mock";
+import * as releaseStore from "../release-store";
+import type { AgentReleaseInput } from "../../types";
+
+const ddbMock = mockClient(DynamoDBDocumentClient);
+
+function baseInput(
+  overrides: Partial<AgentReleaseInput> = {},
+): AgentReleaseInput {
+  return {
+    orgId: "org-1",
+    agentTargetId: "agent-1",
+    semver: "1.0.0",
+    createdAt: "2026-08-06T00:00:00.000Z",
+    createdBy: "user-1",
+    gitSha: "abc123",
+    region: "us-east-1",
+    runId: "run-abc",
+    agentConfig: {
+      sourceId: "agent-1",
+      content: '{"name":"intake-agent"}',
+      digest: "digest-a",
+    },
+    promptVersions: {
+      supervisor: { sourceId: "p1", content: "you are...", digest: "d1" },
+    },
+    execSpecId: "spec-123",
+    execSpecVersion: 3,
+    modelConfigSnapshots: [
+      { slot: "supervisor", content: "claude-x", digest: "m1" },
+    ],
+    toolConfigs: [{ sourceId: "tool-a", content: "{}", digest: "t1" }],
+    policySnapshot: {
+      enforcementMode: "strict",
+      ruleSetVersion: "v3",
+      authorityUnitGrantIds: ["grant-1"],
+    },
+    evalEvidence: {
+      evalRunId: "run-1",
+      evalSuiteId: "suite-1",
+      evalSuiteVersion: 2,
+    },
+    ...overrides,
+  };
+}
+
+beforeEach(() => {
+  ddbMock.reset();
+  process.env.AGENT_RELEASES_TABLE = "test-agent-releases";
+});
+
+afterEach(() => {
+  delete process.env.AGENT_RELEASES_TABLE;
+});
+
+describe("release-store — module surface", () => {
+  it("exports exactly putRelease, getRelease (create + read only — no update, no delete)", () => {
+    const exported = Object.keys(releaseStore).sort();
+    expect(exported).toEqual(["getRelease", "putRelease"]);
+  });
+});
+
+describe("release-store — putRelease create-only semantics", () => {
+  it("issues a PutCommand with ConditionExpression attribute_not_exists(releaseId)", async () => {
+    ddbMock.on(PutCommand).resolves({});
+    const input = baseInput();
+
+    await releaseStore.putRelease(input);
+
+    const calls = ddbMock.commandCalls(PutCommand);
+    expect(calls).toHaveLength(1);
+    expect(calls[0].args[0].input.ConditionExpression).toBe(
+      "attribute_not_exists(releaseId)",
+    );
+    expect(calls[0].args[0].input.TableName).toBe("test-agent-releases");
+  });
+
+  it("computes releaseId as the content hash and includes it in the Put item", async () => {
+    ddbMock.on(PutCommand).resolves({});
+    const input = baseInput();
+
+    const result = await releaseStore.putRelease(input);
+
+    const calls = ddbMock.commandCalls(PutCommand);
+    const item = calls[0].args[0].input.Item as { releaseId: string };
+    expect(item.releaseId).toBe(result.releaseId);
+    expect(result.releaseId).toMatch(/^[0-9a-f]{64}$/);
+  });
+
+  it("putting identical content twice is an idempotent no-op: second call does not overwrite, returns the same release", async () => {
+    const input = baseInput();
+
+    // First call succeeds.
+    ddbMock.on(PutCommand).resolvesOnce({});
+    const first = await releaseStore.putRelease(input);
+
+    // Second call with identical content hits the condition check and
+    // fails, exactly as DynamoDB would for a duplicate key.
+    ddbMock.on(PutCommand).rejects(
+      Object.assign(new Error("The conditional request failed"), {
+        name: "ConditionalCheckFailedException",
+      }),
+    );
+    ddbMock.on(GetCommand).resolves({
+      Item: { ...input, releaseId: first.releaseId },
+    });
+
+    const second = await releaseStore.putRelease(input);
+
+    expect(second.releaseId).toBe(first.releaseId);
+    // No update path exists: the second Put attempt must have been made
+    // (and rejected by the condition), but the stored row content must
+    // be identical to what getRelease now returns.
+    const stored = await releaseStore.getRelease(first.releaseId);
+    expect(stored?.releaseId).toBe(first.releaseId);
+  });
+
+  it("differing content produces a distinct releaseId and does not overwrite the first row", async () => {
+    ddbMock.on(PutCommand).resolves({});
+    const inputA = baseInput();
+    const inputB = baseInput({
+      agentConfig: {
+        sourceId: "agent-1",
+        content: '{"name":"intake-agent-v2"}',
+        digest: "digest-b",
+      },
+    });
+
+    const resultA = await releaseStore.putRelease(inputA);
+    const resultB = await releaseStore.putRelease(inputB);
+
+    expect(resultA.releaseId).not.toBe(resultB.releaseId);
+
+    const calls = ddbMock.commandCalls(PutCommand);
+    expect(calls).toHaveLength(2);
+    // Each Put must still be create-only.
+    for (const call of calls) {
+      expect(call.args[0].input.ConditionExpression).toBe(
+        "attribute_not_exists(releaseId)",
+      );
+    }
+  });
+
+  it("propagates a non-conditional-check DynamoDB error", async () => {
+    ddbMock.on(PutCommand).rejects(new Error("ProvisionedThroughputExceeded"));
+    await expect(releaseStore.putRelease(baseInput())).rejects.toThrow(
+      "ProvisionedThroughputExceeded",
+    );
+  });
+});
+
+describe("release-store — getRelease", () => {
+  it("returns null when the release does not exist", async () => {
+    ddbMock.on(GetCommand).resolves({});
+    const result = await releaseStore.getRelease("nonexistent");
+    expect(result).toBeNull();
+  });
+
+  it("returns the stored release when it exists", async () => {
+    ddbMock.on(GetCommand).resolves({
+      Item: { releaseId: "abc", orgId: "org-1" },
+    });
+    const result = await releaseStore.getRelease("abc");
+    expect(result).toEqual({ releaseId: "abc", orgId: "org-1" });
+  });
+});

--- a/backend/src/lambda/environment-release-pointer-resolver.ts
+++ b/backend/src/lambda/environment-release-pointer-resolver.ts
@@ -1,0 +1,249 @@
+/**
+ * environment-release-pointer-resolver.ts — promoteEnvironmentReleasePointer
+ * mutation, plus the two read queries (current pointer for one
+ * agent+environment; every environment's pointer for one agent).
+ *
+ * Unlike release-resolver.ts's cutAgentRelease, the record this resolver
+ * writes is deliberately MUTABLE. The write itself, and its optimistic
+ * lock, live one layer down in environment-release-pointer-store.ts (the
+ * SOLE writer for EnvironmentReleasePointersTable) — this module never
+ * issues a raw DDB command against that table, only against
+ * AgentReleasesTable for the target-release existence/org check.
+ *
+ * Validation order — permission check FIRST (matches release-resolver.ts
+ * / execspec-resolver.ts's "permission check before any DDB access"
+ * convention), then target-release existence, then target-release
+ * org-ownership, ALL before the store's conditional write. Cross-org
+ * pointer promotion is a distinct SecurityError, not folded into the
+ * generic ValidationError bucket, mirroring release-resolver.ts's
+ * "malformed input" vs "attempted to pin/point at another tenant's data"
+ * distinction.
+ *
+ * QUALITY GATING SEAM: validateReleaseGate() is exported here (not
+ * imported from release-resolver.ts) and is an intentional no-op. It is
+ * the explicit, named place a later story attaches release-quality gating
+ * (test pass rate, eval score thresholds, etc.) before a promotion is
+ * allowed to proceed. It is NOT called from promoteEnvironmentReleasePointer
+ * — this slice ships an existence + org + permission gate only, never an
+ * ungated promotion path that silently skips a check a caller might
+ * assume is already enforced.
+ *
+ * The caller's org is derived from the AppSync identity's
+ * `custom:organization` claim (extractOrgFromEvent), never from
+ * caller-supplied input — the same doctrine as release-resolver.ts.
+ */
+import { DynamoDBClient } from "@aws-sdk/client-dynamodb";
+import { DynamoDBDocumentClient, GetCommand } from "@aws-sdk/lib-dynamodb";
+import { hasPermission } from "../utils/auth";
+import { extractOrgFromEvent } from "../utils/auth-event";
+import {
+  getEnvironmentReleasePointer,
+  listEnvironmentReleasePointersForAgent,
+  setEnvironmentReleasePointer,
+} from "./environment-release-pointer-store";
+import type {
+  AgentRelease,
+  AuthContext,
+  EnvironmentReleasePointer,
+  GovernanceEventIdentity,
+  GovernanceResolverEvent,
+  SetEnvironmentReleasePointerInput,
+} from "../types";
+
+const dynamoClient = new DynamoDBClient({});
+const docClient = DynamoDBDocumentClient.from(dynamoClient);
+
+function agentReleasesTable(): string {
+  return process.env.AGENT_RELEASES_TABLE!;
+}
+
+function requireReleasePromotePermission(authContext: AuthContext): void {
+  if (!hasPermission(authContext, "release:promote")) {
+    throw new Error(
+      "UnauthorizedError: release:promote permission required to move an environment release pointer",
+    );
+  }
+}
+
+/**
+ * Deferred quality-gating seam (mirrors release-resolver.ts's
+ * validateReleaseGate — same pattern, separate seam because promotion
+ * gating and cut-time gating are different concerns). Intentionally a
+ * no-op and NOT called from promoteEnvironmentReleasePointer. Quality
+ * gating (test pass rate, eval score thresholds, canary results) is a
+ * later story; this exists purely so that story has a named place to hang
+ * gate logic without an interface-shape migration.
+ */
+export function validateReleaseGate(): void {
+  // Intentionally empty — see doc comment above.
+}
+
+async function getAgentRelease(
+  releaseId: string,
+): Promise<AgentRelease | null> {
+  const res = await docClient.send(
+    new GetCommand({ TableName: agentReleasesTable(), Key: { releaseId } }),
+  );
+  return (res.Item as AgentRelease | undefined) ?? null;
+}
+
+/**
+ * promoteEnvironmentReleasePointer — validates the target release EXISTS
+ * and belongs to the caller's org, then moves the (org, agentTargetId,
+ * environment) pointer to it via the version-gated write boundary in
+ * environment-release-pointer-store.ts. Permission-gated by
+ * release:promote (do not ship an ungated promotion path).
+ *
+ * Reads the current pointer first only to derive expectedVersion and
+ * currentReleaseId for the store's optimistic-lock write — the actual
+ * lock enforcement happens in the store's ConditionExpression, not by
+ * this function re-checking the read after the fact. If another
+ * promotion wins the race between this read and the store's write, the
+ * store throws ConcurrentPromotionError, which propagates unchanged.
+ */
+export async function promoteEnvironmentReleasePointer(
+  input: SetEnvironmentReleasePointerInput,
+  authContext: AuthContext,
+  callerOrgId: string,
+): Promise<EnvironmentReleasePointer> {
+  requireReleasePromotePermission(authContext);
+
+  const targetRelease = await getAgentRelease(input.releaseId);
+  if (!targetRelease) {
+    throw new Error(
+      `ValidationError: target release not found: ${input.releaseId}`,
+    );
+  }
+  if (targetRelease.orgId !== callerOrgId) {
+    throw new Error(
+      `SecurityError: release ${input.releaseId} belongs to a different org — an environment pointer must never point at another org's release`,
+    );
+  }
+
+  const currentPointer = await getEnvironmentReleasePointer(
+    callerOrgId,
+    input.agentTargetId,
+    input.environment,
+  );
+
+  return setEnvironmentReleasePointer({
+    orgId: callerOrgId,
+    agentTargetId: input.agentTargetId,
+    environment: input.environment,
+    releaseId: input.releaseId,
+    expectedVersion: currentPointer?.version ?? null,
+    currentReleaseId: currentPointer?.releaseId ?? null,
+    promotedBy: authContext.userId,
+  });
+}
+
+/** Read: the current pointer for one agent+environment. Returns null when
+ * nothing has ever been promoted for that pair. */
+export async function getCurrentEnvironmentReleasePointer(
+  orgId: string,
+  agentTargetId: string,
+  environment: SetEnvironmentReleasePointerInput["environment"],
+): Promise<EnvironmentReleasePointer | null> {
+  return getEnvironmentReleasePointer(orgId, agentTargetId, environment);
+}
+
+/** Read: every environment's pointer for one agent. */
+export async function listEnvironmentReleasePointers(
+  orgId: string,
+  agentTargetId: string,
+): Promise<EnvironmentReleasePointer[]> {
+  return listEnvironmentReleasePointersForAgent(orgId, agentTargetId);
+}
+
+/** Merged view of every argument this resolver's fields receive. */
+interface EnvironmentReleasePointerResolverArguments {
+  input: SetEnvironmentReleasePointerInput;
+  agentTargetId: string;
+  environment: SetEnvironmentReleasePointerInput["environment"];
+}
+
+type EnvironmentReleasePointerResolverEvent =
+  GovernanceResolverEvent<EnvironmentReleasePointerResolverArguments>;
+
+function authContextFromEvent(
+  event: EnvironmentReleasePointerResolverEvent,
+): AuthContext {
+  const identity: GovernanceEventIdentity = event?.identity || {};
+  const claimRole = identity["custom:role"] ?? identity.claims?.["custom:role"];
+  return {
+    userId: identity.sub || identity.username || "anonymous",
+    username: identity.username,
+    groups: identity["cognito:groups"] || [],
+    roles: claimRole ? [claimRole as string] : [],
+  };
+}
+
+/** Truncate long string values in event.arguments for safe error logging
+ * (mirrors release-resolver.ts's sanitizeForLog convention). */
+function sanitizeForLog(input: unknown): unknown {
+  if (!input || typeof input !== "object") return input;
+  const out: Record<string, unknown> = {};
+  for (const [k, v] of Object.entries(input as Record<string, unknown>)) {
+    out[k] =
+      typeof v === "string" && v.length > 200 ? v.slice(0, 200) + "…" : v;
+  }
+  return out;
+}
+
+export const handler = async (
+  event: EnvironmentReleasePointerResolverEvent,
+): Promise<unknown> => {
+  const fieldName = event?.info?.fieldName;
+  const authContext = authContextFromEvent(event);
+  try {
+    switch (fieldName) {
+      case "promoteEnvironmentReleasePointer": {
+        const callerOrgId = await extractOrgFromEvent(event);
+        if (!callerOrgId) {
+          throw new Error(
+            "ValidationError: caller organization could not be determined",
+          );
+        }
+        return await promoteEnvironmentReleasePointer(
+          event.arguments.input,
+          authContext,
+          callerOrgId,
+        );
+      }
+      case "getCurrentEnvironmentReleasePointer": {
+        const callerOrgId = await extractOrgFromEvent(event);
+        if (!callerOrgId) {
+          throw new Error(
+            "ValidationError: caller organization could not be determined",
+          );
+        }
+        return await getCurrentEnvironmentReleasePointer(
+          callerOrgId,
+          event.arguments.agentTargetId,
+          event.arguments.environment,
+        );
+      }
+      case "listEnvironmentReleasePointers": {
+        const callerOrgId = await extractOrgFromEvent(event);
+        if (!callerOrgId) {
+          throw new Error(
+            "ValidationError: caller organization could not be determined",
+          );
+        }
+        return await listEnvironmentReleasePointers(
+          callerOrgId,
+          event.arguments.agentTargetId,
+        );
+      }
+      default:
+        throw new Error(`Unsupported field: ${fieldName}`);
+    }
+  } catch (err: unknown) {
+    console.error("environment-release-pointer-resolver error", {
+      fieldName,
+      message: err instanceof Error ? err.message : undefined,
+      args: sanitizeForLog(event?.arguments),
+    });
+    throw err;
+  }
+};

--- a/backend/src/lambda/environment-release-pointer-store.ts
+++ b/backend/src/lambda/environment-release-pointer-store.ts
@@ -1,0 +1,202 @@
+/**
+ * environment-release-pointer-store.ts — the SOLE write choke point for
+ * EnvironmentReleasePointersTable.
+ *
+ * Unlike release-store.ts (AgentReleasesTable), this record is
+ * deliberately MUTABLE — it is the cursor saying which AgentRelease an
+ * (org, agent, environment) triple currently runs. Two properties this
+ * module exists to guarantee at the WRITE BOUNDARY, not in application
+ * logic alone:
+ *
+ *  1. Optimistic locking via a DynamoDB ConditionExpression on the
+ *     `version` attribute. Two concurrent promotions racing against the
+ *     same stale read must not both succeed — the second Put is rejected
+ *     by DynamoDB itself (ConditionalCheckFailedException, surfaced here
+ *     as ConcurrentPromotionError) rather than silently overwriting the
+ *     first caller's move. A single conditional Put covers both the
+ *     first-ever promotion (attribute_not_exists(orgId), mirroring
+ *     release-store.ts's create-only guard) and every subsequent move
+ *     (#version = :expectedVersion) via one OR'd ConditionExpression, so
+ *     there is exactly one write path rather than a create/update branch
+ *     that could disagree on locking semantics.
+ *  2. previousReleaseId retention on every move, so a later rollback
+ *     story can read what was running immediately before the current
+ *     release without replaying history from another table.
+ */
+import { DynamoDBClient } from "@aws-sdk/client-dynamodb";
+import {
+  DynamoDBDocumentClient,
+  GetCommand,
+  PutCommand,
+  QueryCommand,
+} from "@aws-sdk/lib-dynamodb";
+import type { EnvironmentLiteral, EnvironmentReleasePointer } from "../types";
+
+const dynamoClient = new DynamoDBClient({});
+const docClient = DynamoDBDocumentClient.from(dynamoClient);
+
+function tableName(): string {
+  return process.env.ENVIRONMENT_RELEASE_POINTERS_TABLE!;
+}
+
+function sortKey(
+  agentTargetId: string,
+  environment: EnvironmentLiteral,
+): string {
+  return `${agentTargetId}#${environment}`;
+}
+
+/** Thrown when the write boundary's ConditionExpression rejects a Put
+ * because the caller's expectedVersion no longer matches the stored row
+ * — i.e. another promotion won the race. Distinct from a generic
+ * DynamoDB error so callers/resolvers can react specifically (surface a
+ * "someone else just promoted this" message rather than a raw AWS
+ * exception) without string-matching on error text. */
+export class ConcurrentPromotionError extends Error {
+  constructor(
+    public readonly orgId: string,
+    public readonly agentTargetId: string,
+    public readonly environment: EnvironmentLiteral,
+  ) {
+    super(
+      `ConcurrentPromotionError: the environment release pointer for ${agentTargetId}/${environment} (org ${orgId}) was moved by another promotion — reload and retry`,
+    );
+    this.name = "ConcurrentPromotionError";
+  }
+}
+
+function isConditionalCheckFailed(err: unknown): boolean {
+  return (
+    !!err &&
+    typeof err === "object" &&
+    (err as { name?: string }).name === "ConditionalCheckFailedException"
+  );
+}
+
+/** Point read for the current pointer of one (org, agent, environment). */
+export async function getEnvironmentReleasePointer(
+  orgId: string,
+  agentTargetId: string,
+  environment: EnvironmentLiteral,
+): Promise<EnvironmentReleasePointer | null> {
+  const res = await docClient.send(
+    new GetCommand({
+      TableName: tableName(),
+      Key: {
+        orgId,
+        agentTargetId_environment: sortKey(agentTargetId, environment),
+      },
+    }),
+  );
+  return (res.Item as EnvironmentReleasePointer | undefined) ?? null;
+}
+
+/** Every environment's pointer for one agent, within the caller's org. */
+export async function listEnvironmentReleasePointersForAgent(
+  orgId: string,
+  agentTargetId: string,
+): Promise<EnvironmentReleasePointer[]> {
+  const res = await docClient.send(
+    new QueryCommand({
+      TableName: tableName(),
+      KeyConditionExpression:
+        "orgId = :oid AND begins_with(agentTargetId_environment, :prefix)",
+      ExpressionAttributeValues: {
+        ":oid": orgId,
+        ":prefix": `${agentTargetId}#`,
+      },
+    }),
+  );
+  return (res.Items as EnvironmentReleasePointer[] | undefined) ?? [];
+}
+
+export interface SetEnvironmentReleasePointerParams {
+  orgId: string;
+  agentTargetId: string;
+  environment: EnvironmentLiteral;
+  releaseId: string;
+  /** The version the caller last read (null for a brand-new pointer that
+   * has never been set). Enforced via ConditionExpression, not re-checked
+   * in application logic after the read. */
+  expectedVersion: number | null;
+  /** The releaseId the caller observed as currently active, carried
+   * forward verbatim as previousReleaseId on this move. Omitted (or
+   * undefined) on a first-ever promotion, where previousReleaseId is
+   * null. */
+  currentReleaseId?: string | null;
+  promotedBy: string;
+}
+
+/**
+ * Create-or-move write for the (orgId, agentTargetId, environment)
+ * pointer. This is the ONLY function in the codebase permitted to issue a
+ * write against EnvironmentReleasePointersTable.
+ *
+ * The single ConditionExpression `attribute_not_exists(orgId) OR
+ * #version = :expectedVersion` covers both cases with one write path:
+ *  - First-ever promotion (expectedVersion === null): the row must not
+ *    exist yet, mirroring release-store.ts's create-only idempotency
+ *    guard structurally, though this table is mutable thereafter.
+ *  - Every subsequent move: the row's current `version` must equal what
+ *    the caller last read. A stale caller's Put is rejected by DynamoDB
+ *    with ConditionalCheckFailedException, surfaced as
+ *    ConcurrentPromotionError, BEFORE any data is overwritten — this is
+ *    the write-boundary enforcement the optimistic lock exists for, not
+ *    a read-then-compare done in this function's own logic.
+ */
+export async function setEnvironmentReleasePointer(
+  params: SetEnvironmentReleasePointerParams,
+): Promise<EnvironmentReleasePointer> {
+  const nextVersion = (params.expectedVersion ?? 0) + 1;
+  const promotedAt = new Date().toISOString();
+  const previousReleaseId = params.currentReleaseId ?? null;
+
+  const pointer: EnvironmentReleasePointer = {
+    orgId: params.orgId,
+    agentTargetId: params.agentTargetId,
+    environment: params.environment,
+    releaseId: params.releaseId,
+    previousReleaseId,
+    promotedAt,
+    promotedBy: params.promotedBy,
+    version: nextVersion,
+  };
+
+  try {
+    const conditionExpression =
+      params.expectedVersion === null
+        ? "attribute_not_exists(orgId)"
+        : "attribute_not_exists(orgId) OR #version = :expectedVersion";
+    await docClient.send(
+      new PutCommand({
+        TableName: tableName(),
+        Item: {
+          ...pointer,
+          agentTargetId_environment: sortKey(
+            params.agentTargetId,
+            params.environment,
+          ),
+        },
+        ConditionExpression: conditionExpression,
+        ExpressionAttributeNames:
+          params.expectedVersion === null
+            ? undefined
+            : { "#version": "version" },
+        ExpressionAttributeValues:
+          params.expectedVersion === null
+            ? undefined
+            : { ":expectedVersion": params.expectedVersion },
+      }),
+    );
+    return pointer;
+  } catch (err: unknown) {
+    if (isConditionalCheckFailed(err)) {
+      throw new ConcurrentPromotionError(
+        params.orgId,
+        params.agentTargetId,
+        params.environment,
+      );
+    }
+    throw err;
+  }
+}

--- a/backend/src/lambda/release-resolver.ts
+++ b/backend/src/lambda/release-resolver.ts
@@ -1,0 +1,513 @@
+/**
+ * release-resolver.ts — cutAgentRelease assembly operation (slice 2).
+ *
+ * Assembles a content-addressed AgentRelease from its constituents at cut
+ * time and writes it through the slice-1 store (release-store.ts, the SOLE
+ * writer for AgentReleasesTable — this module never issues a raw DDB
+ * command against that table, only against ExecutionSpecificationsTable/
+ * EvalRunsTable/EvalSuitesTable for read-side validation and the suite
+ * reference freeze).
+ *
+ * Snapshot vs pin-by-reference (design's Class A / Class B split, mirrored
+ * from AgentReleaseConstituents in ../types):
+ *   - Class B (mutable at cut time, so SNAPSHOTTED inline): agentConfig,
+ *     promptVersions, modelConfigSnapshots, toolConfigs, policySnapshot.
+ *     The caller supplies these already-resolved snapshots except
+ *     agentConfig, which this resolver derives from the registry record
+ *     itself (content = customDescriptorContent, digest = sha256 of that
+ *     content) so the release can't drift from what was actually
+ *     validated.
+ *   - Class A (already frozen/terminal, so PINNED BY REFERENCE):
+ *     execSpecId/execSpecVersion (an APPROVED ExecutionSpecification is
+ *     terminal — see lifecycle.ts EXECSPEC_TRANSITIONS) and evalEvidence
+ *     (evalRunId/evalSuiteId/evalSuiteVersion — EvalRun rows are
+ *     append-only and the suite is frozen-by-reference via
+ *     markEvalSuiteReferenced below, never snapshotted).
+ *
+ * Validation order — permission check, then EVERY structural/status/org
+ * check, ALL before hashing or any write (design requirement: "validate
+ * BEFORE hashing/storing"). Cross-org references are treated as a security
+ * rejection (thrown as a distinct error text), not folded into the generic
+ * ValidationError bucket, so callers/logs can distinguish "malformed
+ * input" from "attempted to pin another tenant's evidence".
+ *
+ * Org-check scope: RegistryRecord (via customDescriptorContent.orgId),
+ * EvalRun (via its own orgId field), and EvalSuite (via its own orgId
+ * field) all carry an orgId in this codebase and are checked against the
+ * caller's org — each fails CLOSED (rejects) when the org cannot be
+ * determined, never open. The registry record's descriptor-derived org
+ * check in particular used to fail OPEN when the descriptor lacked an
+ * orgId; it now rejects in that case, consistent with every other check
+ * here.
+ *
+ * ExecutionSpecification does NOT carry an orgId field directly anywhere
+ * in this codebase (see ../types.ts — it only has projectId, and Project
+ * itself has no orgId field either). That does NOT make the exec spec's
+ * org boundary inexpressible: an indirect path exists via
+ * Project.owner -> lookupUserOrganization (../utils/auth-event.ts), the
+ * exact derivation already used in production by
+ * intake-orchestration-resolver.ts's resolveOrgId() (project-owner
+ * fallback for org-less project rows). This module uses that same
+ * precedented path to resolve the exec spec's org and reject a
+ * cross-org exec spec. Consistent with this codebase's fail-closed gate
+ * doctrine, if the project cannot be found, or the owner's org cannot be
+ * resolved (no USER_POOL_ID, Cognito lookup failure, or no
+ * custom:organization attribute), the cut is REFUSED — never
+ * warn-and-proceed.
+ *
+ * The release's own orgId field is DERIVED from callerOrgId, not trusted
+ * from caller-supplied input — input.orgId is a forgeable label and is
+ * never stored verbatim.
+ *
+ * ORDERING / PARTIAL FAILURE (store-then-freeze, never the reverse):
+ * putRelease() is called BEFORE markEvalSuiteReferenced(). If the release
+ * put succeeds but the suite-freeze update then fails, the release row
+ * exists durably while its evidence's suite is still technically mutable
+ * (not yet marked referenced) — a real residual risk, but a strictly
+ * smaller one than the alternative ordering. Freezing first and then
+ * failing to store the release would leave an over-frozen suite (harmless
+ * — freezing is monotonic and idempotent, and a suite gains nothing but a
+ * reference id it doesn't strictly need yet) while ALSO not producing the
+ * release at all, so the caller has nothing to retry against and no
+ * record of intent. Store-then-freeze means: (a) the release, once
+ * stored, is the durable source of truth callers care about, and (b) a
+ * freeze failure is NOT swallowed — it propagates as a thrown error (see
+ * the try/finally-free straight propagation below), making the gap
+ * observable to the caller/logs/alerting rather than silently returning a
+ * "successful" release whose evidence isn't actually frozen yet. Retrying
+ * the identical cutAgentRelease call is safe: putRelease is idempotent on
+ * content hash (slice 1), and markEvalSuiteReferenced is idempotent on its
+ * Set-based references[] update (eval-resolver.ts) — so a retry re-does
+ * the (already-succeeded) store as a no-op and re-attempts the freeze.
+ */
+import { DynamoDBClient } from "@aws-sdk/client-dynamodb";
+import {
+  DynamoDBDocumentClient,
+  GetCommand,
+  UpdateCommand,
+} from "@aws-sdk/lib-dynamodb";
+import { createHash } from "crypto";
+import { hasPermission } from "../utils/auth";
+import {
+  extractOrgFromEvent,
+  lookupUserOrganization,
+} from "../utils/auth-event";
+import { putRelease } from "./release-store";
+import { RegistryService } from "../services/registry-service";
+import type {
+  AgentRelease,
+  AgentReleaseConstituents,
+  AuthContext,
+  ContentSnapshot,
+  EvalRun,
+  EvalSuite,
+  ExecutionSpecification,
+  GovernanceEventIdentity,
+  GovernanceResolverEvent,
+  ModelConfigSnapshot,
+  PolicySnapshot,
+  Project,
+} from "../types";
+
+const dynamoClient = new DynamoDBClient({});
+const docClient = DynamoDBDocumentClient.from(dynamoClient);
+
+function executionSpecsTable(): string {
+  return process.env.EXECUTION_SPECS_TABLE!;
+}
+function evalRunsTable(): string {
+  return process.env.EVAL_RUNS_TABLE!;
+}
+function evalSuitesTable(): string {
+  return process.env.EVAL_SUITES_TABLE!;
+}
+function projectsTable(): string {
+  return process.env.PROJECTS_TABLE!;
+}
+
+let registryServiceInstance: RegistryService | null = null;
+
+/** Shared RegistryService instance, created on first call. Mirrors
+ * agent-config-resolver.ts's getRegistryService() singleton — kept
+ * file-local rather than imported to avoid coupling this resolver's
+ * lifecycle to that module's env-var assumptions. */
+function getRegistryService(): RegistryService {
+  if (!registryServiceInstance) {
+    const registryId = process.env.REGISTRY_ID;
+    if (!registryId) {
+      throw new Error(
+        "REGISTRY_ID environment variable is required to cut a release",
+      );
+    }
+    registryServiceInstance = new RegistryService({
+      registryId,
+      region: process.env.AWS_REGION || "us-east-1",
+    });
+  }
+  return registryServiceInstance;
+}
+
+/** Test-only seam mirroring agent-config-resolver.ts's _resetRegistryService. */
+export function _resetRegistryService(): void {
+  registryServiceInstance = null;
+}
+
+function requireReleaseCutPermission(authContext: AuthContext): void {
+  if (!hasPermission(authContext, "release:cut")) {
+    throw new Error(
+      "UnauthorizedError: release:cut permission required to cut agent releases",
+    );
+  }
+}
+
+/** Input to cutAgentRelease — everything the store's AgentReleaseInput
+ * needs, but expressed as references to the mutable/frozen sources rather
+ * than pre-resolved constituents (agentConfig, execSpecId/Version, and
+ * evalEvidence are all DERIVED below, not accepted as caller-supplied
+ * data, so a caller can't smuggle in a snapshot that doesn't match what
+ * was actually validated). */
+export interface CutAgentReleaseInput {
+  orgId: string;
+  agentTargetId: string;
+  semver: string;
+  registryRecordId: string;
+  execSpecId: string;
+  evalRunId: string;
+  promptVersions: Record<string, ContentSnapshot>;
+  modelConfigSnapshots: ModelConfigSnapshot[];
+  toolConfigs: ContentSnapshot[];
+  policySnapshot: PolicySnapshot;
+  gitSha: string;
+  region: string;
+  runId: string;
+}
+
+function sha256(content: string): string {
+  return createHash("sha256").update(content, "utf8").digest("hex");
+}
+
+/**
+ * Deferred quality-gating seam (design: "leave a validateReleaseGate()
+ * seam only if it costs nothing"). Intentionally a no-op, not called from
+ * cutAgentRelease — environment pointer / dispatch integration / quality
+ * gating / promotion / canary / rollback / diff are all out of scope for
+ * slice 2. Exists purely so a future slice has a named place to hang gate
+ * logic without an interface-shape migration.
+ */
+export function validateReleaseGate(): void {
+  // Intentionally empty — see doc comment above.
+}
+
+async function getExecutionSpecification(
+  specId: string,
+): Promise<ExecutionSpecification | null> {
+  const res = await docClient.send(
+    new GetCommand({ TableName: executionSpecsTable(), Key: { specId } }),
+  );
+  return (res.Item as ExecutionSpecification | undefined) ?? null;
+}
+
+async function getEvalRun(evalRunId: string): Promise<EvalRun | null> {
+  const res = await docClient.send(
+    new GetCommand({ TableName: evalRunsTable(), Key: { evalRunId } }),
+  );
+  return (res.Item as EvalRun | undefined) ?? null;
+}
+
+async function getEvalSuite(suiteId: string): Promise<EvalSuite | null> {
+  const res = await docClient.send(
+    new GetCommand({ TableName: evalSuitesTable(), Key: { suiteId } }),
+  );
+  return (res.Item as EvalSuite | undefined) ?? null;
+}
+
+async function getProjectForOrgCheck(
+  projectId: string,
+): Promise<Project | null> {
+  const res = await docClient.send(
+    new GetCommand({ TableName: projectsTable(), Key: { id: projectId } }),
+  );
+  return (res.Item as Project | undefined) ?? null;
+}
+
+/**
+ * Resolves the org an ExecutionSpecification was created under via the
+ * precedented indirect path: projectId -> Project.owner ->
+ * lookupUserOrganization(owner) — the exact derivation used in production
+ * by intake-orchestration-resolver.ts's resolveOrgId() (project-owner
+ * fallback for org-less project rows). ExecutionSpecification has no
+ * orgId field of its own, and Project itself has no orgId field either
+ * (only `owner`), so this is the only available signal.
+ *
+ * Returns null (never throws) when the org cannot be determined — e.g.
+ * the project row doesn't exist, the project has no owner, or
+ * lookupUserOrganization can't resolve the owner's org (no USER_POOL_ID,
+ * Cognito lookup failure, or a missing custom:organization attribute).
+ * Callers of this function are responsible for treating null as a
+ * rejection (fail closed), per this codebase's established gate doctrine
+ * — never warn-and-proceed.
+ */
+async function resolveExecSpecOrgId(
+  execSpec: ExecutionSpecification,
+): Promise<string | null> {
+  const project = await getProjectForOrgCheck(execSpec.projectId);
+  if (!project?.owner) {
+    return null;
+  }
+  return lookupUserOrganization(project.owner);
+}
+
+/**
+ * Freezes the release's own evidence by marking the referenced eval suite
+ * as referenced (adds evalRunId's suite reference, Set-semantics —
+ * idempotent on retry). Duplicated here rather than imported from
+ * eval-resolver.ts because that module's markEvalSuiteReferenced is itself
+ * eval:approve-gated internally (requireEvalApprovePermission) and this
+ * resolver's caller has already passed the DISTINCT release:cut gate —
+ * re-running an internal eval:approve check against the SAME authContext
+ * would incorrectly require the caller to hold both permissions to cut a
+ * release. The write shape (Set-union UpdateExpression) is intentionally
+ * identical to eval-resolver.ts's implementation.
+ */
+async function markEvalSuiteReferencedForRelease(
+  suite: EvalSuite,
+  referenceId: string,
+): Promise<void> {
+  const nextReferences = Array.from(
+    new Set([...(suite.references ?? []), referenceId]),
+  );
+  await docClient.send(
+    new UpdateCommand({
+      TableName: evalSuitesTable(),
+      Key: { suiteId: suite.suiteId },
+      UpdateExpression: "SET #references = :refs",
+      ExpressionAttributeNames: { "#references": "references" },
+      ExpressionAttributeValues: { ":refs": nextReferences },
+    }),
+  );
+}
+
+export async function cutAgentRelease(
+  input: CutAgentReleaseInput,
+  authContext: AuthContext,
+  callerOrgId: string,
+): Promise<AgentRelease> {
+  // Permission check FIRST — no DDB access, no Registry call, before any
+  // other work (matches execspec-resolver.ts's approveExecutionSpecification
+  // convention: "Permission check FIRST").
+  requireReleaseCutPermission(authContext);
+
+  // ---- Registry record (agent config) validation ----
+  const record = await getRegistryService().getResource(
+    "agent",
+    input.registryRecordId,
+  );
+  if (!record) {
+    throw new Error(
+      `ValidationError: registry record not found: ${input.registryRecordId}`,
+    );
+  }
+  if (record.status !== "APPROVED") {
+    throw new Error(
+      `ValidationError: registry record ${input.registryRecordId} must be APPROVED to cut a release (status: ${record.status})`,
+    );
+  }
+  const recordMeta = record.customDescriptorContent
+    ? (JSON.parse(record.customDescriptorContent) as { orgId?: string })
+    : {};
+  // Fail CLOSED: a descriptor that lacks an orgId is treated as a
+  // rejection, not an all-org bypass. A missing orgId on a registry
+  // descriptor must never be interpreted as "no boundary to enforce" —
+  // that is exactly the fail-open hole that let a release pin a
+  // descriptor with no verifiable org at all.
+  if (!recordMeta.orgId) {
+    throw new Error(
+      `SecurityError: registry record ${input.registryRecordId}'s descriptor carries no orgId — cannot verify org ownership, refusing to cut a release against unverifiable evidence`,
+    );
+  }
+  if (recordMeta.orgId !== callerOrgId) {
+    throw new Error(
+      `SecurityError: registry record ${input.registryRecordId} belongs to a different org — a release must never pin another org's evidence`,
+    );
+  }
+
+  // ---- ExecutionSpecification validation ----
+  const execSpec = await getExecutionSpecification(input.execSpecId);
+  if (!execSpec) {
+    throw new Error(
+      `ValidationError: exec spec not found: ${input.execSpecId}`,
+    );
+  }
+  if (execSpec.status !== "APPROVED") {
+    throw new Error(
+      `ValidationError: exec spec ${input.execSpecId} must be APPROVED to cut a release (status: ${execSpec.status})`,
+    );
+  }
+  // Cross-org check via the precedented indirect path: exec spec has no
+  // orgId field directly, but its projectId -> Project.owner ->
+  // lookupUserOrganization resolves the org the spec was created under
+  // (same derivation as intake-orchestration-resolver.ts's resolveOrgId()
+  // project-owner fallback). Fail CLOSED at every step — project not
+  // found, or the owner's org not resolvable, is a rejection, never a
+  // silent pass-through.
+  const execSpecOrgId = await resolveExecSpecOrgId(execSpec);
+  if (!execSpecOrgId) {
+    throw new Error(
+      `SecurityError: exec spec ${input.execSpecId}'s owning org could not be determined (project not found or owner's organization unresolvable) — refusing to cut a release against unverifiable evidence`,
+    );
+  }
+  if (execSpecOrgId !== callerOrgId) {
+    throw new Error(
+      `SecurityError: exec spec ${input.execSpecId} belongs to a different org — a release must never pin another org's evidence`,
+    );
+  }
+
+  // ---- EvalRun validation ----
+  const evalRun = await getEvalRun(input.evalRunId);
+  if (!evalRun) {
+    throw new Error(`ValidationError: eval run not found: ${input.evalRunId}`);
+  }
+  if (evalRun.status !== "COMPLETED") {
+    throw new Error(
+      `ValidationError: eval run ${input.evalRunId} must be COMPLETED to cut a release (status: ${evalRun.status})`,
+    );
+  }
+  if (evalRun.orgId !== callerOrgId) {
+    throw new Error(
+      `SecurityError: eval run ${input.evalRunId} belongs to a different org — a release must never pin another org's evidence`,
+    );
+  }
+  const evalSuite = await getEvalSuite(evalRun.suiteId);
+  if (!evalSuite) {
+    throw new Error(
+      `ValidationError: eval suite not found for eval run ${input.evalRunId}: ${evalRun.suiteId}`,
+    );
+  }
+  if (evalSuite.orgId !== callerOrgId) {
+    throw new Error(
+      `SecurityError: eval suite ${evalSuite.suiteId} belongs to a different org — the freeze step must never write to a foreign-org suite`,
+    );
+  }
+  if (evalSuite.version !== evalRun.suiteVersion) {
+    throw new Error(
+      `ValidationError: eval run ${input.evalRunId}'s suiteVersion (${evalRun.suiteVersion}) does not match the current suite version (${evalSuite.version})`,
+    );
+  }
+
+  // ---- Assembly: snapshot the mutable constituents, pin the frozen ones ----
+  const agentConfigContent = record.customDescriptorContent ?? "{}";
+  const constituents: AgentReleaseConstituents = {
+    agentConfig: {
+      sourceId: input.registryRecordId,
+      content: agentConfigContent,
+      digest: sha256(agentConfigContent),
+    },
+    promptVersions: input.promptVersions,
+    execSpecId: execSpec.specId,
+    execSpecVersion: execSpec.version,
+    modelConfigSnapshots: input.modelConfigSnapshots,
+    toolConfigs: input.toolConfigs,
+    policySnapshot: input.policySnapshot,
+    evalEvidence: {
+      evalRunId: evalRun.evalRunId,
+      evalSuiteId: evalRun.suiteId,
+      evalSuiteVersion: evalRun.suiteVersion,
+    },
+  };
+
+  // ---- Store (create-only, content-addressed, idempotent — slice 1) ----
+  // orgId is DERIVED from callerOrgId, never trusted from caller-supplied
+  // input.orgId — that field is a forgeable label and must not become the
+  // stored record of which org actually cut the release.
+  const release = await putRelease({
+    ...constituents,
+    orgId: callerOrgId,
+    agentTargetId: input.agentTargetId,
+    semver: input.semver,
+    createdAt: new Date().toISOString(),
+    createdBy: authContext.userId,
+    gitSha: input.gitSha,
+    region: input.region,
+    runId: input.runId,
+  });
+
+  // ---- Freeze the release's own evidence (fail-safe ordering — see
+  // module doc comment: store-then-freeze, and a freeze failure here
+  // propagates rather than being swallowed). ----
+  await markEvalSuiteReferencedForRelease(evalSuite, evalRun.evalRunId);
+
+  return release;
+}
+
+/** Merged view of every argument this resolver's fields receive. */
+interface ReleaseResolverArguments {
+  input: CutAgentReleaseInput;
+  releaseId: string;
+}
+
+type ReleaseResolverEvent = GovernanceResolverEvent<ReleaseResolverArguments>;
+
+function authContextFromEvent(event: ReleaseResolverEvent): AuthContext {
+  const identity: GovernanceEventIdentity = event?.identity || {};
+  const claimRole = identity["custom:role"] ?? identity.claims?.["custom:role"];
+  return {
+    userId: identity.sub || identity.username || "anonymous",
+    username: identity.username,
+    groups: identity["cognito:groups"] || [],
+    roles: claimRole ? [claimRole] : [],
+  };
+}
+
+/**
+ * Truncate long string values in event.arguments so error logs cannot be
+ * weaponised to exfiltrate long payloads. Mirrors execspec-resolver.ts /
+ * eval-run-resolver.ts's sanitizeForLog convention.
+ */
+function sanitizeForLog(input: unknown): unknown {
+  if (!input || typeof input !== "object") return input;
+  const out: Record<string, unknown> = {};
+  for (const [k, v] of Object.entries(input as Record<string, unknown>)) {
+    out[k] =
+      typeof v === "string" && v.length > 200 ? v.slice(0, 200) + "…" : v;
+  }
+  return out;
+}
+
+export const handler = async (
+  event: ReleaseResolverEvent,
+): Promise<unknown> => {
+  const fieldName = event?.info?.fieldName;
+  const authContext = authContextFromEvent(event);
+  try {
+    switch (fieldName) {
+      case "cutAgentRelease": {
+        // Caller org is read from the event identity (custom:organization
+        // claim, with the Cognito AdminGetUser fallback), NOT from
+        // authContext — AuthContext carries no orgId field in this
+        // codebase (see ../types.ts). A missing org is a validation
+        // failure, not a silent all-org bypass: the security-critical
+        // cross-org checks in cutAgentRelease compare against it directly.
+        const callerOrgId = await extractOrgFromEvent(event);
+        if (!callerOrgId) {
+          throw new Error(
+            "ValidationError: caller organization could not be determined",
+          );
+        }
+        return await cutAgentRelease(
+          event.arguments.input,
+          authContext,
+          callerOrgId,
+        );
+      }
+      default:
+        throw new Error(`Unsupported field: ${fieldName}`);
+    }
+  } catch (err: unknown) {
+    console.error("release-resolver error", {
+      fieldName,
+      message: err instanceof Error ? err.message : undefined,
+      args: sanitizeForLog(event?.arguments),
+    });
+    throw err;
+  }
+};

--- a/backend/src/lambda/release-store.ts
+++ b/backend/src/lambda/release-store.ts
@@ -25,7 +25,11 @@ import {
   GetCommand,
 } from "@aws-sdk/lib-dynamodb";
 import { computeReleaseHash } from "./utils/release-hash";
-import type { AgentRelease, AgentReleaseInput } from "../types";
+import type {
+  AgentRelease,
+  AgentReleaseConstituents,
+  AgentReleaseInput,
+} from "../types";
 
 const dynamoClient = new DynamoDBClient({});
 const docClient = DynamoDBDocumentClient.from(dynamoClient);
@@ -43,17 +47,35 @@ function isConditionalCheckFailed(err: unknown): boolean {
 }
 
 /**
- * Create-only write. Computes releaseId from the constituents (pure,
- * order-independent hash) and attempts a conditional Put keyed on that
- * hash. If a row with the same releaseId already exists (identical
- * content), the Put is rejected by DynamoDB and this function treats
- * that as a no-op, returning the already-stored release. Any other
- * DynamoDB error propagates.
+ * Create-only write. Computes releaseId from the constituents ONLY (pure,
+ * order-independent hash) — volatile metadata that varies per call
+ * (createdAt, and any other non-constituent field on AgentReleaseInput)
+ * is deliberately excluded from the hash domain, so that re-cutting
+ * identical constituents at a different wall-clock time still collides on
+ * the same releaseId. Feeding the full input (including createdAt) into
+ * the hash would defeat content-addressing: a real retry after a
+ * transient failure mints a fresh createdAt and would otherwise produce a
+ * distinct row instead of the idempotent no-op this store exists to
+ * guarantee. Attempts a conditional Put keyed on that hash. If a row with
+ * the same releaseId already exists (identical constituents), the Put is
+ * rejected by DynamoDB and this function treats that as a no-op,
+ * returning the already-stored release. Any other DynamoDB error
+ * propagates.
  */
 export async function putRelease(
   input: AgentReleaseInput,
 ): Promise<AgentRelease> {
-  const releaseId = computeReleaseHash(input);
+  const constituents: AgentReleaseConstituents = {
+    agentConfig: input.agentConfig,
+    promptVersions: input.promptVersions,
+    execSpecId: input.execSpecId,
+    execSpecVersion: input.execSpecVersion,
+    modelConfigSnapshots: input.modelConfigSnapshots,
+    toolConfigs: input.toolConfigs,
+    policySnapshot: input.policySnapshot,
+    evalEvidence: input.evalEvidence,
+  };
+  const releaseId = computeReleaseHash(constituents);
   const release: AgentRelease = { ...input, releaseId };
 
   try {

--- a/backend/src/lambda/release-store.ts
+++ b/backend/src/lambda/release-store.ts
@@ -1,0 +1,87 @@
+/**
+ * release-store.ts — the SOLE write choke point for AgentReleasesTable.
+ *
+ * Immutability layer L1 (design §2): this is the ONLY module in the
+ * codebase permitted to reference AgentReleasesTable or issue a raw
+ * Put/Update/Delete command against it. It exports create (putRelease)
+ * and read (getRelease) only — deliberately no update, no delete, not
+ * even unused. A CI guard test
+ * (release-store-choke-point.guard.test.ts) fails the build if any other
+ * file references the table or those commands.
+ *
+ * Immutability layer L2: putRelease uses
+ * ConditionExpression attribute_not_exists(releaseId). Because releaseId
+ * IS the content hash of the constituents (release-hash.ts), re-putting
+ * identical content always collides on the same key and is treated as an
+ * idempotent no-op (the existing row is fetched and returned) rather than
+ * an error; differing content hashes to a different key and is inserted
+ * as a new, distinct row — an existing row can never be overwritten by
+ * any Put through this module.
+ */
+import { DynamoDBClient } from "@aws-sdk/client-dynamodb";
+import {
+  DynamoDBDocumentClient,
+  PutCommand,
+  GetCommand,
+} from "@aws-sdk/lib-dynamodb";
+import { computeReleaseHash } from "./utils/release-hash";
+import type { AgentRelease, AgentReleaseInput } from "../types";
+
+const dynamoClient = new DynamoDBClient({});
+const docClient = DynamoDBDocumentClient.from(dynamoClient);
+
+function tableName(): string {
+  return process.env.AGENT_RELEASES_TABLE!;
+}
+
+function isConditionalCheckFailed(err: unknown): boolean {
+  return (
+    !!err &&
+    typeof err === "object" &&
+    (err as { name?: string }).name === "ConditionalCheckFailedException"
+  );
+}
+
+/**
+ * Create-only write. Computes releaseId from the constituents (pure,
+ * order-independent hash) and attempts a conditional Put keyed on that
+ * hash. If a row with the same releaseId already exists (identical
+ * content), the Put is rejected by DynamoDB and this function treats
+ * that as a no-op, returning the already-stored release. Any other
+ * DynamoDB error propagates.
+ */
+export async function putRelease(
+  input: AgentReleaseInput,
+): Promise<AgentRelease> {
+  const releaseId = computeReleaseHash(input);
+  const release: AgentRelease = { ...input, releaseId };
+
+  try {
+    await docClient.send(
+      new PutCommand({
+        TableName: tableName(),
+        Item: release,
+        ConditionExpression: "attribute_not_exists(releaseId)",
+      }),
+    );
+    return release;
+  } catch (err: unknown) {
+    if (isConditionalCheckFailed(err)) {
+      const existing = await getRelease(releaseId);
+      if (existing) {
+        return existing;
+      }
+    }
+    throw err;
+  }
+}
+
+/** Point read by releaseId. Returns null when the release does not exist. */
+export async function getRelease(
+  releaseId: string,
+): Promise<AgentRelease | null> {
+  const res = await docClient.send(
+    new GetCommand({ TableName: tableName(), Key: { releaseId } }),
+  );
+  return (res.Item as AgentRelease | undefined) ?? null;
+}

--- a/backend/src/lambda/utils/__tests__/release-hash.property.test.ts
+++ b/backend/src/lambda/utils/__tests__/release-hash.property.test.ts
@@ -1,0 +1,185 @@
+/**
+ * release-hash.property.test.ts — property test for the pure,
+ * order-independent content hash that gives an AgentRelease its identity
+ * (releaseId = sha256(canonicalize(constituents))).
+ *
+ * Binding invariants (design §1/§5):
+ *   1. A release reconstructed from the same constituents hashes
+ *      identically — the hash is a pure function of content, not identity
+ *      or call order.
+ *   2. Object key ordering never changes the hash (canonicalization sorts
+ *      keys before hashing).
+ *   3. Ordering of any set-like collection (promptVersions map iteration
+ *      order, toolConfigs array, modelConfigSnapshots array,
+ *      authorityUnitGrantIds array) never changes the hash — these are
+ *      treated as sets, not sequences.
+ *   4. Differing content produces a different hash (sanity check that the
+ *      function is not trivially constant).
+ */
+import fc from "fast-check";
+import { computeReleaseHash } from "../release-hash";
+import type { AgentReleaseConstituents } from "../../../types";
+
+function baseConstituents(): AgentReleaseConstituents {
+  return {
+    agentConfig: {
+      sourceId: "agent-1",
+      content: '{"name":"intake-agent"}',
+      digest: "digest-a",
+    },
+    promptVersions: {
+      supervisor: { sourceId: "p1", content: "you are...", digest: "d1" },
+      fabricator: { sourceId: "p2", content: "you build...", digest: "d2" },
+    },
+    execSpecId: "spec-123",
+    execSpecVersion: 3,
+    modelConfigSnapshots: [
+      { slot: "supervisor", content: "claude-x", digest: "m1" },
+      { slot: "fabricator", content: "claude-y", digest: "m2" },
+    ],
+    toolConfigs: [
+      { sourceId: "tool-a", content: "{}", digest: "t1" },
+      { sourceId: "tool-b", content: "{}", digest: "t2" },
+    ],
+    policySnapshot: {
+      enforcementMode: "strict",
+      ruleSetVersion: "v3",
+      authorityUnitGrantIds: ["grant-1", "grant-2"],
+    },
+    evalEvidence: {
+      evalRunId: "run-1",
+      evalSuiteId: "suite-1",
+      evalSuiteVersion: 2,
+    },
+  };
+}
+
+describe("computeReleaseHash — reconstruct-from-hash property", () => {
+  it("hashing the same constituents object twice yields an identical hash", () => {
+    const constituents = baseConstituents();
+    const h1 = computeReleaseHash(constituents);
+    const h2 = computeReleaseHash(constituents);
+    expect(h1).toBe(h2);
+  });
+
+  it("hashing a deep-cloned (structurally identical) copy yields an identical hash", () => {
+    const a = baseConstituents();
+    const b = JSON.parse(JSON.stringify(baseConstituents()));
+    expect(computeReleaseHash(a)).toBe(computeReleaseHash(b));
+  });
+
+  it("reordering top-level object keys does not change the hash", () => {
+    const a = baseConstituents();
+    // Re-key in reverse order — same values, different property order.
+    const entries = Object.entries(a).reverse();
+    const reordered = Object.fromEntries(
+      entries,
+    ) as unknown as AgentReleaseConstituents;
+    expect(computeReleaseHash(reordered)).toBe(computeReleaseHash(a));
+  });
+
+  it("reordering nested object keys (policySnapshot) does not change the hash", () => {
+    const a = baseConstituents();
+    const b = baseConstituents();
+    b.policySnapshot = {
+      authorityUnitGrantIds: [...a.policySnapshot.authorityUnitGrantIds],
+      ruleSetVersion: a.policySnapshot.ruleSetVersion,
+      enforcementMode: a.policySnapshot.enforcementMode,
+    };
+    expect(computeReleaseHash(b)).toBe(computeReleaseHash(a));
+  });
+
+  it("reordering the set-like toolConfigs array does not change the hash", () => {
+    const a = baseConstituents();
+    const b = baseConstituents();
+    b.toolConfigs = [...a.toolConfigs].reverse();
+    expect(computeReleaseHash(b)).toBe(computeReleaseHash(a));
+  });
+
+  it("reordering the set-like modelConfigSnapshots array does not change the hash", () => {
+    const a = baseConstituents();
+    const b = baseConstituents();
+    b.modelConfigSnapshots = [...a.modelConfigSnapshots].reverse();
+    expect(computeReleaseHash(b)).toBe(computeReleaseHash(a));
+  });
+
+  it("reordering the set-like authorityUnitGrantIds array does not change the hash", () => {
+    const a = baseConstituents();
+    const b = baseConstituents();
+    b.policySnapshot = {
+      ...a.policySnapshot,
+      authorityUnitGrantIds: [
+        ...a.policySnapshot.authorityUnitGrantIds,
+      ].reverse(),
+    };
+    expect(computeReleaseHash(b)).toBe(computeReleaseHash(a));
+  });
+
+  it("reordering promptVersions map insertion order does not change the hash", () => {
+    const a = baseConstituents();
+    const b = baseConstituents();
+    b.promptVersions = {
+      fabricator: a.promptVersions.fabricator,
+      supervisor: a.promptVersions.supervisor,
+    };
+    expect(computeReleaseHash(b)).toBe(computeReleaseHash(a));
+  });
+
+  it("differing content (one changed digest) produces a distinct hash", () => {
+    const a = baseConstituents();
+    const b = baseConstituents();
+    b.agentConfig = { ...a.agentConfig, digest: "digest-b-different" };
+    expect(computeReleaseHash(b)).not.toBe(computeReleaseHash(a));
+  });
+
+  it("property: for arbitrary constituents, shuffling any set-like collection never changes the hash", () => {
+    fc.assert(
+      fc.property(
+        fc.array(
+          fc.record({
+            sourceId: fc.string({ minLength: 1, maxLength: 10 }),
+            content: fc.string({ minLength: 0, maxLength: 20 }),
+            digest: fc.string({ minLength: 1, maxLength: 10 }),
+          }),
+          { minLength: 0, maxLength: 6 },
+        ),
+        (toolConfigs) => {
+          const constituents = baseConstituents();
+          constituents.toolConfigs = toolConfigs;
+          const shuffled = [...toolConfigs].reverse();
+          const constituentsShuffled = {
+            ...constituents,
+            toolConfigs: shuffled,
+          };
+          expect(computeReleaseHash(constituentsShuffled)).toBe(
+            computeReleaseHash(constituents),
+          );
+        },
+      ),
+      { numRuns: 50 },
+    );
+  });
+
+  it("property: for arbitrary distinct constituents pairs, differing content yields differing hashes", () => {
+    fc.assert(
+      fc.property(
+        fc.string({ minLength: 1, maxLength: 20 }),
+        fc.string({ minLength: 1, maxLength: 20 }),
+        (digestA, digestB) => {
+          fc.pre(digestA !== digestB);
+          const a = baseConstituents();
+          const b = baseConstituents();
+          a.agentConfig = { ...a.agentConfig, digest: digestA };
+          b.agentConfig = { ...b.agentConfig, digest: digestB };
+          expect(computeReleaseHash(a)).not.toBe(computeReleaseHash(b));
+        },
+      ),
+      { numRuns: 50 },
+    );
+  });
+
+  it("returns a 64-character lowercase hex sha256 digest", () => {
+    const hash = computeReleaseHash(baseConstituents());
+    expect(hash).toMatch(/^[0-9a-f]{64}$/);
+  });
+});

--- a/backend/src/lambda/utils/release-hash.ts
+++ b/backend/src/lambda/utils/release-hash.ts
@@ -1,0 +1,68 @@
+/**
+ * release-hash.ts — pure content-addressing for AgentRelease.
+ *
+ * releaseId = sha256(canonicalize(constituents)). Canonicalization is
+ * order-independent over:
+ *   - object keys (sorted lexicographically before serialization), and
+ *   - set-like collections — arrays of {sourceId|slot, ...} snapshot
+ *     objects (toolConfigs, modelConfigSnapshots) and plain string arrays
+ *     (authorityUnitGrantIds) are sorted by their own canonical
+ *     serialization before being joined into the parent structure.
+ *
+ * This module has no side effects and no I/O — pure function of its
+ * input, matching the "pure release-hash module" requirement.
+ */
+import { createHash } from "crypto";
+import type { AgentReleaseConstituents } from "../../types";
+
+/**
+ * Recursively canonicalize a JSON-serializable value: object keys are
+ * sorted; arrays are treated as SETS and sorted by the canonical string
+ * of each element (never by original position), so any permutation of a
+ * set-like collection serializes identically. Primitives pass through.
+ */
+function canonicalize(value: unknown): unknown {
+  if (Array.isArray(value)) {
+    const canonicalItems = value.map((item) => canonicalize(item));
+    // Sort by the JSON-stable string form of each canonicalized item so
+    // element order never affects the result — arrays are set-like here.
+    return canonicalItems
+      .map((item) => JSON.stringify(item))
+      .sort()
+      .map((s) => JSON.parse(s));
+  }
+
+  if (value !== null && typeof value === "object") {
+    const obj = value as Record<string, unknown>;
+    const sortedKeys = Object.keys(obj).sort();
+    const result: Record<string, unknown> = {};
+    for (const key of sortedKeys) {
+      result[key] = canonicalize(obj[key]);
+    }
+    return result;
+  }
+
+  return value;
+}
+
+/** Deterministic JSON serialization of a canonicalized value. Because
+ * canonicalize() has already sorted every object's keys and every
+ * array's elements, JSON.stringify's own (order-preserving) traversal
+ * yields a byte-identical string for structurally-identical input
+ * regardless of original key/collection order. */
+function canonicalStringify(value: unknown): string {
+  return JSON.stringify(canonicalize(value));
+}
+
+/**
+ * Compute the content-addressed hash of a release's constituents. Pure:
+ * given structurally-identical constituents (any key ordering, any
+ * ordering of set-like collections), returns the same 64-character
+ * lowercase hex sha256 digest every time.
+ */
+export function computeReleaseHash(
+  constituents: AgentReleaseConstituents,
+): string {
+  const canonical = canonicalStringify(constituents);
+  return createHash("sha256").update(canonical, "utf8").digest("hex");
+}

--- a/backend/src/schema/schema.graphql
+++ b/backend/src/schema/schema.graphql
@@ -85,6 +85,11 @@ type Query {
   # Eval baseline comparison + regression (CIT-105)
   getEvalBaseline(orgId: ID!, agentTargetId: ID!, suiteId: ID!): EvalBaseline
   listEvalBaselines(orgId: ID!): [EvalBaseline!]!
+  # Environment release pointer — the MUTABLE cursor saying which release
+  # an environment currently runs (orgId is always the caller's own org,
+  # resolved server-side, never a client-supplied value here).
+  getCurrentEnvironmentReleasePointer(agentTargetId: ID!, environment: DeploymentEnvironment!): EnvironmentReleasePointer
+  listEnvironmentReleasePointers(agentTargetId: ID!): [EnvironmentReleasePointer!]!
   getEvalComparison(comparisonId: ID!): EvalComparisonVerdict
   listEvalComparisons(orgId: ID!, suiteId: ID): [EvalComparisonVerdict!]!
   getEvalComparisonThresholdConfig(orgId: ID!, suiteId: ID!): EvalComparisonThresholdConfig
@@ -365,6 +370,12 @@ type Mutation {
   # AgentRelease — cut is the only mutation; releases are immutable,
   # content-addressed audit records (no update/delete field exists).
   cutAgentRelease(input: CutAgentReleaseInput!): AgentRelease!
+  # Environment release pointer — moves the mutable per-environment
+  # cursor to an existing, same-org release. release:promote-gated in the
+  # resolver (schema visibility alone is not the enforcement boundary).
+  # Quality gating is deferred to a later story — see
+  # environment-release-pointer-resolver.ts's validateReleaseGate() seam.
+  promoteEnvironmentReleasePointer(input: SetEnvironmentReleasePointerInput!): EnvironmentReleasePointer!
   # Eval baseline comparison + regression (CIT-105). UI: OUT OF SCOPE.
   designateEvalBaseline(input: DesignateEvalBaselineInput!): EvalBaseline!
   computeEvalComparison(input: ComputeEvalComparisonInput!): EvalComparisonVerdict!
@@ -2375,6 +2386,38 @@ input CutAgentReleaseInput {
   gitSha: String!
   region: String!
   runId: String!
+}
+
+# Reuses the CDK deploy-stage literal already threaded through this
+# codebase as `props.environment` / `process.env.ENVIRONMENT` (see
+# bin/app.ts, backend-stack.ts's `${props.environment}` table-name
+# suffixing) rather than a new set of tokens. "test" is excluded — it is a
+# CDK-synth-only stack suffix, never a real promotion target.
+enum DeploymentEnvironment { DEV STAGING PROD }
+
+# EnvironmentReleasePointer — the MUTABLE cursor saying which
+# AgentRelease an (org, agentTargetId, environment) triple currently
+# runs. Unlike AgentRelease, this record is overwritten on every
+# promotion; previousReleaseId is retained on every move so a later
+# rollback story can read what was running immediately before the
+# current release. version is the optimistic-lock counter enforced via a
+# DynamoDB ConditionExpression at the write boundary (see
+# environment-release-pointer-store.ts) — not merely advisory metadata.
+type EnvironmentReleasePointer {
+  orgId: ID!
+  agentTargetId: String!
+  environment: DeploymentEnvironment!
+  releaseId: ID!
+  previousReleaseId: ID
+  promotedAt: AWSDateTime!
+  promotedBy: String!
+  version: Int!
+}
+
+input SetEnvironmentReleasePointerInput {
+  agentTargetId: String!
+  environment: DeploymentEnvironment!
+  releaseId: ID!
 }
 
 type EvalRunCaseResult {

--- a/backend/src/schema/schema.graphql
+++ b/backend/src/schema/schema.graphql
@@ -362,6 +362,9 @@ type Mutation {
   # EvalRun (CIT-102) — start is the only mutation; runs are immutable
   # once created (outcome-only progression via the driver, not client edits).
   startEvalRun(input: StartEvalRunInput!): EvalRun!
+  # AgentRelease — cut is the only mutation; releases are immutable,
+  # content-addressed audit records (no update/delete field exists).
+  cutAgentRelease(input: CutAgentReleaseInput!): AgentRelease!
   # Eval baseline comparison + regression (CIT-105). UI: OUT OF SCOPE.
   designateEvalBaseline(input: DesignateEvalBaselineInput!): EvalBaseline!
   computeEvalComparison(input: ComputeEvalComparisonInput!): EvalComparisonVerdict!
@@ -2326,6 +2329,52 @@ input StartEvalRunInput {
   agentTargetId: String!
   agentTargetVersion: String!
   idempotencyKey: String!
+}
+
+# AgentRelease (agent release bundles, slices 1-2) — a content-addressed,
+# immutable audit record. releaseId is the sha256 hash of its constituents
+# (see release-hash.ts); there is no lifecycle/status field because a
+# release is a pure snapshot, never updated or deleted after creation.
+# Class A constituents (execSpecId/execSpecVersion, evalRunId/
+# evalSuiteId/evalSuiteVersion) are pinned by reference to already-frozen
+# sources; Class B constituents (agentConfig, promptVersions,
+# modelConfigSnapshots, toolConfigs, policySnapshot) are inline content
+# snapshots taken at cut time. Mirrors AWSJSON usage on EvalRun's
+# scoreAggregates for the free-form snapshot payloads below.
+type AgentRelease {
+  releaseId: ID!
+  orgId: ID!
+  agentTargetId: String!
+  semver: String!
+  agentConfig: AWSJSON!
+  promptVersions: AWSJSON!
+  execSpecId: ID!
+  execSpecVersion: Int!
+  modelConfigSnapshots: AWSJSON!
+  toolConfigs: AWSJSON!
+  policySnapshot: AWSJSON!
+  evalEvidence: AWSJSON!
+  createdAt: AWSDateTime!
+  createdBy: String!
+  gitSha: String!
+  region: String!
+  runId: String!
+}
+
+input CutAgentReleaseInput {
+  orgId: ID!
+  agentTargetId: String!
+  semver: String!
+  registryRecordId: ID!
+  execSpecId: ID!
+  evalRunId: ID!
+  promptVersions: AWSJSON!
+  modelConfigSnapshots: AWSJSON!
+  toolConfigs: AWSJSON!
+  policySnapshot: AWSJSON!
+  gitSha: String!
+  region: String!
+  runId: String!
 }
 
 type EvalRunCaseResult {

--- a/backend/src/types/index.ts
+++ b/backend/src/types/index.ts
@@ -952,3 +952,51 @@ export interface AgentRelease extends AgentReleaseConstituents {
 
 /** Input to cut a new release — everything but the computed releaseId. */
 export type AgentReleaseInput = Omit<AgentRelease, "releaseId">;
+
+// ── Environment Release Pointer (agent releases, follow-on slice) ──────
+//
+// Value set mirrors the CDK deploy-stage literal already threaded through
+// this codebase as `props.environment` / `process.env.ENVIRONMENT` (see
+// bin/app.ts: `process.env.ENVIRONMENT || "dev"`; backend-stack.ts's
+// `${props.environment}` table-name suffixing) rather than inventing a
+// separate set of environment names. Cased UPPERCASE here, not lowercase
+// like the CDK prop, to match this codebase's own enum convention (every
+// other GraphQL-enum-backed literal type in this file —
+// EvalCaseKindLiteral, EvalRunStatusLiteral, SpecStatusLiteral, etc. — is
+// UPPERCASE end-to-end with its GraphQL enum). "TEST" is excluded — it is
+// a CDK-synth-only stack suffix (see e.g.
+// test/backend-stack-agent-releases-table.test.ts), never a real
+// promotion target an agent is dispatched against.
+export type EnvironmentLiteral = "DEV" | "STAGING" | "PROD";
+
+/**
+ * EnvironmentReleasePointerTable row (PK orgId, SK
+ * `${agentTargetId}#${environment}`) — the MUTABLE cursor saying which
+ * AgentRelease an (org, agent, environment) triple currently runs.
+ * Deliberately the opposite of AgentRelease's immutability: this row is
+ * overwritten on every promotion, but ONLY via a version-gated
+ * ConditionExpression at the write boundary (environment-release-
+ * pointer-store.ts) — never a blind Put. previousReleaseId is carried
+ * forward on every move so a later rollback story can read what was
+ * running immediately before the current release, without having to
+ * replay history from elsewhere.
+ */
+export interface EnvironmentReleasePointer {
+  orgId: string;
+  agentTargetId: string;
+  environment: EnvironmentLiteral;
+  releaseId: string;
+  previousReleaseId: string | null;
+  promotedAt: string;
+  promotedBy: string;
+  version: number;
+}
+
+/** Input to set (create-or-move) the pointer for one (agentTargetId,
+ * environment) pair. orgId is derived from the caller, never taken from
+ * caller-supplied input — same doctrine as CutAgentReleaseInput. */
+export interface SetEnvironmentReleasePointerInput {
+  agentTargetId: string;
+  environment: EnvironmentLiteral;
+  releaseId: string;
+}

--- a/backend/src/types/index.ts
+++ b/backend/src/types/index.ts
@@ -859,3 +859,96 @@ export interface ProgramReview {
   runBy: string;
   createdAt: string;
 }
+
+// ── Agent Release Bundles (slice 1) ─────────────────────────────────────
+//
+// AgentRelease is a content-addressed, immutable audit record: its
+// identity (releaseId) is the sha256 of the canonicalized constituents
+// below, computed order-independently over object keys and set-like
+// collections (see release-hash.ts). It has no lifecycle/status field —
+// it is a pure snapshot, never updated or deleted after creation.
+//
+// Two reference classes (per design):
+//   Class A — POINTER: sources that are immutable-by-lifecycle
+//     (execSpecId+execSpecVersion; evalRunId+evalSuiteId+evalSuiteVersion).
+//   Class B — SNAPSHOT: sources that mutate in place, so the release
+//     pins an inline content snapshot + digest rather than a version
+//     pointer (agentConfig, promptVersions, modelConfigSnapshot,
+//     toolConfigs, policySnapshot).
+//
+// Eval evidence is intentionally NON-NULLABLE: a release cannot exist
+// without evalRunId + evalSuiteId + evalSuiteVersion.
+
+/** Class B — inline content snapshot + digest of a mutable source. */
+export interface ContentSnapshot {
+  /** Identifier of the source record this snapshot was taken from. */
+  sourceId: string;
+  /** Inline snapshot of the source's content at cut time. */
+  content: string;
+  /** sha256 digest of `content`, computed independently for tamper
+   * detection at the constituent level (in addition to the release-wide
+   * releaseId hash). */
+  digest: string;
+}
+
+/** Class B — resolved per-slot model configuration snapshot. */
+export interface ModelConfigSnapshot {
+  slot: string;
+  content: string;
+  digest: string;
+}
+
+/** Class B — governance/policy posture snapshot at cut time. */
+export interface PolicySnapshot {
+  enforcementMode: string;
+  ruleSetVersion: string;
+  authorityUnitGrantIds: string[];
+}
+
+/** Non-nullable eval evidence pinned into a release. Class A — referenced
+ * by pointer because EvalRun rows are append-only and the suite is frozen
+ * (references[]>0) at cut time rather than snapshotted. */
+export interface AgentReleaseEvalEvidence {
+  evalRunId: string;
+  evalSuiteId: string;
+  evalSuiteVersion: number;
+}
+
+/** The full set of constituents pinned by a release. This exact shape
+ * (independent of key/array ordering) is what releaseId's hash covers. */
+export interface AgentReleaseConstituents {
+  /** Class B — registry descriptor snapshot for the agent config. */
+  agentConfig: ContentSnapshot;
+  /** Class B — promptName -> content snapshot. */
+  promptVersions: Record<string, ContentSnapshot>;
+  /** Class A — APPROVED (terminal/immutable) execution specification. */
+  execSpecId: string;
+  execSpecVersion: number;
+  /** Class B — resolved per-slot model configuration snapshots. */
+  modelConfigSnapshots: ModelConfigSnapshot[];
+  /** Class B — tool descriptor snapshots. */
+  toolConfigs: ContentSnapshot[];
+  /** Class B — governance/policy posture snapshot. */
+  policySnapshot: PolicySnapshot;
+  /** Class A — non-nullable eval evidence. */
+  evalEvidence: AgentReleaseEvalEvidence;
+}
+
+/** A cut, immutable AgentRelease row. releaseId is the content hash of
+ * `constituents` (see release-hash.ts) and is never recomputed or
+ * reassigned after the row is created. */
+export interface AgentRelease extends AgentReleaseConstituents {
+  releaseId: string;
+  orgId: string;
+  agentTargetId: string;
+  semver: string;
+  createdAt: string;
+  createdBy: string;
+  /** Provenance mirrored from deployment-manifest.json. */
+  gitSha: string;
+  region: string;
+  runId: string;
+}
+
+/** Input to cut a new release — everything but the computed releaseId. */
+export type AgentReleaseInput = Omit<AgentRelease, "releaseId">;

--- a/backend/src/utils/__tests__/auth-governance-permissions.test.ts
+++ b/backend/src/utils/__tests__/auth-governance-permissions.test.ts
@@ -10,115 +10,146 @@
  * — spec:approve (later wave)
  */
 
-import { hasPermission } from '../auth';
-import type { AuthContext } from '../../types';
+import { hasPermission } from "../auth";
+import type { AuthContext } from "../../types";
 
 function ctx(roles: string[]): AuthContext {
-  return { userId: 'u1', username: 'u1', groups: [], roles };
+  return { userId: "u1", username: "u1", groups: [], roles };
 }
 
-describe('Governance permissions — architect role', () => {
-  describe('adr:create', () => {
-    test('architect role has adr:create', () => {
-      expect(hasPermission(ctx(['architect']), 'adr:create')).toBe(true);
+describe("Governance permissions — architect role", () => {
+  describe("adr:create", () => {
+    test("architect role has adr:create", () => {
+      expect(hasPermission(ctx(["architect"]), "adr:create")).toBe(true);
     });
 
-    test('developer role does NOT have adr:create', () => {
-      expect(hasPermission(ctx(['developer']), 'adr:create')).toBe(false);
+    test("developer role does NOT have adr:create", () => {
+      expect(hasPermission(ctx(["developer"]), "adr:create")).toBe(false);
     });
 
-    test('project_manager role does NOT have adr:create', () => {
-      expect(hasPermission(ctx(['project_manager']), 'adr:create')).toBe(false);
+    test("project_manager role does NOT have adr:create", () => {
+      expect(hasPermission(ctx(["project_manager"]), "adr:create")).toBe(false);
     });
 
-    test('admin bypass grants adr:create even without explicit listing', () => {
-      expect(hasPermission(ctx(['admin']), 'adr:create')).toBe(true);
+    test("admin bypass grants adr:create even without explicit listing", () => {
+      expect(hasPermission(ctx(["admin"]), "adr:create")).toBe(true);
     });
 
-    test('no role + no admin denies adr:create', () => {
-      expect(hasPermission(ctx([]), 'adr:create')).toBe(false);
+    test("no role + no admin denies adr:create", () => {
+      expect(hasPermission(ctx([]), "adr:create")).toBe(false);
     });
   });
 
-  describe('regression — existing architect permissions preserved', () => {
-    const architect = ctx(['architect']);
+  describe("regression — existing architect permissions preserved", () => {
+    const architect = ctx(["architect"]);
 
     test.each([
-      'project:read',
-      'project:update',
-      'agent:interact',
-      'conversation:read',
-      'conversation:write',
-      'document:upload',
-    ])('architect retains existing permission %s', (perm) => {
+      "project:read",
+      "project:update",
+      "agent:interact",
+      "conversation:read",
+      "conversation:write",
+      "document:upload",
+    ])("architect retains existing permission %s", (perm) => {
       expect(hasPermission(architect, perm)).toBe(true);
     });
   });
 });
 
-describe('registry permissions (Decision #7)', () => {
-  const architect = ctx(['architect']);
-  const developer = ctx(['developer']);
-  const admin = ctx(['admin']);
-  const pm = ctx(['project_manager']);
+describe("registry permissions (Decision #7)", () => {
+  const architect = ctx(["architect"]);
+  const developer = ctx(["developer"]);
+  const admin = ctx(["admin"]);
+  const pm = ctx(["project_manager"]);
 
-  test('architect has registry:create', () => {
-    expect(hasPermission(architect, 'registry:create')).toBe(true);
+  test("architect has registry:create", () => {
+    expect(hasPermission(architect, "registry:create")).toBe(true);
   });
 
-  test('architect has registry:update', () => {
-    expect(hasPermission(architect, 'registry:update')).toBe(true);
+  test("architect has registry:update", () => {
+    expect(hasPermission(architect, "registry:update")).toBe(true);
   });
 
-  test('architect has registry:submit', () => {
-    expect(hasPermission(architect, 'registry:submit')).toBe(true);
+  test("architect has registry:submit", () => {
+    expect(hasPermission(architect, "registry:submit")).toBe(true);
   });
 
-  test('developer has registry:read', () => {
-    expect(hasPermission(developer, 'registry:read')).toBe(true);
+  test("developer has registry:read", () => {
+    expect(hasPermission(developer, "registry:read")).toBe(true);
   });
 
-  test('admin has registry:create', () => {
-    expect(hasPermission(admin, 'registry:create')).toBe(true);
+  test("admin has registry:create", () => {
+    expect(hasPermission(admin, "registry:create")).toBe(true);
   });
 
-  test('admin has registry:update', () => {
-    expect(hasPermission(admin, 'registry:update')).toBe(true);
+  test("admin has registry:update", () => {
+    expect(hasPermission(admin, "registry:update")).toBe(true);
   });
 
-  test('admin has registry:delete', () => {
-    expect(hasPermission(admin, 'registry:delete')).toBe(true);
+  test("admin has registry:delete", () => {
+    expect(hasPermission(admin, "registry:delete")).toBe(true);
   });
 
-  test('admin has registry:approve', () => {
-    expect(hasPermission(admin, 'registry:approve')).toBe(true);
+  test("admin has registry:approve", () => {
+    expect(hasPermission(admin, "registry:approve")).toBe(true);
   });
 
-  test('admin has registry:read', () => {
-    expect(hasPermission(admin, 'registry:read')).toBe(true);
+  test("admin has registry:read", () => {
+    expect(hasPermission(admin, "registry:read")).toBe(true);
   });
 
-  test('developer does NOT have registry:create', () => {
-    expect(hasPermission(developer, 'registry:create')).toBe(false);
+  test("developer does NOT have registry:create", () => {
+    expect(hasPermission(developer, "registry:create")).toBe(false);
   });
 
-  test('project_manager does NOT have registry:create', () => {
-    expect(hasPermission(pm, 'registry:create')).toBe(false);
+  test("project_manager does NOT have registry:create", () => {
+    expect(hasPermission(pm, "registry:create")).toBe(false);
   });
 
-  test('project_manager does NOT have registry:read', () => {
-    expect(hasPermission(pm, 'registry:read')).toBe(false);
+  test("project_manager does NOT have registry:read", () => {
+    expect(hasPermission(pm, "registry:read")).toBe(false);
   });
 
-  test('project_manager does NOT have registry:update', () => {
-    expect(hasPermission(pm, 'registry:update')).toBe(false);
+  test("project_manager does NOT have registry:update", () => {
+    expect(hasPermission(pm, "registry:update")).toBe(false);
   });
 
-  test('architect does NOT have registry:delete', () => {
-    expect(hasPermission(architect, 'registry:delete')).toBe(false);
+  test("architect does NOT have registry:delete", () => {
+    expect(hasPermission(architect, "registry:delete")).toBe(false);
   });
 
-  test('architect does NOT have registry:approve', () => {
-    expect(hasPermission(architect, 'registry:approve')).toBe(false);
+  test("architect does NOT have registry:approve", () => {
+    expect(hasPermission(architect, "registry:approve")).toBe(false);
+  });
+});
+
+describe("release:promote (environment release pointer)", () => {
+  const architect = ctx(["architect"]);
+  const developer = ctx(["developer"]);
+  const pm = ctx(["project_manager"]);
+  const admin = ctx(["admin"]);
+
+  // Same grantee tier as release:cut — moving an environment's pointer is
+  // a governance-grade action (it changes which release an environment
+  // dispatches against), not an operational one, so it stays with the
+  // architect role rather than project_manager or developer.
+  test("architect has release:promote", () => {
+    expect(hasPermission(architect, "release:promote")).toBe(true);
+  });
+
+  test("developer does NOT have release:promote", () => {
+    expect(hasPermission(developer, "release:promote")).toBe(false);
+  });
+
+  test("project_manager does NOT have release:promote", () => {
+    expect(hasPermission(pm, "release:promote")).toBe(false);
+  });
+
+  test("admin bypass grants release:promote even without explicit listing", () => {
+    expect(hasPermission(admin, "release:promote")).toBe(true);
+  });
+
+  test("no role + no admin denies release:promote", () => {
+    expect(hasPermission(ctx([]), "release:promote")).toBe(false);
   });
 });

--- a/backend/src/utils/auth.ts
+++ b/backend/src/utils/auth.ts
@@ -98,6 +98,12 @@ export function hasPermission(
       // CIT-102: architect may start/read eval runs (execute a frozen
       // suite against an agent target).
       "eval:run",
+      // Slice 2 (agent release bundles): cutting a release is a
+      // governance-grade freeze action (it pins APPROVED spec + registry
+      // state and permanently marks eval evidence referenced) — same
+      // grantee set as spec:approve/eval:approve, not project_manager or
+      // developer.
+      "release:cut",
     ],
     developer: [
       "project:read",

--- a/backend/src/utils/auth.ts
+++ b/backend/src/utils/auth.ts
@@ -104,6 +104,12 @@ export function hasPermission(
       // grantee set as spec:approve/eval:approve, not project_manager or
       // developer.
       "release:cut",
+      // Environment release pointer: moving the mutable per-environment
+      // cursor is the same governance-grade trust tier as release:cut —
+      // it determines which immutable release an environment dispatches
+      // against, so it stays with architect rather than project_manager
+      // or developer.
+      "release:promote",
     ],
     developer: [
       "project:read",

--- a/backend/src/utils/metrics-constants.ts
+++ b/backend/src/utils/metrics-constants.ts
@@ -59,5 +59,19 @@ export const METRIC_UNSTAMPED_DISPATCH = "UnstampedDispatch";
 export const UNIT_MILLISECONDS = "Milliseconds";
 export const UNIT_COUNT = "Count";
 
+// ── Release-aware dispatch (this story) ─────────────────────────────────
+// Mirrors the Python arbiter tier's METRIC_RELEASE_DISPATCH_EVALUATED /
+// METRIC_RELEASE_DISPATCH_WOULD_BLOCK / METRIC_RELEASE_DISPATCH_REFUSED in
+// arbiter/common/metrics_constants.py. TypeScript resolvers do not emit
+// these today (the release-aware dispatch gate lives entirely in the
+// Python arbiter tier); declared here so a future TS-side emitter (or a
+// cross-language dashboard) references the same literal rather than
+// hand-typing it, mirroring every other metric name in this file.
+export const METRIC_RELEASE_DISPATCH_EVALUATED = "ReleaseDispatchEvaluated";
+export const METRIC_RELEASE_DISPATCH_WOULD_BLOCK = "ReleaseDispatchWouldBlock";
+export const METRIC_RELEASE_DISPATCH_REFUSED = "ReleaseDispatchRefused";
+export const DIMENSION_RELEASE_MODE = "ReleaseDispatchMode";
+export const DIMENSION_RELEASE_OUTCOME = "ReleaseDispatchOutcome";
+
 export const DIMENSION_WORKFLOW_ID = "WorkflowId";
 export const DIMENSION_AGENT_ID = "AgentId";

--- a/backend/test/backend-stack-agent-releases-table.test.ts
+++ b/backend/test/backend-stack-agent-releases-table.test.ts
@@ -1,0 +1,165 @@
+/**
+ * Agent release bundles (slice 1) — AgentReleasesTable CDK template
+ * assertions. Required up front per task instructions: "the eval tables
+ * shipped without CDK assertions and needed a retrofit; do not repeat
+ * that" — this test ships in the same change as the table.
+ *
+ * Governed exactly like EvalRunsTable/ExecutionSpecificationsTable
+ * (RETAIN + deletionProtection + PITR — see backend-stack.ts's
+ * AgentReleasesTable construction site, sibling to EvalRunsTable/
+ * EvalRunCaseResultsTable). Additionally asserts the IAM floor (design
+ * §2, L3): the granted writer role carries dynamodb:PutItem,
+ * dynamodb:GetItem, dynamodb:Query and NOTHING ELSE against this table —
+ * no UpdateItem, no DeleteItem, anywhere in the synthesized template.
+ *
+ * Style mirrors backend-stack-eval-tables.test.ts: synth a real
+ * BackendStack and assert via Template.fromStack(...).
+ */
+
+import * as cdk from "aws-cdk-lib";
+import { Template, Match } from "aws-cdk-lib/assertions";
+import * as path from "path";
+import * as fs from "fs";
+
+// Ensure asset directories exist for CDK synthesis (CI + clean-checkout safety).
+const assetDirs = [
+  path.resolve(__dirname, "../src/schema"),
+  path.resolve(__dirname, "../dist/lambda"),
+  path.resolve(__dirname, "../../src/lambda/seed-organizations"),
+  path.resolve(__dirname, "../src/lambda/seed-admin-user"),
+  path.resolve(__dirname, "../src/lambda/seed-organizations"),
+];
+for (const dir of assetDirs) {
+  if (!fs.existsSync(dir)) fs.mkdirSync(dir, { recursive: true });
+}
+
+import { BackendStack } from "../lib/backend-stack";
+
+describe("BackendStack — AgentReleasesTable (agent release bundles, slice 1)", () => {
+  let template: Template;
+
+  beforeAll(() => {
+    const app = new cdk.App();
+    const stack = new BackendStack(app, "TestBackendStackAgentReleases", {
+      environment: "test",
+      env: { account: "123456789012", region: "us-east-1" },
+    });
+    template = Template.fromStack(stack);
+  });
+
+  test("has RETAIN removal policy and DeletionProtection enabled", () => {
+    template.hasResource("AWS::DynamoDB::Table", {
+      Properties: Match.objectLike({
+        TableName: "citadel-agent-releases-test",
+        DeletionProtectionEnabled: true,
+      }),
+      DeletionPolicy: "Retain",
+      UpdateReplacePolicy: "Retain",
+    });
+  });
+
+  test("has point-in-time recovery enabled", () => {
+    template.hasResourceProperties("AWS::DynamoDB::Table", {
+      TableName: "citadel-agent-releases-test",
+      PointInTimeRecoverySpecification: { PointInTimeRecoveryEnabled: true },
+    });
+  });
+
+  test("is PAY_PER_REQUEST billing with simple releaseId partition key", () => {
+    template.hasResourceProperties("AWS::DynamoDB::Table", {
+      TableName: "citadel-agent-releases-test",
+      BillingMode: "PAY_PER_REQUEST",
+      KeySchema: [{ AttributeName: "releaseId", KeyType: "HASH" }],
+    });
+  });
+
+  test("has org-index GSI (orgId HASH / createdAt RANGE, ProjectionType ALL)", () => {
+    template.hasResourceProperties("AWS::DynamoDB::Table", {
+      TableName: "citadel-agent-releases-test",
+      GlobalSecondaryIndexes: Match.arrayWith([
+        Match.objectLike({
+          IndexName: "org-index",
+          KeySchema: [
+            { AttributeName: "orgId", KeyType: "HASH" },
+            { AttributeName: "createdAt", KeyType: "RANGE" },
+          ],
+          Projection: { ProjectionType: "ALL" },
+        }),
+      ]),
+    });
+  });
+
+  describe("IAM floor — PutItem/GetItem/Query only, no UpdateItem/DeleteItem anywhere", () => {
+    test("AgentReleaseWriterRole's policy grants exactly PutItem, GetItem, Query on the table (and its indexes)", () => {
+      const policies = template.findResources("AWS::IAM::Policy");
+      const releasePolicies = Object.values(policies).filter((p) => {
+        const doc = p.Properties?.PolicyDocument;
+        const stmts = doc?.Statement ?? [];
+        return stmts.some((s: { Resource?: unknown }) => {
+          const resources = Array.isArray(s.Resource)
+            ? s.Resource
+            : [s.Resource];
+          return resources.some((r: unknown) => {
+            const asStr = JSON.stringify(r);
+            return asStr.includes("AgentReleasesTable");
+          });
+        });
+      });
+
+      expect(releasePolicies.length).toBeGreaterThan(0);
+
+      for (const policy of releasePolicies) {
+        const stmts = policy.Properties.PolicyDocument.Statement as Array<{
+          Action?: string | string[];
+          Resource?: unknown;
+        }>;
+        for (const stmt of stmts) {
+          const resources = Array.isArray(stmt.Resource)
+            ? stmt.Resource
+            : [stmt.Resource];
+          const targetsReleaseTable = resources.some((r) =>
+            JSON.stringify(r).includes("AgentReleasesTable"),
+          );
+          if (!targetsReleaseTable) continue;
+
+          const actions = Array.isArray(stmt.Action)
+            ? stmt.Action
+            : [stmt.Action];
+          expect(actions).toEqual(
+            expect.arrayContaining([
+              "dynamodb:PutItem",
+              "dynamodb:GetItem",
+              "dynamodb:Query",
+            ]),
+          );
+          expect(actions).not.toContain("dynamodb:UpdateItem");
+          expect(actions).not.toContain("dynamodb:DeleteItem");
+          expect(actions).not.toContain("dynamodb:Scan");
+        }
+      }
+    });
+
+    test("no IAM policy anywhere in the synthesized template grants UpdateItem or DeleteItem on AgentReleasesTable", () => {
+      const policies = template.findResources("AWS::IAM::Policy");
+      for (const policy of Object.values(policies)) {
+        const stmts: Array<{ Action?: string | string[]; Resource?: unknown }> =
+          policy.Properties?.PolicyDocument?.Statement ?? [];
+        for (const stmt of stmts) {
+          const resources = Array.isArray(stmt.Resource)
+            ? stmt.Resource
+            : [stmt.Resource];
+          const targetsReleaseTable = resources.some((r) =>
+            JSON.stringify(r).includes("AgentReleasesTable"),
+          );
+          if (!targetsReleaseTable) continue;
+
+          const actions = Array.isArray(stmt.Action)
+            ? stmt.Action
+            : [stmt.Action];
+          expect(actions).not.toContain("dynamodb:UpdateItem");
+          expect(actions).not.toContain("dynamodb:DeleteItem");
+        }
+      }
+    });
+  });
+});

--- a/backend/test/backend-stack-environment-release-pointer-table.test.ts
+++ b/backend/test/backend-stack-environment-release-pointer-table.test.ts
@@ -1,0 +1,211 @@
+/**
+ * Environment release pointer — EnvironmentReleasePointersTable CDK
+ * template assertions, shipped in the same change as the table (per the
+ * lesson recorded on AgentReleasesTable's own test: "do not repeat the
+ * eval-tables retrofit").
+ *
+ * THE INVARIANT AT RISK (why this table's test exists on its own, not
+ * folded into backend-stack-agent-releases-table.test.ts): the pointer
+ * table legitimately needs UpdateItem because it is mutable, and its
+ * resolver's role must NEVER cause that UpdateItem capability to leak
+ * onto AgentReleasesTable, which Slice 1 guarantees carries zero
+ * UpdateItem/DeleteItem from any principal. A previous slice broke this
+ * exact way via grantReadWriteData widening a shared role's floor — see
+ * governance-stack.ts's AgentReleaseResolverFunction comment. This test
+ * asserts the separation holds for the pointer's own IAM floor too:
+ * PutItem/GetItem/Query allowed on the pointer table, DeleteItem never
+ * granted anywhere (deleting a pointer would erase deployment history),
+ * and — the specific regression this table's write floor must not
+ * reintroduce — no statement that grants UpdateItem on the pointer table
+ * also names AgentReleasesTable as a resource.
+ *
+ * Style mirrors backend-stack-agent-releases-table.test.ts: synth a real
+ * BackendStack and assert via Template.fromStack(...).
+ */
+
+import * as cdk from "aws-cdk-lib";
+import { Template, Match } from "aws-cdk-lib/assertions";
+import * as path from "path";
+import * as fs from "fs";
+
+// Ensure asset directories exist for CDK synthesis (CI + clean-checkout safety).
+const assetDirs = [
+  path.resolve(__dirname, "../src/schema"),
+  path.resolve(__dirname, "../dist/lambda"),
+  path.resolve(__dirname, "../../src/lambda/seed-organizations"),
+  path.resolve(__dirname, "../src/lambda/seed-admin-user"),
+  path.resolve(__dirname, "../src/lambda/seed-organizations"),
+];
+for (const dir of assetDirs) {
+  if (!fs.existsSync(dir)) fs.mkdirSync(dir, { recursive: true });
+}
+
+import { BackendStack } from "../lib/backend-stack";
+
+describe("BackendStack — EnvironmentReleasePointersTable (environment release pointer)", () => {
+  let template: Template;
+
+  beforeAll(() => {
+    const app = new cdk.App();
+    const stack = new BackendStack(app, "TestBackendStackEnvReleasePointers", {
+      environment: "test",
+      env: { account: "123456789012", region: "us-east-1" },
+    });
+    template = Template.fromStack(stack);
+  });
+
+  test("has RETAIN removal policy and DeletionProtection enabled", () => {
+    template.hasResource("AWS::DynamoDB::Table", {
+      Properties: Match.objectLike({
+        TableName: "citadel-environment-release-pointers-test",
+        DeletionProtectionEnabled: true,
+      }),
+      DeletionPolicy: "Retain",
+      UpdateReplacePolicy: "Retain",
+    });
+  });
+
+  test("has point-in-time recovery enabled", () => {
+    template.hasResourceProperties("AWS::DynamoDB::Table", {
+      TableName: "citadel-environment-release-pointers-test",
+      PointInTimeRecoverySpecification: { PointInTimeRecoveryEnabled: true },
+    });
+  });
+
+  test("is PAY_PER_REQUEST billing with orgId HASH / agentTargetId_environment RANGE key", () => {
+    template.hasResourceProperties("AWS::DynamoDB::Table", {
+      TableName: "citadel-environment-release-pointers-test",
+      BillingMode: "PAY_PER_REQUEST",
+      KeySchema: [
+        { AttributeName: "orgId", KeyType: "HASH" },
+        { AttributeName: "agentTargetId_environment", KeyType: "RANGE" },
+      ],
+    });
+  });
+
+  describe("IAM floor — PutItem/GetItem/Query/UpdateItem allowed, DeleteItem never granted", () => {
+    function policiesTargeting(tableLogicalIdFragment: string) {
+      const policies = template.findResources("AWS::IAM::Policy");
+      return Object.values(policies).filter((p) => {
+        const stmts = p.Properties?.PolicyDocument?.Statement ?? [];
+        return stmts.some((s: { Resource?: unknown }) => {
+          const resources = Array.isArray(s.Resource)
+            ? s.Resource
+            : [s.Resource];
+          return resources.some((r: unknown) =>
+            JSON.stringify(r).includes(tableLogicalIdFragment),
+          );
+        });
+      });
+    }
+
+    test("no IAM policy anywhere grants DeleteItem on EnvironmentReleasePointersTable", () => {
+      const policies = policiesTargeting("EnvironmentReleasePointersTable");
+      expect(policies.length).toBeGreaterThan(0);
+
+      for (const policy of policies) {
+        const stmts = policy.Properties.PolicyDocument.Statement as Array<{
+          Action?: string | string[];
+          Resource?: unknown;
+        }>;
+        for (const stmt of stmts) {
+          const resources = Array.isArray(stmt.Resource)
+            ? stmt.Resource
+            : [stmt.Resource];
+          const targetsPointerTable = resources.some((r) =>
+            JSON.stringify(r).includes("EnvironmentReleasePointersTable"),
+          );
+          if (!targetsPointerTable) continue;
+
+          const actions = Array.isArray(stmt.Action)
+            ? stmt.Action
+            : [stmt.Action];
+          expect(actions).not.toContain("dynamodb:DeleteItem");
+          expect(actions).not.toContain("dynamodb:Scan");
+          expect(actions).not.toContain("dynamodb:BatchWriteItem");
+        }
+      }
+    });
+
+    test("the pointer writer role's policy grants PutItem on the pointer table (the move IS a conditional Put, not a separate UpdateItem call — see environment-release-pointer-store.ts)", () => {
+      const policies = policiesTargeting("EnvironmentReleasePointersTable");
+      const grantsUpdate = policies.some((policy) => {
+        const stmts = policy.Properties.PolicyDocument.Statement as Array<{
+          Action?: string | string[];
+          Resource?: unknown;
+        }>;
+        return stmts.some((stmt) => {
+          const resources = Array.isArray(stmt.Resource)
+            ? stmt.Resource
+            : [stmt.Resource];
+          const targetsPointerTable = resources.some((r) =>
+            JSON.stringify(r).includes("EnvironmentReleasePointersTable"),
+          );
+          if (!targetsPointerTable) return false;
+          const actions = Array.isArray(stmt.Action)
+            ? stmt.Action
+            : [stmt.Action];
+          return actions.includes("dynamodb:PutItem");
+        });
+      });
+      expect(grantsUpdate).toBe(true);
+    });
+
+    // THE regression this whole slice is delicate about (see module doc
+    // comment above and governance-stack.ts's AgentReleaseResolverFunction
+    // comment): a prior slice broke this exact way via grantReadWriteData
+    // on a shared role. Assert directly that no single IAM statement names
+    // BOTH tables as a resource — the pointer's write capability must
+    // never be co-granted with the releases table in the same statement,
+    // which is how a shared-role grant would leak write access across
+    // tables that must stay isolated.
+    test("no single IAM statement grants access to both AgentReleasesTable and EnvironmentReleasePointersTable", () => {
+      const policies = template.findResources("AWS::IAM::Policy");
+      for (const policy of Object.values(policies)) {
+        const stmts: Array<{ Action?: string | string[]; Resource?: unknown }> =
+          policy.Properties?.PolicyDocument?.Statement ?? [];
+        for (const stmt of stmts) {
+          const resources = Array.isArray(stmt.Resource)
+            ? stmt.Resource
+            : [stmt.Resource];
+          const asStrings = resources.map((r) => JSON.stringify(r));
+          const targetsReleases = asStrings.some((s) =>
+            s.includes("AgentReleasesTable"),
+          );
+          const targetsPointers = asStrings.some((s) =>
+            s.includes("EnvironmentReleasePointersTable"),
+          );
+          expect(targetsReleases && targetsPointers).toBe(false);
+        }
+      }
+    });
+
+    // Mirrors backend-stack-agent-releases-table.test.ts's sibling
+    // assertion: reconfirm Slice 1's invariant still holds after this
+    // slice adds the pointer table's UpdateItem-carrying role — the
+    // releases table itself must still carry zero UpdateItem/DeleteItem
+    // anywhere in the synthesized template.
+    test("AgentReleasesTable still has zero UpdateItem/DeleteItem grants anywhere (regression: previous slice broke this via grantReadWriteData)", () => {
+      const policies = template.findResources("AWS::IAM::Policy");
+      for (const policy of Object.values(policies)) {
+        const stmts: Array<{ Action?: string | string[]; Resource?: unknown }> =
+          policy.Properties?.PolicyDocument?.Statement ?? [];
+        for (const stmt of stmts) {
+          const resources = Array.isArray(stmt.Resource)
+            ? stmt.Resource
+            : [stmt.Resource];
+          const targetsReleaseTable = resources.some((r) =>
+            JSON.stringify(r).includes("AgentReleasesTable"),
+          );
+          if (!targetsReleaseTable) continue;
+
+          const actions = Array.isArray(stmt.Action)
+            ? stmt.Action
+            : [stmt.Action];
+          expect(actions).not.toContain("dynamodb:UpdateItem");
+          expect(actions).not.toContain("dynamodb:DeleteItem");
+        }
+      }
+    });
+  });
+});

--- a/backend/test/governance-stack-agent-release.test.ts
+++ b/backend/test/governance-stack-agent-release.test.ts
@@ -183,6 +183,43 @@ function createTestStack(): {
     }),
   );
 
+  // Environment release pointer — separate table + separate role from
+  // AgentReleasesTable/AgentReleaseWriterRole above, mirroring
+  // backend-stack.ts's real EnvironmentReleasePointersTable /
+  // EnvironmentReleasePointerWriterRole construction. Kept separate on
+  // purpose — this is the invariant this slice guards.
+  const environmentReleasePointersTable = new dynamodb.Table(
+    backendStack,
+    "EnvironmentReleasePointersTable",
+    {
+      tableName: "citadel-environment-release-pointers-test",
+      partitionKey: { name: "orgId", type: dynamodb.AttributeType.STRING },
+      sortKey: {
+        name: "agentTargetId_environment",
+        type: dynamodb.AttributeType.STRING,
+      },
+      billingMode: dynamodb.BillingMode.PAY_PER_REQUEST,
+      removalPolicy: cdk.RemovalPolicy.DESTROY,
+    },
+  );
+  const environmentReleasePointerWriterRole = new iam.Role(
+    backendStack,
+    "EnvironmentReleasePointerWriterRole",
+    {
+      assumedBy: new iam.ServicePrincipal("lambda.amazonaws.com"),
+    },
+  );
+  environmentReleasePointerWriterRole.addToPolicy(
+    new iam.PolicyStatement({
+      effect: iam.Effect.ALLOW,
+      actions: ["dynamodb:PutItem", "dynamodb:GetItem", "dynamodb:Query"],
+      resources: [
+        environmentReleasePointersTable.tableArn,
+        `${environmentReleasePointersTable.tableArn}/index/*`,
+      ],
+    }),
+  );
+
   const registryArn =
     "arn:aws:bedrock-agentcore:us-east-1:123456789012:registry/citadel-test";
 
@@ -212,6 +249,8 @@ function createTestStack(): {
     agentReleaseWriterRole,
     registryArn,
     registryId: "citadel-test",
+    environmentReleasePointersTable,
+    environmentReleasePointerWriterRole,
   });
 
   const template = Template.fromStack(stack);

--- a/backend/test/governance-stack-agent-release.test.ts
+++ b/backend/test/governance-stack-agent-release.test.ts
@@ -1,0 +1,375 @@
+/**
+ * governance-stack-agent-release.test.ts — GovernanceStack agent-release
+ * wiring assertions (agent release bundles, slice 3: wiring only).
+ *
+ * Mirrors governance-stack-eval-run.test.ts: one AgentReleaseResolverFunction,
+ * one AgentReleaseLambdaDataSource, and a CfnResolver for the
+ * Mutation.cutAgentRelease field, bound to that data source.
+ *
+ * The two invariants under test here are the whole risk of this slice:
+ *  - The resolver Lambda's role is the EXISTING AgentReleaseWriterRole
+ *    (assumed, not a fresh grantReadWriteData call) — so this test also
+ *    re-asserts, at the GovernanceStack synth level, that no UpdateItem/
+ *    DeleteItem is granted on AgentReleasesTable anywhere in the
+ *    template (the IAM immutability floor must survive wiring).
+ *  - No new principal picks up broader-than-Put/Get/Query access to the
+ *    releases table as a side effect of AppSync/data-source wiring.
+ */
+import * as cdk from "aws-cdk-lib";
+import { Template, Match } from "aws-cdk-lib/assertions";
+import * as appsync from "aws-cdk-lib/aws-appsync";
+import * as dynamodb from "aws-cdk-lib/aws-dynamodb";
+import * as events from "aws-cdk-lib/aws-events";
+import * as iam from "aws-cdk-lib/aws-iam";
+import { Bucket } from "aws-cdk-lib/aws-s3";
+import * as path from "path";
+import { scaffoldBackendAssetDirs } from "./helpers/scaffold-stub-assets";
+
+scaffoldBackendAssetDirs(["dist/lambda", "src/schema"]);
+
+import { GovernanceStack } from "../lib/governance-stack";
+
+function mockTable(
+  scope: cdk.Stack,
+  id: string,
+  tableName: string,
+): dynamodb.Table {
+  return new dynamodb.Table(scope, id, {
+    tableName,
+    partitionKey: { name: `${id}Id`, type: dynamodb.AttributeType.STRING },
+    billingMode: dynamodb.BillingMode.PAY_PER_REQUEST,
+    removalPolicy: cdk.RemovalPolicy.DESTROY,
+  });
+}
+
+function createTestStack(): {
+  stack: GovernanceStack;
+  template: Template;
+  backendTemplate: Template;
+} {
+  const app = new cdk.App();
+  const backendStack = new cdk.Stack(app, "MockBackendStackAgentRelease", {
+    env: { account: "123456789012", region: "us-east-1" },
+  });
+
+  const agentEventBus = new events.EventBus(backendStack, "AgentEventBus", {
+    eventBusName: "citadel-agents-test",
+  });
+
+  const appSyncApi = new appsync.GraphqlApi(backendStack, "MockApi", {
+    name: "mock-api",
+    schema: appsync.SchemaFile.fromAsset(
+      path.resolve(__dirname, "../src/schema/schema.graphql"),
+    ),
+  });
+
+  const accessLogsBucket = new Bucket(backendStack, "AccessLogsBucket", {
+    bucketName: "citadel-access-logs-test",
+  });
+
+  const adrsTable = mockTable(backendStack, "Adrs", "citadel-adrs-test");
+  const adrReopenAttemptsTable = mockTable(
+    backendStack,
+    "AdrReopenAttempts",
+    "citadel-adr-reopen-attempts-test",
+  );
+  const executionSpecificationsTable = mockTable(
+    backendStack,
+    "ExecutionSpecifications",
+    "citadel-execution-specifications-test",
+  );
+  const interrogationRoundsTable = mockTable(
+    backendStack,
+    "InterrogationRounds",
+    "citadel-interrogation-rounds-test",
+  );
+  const agentDesignAssessmentsTable = mockTable(
+    backendStack,
+    "AgentDesignAssessments",
+    "citadel-agent-design-assessments-test",
+  );
+  const programReviewsTable = mockTable(
+    backendStack,
+    "ProgramReviews",
+    "citadel-program-reviews-test",
+  );
+  const projectsTable = mockTable(
+    backendStack,
+    "Projects",
+    "citadel-projects-test",
+  );
+  const evalSuitesTable = mockTable(
+    backendStack,
+    "EvalSuites",
+    "citadel-eval-suites-test",
+  );
+  const evalCasesTable = mockTable(
+    backendStack,
+    "EvalCases",
+    "citadel-eval-cases-test",
+  );
+  const evalRunsTable = mockTable(
+    backendStack,
+    "EvalRuns",
+    "citadel-eval-runs-test",
+  );
+  const evalRunCaseResultsTable = mockTable(
+    backendStack,
+    "EvalRunCaseResults",
+    "citadel-eval-run-case-results-test",
+  );
+  const evalBaselinesTable = mockTable(
+    backendStack,
+    "EvalBaselines",
+    "citadel-eval-baselines-test",
+  );
+  const evalComparisonsTable = mockTable(
+    backendStack,
+    "EvalComparisons",
+    "citadel-eval-comparisons-test",
+  );
+  const evalComparisonConfigTable = mockTable(
+    backendStack,
+    "EvalComparisonConfig",
+    "citadel-eval-comparison-config-test",
+  );
+  const executionsTable = mockTable(
+    backendStack,
+    "Executions",
+    "citadel-executions-test",
+  );
+  const conversationsTable = mockTable(
+    backendStack,
+    "Conversations",
+    "citadel-conversations-test",
+  );
+
+  // Slice 1's actual releases table shape (simple PK on releaseId) plus
+  // the pre-existing writer role this slice must ASSUME rather than
+  // grant afresh — mirrors backend-stack.ts's real AgentReleasesTable /
+  // AgentReleaseWriterRole construction exactly (PutItem/GetItem/Query
+  // only, nothing else, ever).
+  const agentReleasesTable = new dynamodb.Table(
+    backendStack,
+    "AgentReleasesTable",
+    {
+      tableName: "citadel-agent-releases-test",
+      partitionKey: { name: "releaseId", type: dynamodb.AttributeType.STRING },
+      billingMode: dynamodb.BillingMode.PAY_PER_REQUEST,
+      removalPolicy: cdk.RemovalPolicy.DESTROY,
+    },
+  );
+  agentReleasesTable.addGlobalSecondaryIndex({
+    indexName: "org-index",
+    partitionKey: { name: "orgId", type: dynamodb.AttributeType.STRING },
+    sortKey: { name: "createdAt", type: dynamodb.AttributeType.STRING },
+    projectionType: dynamodb.ProjectionType.ALL,
+  });
+  const agentReleaseWriterRole = new iam.Role(
+    backendStack,
+    "AgentReleaseWriterRole",
+    {
+      assumedBy: new iam.ServicePrincipal("lambda.amazonaws.com"),
+    },
+  );
+  agentReleaseWriterRole.addToPolicy(
+    new iam.PolicyStatement({
+      effect: iam.Effect.ALLOW,
+      actions: ["dynamodb:PutItem", "dynamodb:GetItem", "dynamodb:Query"],
+      resources: [
+        agentReleasesTable.tableArn,
+        `${agentReleasesTable.tableArn}/index/*`,
+      ],
+    }),
+  );
+
+  const registryArn =
+    "arn:aws:bedrock-agentcore:us-east-1:123456789012:registry/citadel-test";
+
+  const stack = new GovernanceStack(app, "TestGovernanceStackAgentRelease", {
+    env: { account: "123456789012", region: "us-east-1" },
+    environment: "test",
+    appSyncApi,
+    agentEventBus,
+    accessLogsBucket,
+    adrsTable,
+    adrReopenAttemptsTable,
+    executionSpecificationsTable,
+    interrogationRoundsTable,
+    agentDesignAssessmentsTable,
+    programReviewsTable,
+    projectsTable,
+    evalSuitesTable,
+    evalCasesTable,
+    evalRunsTable,
+    evalRunCaseResultsTable,
+    evalBaselinesTable,
+    evalComparisonsTable,
+    evalComparisonConfigTable,
+    executionsTable,
+    conversationsTable,
+    agentReleasesTable,
+    agentReleaseWriterRole,
+    registryArn,
+    registryId: "citadel-test",
+  });
+
+  const template = Template.fromStack(stack);
+  const backendTemplate = Template.fromStack(backendStack);
+  return { stack, template, backendTemplate };
+}
+
+describe("GovernanceStack — agent-release wiring (cutAgentRelease reachability)", () => {
+  let template: Template;
+  let backendTemplate: Template;
+
+  beforeAll(() => {
+    ({ template, backendTemplate } = createTestStack());
+  });
+
+  test("AgentReleaseResolverFunction exists with Node.js 24.x runtime and the expected table/registry env vars", () => {
+    template.hasResourceProperties("AWS::Lambda::Function", {
+      Handler: "release-resolver.handler",
+      Runtime: "nodejs24.x",
+      Environment: {
+        Variables: Match.objectLike({
+          AGENT_RELEASES_TABLE: Match.anyValue(),
+          EXECUTION_SPECS_TABLE: Match.anyValue(),
+          EVAL_RUNS_TABLE: Match.anyValue(),
+          EVAL_SUITES_TABLE: Match.anyValue(),
+          PROJECTS_TABLE: Match.anyValue(),
+          REGISTRY_ID: Match.anyValue(),
+        }),
+      },
+    });
+  });
+
+  test("AgentReleaseResolverFunction's execution role IS the existing AgentReleaseWriterRole (assumed, not a fresh grantReadWriteData role)", () => {
+    const fns = template.findResources("AWS::Lambda::Function");
+    const match = Object.values(fns).find(
+      (f) => f.Properties?.Handler === "release-resolver.handler",
+    );
+    expect(match).toBeDefined();
+    const roleProp = JSON.stringify(match!.Properties.Role);
+    // Cross-stack role reference: CDK exports agentReleaseWriterRole's ARN
+    // from BackendStack and imports it here via Fn::ImportValue — proof
+    // this Lambda ASSUMES the existing role rather than getting a
+    // freshly-generated "...ServiceRole..." (which grantReadWriteData
+    // or an implicit default role would produce).
+    expect(roleProp).toContain("AgentReleaseWriterRole");
+    expect(roleProp).not.toContain("ServiceRole");
+  });
+
+  test("no fresh IAM Role named *AgentReleaseResolverFunctionServiceRole* is synthesized (confirms no default/grantReadWriteData role was created)", () => {
+    const roles = template.findResources("AWS::IAM::Role");
+    const freshRoles = Object.keys(roles).filter((id) =>
+      id.startsWith("AgentReleaseResolverFunctionServiceRole"),
+    );
+    expect(freshRoles).toEqual([]);
+  });
+
+  test("AgentReleaseLambdaDataSource exists as an AWS_LAMBDA AppSync data source", () => {
+    template.hasResourceProperties("AWS::AppSync::DataSource", {
+      Name: "AgentReleaseLambdaDataSource",
+      Type: "AWS_LAMBDA",
+    });
+  });
+
+  test("has a Mutation.cutAgentRelease CfnResolver bound to AgentReleaseLambdaDataSource", () => {
+    template.hasResourceProperties("AWS::AppSync::Resolver", {
+      TypeName: "Mutation",
+      FieldName: "cutAgentRelease",
+      DataSourceName: {
+        "Fn::GetAtt": [
+          Match.stringLikeRegexp("AgentReleaseLambdaDataSource"),
+          "Name",
+        ],
+      },
+    });
+  });
+
+  test("grants read access (via the assumed AgentReleaseWriterRole's policy) to exec-specs/eval-runs/eval-suites/projects tables and the registry", () => {
+    // Because agentReleaseWriterRole is an existing role passed in as a
+    // prop (not created inside GovernanceStack), grantXxx calls against
+    // it attach their statements to a policy owned by the role's own
+    // stack (the mock "backend" stack here), not to a fresh
+    // ServiceRole/DefaultPolicy inside GovernanceStack. This is the
+    // expected cross-stack shape, and it is itself part of what proves
+    // the resolver assumes the existing role rather than getting a new
+    // grantReadWriteData-generated one.
+    const policies = backendTemplate.findResources("AWS::IAM::Policy");
+    const writerRolePolicies = Object.values(policies).filter((p) => {
+      const roles = (p.Properties?.Roles ?? []) as Array<{ Ref?: string }>;
+      return roles.some((r) =>
+        (r.Ref ?? "").startsWith("AgentReleaseWriterRole"),
+      );
+    });
+    expect(writerRolePolicies.length).toBeGreaterThan(0);
+
+    const allStatements = writerRolePolicies.flatMap(
+      (p) =>
+        p.Properties.PolicyDocument.Statement as Array<{
+          Action?: string | string[];
+          Resource?: unknown;
+        }>,
+    );
+    const allActions = allStatements.flatMap((s) =>
+      Array.isArray(s.Action) ? s.Action : [s.Action],
+    );
+    expect(allActions).toEqual(expect.arrayContaining(["dynamodb:GetItem"]));
+    expect(allActions).toEqual(
+      expect.arrayContaining(["bedrock-agentcore:GetRegistryRecord"]),
+    );
+  });
+
+  describe("IAM immutability floor survives wiring", () => {
+    function collectReleaseTableActions(tmpl: Template): string[] {
+      const policies = tmpl.findResources("AWS::IAM::Policy");
+      const actions: string[] = [];
+      for (const policy of Object.values(policies)) {
+        const stmts: Array<{
+          Action?: string | string[];
+          Resource?: unknown;
+        }> = policy.Properties?.PolicyDocument?.Statement ?? [];
+        for (const stmt of stmts) {
+          const resources = Array.isArray(stmt.Resource)
+            ? stmt.Resource
+            : [stmt.Resource];
+          const targetsReleaseTable = resources.some((r) =>
+            JSON.stringify(r).includes("AgentReleasesTable"),
+          );
+          if (!targetsReleaseTable) continue;
+          const stmtActions = Array.isArray(stmt.Action)
+            ? stmt.Action
+            : [stmt.Action];
+          actions.push(...stmtActions.filter((a): a is string => !!a));
+        }
+      }
+      return actions;
+    }
+
+    test("no IAM policy in either the GovernanceStack or the table-owning stack grants UpdateItem or DeleteItem on AgentReleasesTable", () => {
+      const actions = [
+        ...collectReleaseTableActions(template),
+        ...collectReleaseTableActions(backendTemplate),
+      ];
+      expect(actions).not.toContain("dynamodb:UpdateItem");
+      expect(actions).not.toContain("dynamodb:DeleteItem");
+    });
+
+    test("every statement referencing AgentReleasesTable grants only Put/Get/Query — no grantReadWriteData-shaped Allow-all-actions was introduced by wiring", () => {
+      const actions = [
+        ...collectReleaseTableActions(template),
+        ...collectReleaseTableActions(backendTemplate),
+      ];
+      expect(actions.length).toBeGreaterThan(0);
+      for (const action of actions) {
+        expect([
+          "dynamodb:PutItem",
+          "dynamodb:GetItem",
+          "dynamodb:Query",
+        ]).toContain(action);
+      }
+    });
+  });
+});

--- a/backend/test/governance-stack-eval-comparison.test.ts
+++ b/backend/test/governance-stack-eval-comparison.test.ts
@@ -17,6 +17,7 @@ import { Template, Match } from "aws-cdk-lib/assertions";
 import * as appsync from "aws-cdk-lib/aws-appsync";
 import * as dynamodb from "aws-cdk-lib/aws-dynamodb";
 import * as events from "aws-cdk-lib/aws-events";
+import * as iam from "aws-cdk-lib/aws-iam";
 import { Bucket } from "aws-cdk-lib/aws-s3";
 import * as path from "path";
 import { scaffoldBackendAssetDirs } from "./helpers/scaffold-stub-assets";
@@ -72,6 +73,22 @@ function createTestStack(): { stack: GovernanceStack; template: Template } {
   const accessLogsBucket = new Bucket(backendStack, "AccessLogsBucket", {
     bucketName: "citadel-access-logs-test",
   });
+
+  const agentReleasesTable = new dynamodb.Table(
+    backendStack,
+    "AgentReleasesTable",
+    {
+      tableName: "citadel-agent-releases-test",
+      partitionKey: { name: "releaseId", type: dynamodb.AttributeType.STRING },
+      billingMode: dynamodb.BillingMode.PAY_PER_REQUEST,
+      removalPolicy: cdk.RemovalPolicy.DESTROY,
+    },
+  );
+  const agentReleaseWriterRole = new iam.Role(
+    backendStack,
+    "AgentReleaseWriterRole",
+    { assumedBy: new iam.ServicePrincipal("lambda.amazonaws.com") },
+  );
 
   const stack = new GovernanceStack(app, "TestGovernanceStackEvalComparison", {
     env: { account: "123456789012", region: "us-east-1" },
@@ -151,6 +168,11 @@ function createTestStack(): { stack: GovernanceStack; template: Template } {
       "Conversations",
       "citadel-conversations-test",
     ),
+    agentReleasesTable,
+    agentReleaseWriterRole,
+    registryArn:
+      "arn:aws:bedrock-agentcore:us-east-1:123456789012:registry/citadel-test",
+    registryId: "citadel-test",
   });
 
   const template = Template.fromStack(stack);

--- a/backend/test/governance-stack-eval-comparison.test.ts
+++ b/backend/test/governance-stack-eval-comparison.test.ts
@@ -89,6 +89,25 @@ function createTestStack(): { stack: GovernanceStack; template: Template } {
     "AgentReleaseWriterRole",
     { assumedBy: new iam.ServicePrincipal("lambda.amazonaws.com") },
   );
+  const environmentReleasePointersTable = new dynamodb.Table(
+    backendStack,
+    "EnvironmentReleasePointersTable",
+    {
+      tableName: "citadel-environment-release-pointers-test",
+      partitionKey: { name: "orgId", type: dynamodb.AttributeType.STRING },
+      sortKey: {
+        name: "agentTargetId_environment",
+        type: dynamodb.AttributeType.STRING,
+      },
+      billingMode: dynamodb.BillingMode.PAY_PER_REQUEST,
+      removalPolicy: cdk.RemovalPolicy.DESTROY,
+    },
+  );
+  const environmentReleasePointerWriterRole = new iam.Role(
+    backendStack,
+    "EnvironmentReleasePointerWriterRole",
+    { assumedBy: new iam.ServicePrincipal("lambda.amazonaws.com") },
+  );
 
   const stack = new GovernanceStack(app, "TestGovernanceStackEvalComparison", {
     env: { account: "123456789012", region: "us-east-1" },
@@ -173,6 +192,8 @@ function createTestStack(): { stack: GovernanceStack; template: Template } {
     registryArn:
       "arn:aws:bedrock-agentcore:us-east-1:123456789012:registry/citadel-test",
     registryId: "citadel-test",
+    environmentReleasePointersTable,
+    environmentReleasePointerWriterRole,
   });
 
   const template = Template.fromStack(stack);

--- a/backend/test/governance-stack-eval-resolver.test.ts
+++ b/backend/test/governance-stack-eval-resolver.test.ts
@@ -174,6 +174,25 @@ function createTestStack(): { stack: GovernanceStack; template: Template } {
     "AgentReleaseWriterRole",
     { assumedBy: new iam.ServicePrincipal("lambda.amazonaws.com") },
   );
+  const environmentReleasePointersTable = new dynamodb.Table(
+    backendStack,
+    "EnvironmentReleasePointersTable",
+    {
+      tableName: "citadel-environment-release-pointers-test",
+      partitionKey: { name: "orgId", type: dynamodb.AttributeType.STRING },
+      sortKey: {
+        name: "agentTargetId_environment",
+        type: dynamodb.AttributeType.STRING,
+      },
+      billingMode: dynamodb.BillingMode.PAY_PER_REQUEST,
+      removalPolicy: cdk.RemovalPolicy.DESTROY,
+    },
+  );
+  const environmentReleasePointerWriterRole = new iam.Role(
+    backendStack,
+    "EnvironmentReleasePointerWriterRole",
+    { assumedBy: new iam.ServicePrincipal("lambda.amazonaws.com") },
+  );
 
   const stack = new GovernanceStack(app, "TestGovernanceStackEval", {
     env: { account: "123456789012", region: "us-east-1" },
@@ -202,6 +221,8 @@ function createTestStack(): { stack: GovernanceStack; template: Template } {
     registryArn:
       "arn:aws:bedrock-agentcore:us-east-1:123456789012:registry/citadel-test",
     registryId: "citadel-test",
+    environmentReleasePointersTable,
+    environmentReleasePointerWriterRole,
   });
 
   const template = Template.fromStack(stack);

--- a/backend/test/governance-stack-eval-resolver.test.ts
+++ b/backend/test/governance-stack-eval-resolver.test.ts
@@ -21,6 +21,7 @@ import { Template, Match } from "aws-cdk-lib/assertions";
 import * as appsync from "aws-cdk-lib/aws-appsync";
 import * as dynamodb from "aws-cdk-lib/aws-dynamodb";
 import * as events from "aws-cdk-lib/aws-events";
+import * as iam from "aws-cdk-lib/aws-iam";
 import { Bucket } from "aws-cdk-lib/aws-s3";
 import * as path from "path";
 import { scaffoldBackendAssetDirs } from "./helpers/scaffold-stub-assets";
@@ -158,6 +159,22 @@ function createTestStack(): { stack: GovernanceStack; template: Template } {
     "citadel-conversations-test",
   );
 
+  const agentReleasesTable = new dynamodb.Table(
+    backendStack,
+    "AgentReleasesTable",
+    {
+      tableName: "citadel-agent-releases-test",
+      partitionKey: { name: "releaseId", type: dynamodb.AttributeType.STRING },
+      billingMode: dynamodb.BillingMode.PAY_PER_REQUEST,
+      removalPolicy: cdk.RemovalPolicy.DESTROY,
+    },
+  );
+  const agentReleaseWriterRole = new iam.Role(
+    backendStack,
+    "AgentReleaseWriterRole",
+    { assumedBy: new iam.ServicePrincipal("lambda.amazonaws.com") },
+  );
+
   const stack = new GovernanceStack(app, "TestGovernanceStackEval", {
     env: { account: "123456789012", region: "us-east-1" },
     environment: "test",
@@ -180,6 +197,11 @@ function createTestStack(): { stack: GovernanceStack; template: Template } {
     evalComparisonConfigTable,
     executionsTable,
     conversationsTable,
+    agentReleasesTable,
+    agentReleaseWriterRole,
+    registryArn:
+      "arn:aws:bedrock-agentcore:us-east-1:123456789012:registry/citadel-test",
+    registryId: "citadel-test",
   });
 
   const template = Template.fromStack(stack);

--- a/backend/test/governance-stack-eval-run.test.ts
+++ b/backend/test/governance-stack-eval-run.test.ts
@@ -11,6 +11,7 @@ import { Template, Match } from "aws-cdk-lib/assertions";
 import * as appsync from "aws-cdk-lib/aws-appsync";
 import * as dynamodb from "aws-cdk-lib/aws-dynamodb";
 import * as events from "aws-cdk-lib/aws-events";
+import * as iam from "aws-cdk-lib/aws-iam";
 import { Bucket } from "aws-cdk-lib/aws-s3";
 import * as path from "path";
 import { scaffoldBackendAssetDirs } from "./helpers/scaffold-stub-assets";
@@ -137,6 +138,22 @@ function createTestStack(): { stack: GovernanceStack; template: Template } {
     "citadel-conversations-test",
   );
 
+  const agentReleasesTable = new dynamodb.Table(
+    backendStack,
+    "AgentReleasesTable",
+    {
+      tableName: "citadel-agent-releases-test",
+      partitionKey: { name: "releaseId", type: dynamodb.AttributeType.STRING },
+      billingMode: dynamodb.BillingMode.PAY_PER_REQUEST,
+      removalPolicy: cdk.RemovalPolicy.DESTROY,
+    },
+  );
+  const agentReleaseWriterRole = new iam.Role(
+    backendStack,
+    "AgentReleaseWriterRole",
+    { assumedBy: new iam.ServicePrincipal("lambda.amazonaws.com") },
+  );
+
   const stack = new GovernanceStack(app, "TestGovernanceStackEvalRun", {
     env: { account: "123456789012", region: "us-east-1" },
     environment: "test",
@@ -159,6 +176,11 @@ function createTestStack(): { stack: GovernanceStack; template: Template } {
     evalComparisonConfigTable,
     executionsTable,
     conversationsTable,
+    agentReleasesTable,
+    agentReleaseWriterRole,
+    registryArn:
+      "arn:aws:bedrock-agentcore:us-east-1:123456789012:registry/citadel-test",
+    registryId: "citadel-test",
   });
 
   const template = Template.fromStack(stack);

--- a/backend/test/governance-stack-eval-run.test.ts
+++ b/backend/test/governance-stack-eval-run.test.ts
@@ -153,6 +153,25 @@ function createTestStack(): { stack: GovernanceStack; template: Template } {
     "AgentReleaseWriterRole",
     { assumedBy: new iam.ServicePrincipal("lambda.amazonaws.com") },
   );
+  const environmentReleasePointersTable = new dynamodb.Table(
+    backendStack,
+    "EnvironmentReleasePointersTable",
+    {
+      tableName: "citadel-environment-release-pointers-test",
+      partitionKey: { name: "orgId", type: dynamodb.AttributeType.STRING },
+      sortKey: {
+        name: "agentTargetId_environment",
+        type: dynamodb.AttributeType.STRING,
+      },
+      billingMode: dynamodb.BillingMode.PAY_PER_REQUEST,
+      removalPolicy: cdk.RemovalPolicy.DESTROY,
+    },
+  );
+  const environmentReleasePointerWriterRole = new iam.Role(
+    backendStack,
+    "EnvironmentReleasePointerWriterRole",
+    { assumedBy: new iam.ServicePrincipal("lambda.amazonaws.com") },
+  );
 
   const stack = new GovernanceStack(app, "TestGovernanceStackEvalRun", {
     env: { account: "123456789012", region: "us-east-1" },
@@ -181,6 +200,8 @@ function createTestStack(): { stack: GovernanceStack; template: Template } {
     registryArn:
       "arn:aws:bedrock-agentcore:us-east-1:123456789012:registry/citadel-test",
     registryId: "citadel-test",
+    environmentReleasePointersTable,
+    environmentReleasePointerWriterRole,
   });
 
   const template = Template.fromStack(stack);


### PR DESCRIPTION
## feat(release): immutable agent release bundles

Introduces the per-agent release unit the platform lacked: agent config, prompts, exec spec, model config, tools, policies, and evaluation evidence previously versioned independently with no bundle binding them together. Shipped in four parts, each with its own tests.

**The record.** A release is content-addressed — its id IS the hash of the constituents it pins, computed order-independently. Evaluation evidence is required, not optional, so a release cannot exist without the run, suite, and suite version it was judged against.

**The cut.** Constituents are derived server-side from validated source records rather than accepted from the caller, so a caller cannot submit a snapshot differing from what was checked. A cut is refused unless the registry record and exec spec are approved and the eval run is complete with a matching suite version. Every org boundary fails closed, including refusing when an org cannot be determined at all; the exec spec has no org field of its own and is resolved through its project owner, following existing precedent.

**The pointer.** A mutable cursor per org, agent, and environment naming the current release, with the version check enforced as a condition expression on the write rather than an application-level comparison, so concurrent promotions cannot silently lose one another. Each move retains what it moved away from, which rollback will read. Moving requires an explicit promote permission.

**Dispatch.** The supervisor and step runner resolve the pointer to the immutable snapshot, read-only, driven by the existing enforcement hierarchy rather than a parallel mode system: permissive emits telemetry, shadow records a would-block, strict refuses when no release resolves. Grandfathered agents are never blocked. A failed lookup is treated as unknown state and refused in strict mode rather than passed through.

### Rollout safety
Default mode is non-blocking. A deployment with no releases and no pointers dispatches exactly as before, performing no lookup when the feature is off. Telemetry is emitted in every mode so the rollout can be measured before strict is flipped.

### Immutability is enforced structurally, not by convention
A release cannot be mutated by any principal: a single store module is the only writer and exposes no update or delete, a guard test fails the build if any other file writes to the table, the conditional put makes identical content idempotent, and no IAM policy grants UpdateItem or DeleteItem on the releases table. The pointer table needs update capability and is therefore reached through a separate role; template assertions cover that separation. Review twice caught wiring that would have widened the shared role and undone this.

### Verification
pytest 1453 passed; jest 412 suites / 6153 tests; lint 0 warnings under --max-warnings 0; tsc clean; cdk synth clean with zero policy findings.

### Follow-ups filed
The grandfathering rule is now duplicated as a Python port because the TypeScript module is unreachable from the Python runtime — parity-tested today, but it wants a cross-language guard since it decides exemption from a security gate. The pointer's lock rejection is proven against a mock rather than stateful emulation.

### Not in scope
Quality gating, promotion, canary, rollback, and release diff are later stories; each has a named seam.