### PR TITLE
test(smoke): end-to-end fixtures for the release path

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,6 +20,10 @@ ENV/
 # E2E test artifacts
 scripts/*
 !scripts/verify-doc-claims.js
+!scripts/smoke/
+!scripts/smoke/**
+scripts/smoke/**/node_modules/
+scripts/smoke/**/dist/
 
 # Build outputs
 dist/

--- a/scripts/smoke/release-path/README.md
+++ b/scripts/smoke/release-path/README.md
@@ -1,0 +1,145 @@
+# Release-Path Smoke Fixture — README
+
+Proves three real code paths run end to end in a dev deployment:
+
+1. `cutAgentRelease` (backend/src/lambda/release-resolver.ts)
+2. `promoteEnvironmentReleasePointer` (backend/src/lambda/environment-release-pointer-resolver.ts)
+3. `resolve_release` (arbiter/governance/release_resolution.py) — the dispatch-side read
+
+It arranges the *prerequisites* these two mutations only ever READ, then
+exercises the mutations themselves for real through AppSync, then asserts
+dispatch resolution sees the promoted release, in a **non-blocking**
+governance mode. See `../../../RUNBOOK.md` for how to run it; this file
+explains what it does and why it is safe to run repeatedly.
+
+## Files
+
+| File | Purpose |
+|---|---|
+| `fixtures.ts` | Sentinel constants + idempotent arrange (Project, APPROVED registry record, APPROVED exec spec, throwaway FROZEN eval suite + case, COMPLETED eval run) + post-arrange invariant assertions. |
+| `env.ts` | Reads operator-provisioned identity/config from the environment. Never provisions anything itself. |
+| `appsync-client.ts` | Minimal `fetch`-based AppSync GraphQL client (no new SDK dependency). |
+| `run-smoke.ts` | Exercises the real `cutAgentRelease` then `promoteEnvironmentReleasePointer` through AppSync, asserting each stage and its idempotency. |
+| `assert_dispatch_resolves.py` | Read-only: calls `resolve_release` and asserts `RESOLVED` with the matching `releaseId`. |
+| `RUNBOOK.md` | One-time operator setup + how to run. |
+
+## Why every field is what it is
+
+Every field this harness supplies to `cutAgentRelease` /
+`promoteEnvironmentReleasePointer` was derived by reading the validation
+in `release-resolver.ts` and `environment-release-pointer-resolver.ts`
+directly (never guessed):
+
+- `cutAgentRelease` needs, IN THIS ORDER: `release:cut` permission
+  (`custom:role` → `architect`/`admin`), a non-empty caller org
+  (`extractOrgFromEvent`), an **APPROVED** registry record whose
+  `customDescriptorContent.orgId` equals the caller's org, an **APPROVED**
+  `ExecutionSpecification` whose project's owner resolves (via Cognito) to
+  the caller's org, and a **COMPLETED** `EvalRun` whose `orgId` matches and
+  whose `suiteVersion` matches its suite's current `version` — and that
+  suite must also belong to the caller's org. `fixtures.ts`'s `arrange()`
+  builds exactly this shape and `assertArrangeInvariants()` re-checks every
+  one of these predicates by reading the rows back through the API before
+  `run-smoke.ts` ever calls `cutAgentRelease`.
+- `promoteEnvironmentReleasePointer` needs `release:promote` permission
+  (same `architect`/`admin` grantee set), a non-empty caller org, and a
+  target release that exists and belongs to that org — `run-smoke.ts`
+  reads the current pointer first (to report the pre-promotion state) but
+  never re-implements the optimistic-lock check itself; the store's
+  `ConditionExpression` is the actual enforcement.
+- `resolve_release` is a pure two-GetItem read
+  (`EnvironmentReleasePointersTable` then `AgentReleasesTable`) that never
+  raises; `assert_dispatch_resolves.py` asserts its `RESOLVED` outcome and
+  the resolved `releaseId`, nothing more.
+
+## Never references a shipped seed suite
+
+`fixtures.ts` creates its **own** eval suite (`SMOKE-RELEASE-FIXTURE-SUITE`)
+under a dedicated sentinel org (`SMOKE-RELEASE-FIXTURE-ORG`) and freezes
+*that* suite before cutting a release against it. `markEvalSuiteReferenced`
+(the permanent freeze — `references[]` never shrinks) only ever touches the
+suite whose id this harness looked up or created, and that suite's name is
+namespaced so it can never collide with, or be confused for, a shipped seed
+suite. No shipped seed suite id, name, or org is ever referenced anywhere in
+these files. Because the freeze is genuinely permanent, this is a one-way
+door — which is exactly why the fixture suite must be, and is, one this
+harness owns end to end rather than one that ships with the product.
+
+## Why exactly one `AgentRelease` row can ever exist
+
+`AgentReleasesTable` is content-addressed: `release-store.ts`'s
+`putRelease` computes `releaseId = computeReleaseHash(constituents)` over
+the release's constituents **only** (excluding volatile fields like
+`createdAt`), then does a create-only conditional `Put` on
+`attribute_not_exists(releaseId)`. `run-smoke.ts` supplies every
+constituent — `agentConfig` (derived from the registry record's own
+`customDescriptorContent`, which `fixtures.ts` always creates with the same
+literal marker payload), `promptVersions`, `modelConfigSnapshots`,
+`toolConfigs`, `policySnapshot`, `execSpecId`/`execSpecVersion` (pinned to
+the one APPROVED spec `arrange()` finds-or-creates), and `evalEvidence`
+(pinned to the one COMPLETED run `arrange()` seeds deterministically) — as
+fixed `SENTINEL_*` literals or as ids read back from the idempotently
+arranged fixtures. None of these vary between runs once `arrange()` has
+converged, so `computeReleaseHash` always produces the SAME `releaseId`,
+and every rerun after the first hits the conditional Put's
+already-exists branch and returns the existing row. **There is
+structurally no way for this harness to produce a second
+`AgentRelease` row**, short of deliberately changing one of the
+`SENTINEL_*` constants in this directory.
+
+`EnvironmentReleasePointersTable` is the one row that is *intentionally*
+mutable (it is the cursor, not the audit record): every successful
+promotion increments its `version` by exactly 1 via the
+optimistic-lock `ConditionExpression`, and `run-smoke.ts` asserts that
+increment explicitly. Re-running this harness therefore converges to
+**exactly one pointer row** (keyed by
+`(SENTINEL_ORG, SENTINEL_AGENT_TARGET_ID#DEV)`) whose `version` grows by 1
+per run — bounded, monotonic growth of a single row's counter, not
+row accumulation.
+
+`EvalSuitesTable`/`EvalCasesTable`/`ExecutionSpecificationsTable`/
+`ProjectsTable` rows are found-by-sentinel-name-if-present, so those stay
+at one row each too (see `fixtures.ts`'s module doc for why these ids
+can't be pinned deterministically the way the release/eval-run ids can,
+and how "create-if-absent" is implemented as "list, match by sentinel
+name, create only if absent" instead).
+
+## Never weakens the release-store choke point
+
+Neither this harness nor its dependencies (`arbiter/governance/release_resolution.py`)
+ever imports a write command against `AgentReleasesTable` or
+`EnvironmentReleasePointersTable`. The only direct-DynamoDB write in this
+directory is `fixtures.ts`'s seed of a `COMPLETED` `EvalRun` row into
+`EVAL_RUNS_TABLE` — a table `cutAgentRelease` only ever `GetItem`s, and
+which is not covered by `release-store-choke-point.guard.test.ts` (that
+guard scopes to `AgentReleasesTable` specifically). Every read this
+harness needs against the release/pointer tables goes through the API:
+`cutAgentRelease`'s return value, `getCurrentEnvironmentReleasePointer`,
+and — on the dispatch side — the existing read-only
+`resolve_release` Python module, which is itself IAM-floored to
+GetItem/Query only (see that module's own docstring). No table is read
+directly where an API read would do, and the one direct read
+(`assert_dispatch_resolves.py` calling `resolve_release`) mirrors the
+exact call the real dispatch gate (`_check_release_gate` in
+`arbiter/stepRunner/executor.py`) already makes in production — it is not
+a new read path.
+
+## Namespacing
+
+Every string this harness creates carries a `SMOKE-RELEASE-FIXTURE`
+marker, `SMOKE-RELEASE-FIXTURE-ORG`, or both — see `fixtures.ts`'s
+`SENTINEL_*` constants. A table scan or console browse can distinguish
+every row this harness ever writes from real tenant data at a glance.
+
+## Dependency pinning note
+
+`package.json` in this directory pins exact, package-manager-resolved
+versions of `@aws-sdk/client-cognito-identity-provider`,
+`@aws-sdk/client-dynamodb`, `@aws-sdk/lib-dynamodb`, `typescript`,
+`ts-node`, and `@types/node` — resolved via `npm install` against the
+same `^`-ranges `backend/package.json` already depends on, then pinned
+to the exact versions npm actually installed (never hand-typed from
+memory). `dependency_check` reported zero known advisories for every one
+of these exact versions at pin time. If you bump these here, re-run
+`npm install` to resolve the new version and `npm audit` to confirm
+zero vulnerabilities before pinning it.

--- a/scripts/smoke/release-path/RUNBOOK.md
+++ b/scripts/smoke/release-path/RUNBOOK.md
@@ -1,0 +1,146 @@
+# Release-Path Smoke Fixture — RUNBOOK
+
+Dev-only. Never run this against `PROD` or `STAGING`. Nothing in this
+directory is wired into CI (`npm test`, `npm run lint`, `pytest` never
+import or execute these files) — it is an opt-in, on-demand harness.
+
+## One-time operator setup (you must do this manually)
+
+**These scripts NEVER create Cognito users, IAM roles, or any other
+principal.** If the identity or credentials below are missing, every
+script in this directory fails immediately with a message pointing back
+here — it will not attempt to provision anything on your behalf.
+
+### 1. Create the dedicated fixture Cognito user (once per dev pool)
+
+Using an account that already has Cognito admin access to your dev user
+pool:
+
+```bash
+aws cognito-idp admin-create-user \
+  --user-pool-id "$USER_POOL_ID" \
+  --username smoke-release-fixture \
+  --user-attributes \
+      Name=email,Value=smoke-release-fixture@example.invalid \
+      Name=email_verified,Value=true \
+      Name="custom:role",Value=architect \
+      Name="custom:organization",Value=SMOKE-RELEASE-FIXTURE-ORG \
+  --message-action SUPPRESS
+
+aws cognito-idp admin-set-user-password \
+  --user-pool-id "$USER_POOL_ID" \
+  --username smoke-release-fixture \
+  --password '<choose a strong password>' \
+  --permanent
+```
+
+`custom:role=architect` is the SAME grantee tier `release:cut` and
+`release:promote` already require in `backend/src/utils/auth.ts` — this
+is not a new role, it reuses the existing one. `--permanent` avoids a
+`NEW_PASSWORD_REQUIRED` challenge on first `USER_PASSWORD_AUTH` login (a
+challenge this harness does not handle, by design — see `env.ts`).
+
+If your user pool client does not have the `USER_PASSWORD_AUTH` auth flow
+enabled, enable it on the **existing** app client used for this dev pool
+(do not create a new one):
+
+```bash
+aws cognito-idp update-user-pool-client \
+  --user-pool-id "$USER_POOL_ID" \
+  --client-id "$USER_POOL_CLIENT_ID" \
+  --explicit-auth-flows ALLOW_USER_PASSWORD_AUTH ALLOW_REFRESH_TOKEN_AUTH
+```
+
+### 2. Discover the remaining configuration values
+
+From your dev deployment's CloudFormation outputs / stack resources
+(read-only `describe-stacks`/`describe-stack-resources` calls — no
+writes):
+
+```bash
+aws cloudformation describe-stacks --stack-name BackendStack-dev \
+  --query "Stacks[0].Outputs"
+# -> GraphQLApiUrl, UserPoolId, UserPoolClientId
+
+aws cloudformation describe-stack-resources --stack-name BackendStack-dev \
+  --query "StackResources[?ResourceType=='AWS::DynamoDB::Table'].PhysicalResourceId"
+# -> find the EvalRuns table's physical name
+
+aws cloudformation describe-stack-resources --stack-name GovernanceStack-dev \
+  --query "StackResources[?ResourceType=='AWS::DynamoDB::Table'].PhysicalResourceId"
+# -> find the EnvironmentReleasePointers table's physical name (needed
+#    only by assert_dispatch_resolves.py; AgentReleasesTable too if you
+#    want to sanity-check it directly, though the scripts never require
+#    that one by name)
+```
+
+The governance-transcripts S3 bucket name (needed for `narrativeS3Uri`,
+see `NARRATIVE_URI_ALLOWLIST` in `backend/src/utils/auth-event.ts`'s
+sibling `execspec-resolver.ts`) follows the pattern
+`citadel-governance-transcripts-<env>-<account>-<region>` — confirm the
+exact name for your account/region rather than assuming it.
+
+### 3. Export the environment
+
+```bash
+export AWS_REGION=us-east-1
+export AWS_PROFILE=your-dev-profile          # scoped dev credentials only
+export GRAPHQL_API_URL='https://....appsync-api...amazonaws.com/graphql'
+export USER_POOL_ID='us-east-1_xxxxxxxxx'
+export USER_POOL_CLIENT_ID='xxxxxxxxxxxxxxxxxxxxxxxxxx'
+export SMOKE_FIXTURE_USERNAME=smoke-release-fixture
+export SMOKE_FIXTURE_PASSWORD='<the password you set above>'
+export EVAL_RUNS_TABLE='citadel-eval-runs-dev-xxxxxxxx'
+export ENVIRONMENT_RELEASE_POINTERS_TABLE='citadel-environment-release-pointers-dev-xxxxxxxx'
+export SMOKE_GOVERNANCE_TRANSCRIPTS_BUCKET_NAME='citadel-governance-transcripts-dev-123456789012-us-east-1'
+```
+
+If any of these is missing when you run a script, that script exits
+immediately with a message naming exactly which variable is missing and
+pointing back to this file — it never falls back to a guess.
+
+## Running (only once the above is done)
+
+```bash
+cd scripts/smoke/release-path
+npm install       # first time only — installs this directory's own,
+                   # independently-pinned dependencies (see README.md's
+                   # "Dependency pinning note")
+npm run typecheck # tsc --noEmit, zero-execution sanity check
+
+# Arrange + cut + promote (writes fixture rows + one release + one pointer
+# move to your DEV deployment):
+npx ts-node run-smoke.ts
+# prints: [run-smoke] DONE. releaseId=<sha256 hex> ...
+
+# Read-only dispatch-side check (needs the releaseId printed above):
+.venv-check/bin/python3 assert_dispatch_resolves.py --release-id <the releaseId printed above>
+# prints PASS: dispatch resolution RESOLVED to the expected release ...
+```
+
+Re-running `run-smoke.ts` is safe and expected — see README.md's
+"Why exactly one AgentRelease row can ever exist" section. It always
+converges to the same single release row; the pointer row's `version`
+increments by 1 on each rerun, which the script itself asserts.
+
+## What this does NOT cover (by design)
+
+- It never runs the real eval-runner/judge pipeline — the `COMPLETED`
+  `EvalRun` is seeded directly (see `fixtures.ts`'s module doc for why).
+- It never flips governance enforcement to `strict`, and never asserts
+  anything about dispatch actually being *blocked* — only that resolution
+  is observable in shadow/permissive mode.
+- It never exercises the `ConcurrentPromotionError` race, cross-org
+  rejection paths, rollback, or grandfathering.
+- It never touches `STAGING` or `PROD` — every example above targets a
+  `-dev` deployment; there is no environment switch to make it target
+  anything else.
+
+## Cleanup
+
+There is no delete path (by design — `AgentReleasesTable` has no delete
+operation anywhere in the codebase, and this repo's tables generally
+don't support deletion of governance-relevant rows). The fixture rows are
+permanently but obviously namespaced (`SMOKE-RELEASE-FIXTURE-*` /
+`SMOKE-RELEASE-FIXTURE-ORG`) — see README.md's "Namespacing" section —
+so they are trivially filterable out of any real report or audit.

--- a/scripts/smoke/release-path/appsync-client.ts
+++ b/scripts/smoke/release-path/appsync-client.ts
@@ -1,0 +1,78 @@
+/**
+ * appsync-client.ts — minimal AppSync GraphQL HTTP client.
+ *
+ * Deliberately NOT using an AppSync/Amplify SDK: the backend package has
+ * no server-side GraphQL client dependency (frontend uses Amplify with a
+ * browser-only config), and pulling one in for a single-purpose smoke
+ * script would be a new dependency for a handful of POST calls. Node 22+
+ * ships a native `fetch`, which is all a Cognito-user-pool-authorized
+ * AppSync request needs: an `Authorization: <idToken>` header (AppSync's
+ * COGNITO_USER_POOLS auth mode reads the raw JWT directly, no SigV4).
+ */
+
+import { readRequiredEnv } from "./env";
+
+export interface GraphQLError {
+  message: string;
+  errorType?: string;
+  path?: (string | number)[];
+}
+
+export class AppSyncRequestError extends Error {
+  constructor(
+    message: string,
+    public readonly errors: GraphQLError[],
+  ) {
+    super(message);
+    this.name = "AppSyncRequestError";
+  }
+}
+
+/**
+ * Issues one GraphQL request (query or mutation) against the deployment's
+ * AppSync endpoint, authenticated as the caller identified by `idToken`
+ * (from env.cognitoAuth()). Throws AppSyncRequestError with the full
+ * GraphQL errors array on any `errors` field in the response — callers
+ * must not silently ignore a partial-success/error response.
+ */
+export async function appsyncRequest<T>(
+  idToken: string,
+  query: string,
+  variables: Record<string, unknown> = {},
+): Promise<T> {
+  const endpoint = readRequiredEnv("GRAPHQL_API_URL");
+
+  const res = await fetch(endpoint, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      Authorization: idToken,
+    },
+    body: JSON.stringify({ query, variables }),
+  });
+
+  if (!res.ok) {
+    const text = await res.text().catch(() => "<unreadable body>");
+    throw new Error(
+      `AppSync request failed with HTTP ${res.status}: ${text.slice(0, 500)}`,
+    );
+  }
+
+  const body = (await res.json()) as { data?: T; errors?: GraphQLError[] };
+
+  if (body.errors && body.errors.length > 0) {
+    throw new AppSyncRequestError(
+      `AppSync returned ${body.errors.length} error(s): ` +
+        body.errors.map((e) => e.message).join("; "),
+      body.errors,
+    );
+  }
+
+  if (body.data === undefined) {
+    throw new Error(
+      "AppSync response had neither `data` nor `errors` — unexpected shape.",
+    );
+  }
+
+  return body.data;
+}

--- a/scripts/smoke/release-path/assert_dispatch_resolves.py
+++ b/scripts/smoke/release-path/assert_dispatch_resolves.py
@@ -1,0 +1,184 @@
+#!/usr/bin/env python3
+"""assert_dispatch_resolves.py — read-only dispatch-side resolution check
+for the release-path smoke fixture.
+
+Calls arbiter.governance.release_resolution.resolve_release(org_id,
+agent_target_id, environment) for the SENTINEL org/agent/environment this
+fixture set promoted a release for (via run-smoke.ts), and asserts:
+
+  1. status == RESOLVED
+  2. release['releaseId'] == the releaseId that was cut/promoted
+
+This module (resolve_release) is READ-ONLY BY CONSTRUCTION: it issues at
+most one GetItem against EnvironmentReleasePointersTable and one against
+AgentReleasesTable, and never imports/calls anything that could write to
+either. See release_resolution.py's own module docstring — "IAM floor
+(enforced at the CDK layer, not here): GetItem/Query only on both
+tables." This script adds NO additional AWS calls beyond that single
+resolve_release invocation; it does not touch DynamoDB directly at all.
+
+NON-BLOCKING MODE: this script never sets/checks strict enforcement mode
+and never asserts anything about `_check_release_gate`'s would_block
+behavior — the approved design is explicit that resolve_release's
+RESOLVED outcome is observable in shadow/permissive without needing
+strict mode at all (strict changes whether an unresolved lookup BLOCKS
+dispatch, not whether resolution itself succeeds). Running this script
+never flips governance enforcement mode.
+
+WHY THIS DOES NOT NEED TO WEAKEN THE release-store CHOKE POINT: the
+choke-point guard (release-store-choke-point.guard.test.ts) protects
+AgentReleasesTable's WRITE surface (Put/Update/Delete) inside
+backend/src/lambda/**. This script never writes to that table (or
+EnvironmentReleasePointersTable) — it only reads, and it reads via the
+SAME read-only Python module the real dispatch gate
+(arbiter/stepRunner/executor.py's _check_release_gate) already calls in
+production, rather than a bespoke table read. No new read/write path is
+introduced and the guard's effectiveness against runtime writes is
+untouched.
+
+Exit codes:
+  0 - resolution RESOLVED with the expected releaseId.
+  1 - resolution did not match (NO_POINTER / LOOKUP_FAILED / releaseId
+      mismatch), or required environment variables are missing.
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import sys
+from pathlib import Path
+
+# Repo root (two levels up: scripts/smoke/release-path/ -> repo root) so
+# `import arbiter....` resolves the same way it does for every other
+# script/test in this repo, without requiring the caller to have set
+# PYTHONPATH themselves.
+REPO_ROOT = Path(__file__).resolve().parents[3]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+SENTINEL_ORG = "SMOKE-RELEASE-FIXTURE-ORG"
+SENTINEL_AGENT_TARGET_ID = "smoke-release-fixture-agent"
+SENTINEL_ENVIRONMENT = "DEV"
+
+REQUIRED_ENV_VARS = (
+    "ENVIRONMENT_RELEASE_POINTERS_TABLE",
+    "AGENT_RELEASES_TABLE",
+    "AWS_REGION",
+)
+
+
+def _assert_env_complete() -> None:
+    missing = [name for name in REQUIRED_ENV_VARS if not os.environ.get(name)]
+    if missing:
+        raise SystemExit(
+            "Missing required environment variable(s): "
+            + ", ".join(missing)
+            + ". This script never provisions infrastructure or identities "
+            "itself — see RUNBOOK.md (\"One-time operator setup\") for how "
+            "to discover these table names from your dev deployment, and "
+            "note that unlike run-smoke.ts this script needs NO Cognito "
+            "identity at all (it calls the dispatch-side Python resolver "
+            "directly with plain AWS credentials, matching how the real "
+            "Step Runner's _check_release_gate is invoked)."
+        )
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(
+        description=(
+            "Read-only assertion that dispatch resolution for the "
+            "release-path smoke fixture returns RESOLVED with the "
+            "expected releaseId. Never writes to AWS."
+        )
+    )
+    parser.add_argument(
+        "--release-id",
+        required=True,
+        help=(
+            "The releaseId run-smoke.ts's cutAgentRelease call produced "
+            "(printed by run-smoke.ts as 'releaseId=...' on success)."
+        ),
+    )
+    parser.add_argument(
+        "--org-id",
+        default=SENTINEL_ORG,
+        help="Override the sentinel org id (default: %(default)s).",
+    )
+    parser.add_argument(
+        "--agent-target-id",
+        default=SENTINEL_AGENT_TARGET_ID,
+        help="Override the sentinel agent target id (default: %(default)s).",
+    )
+    parser.add_argument(
+        "--environment",
+        default=SENTINEL_ENVIRONMENT,
+        help="Override the sentinel environment literal (default: %(default)s).",
+    )
+    args = parser.parse_args()
+
+    _assert_env_complete()
+
+    # Imported after the env-var check and sys.path setup, and AFTER
+    # argparse, so a --help invocation never touches boto3 credential
+    # resolution.
+    from arbiter.governance.release_resolution import (  # noqa: E402
+        ReleaseResolutionStatus,
+        resolve_release,
+    )
+
+    resolution = resolve_release(
+        org_id=args.org_id,
+        agent_target_id=args.agent_target_id,
+        environment=args.environment,
+    )
+
+    print(
+        json.dumps(
+            {
+                "status": resolution.status.value,
+                "release_id_in_pointer": (
+                    (resolution.release or {}).get("releaseId")
+                    if resolution.release
+                    else None
+                ),
+                "expected_release_id": args.release_id,
+                "error": resolution.error,
+            },
+            indent=2,
+        )
+    )
+
+    if resolution.status != ReleaseResolutionStatus.RESOLVED:
+        print(
+            f"FAIL: expected status RESOLVED, got {resolution.status.value} "
+            f"(error={resolution.error!r}). This usually means run-smoke.ts "
+            "has not been run yet against this deployment, or the "
+            "ENVIRONMENT_RELEASE_POINTERS_TABLE / AGENT_RELEASES_TABLE env "
+            "vars point at a different deployment than the one run-smoke.ts "
+            "targeted.",
+            file=sys.stderr,
+        )
+        return 1
+
+    resolved_release_id = (resolution.release or {}).get("releaseId")
+    if resolved_release_id != args.release_id:
+        print(
+            f"FAIL: resolved releaseId ({resolved_release_id!r}) does not "
+            f"match the expected releaseId ({args.release_id!r}) that "
+            "run-smoke.ts cut/promoted.",
+            file=sys.stderr,
+        )
+        return 1
+
+    print(
+        f"PASS: dispatch resolution RESOLVED to the expected release "
+        f"{args.release_id} for org={args.org_id} "
+        f"agentTargetId={args.agent_target_id} environment={args.environment}. "
+        "Read-only — no writes were issued (see module docstring)."
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/smoke/release-path/env.ts
+++ b/scripts/smoke/release-path/env.ts
@@ -1,0 +1,128 @@
+/**
+ * env.ts — operator-identity + configuration surface for the release-path
+ * smoke fixture harness.
+ *
+ * NON-NEGOTIABLE constraint: this harness must NEVER create Cognito
+ * users, IAM roles, or other principals. The one-time operator step
+ * (provisioning the dedicated dev fixture Cognito user described in the
+ * approved design) is documented in RUNBOOK.md; this module's job is
+ * ONLY to read the already-provisioned identity/credentials from the
+ * environment and fail with a clear, actionable message when they are
+ * absent — never to provision them itself.
+ */
+
+export const REQUIRED_ENV = [
+  "AWS_REGION",
+  "GRAPHQL_API_URL",
+  "USER_POOL_ID",
+  "USER_POOL_CLIENT_ID",
+  "SMOKE_FIXTURE_USERNAME",
+  "SMOKE_FIXTURE_PASSWORD",
+  "EVAL_RUNS_TABLE",
+  "SMOKE_GOVERNANCE_TRANSCRIPTS_BUCKET_NAME",
+  "ENVIRONMENT_RELEASE_POINTERS_TABLE",
+] as const;
+
+export type RequiredEnvVar = (typeof REQUIRED_ENV)[number];
+
+/**
+ * Reads a required env var or throws a clear, actionable error naming
+ * BOTH the missing variable and the RUNBOOK section that explains how to
+ * provision it — never falls back to a guessed default for anything
+ * identity- or infra-shaped.
+ */
+export function readRequiredEnv(name: RequiredEnvVar | string): string {
+  const value = process.env[name];
+  if (!value) {
+    throw new Error(
+      `Missing required environment variable: ${name}. This harness never ` +
+        `provisions identities or infrastructure itself — see ` +
+        `scripts/smoke/release-path/RUNBOOK.md ("One-time operator setup") ` +
+        `for how to create the dedicated fixture Cognito user and how to ` +
+        `discover the remaining values (GraphQL endpoint, table names, ` +
+        `user pool ids) from your dev deployment's CloudFormation outputs.`,
+    );
+  }
+  return value;
+}
+
+/** Fails fast (before any network call) if ANY required env var is
+ * absent, listing every missing one in a single actionable error rather
+ * than failing piecemeal one variable at a time. */
+export function assertEnvComplete(): void {
+  const missing = REQUIRED_ENV.filter((name) => !process.env[name]);
+  if (missing.length > 0) {
+    throw new Error(
+      `Missing required environment variable(s): ${missing.join(", ")}. ` +
+        `This harness never provisions identities or infrastructure itself ` +
+        `— see scripts/smoke/release-path/RUNBOOK.md ("One-time operator ` +
+        `setup") before running against a dev deployment.`,
+    );
+  }
+}
+
+let cachedToken: { token: string; expiresAt: number } | null = null;
+
+/**
+ * Authenticates as the pre-provisioned dedicated fixture Cognito user via
+ * USER_PASSWORD_AUTH and returns a fresh (or cached-if-still-valid) ID
+ * token. NEVER creates the user, a client, or any IAM principal — if
+ * InitiateAuth fails because the user/credentials/pool don't exist, the
+ * underlying Cognito error is rethrown with a pointer to RUNBOOK.md
+ * rather than this script attempting to self-heal by creating one.
+ */
+export async function cognitoAuth(): Promise<string> {
+  if (cachedToken && cachedToken.expiresAt > Date.now()) {
+    return cachedToken.token;
+  }
+
+  assertEnvComplete();
+
+  const {
+    CognitoIdentityProviderClient,
+    InitiateAuthCommand,
+  } = require("@aws-sdk/client-cognito-identity-provider") as typeof import("@aws-sdk/client-cognito-identity-provider");
+
+  const client = new CognitoIdentityProviderClient({
+    region: readRequiredEnv("AWS_REGION"),
+  });
+
+  let response;
+  try {
+    response = await client.send(
+      new InitiateAuthCommand({
+        AuthFlow: "USER_PASSWORD_AUTH",
+        ClientId: readRequiredEnv("USER_POOL_CLIENT_ID"),
+        AuthParameters: {
+          USERNAME: readRequiredEnv("SMOKE_FIXTURE_USERNAME"),
+          PASSWORD: readRequiredEnv("SMOKE_FIXTURE_PASSWORD"),
+        },
+      }),
+    );
+  } catch (err) {
+    throw new Error(
+      `Cognito authentication failed for the dedicated fixture user ` +
+        `(SMOKE_FIXTURE_USERNAME). This harness never creates that user — ` +
+        `see RUNBOOK.md ("One-time operator setup") to provision it with ` +
+        `custom:role=architect and custom:organization=SMOKE-RELEASE-FIXTURE-ORG. ` +
+        `Underlying error: ${err instanceof Error ? err.message : String(err)}`,
+    );
+  }
+
+  const idToken = response.AuthenticationResult?.IdToken;
+  if (!idToken) {
+    throw new Error(
+      "Cognito USER_PASSWORD_AUTH did not return an IdToken (possibly an " +
+        "MFA or NEW_PASSWORD_REQUIRED challenge). See RUNBOOK.md — the " +
+        "fixture user must be created with a permanent password and no MFA.",
+    );
+  }
+
+  const expiresInSec = response.AuthenticationResult?.ExpiresIn ?? 3600;
+  cachedToken = {
+    token: idToken,
+    // Refresh a little early rather than racing the exact expiry.
+    expiresAt: Date.now() + (expiresInSec - 60) * 1000,
+  };
+  return idToken;
+}

--- a/scripts/smoke/release-path/fixtures.ts
+++ b/scripts/smoke/release-path/fixtures.ts
@@ -1,0 +1,609 @@
+/**
+ * fixtures.ts — sentinel constants + idempotent arrange for the
+ * release-path smoke fixture set.
+ *
+ * Seeds (create-if-absent, never update-in-place) every prerequisite
+ * `cutAgentRelease` / `promoteEnvironmentReleasePointer` READ but never
+ * write, per the field-by-field validation read directly out of
+ * backend/src/lambda/release-resolver.ts and
+ * environment-release-pointer-resolver.ts:
+ *
+ *   - a Project (owner = the fixture Cognito user, so
+ *     resolveExecSpecOrgId's Project.owner -> lookupUserOrganization path
+ *     resolves to SENTINEL_ORG)
+ *   - an APPROVED agent registry record via createAgentConfig (AppSync
+ *     createAgentConfig -> createAgentConfigRegistry ->
+ *     RegistryService.createResource + updateResourceStatus("active")
+ *     ->  RegistryRecordStatusValues.APPROVED, customDescriptorContent.orgId
+ *     = the caller's org, exactly what cutAgentRelease's registry check
+ *     reads)
+ *   - an APPROVED ExecutionSpecification (createExecutionSpecification ->
+ *     approveExecutionSpecification)
+ *   - a DEDICATED THROWAWAY EvalSuite (createEvalSuite) + one EvalCase
+ *     (addEvalCase), then FROZEN (freezeEvalSuite) — never the shipped
+ *     seed suite. See the module docstring on SENTINEL_* below for why
+ *     this is safe under the permanent-freeze constraint.
+ *   - a COMPLETED EvalRun whose suiteVersion matches the frozen suite's
+ *     version — seeded directly (there is no AppSync mutation that can
+ *     drive a run to COMPLETED; startEvalRun only ever creates PENDING
+ *     runs, and driving the real eval-runner/judge pipeline to COMPLETED
+ *     is out of scope for this smoke fixture, per the approved design).
+ *     This is the ONE direct-DynamoDB write in this file, and it targets
+ *     EvalRunsTable, which is not the release-store or
+ *     environment-release-pointer-store choke point — cutAgentRelease
+ *     only ever GetItems that table.
+ *
+ * IDEMPOTENCY / BOUNDED-ROW GUARANTEE (constraint: "re-running must
+ * converge, not accumulate"):
+ *   - Project / EvalSuite / ExecutionSpecification IDs are server-minted
+ *     (uuidv4) on every AppSync create call — there is no field in any of
+ *     createProject / createEvalSuite / createExecutionSpecification that
+ *     lets a caller pin a deterministic id. So "create-if-absent" here
+ *     means "list, find-by-sentinel-name, create only if not found",
+ *     never "create, ignore AlreadyExists" — the fixed set is enforced by
+ *     this script's own lookup-before-create discipline, not by a
+ *     database-level conditional key.
+ *   - The EvalRun is the one row that CAN be pinned deterministically: it
+ *     is seeded directly with a fixed evalRunId derived exactly the way
+ *     eval-run-resolver.ts's deriveEvalRunId does (uuidv5 over
+ *     `${suiteId}:${suiteVersion}:${agentTargetVersion}:${idempotencyKey}`
+ *     using the same EVAL_RUN_NAMESPACE constant), keyed off the sentinel
+ *     suite's own id/version, so re-running always recomputes the SAME
+ *     evalRunId and the direct PutCommand is a create-if-absent
+ *     (attribute_not_exists) no-op on repeat.
+ *   - The eventual AgentRelease row cut against these fixtures is
+ *     content-addressed (release-store.ts's computeReleaseHash over
+ *     constituents only) — see run-smoke.ts's module doc for why holding
+ *     every constituent constant here caps the AgentReleasesTable
+ *     footprint at exactly one row forever.
+ *
+ * NAMESPACING (constraint: "everything must be obviously namespaced"):
+ * every string this file creates or looks up carries the
+ * `SMOKE-RELEASE-FIXTURE` marker and/or lives under SENTINEL_ORG, so a
+ * table scan or console browse trivially distinguishes fixture rows from
+ * real tenant data.
+ */
+
+import { randomUUID } from "crypto";
+import { appsyncRequest } from "./appsync-client";
+import { REQUIRED_ENV, readRequiredEnv, cognitoAuth } from "./env";
+
+// ---------------------------------------------------------------------------
+// Sentinel constants
+// ---------------------------------------------------------------------------
+
+/** Never used for any shipped/seed suite — this org exists ONLY for this
+ * fixture harness. Distinguishable at a glance in any table scan. */
+export const SENTINEL_ORG = "SMOKE-RELEASE-FIXTURE-ORG";
+
+/** The (fictitious) agent this fixture cuts a release for. */
+export const SENTINEL_AGENT_TARGET_ID = "smoke-release-fixture-agent";
+
+/** DeploymentEnvironment enum literal the pointer is promoted into.
+ * DEV only — this harness never touches STAGING/PROD pointers. */
+export const SENTINEL_ENVIRONMENT = "DEV" as const;
+
+export const SENTINEL_PROJECT_NAME = "SMOKE-RELEASE-FIXTURE-PROJECT";
+export const SENTINEL_SUITE_NAME = "SMOKE-RELEASE-FIXTURE-SUITE";
+export const SENTINEL_CASE_NAME = "SMOKE-RELEASE-FIXTURE-CASE";
+export const SENTINEL_SEMVER = "0.0.1-smoke";
+
+/** Fixed idempotencyKey feeding deriveEvalRunId's hash — see module doc:
+ * this is what lets the seeded EvalRun's id stay stable across reruns. */
+export const SENTINEL_EVAL_IDEMPOTENCY_KEY =
+  "SMOKE-RELEASE-FIXTURE-EVAL-IDEMPOTENCY-KEY";
+
+/** Mirrors eval-run-resolver.ts's EVAL_RUN_NAMESPACE constant exactly —
+ * deriveEvalRunId must be reproduced bit-for-bit here so the seeded run's
+ * id is stable and matches the shape a real startEvalRun call would have
+ * produced for the same suite/version/agentTargetVersion/idempotencyKey. */
+const EVAL_RUN_NAMESPACE = "1b7e3b2a-6b7b-4b9a-9c9b-4b7b2a6b7b3a";
+
+export const SENTINEL_AGENT_TARGET_VERSION = "v0.0.1-smoke";
+
+/** Fixed provenance stamped on every constituent this harness snapshots
+ * into the release — see run-smoke.ts. Constant content is what keeps
+ * the eventual release content-addressed to a single row. */
+export const SENTINEL_GIT_SHA = "0000000000000000000000000000000000smoke";
+export const SENTINEL_REGION = "us-east-1";
+export const SENTINEL_RUN_ID = "SMOKE-RELEASE-FIXTURE-RUN-ID";
+
+// ---------------------------------------------------------------------------
+// uuidv5 (RFC 4122) — reproduced locally, zero new dependency, to mirror
+// deriveEvalRunId exactly without importing backend/src/lambda internals
+// (which are esbuild-bundled for Lambda and not meant to be imported by
+// a standalone script).
+// ---------------------------------------------------------------------------
+
+function uuidv5(name: string, namespace: string): string {
+  const ns = namespace
+    .replace(/-/g, "")
+    .match(/.{2}/g)!
+    .map((h) => parseInt(h, 16));
+  const nameBytes = Buffer.from(name, "utf8");
+  const data = Buffer.concat([Buffer.from(ns), nameBytes]);
+  const hash = require("crypto").createHash("sha1").update(data).digest();
+  hash[6] = (hash[6] & 0x0f) | 0x50; // version 5
+  hash[8] = (hash[8] & 0x3f) | 0x80; // variant
+  const hex = hash.subarray(0, 16).toString("hex");
+  return [
+    hex.slice(0, 8),
+    hex.slice(8, 12),
+    hex.slice(12, 16),
+    hex.slice(16, 20),
+    hex.slice(20, 32),
+  ].join("-");
+}
+
+export function deriveSentinelEvalRunId(
+  suiteId: string,
+  suiteVersion: number,
+): string {
+  return uuidv5(
+    `${suiteId}:${suiteVersion}:${SENTINEL_AGENT_TARGET_VERSION}:${SENTINEL_EVAL_IDEMPOTENCY_KEY}`,
+    EVAL_RUN_NAMESPACE,
+  );
+}
+
+// ---------------------------------------------------------------------------
+// GraphQL documents
+// ---------------------------------------------------------------------------
+
+const LIST_PROJECTS = /* GraphQL */ `
+  query ListProjects {
+    listProjects {
+      items {
+        id
+        name
+        owner
+      }
+    }
+  }
+`;
+
+const CREATE_PROJECT = /* GraphQL */ `
+  mutation CreateProject($input: CreateProjectInput!) {
+    createProject(input: $input) {
+      id
+      name
+      owner
+    }
+  }
+`;
+
+const CREATE_AGENT_CONFIG = /* GraphQL */ `
+  mutation CreateAgentConfig($input: CreateAgentConfigInput!) {
+    createAgentConfig(input: $input) {
+      agentId
+      orgId
+      state
+    }
+  }
+`;
+
+const LIST_EXEC_SPECS = /* GraphQL */ `
+  query ListExecutionSpecifications($projectId: ID!) {
+    listExecutionSpecifications(projectId: $projectId) {
+      specId
+      status
+      version
+      structuredPayload
+    }
+  }
+`;
+
+const CREATE_EXEC_SPEC = /* GraphQL */ `
+  mutation CreateExecSpec($input: ExecutionSpecificationInput!) {
+    createExecutionSpecification(input: $input) {
+      specId
+      status
+      version
+    }
+  }
+`;
+
+const APPROVE_EXEC_SPEC = /* GraphQL */ `
+  mutation ApproveExecSpec($specId: ID!) {
+    approveExecutionSpecification(specId: $specId) {
+      specId
+      status
+      version
+    }
+  }
+`;
+
+const LIST_EVAL_SUITES = /* GraphQL */ `
+  query ListEvalSuites($orgId: ID!, $agentTargetId: ID) {
+    listEvalSuites(orgId: $orgId, agentTargetId: $agentTargetId) {
+      suiteId
+      name
+      status
+      version
+      references
+    }
+  }
+`;
+
+const CREATE_EVAL_SUITE = /* GraphQL */ `
+  mutation CreateEvalSuite($input: EvalSuiteInput!) {
+    createEvalSuite(input: $input) {
+      suiteId
+      status
+      version
+    }
+  }
+`;
+
+const LIST_EVAL_CASES = /* GraphQL */ `
+  query ListEvalCases($suiteId: ID!) {
+    listEvalCases(suiteId: $suiteId) {
+      caseId
+      name
+    }
+  }
+`;
+
+const ADD_EVAL_CASE = /* GraphQL */ `
+  mutation AddEvalCase($suiteId: ID!, $input: EvalCaseInput!) {
+    addEvalCase(suiteId: $suiteId, input: $input) {
+      caseId
+      name
+    }
+  }
+`;
+
+const FREEZE_EVAL_SUITE = /* GraphQL */ `
+  mutation FreezeEvalSuite($suiteId: ID!) {
+    freezeEvalSuite(suiteId: $suiteId) {
+      suiteId
+      status
+      version
+      references
+    }
+  }
+`;
+
+const GET_EVAL_RUN = /* GraphQL */ `
+  query GetEvalRun($evalRunId: ID!) {
+    getEvalRun(evalRunId: $evalRunId) {
+      evalRunId
+      status
+      suiteId
+      suiteVersion
+      orgId
+    }
+  }
+`;
+
+// ---------------------------------------------------------------------------
+// Arrange result shape
+// ---------------------------------------------------------------------------
+
+export interface ArrangeResult {
+  callerOrgId: string;
+  projectId: string;
+  registryRecordId: string;
+  execSpecId: string;
+  execSpecVersion: number;
+  evalSuiteId: string;
+  evalSuiteVersion: number;
+  evalRunId: string;
+}
+
+// ---------------------------------------------------------------------------
+// Direct-DynamoDB seed for the ONE row that AppSync cannot produce:
+// a COMPLETED EvalRun. This is the sole write in this file that bypasses
+// AppSync; it targets EvalRunsTable only, never AgentReleasesTable or
+// EnvironmentReleasePointersTable (the two choke-point-guarded tables),
+// so it does not touch — let alone weaken — either write boundary.
+// ---------------------------------------------------------------------------
+
+async function seedCompletedEvalRunIfAbsent(
+  evalRunId: string,
+  orgId: string,
+  suiteId: string,
+  suiteVersion: number,
+): Promise<void> {
+  const {
+    DynamoDBClient,
+  } = require("@aws-sdk/client-dynamodb") as typeof import("@aws-sdk/client-dynamodb");
+  const {
+    DynamoDBDocumentClient,
+    PutCommand,
+  } = require("@aws-sdk/lib-dynamodb") as typeof import("@aws-sdk/lib-dynamodb");
+
+  const tableName = readRequiredEnv("EVAL_RUNS_TABLE");
+  const doc = DynamoDBDocumentClient.from(
+    new DynamoDBClient({ region: readRequiredEnv("AWS_REGION") }),
+  );
+
+  const now = new Date().toISOString();
+  const run = {
+    evalRunId,
+    orgId,
+    suiteId,
+    suiteVersion,
+    agentTargetId: SENTINEL_AGENT_TARGET_ID,
+    agentTargetVersion: SENTINEL_AGENT_TARGET_VERSION,
+    status: "COMPLETED",
+    caseCount: 1,
+    pendingCases: 0,
+    startedAt: now,
+    startedBy: "smoke-release-fixture",
+    completedAt: now,
+    idempotencyKey: SENTINEL_EVAL_IDEMPOTENCY_KEY,
+  };
+
+  try {
+    await doc.send(
+      new PutCommand({
+        TableName: tableName,
+        Item: run,
+        // create-if-absent — reruns converge on the same row rather than
+        // clobbering completedAt/startedAt on every invocation.
+        ConditionExpression: "attribute_not_exists(evalRunId)",
+      }),
+    );
+  } catch (err: unknown) {
+    const isConditionalCheckFailed =
+      !!err &&
+      typeof err === "object" &&
+      (err as { name?: string }).name === "ConditionalCheckFailedException";
+    if (!isConditionalCheckFailed) {
+      throw err;
+    }
+    // Already seeded by a previous run — idempotent no-op.
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Arrange
+// ---------------------------------------------------------------------------
+
+/**
+ * Idempotently creates every prerequisite row cutAgentRelease /
+ * promoteEnvironmentReleasePointer read, then asserts (via GetItem-through-
+ * the-API reads, never a raw table read) that each predicate the resolvers
+ * actually check holds. Never cuts a release — that is run-smoke.ts's job.
+ */
+export async function arrange(): Promise<ArrangeResult> {
+  const token = await cognitoAuth();
+  const callerOrgId = SENTINEL_ORG;
+
+  // ---- Project (owner = fixture user; owner's Cognito profile carries
+  // custom:organization = SENTINEL_ORG, so resolveExecSpecOrgId's
+  // Project.owner -> lookupUserOrganization path resolves correctly) ----
+  const existingProjects = await appsyncRequest<{
+    listProjects: { items: { id: string; name: string; owner: string }[] };
+  }>(token, LIST_PROJECTS);
+  let projectId = existingProjects.listProjects.items.find(
+    (p) => p.name === SENTINEL_PROJECT_NAME,
+  )?.id;
+  if (!projectId) {
+    const created = await appsyncRequest<{
+      createProject: { id: string };
+    }>(token, CREATE_PROJECT, {
+      input: {
+        name: SENTINEL_PROJECT_NAME,
+        description:
+          "Throwaway project owned by the release-path smoke fixture harness. Never used by any shipped seed data.",
+      },
+    });
+    projectId = created.createProject.id;
+  }
+
+  // ---- APPROVED agent registry record ----
+  // createAgentConfig -> createAgentConfigRegistry derives orgId from the
+  // caller's own org claim (never trusts client input), and passing
+  // state: active drives RegistryService.updateResourceStatus straight to
+  // APPROVED (toRegistryStatus("active") === APPROVED) with no
+  // currentStatus supplied, so no lifecycle-transition gate blocks the
+  // DRAFT -> APPROVED jump on first create. Re-running targets the SAME
+  // agentId, so createResource's registry-side upsert-by-id keeps this a
+  // single record.
+  const registryRecordId = SENTINEL_AGENT_TARGET_ID;
+  await appsyncRequest(token, CREATE_AGENT_CONFIG, {
+    input: {
+      agentId: registryRecordId,
+      config: JSON.stringify({
+        name: registryRecordId,
+        marker: "SMOKE-RELEASE-FIXTURE-AGENT-CONFIG",
+      }),
+      state: "active",
+      categories: ["smoke-release-fixture"],
+    },
+  });
+
+  // ---- APPROVED ExecutionSpecification ----
+  const existingSpecs = await appsyncRequest<{
+    listExecutionSpecifications: {
+      specId: string;
+      status: string;
+      version: number;
+      structuredPayload: string;
+    }[];
+  }>(token, LIST_EXEC_SPECS, { projectId });
+  let execSpec = existingSpecs.listExecutionSpecifications.find((s) =>
+    s.structuredPayload.includes("SMOKE-RELEASE-FIXTURE-EXEC-SPEC"),
+  );
+  if (!execSpec) {
+    const bucketName = readRequiredEnv(
+      "SMOKE_GOVERNANCE_TRANSCRIPTS_BUCKET_NAME",
+    );
+    const created = await appsyncRequest<{
+      createExecutionSpecification: {
+        specId: string;
+        status: string;
+        version: number;
+      };
+    }>(token, CREATE_EXEC_SPEC, {
+      input: {
+        projectId,
+        sourceAdrIds: ["SMOKE-RELEASE-FIXTURE-ADR"],
+        structuredPayload: JSON.stringify({
+          marker: "SMOKE-RELEASE-FIXTURE-EXEC-SPEC",
+        }),
+        narrativeS3Uri: `s3://${bucketName}/projects/${projectId}/smoke-release-fixture-narrative.md`,
+      },
+    });
+    execSpec = { ...created.createExecutionSpecification, structuredPayload: "" };
+  }
+  if (execSpec.status !== "APPROVED") {
+    const approved = await appsyncRequest<{
+      approveExecutionSpecification: { specId: string; status: string; version: number };
+    }>(token, APPROVE_EXEC_SPEC, { specId: execSpec.specId });
+    execSpec = { ...execSpec, ...approved.approveExecutionSpecification };
+  }
+
+  // ---- Throwaway EvalSuite (FROZEN) + one EvalCase ----
+  // C1: this suite is authored under SENTINEL_ORG with a name that only
+  // this harness ever uses. The freeze below appends to THIS suite's
+  // references[] and no other — no shipped seed suite is ever touched.
+  const existingSuites = await appsyncRequest<{
+    listEvalSuites: {
+      suiteId: string;
+      name: string;
+      status: string;
+      version: number;
+      references: string[];
+    }[];
+  }>(token, LIST_EVAL_SUITES, {
+    orgId: callerOrgId,
+    agentTargetId: SENTINEL_AGENT_TARGET_ID,
+  });
+  let suite = existingSuites.listEvalSuites.find(
+    (s) => s.name === SENTINEL_SUITE_NAME,
+  );
+  if (!suite) {
+    const created = await appsyncRequest<{
+      createEvalSuite: { suiteId: string; status: string; version: number };
+    }>(token, CREATE_EVAL_SUITE, {
+      input: {
+        orgId: callerOrgId,
+        agentTargetId: SENTINEL_AGENT_TARGET_ID,
+        name: SENTINEL_SUITE_NAME,
+        description:
+          "Throwaway eval suite owned by the release-path smoke fixture harness. Never a shipped/seed suite — safe to freeze permanently.",
+        semver: SENTINEL_SEMVER,
+      },
+    });
+    suite = { ...created.createEvalSuite, name: SENTINEL_SUITE_NAME, references: [] };
+  }
+
+  const existingCases = await appsyncRequest<{
+    listEvalCases: { caseId: string; name: string }[];
+  }>(token, LIST_EVAL_CASES, { suiteId: suite.suiteId });
+  if (!existingCases.listEvalCases.some((c) => c.name === SENTINEL_CASE_NAME)) {
+    await appsyncRequest(token, ADD_EVAL_CASE, {
+      suiteId: suite.suiteId,
+      input: {
+        name: SENTINEL_CASE_NAME,
+        description: "Throwaway case for the release-path smoke fixture.",
+        kind: "CONVERSATION",
+        input: { prompt: "smoke-release-fixture-prompt" },
+        expectedOutcome: {
+          mode: "CONTAINS",
+          target: JSON.stringify("smoke"),
+        },
+      },
+    });
+  }
+
+  if (suite.status !== "FROZEN") {
+    const frozen = await appsyncRequest<{
+      freezeEvalSuite: {
+        suiteId: string;
+        status: string;
+        version: number;
+        references: string[];
+      };
+    }>(token, FREEZE_EVAL_SUITE, { suiteId: suite.suiteId });
+    suite = { ...suite, ...frozen.freezeEvalSuite };
+  }
+
+  // ---- COMPLETED EvalRun (suiteVersion pinned to the FROZEN suite's
+  // current version) — the one direct-DynamoDB seed, see module doc. ----
+  const evalRunId = deriveSentinelEvalRunId(suite.suiteId, suite.version);
+  await seedCompletedEvalRunIfAbsent(
+    evalRunId,
+    callerOrgId,
+    suite.suiteId,
+    suite.version,
+  );
+
+  return {
+    callerOrgId,
+    projectId,
+    registryRecordId,
+    execSpecId: execSpec.specId,
+    execSpecVersion: execSpec.version,
+    evalSuiteId: suite.suiteId,
+    evalSuiteVersion: suite.version,
+    evalRunId,
+  };
+}
+
+/**
+ * Post-arrange assertions — reads every row back THROUGH THE API (never
+ * the raw table) and checks the exact predicates release-resolver.ts /
+ * environment-release-pointer-resolver.ts will themselves check at cut
+ * time, so a broken arrange fails loudly here instead of surfacing as a
+ * confusing rejection from run-smoke.ts.
+ */
+export async function assertArrangeInvariants(
+  result: ArrangeResult,
+): Promise<void> {
+  const token = await cognitoAuth();
+
+  const runCheck = await appsyncRequest<{
+    getEvalRun: {
+      evalRunId: string;
+      status: string;
+      suiteId: string;
+      suiteVersion: number;
+      orgId: string;
+    } | null;
+  }>(token, GET_EVAL_RUN, { evalRunId: result.evalRunId });
+  const run = runCheck.getEvalRun;
+  if (!run) {
+    throw new Error(
+      `arrange invariant failed: eval run ${result.evalRunId} not found after seeding`,
+    );
+  }
+  if (run.status !== "COMPLETED") {
+    throw new Error(
+      `arrange invariant failed: eval run ${result.evalRunId} status is ${run.status}, expected COMPLETED`,
+    );
+  }
+  if (run.suiteVersion !== result.evalSuiteVersion) {
+    throw new Error(
+      `arrange invariant failed: eval run suiteVersion (${run.suiteVersion}) does not match frozen suite version (${result.evalSuiteVersion})`,
+    );
+  }
+  if (run.orgId !== result.callerOrgId) {
+    throw new Error(
+      `arrange invariant failed: eval run orgId (${run.orgId}) does not match caller org (${result.callerOrgId})`,
+    );
+  }
+
+  const suitesCheck = await appsyncRequest<{
+    listEvalSuites: { suiteId: string; status: string; version: number }[];
+  }>(token, LIST_EVAL_SUITES, {
+    orgId: result.callerOrgId,
+    agentTargetId: SENTINEL_AGENT_TARGET_ID,
+  });
+  const suite = suitesCheck.listEvalSuites.find(
+    (s) => s.suiteId === result.evalSuiteId,
+  );
+  if (!suite || suite.status !== "FROZEN") {
+    throw new Error(
+      `arrange invariant failed: eval suite ${result.evalSuiteId} is not FROZEN`,
+    );
+  }
+
+  console.log(
+    "[fixtures] arrange invariants verified: suite FROZEN, run COMPLETED, suiteVersion match, org match.",
+  );
+}
+
+export { REQUIRED_ENV };

--- a/scripts/smoke/release-path/package-lock.json
+++ b/scripts/smoke/release-path/package-lock.json
@@ -1,0 +1,719 @@
+{
+  "name": "release-path-smoke-fixture",
+  "version": "0.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "release-path-smoke-fixture",
+      "version": "0.0.0",
+      "dependencies": {
+        "@aws-sdk/client-cognito-identity-provider": "3.1106.0",
+        "@aws-sdk/client-dynamodb": "3.1106.0",
+        "@aws-sdk/lib-dynamodb": "3.1106.0"
+      },
+      "devDependencies": {
+        "@types/node": "20.19.43",
+        "ts-node": "10.9.2",
+        "typescript": "5.9.3"
+      }
+    },
+    "node_modules/@aws-sdk/client-cognito-identity-provider": {
+      "version": "3.1106.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-cognito-identity-provider/-/client-cognito-identity-provider-3.1106.0.tgz",
+      "integrity": "sha512-fR2190SaXnntDkF0gUTSG05Z7DyHQ00Z7HlJip+uR4DkD/9LjbBn5EXLFWEPYQpIC8o2v1UTqjK38HYRQoT7PA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.977.6",
+        "@aws-sdk/credential-provider-node": "^3.972.78",
+        "@aws-sdk/types": "^3.974.2",
+        "@smithy/core": "^3.31.1",
+        "@smithy/fetch-http-handler": "^5.6.13",
+        "@smithy/node-http-handler": "^4.9.13",
+        "@smithy/types": "^4.16.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-dynamodb": {
+      "version": "3.1106.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-dynamodb/-/client-dynamodb-3.1106.0.tgz",
+      "integrity": "sha512-VhYpGatp+5ke7HBc/8CqbukInNmsFT67W4d/QceP8/YIxpKfP0SRCSHlgRU85WTC5JcS88FWX3OxGYR63rEUdA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.977.6",
+        "@aws-sdk/credential-provider-node": "^3.972.78",
+        "@aws-sdk/dynamodb-codec": "^3.973.41",
+        "@aws-sdk/middleware-endpoint-discovery": "^3.972.27",
+        "@aws-sdk/types": "^3.974.2",
+        "@smithy/core": "^3.31.1",
+        "@smithy/fetch-http-handler": "^5.6.13",
+        "@smithy/node-http-handler": "^4.9.13",
+        "@smithy/types": "^4.16.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/core": {
+      "version": "3.977.6",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.977.6.tgz",
+      "integrity": "sha512-QiaJV4/zDrB4ZY2mfeSXSzSTc36W16sZXcGz+SPFk0CJ26gziO0cS+4LjJUMAbdeeBOvS0k0Aq1cZpfGdUXxSw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "^3.974.2",
+        "@aws-sdk/xml-builder": "^3.972.37",
+        "@aws/lambda-invoke-store": "^0.3.0",
+        "@smithy/core": "^3.31.1",
+        "@smithy/signature-v4": "^5.6.12",
+        "@smithy/types": "^4.16.1",
+        "bowser": "^2.11.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-env": {
+      "version": "3.972.67",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.972.67.tgz",
+      "integrity": "sha512-rcIpk5kxUqDaaNa6Xk23pQ6ViY7jlqzmfFWCahQcBT97ddXaXYYwzCen9Tz1Jvo6aJft6wDl5bN44/Jw5B4oLA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.977.6",
+        "@aws-sdk/types": "^3.974.2",
+        "@smithy/core": "^3.31.1",
+        "@smithy/types": "^4.16.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-http": {
+      "version": "3.972.69",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-http/-/credential-provider-http-3.972.69.tgz",
+      "integrity": "sha512-nggwJtZ4eeNsUw5IeWBMXsi1ryct5idi0K+/SCRF3kybLubOMaNTb3XCihXpWMiVpyzyPeIrl0zTkzhBH9porA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.977.6",
+        "@aws-sdk/types": "^3.974.2",
+        "@smithy/core": "^3.31.1",
+        "@smithy/fetch-http-handler": "^5.6.13",
+        "@smithy/node-http-handler": "^4.9.13",
+        "@smithy/types": "^4.16.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-ini": {
+      "version": "3.973.12",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.973.12.tgz",
+      "integrity": "sha512-pNEf/OeyN5X3VmLKlgSO6TqaWmW10CvI3TfwL1XhsuhYjSLT2VDaxFnCPHnOeQXSaFisMX4jNhpETriqN8DOmg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.977.6",
+        "@aws-sdk/credential-provider-env": "^3.972.67",
+        "@aws-sdk/credential-provider-http": "^3.972.69",
+        "@aws-sdk/credential-provider-login": "^3.972.74",
+        "@aws-sdk/credential-provider-process": "^3.972.67",
+        "@aws-sdk/credential-provider-sso": "^3.973.11",
+        "@aws-sdk/credential-provider-web-identity": "^3.972.73",
+        "@aws-sdk/nested-clients": "^3.997.41",
+        "@aws-sdk/types": "^3.974.2",
+        "@smithy/core": "^3.31.1",
+        "@smithy/credential-provider-imds": "^4.4.16",
+        "@smithy/types": "^4.16.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-login": {
+      "version": "3.972.74",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-login/-/credential-provider-login-3.972.74.tgz",
+      "integrity": "sha512-0AQfDcf99TNmqVKv0owHrw/TQs6i4ZE5t9qmz6NvO53bE/sA/tpXhXL9AAcEP1qHc6Zzjd1UMb69+/9zdhvY3g==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.977.6",
+        "@aws-sdk/nested-clients": "^3.997.41",
+        "@aws-sdk/types": "^3.974.2",
+        "@smithy/core": "^3.31.1",
+        "@smithy/types": "^4.16.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-node": {
+      "version": "3.972.78",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.972.78.tgz",
+      "integrity": "sha512-OgPAnfvbGAMWac6yvxJ1ihslrvDpPVwR68D2csospdNCCyPvHk9JLzYKwz48SNiS1T2znDwHauywRKRFfpyYng==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/credential-provider-env": "^3.972.67",
+        "@aws-sdk/credential-provider-http": "^3.972.69",
+        "@aws-sdk/credential-provider-ini": "^3.973.12",
+        "@aws-sdk/credential-provider-process": "^3.972.67",
+        "@aws-sdk/credential-provider-sso": "^3.973.11",
+        "@aws-sdk/credential-provider-web-identity": "^3.972.73",
+        "@aws-sdk/types": "^3.974.2",
+        "@smithy/core": "^3.31.1",
+        "@smithy/credential-provider-imds": "^4.4.16",
+        "@smithy/types": "^4.16.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-process": {
+      "version": "3.972.67",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.972.67.tgz",
+      "integrity": "sha512-IlUEejorGTWKb4/Dm7K5Yw4QxUmXLThLhrvBmzVBqZFTbW72cv9LTcITmo1dsnYriALE4h68mOq4LB99x6sQ7Q==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.977.6",
+        "@aws-sdk/types": "^3.974.2",
+        "@smithy/core": "^3.31.1",
+        "@smithy/types": "^4.16.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-sso": {
+      "version": "3.973.11",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.973.11.tgz",
+      "integrity": "sha512-gAQBkBZxUB84d71+pPcI9L+jh2ujhuAVxc/4FgGiWFDjkPBlMKxzd5XDtkSXTFX8Ro7ansnT88+XadasxMeCRw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.977.6",
+        "@aws-sdk/nested-clients": "^3.997.41",
+        "@aws-sdk/token-providers": "3.1103.0",
+        "@aws-sdk/types": "^3.974.2",
+        "@smithy/core": "^3.31.1",
+        "@smithy/types": "^4.16.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-web-identity": {
+      "version": "3.972.73",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.972.73.tgz",
+      "integrity": "sha512-SnlEmQa6SjOgs6iOPLUQl1Eyq4AKiAdPQlkOhFhqNfDtDCwibMGvL6QlkSmf3o6vAUSImzdPCxowT5dfQUZP1A==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.977.6",
+        "@aws-sdk/nested-clients": "^3.997.41",
+        "@aws-sdk/types": "^3.974.2",
+        "@smithy/core": "^3.31.1",
+        "@smithy/types": "^4.16.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/dynamodb-codec": {
+      "version": "3.973.41",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/dynamodb-codec/-/dynamodb-codec-3.973.41.tgz",
+      "integrity": "sha512-N4go/LzYFd6KJ+r7qqAjzmsw85PFN99RnDYZvw22FzU3VZgL5+umvncfu0M7hlzeIUKHSLL65HTJIXiLY7RJFg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.977.6",
+        "@smithy/core": "^3.31.1",
+        "@smithy/types": "^4.16.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/endpoint-cache": {
+      "version": "3.972.9",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/endpoint-cache/-/endpoint-cache-3.972.9.tgz",
+      "integrity": "sha512-LFvdgq8SriaskUcjpBMDE7J2c9RmuT5v3gU36/znV71EU5DKUis4FmGFjCMelKCCViFeVrQADBAlIiOYRhEx6Q==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "mnemonist": "0.38.3",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/lib-dynamodb": {
+      "version": "3.1106.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/lib-dynamodb/-/lib-dynamodb-3.1106.0.tgz",
+      "integrity": "sha512-izyYFfzmWy5mpSxhhhy6Cbm4qukMP/9rvgsvyEWd+s5qh9o6MXuNkh9s5Qn7G6lLQiIefVENfESLcRdBIVd4fA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.977.6",
+        "@aws-sdk/util-dynamodb": "^3.996.7",
+        "@smithy/core": "^3.31.1",
+        "@smithy/types": "^4.16.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      },
+      "peerDependencies": {
+        "@aws-sdk/client-dynamodb": "^3.1106.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-endpoint-discovery": {
+      "version": "3.972.27",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-endpoint-discovery/-/middleware-endpoint-discovery-3.972.27.tgz",
+      "integrity": "sha512-5AJlxrsg27IGGiQauWOdVyqK55EN0EMIwXndkVHhBiPT4CtdSaz89/sAENSw+GP4KF+BOWcgycZFNjkOLmfo1A==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/endpoint-cache": "^3.972.9",
+        "@aws-sdk/types": "^3.974.2",
+        "@smithy/core": "^3.31.1",
+        "@smithy/types": "^4.16.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/nested-clients": {
+      "version": "3.997.41",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/nested-clients/-/nested-clients-3.997.41.tgz",
+      "integrity": "sha512-RDHqPGQWlF6tatA/Tp3rg6oIwtgN9IVderxE+9av2Y93Dfyu+mO1hZ5Bu2jpfZg2rwdNbsssnwM+sLafIczMlQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.977.6",
+        "@aws-sdk/signature-v4-multi-region": "^3.996.43",
+        "@aws-sdk/types": "^3.974.2",
+        "@smithy/core": "^3.31.1",
+        "@smithy/fetch-http-handler": "^5.6.13",
+        "@smithy/node-http-handler": "^4.9.13",
+        "@smithy/types": "^4.16.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/signature-v4-multi-region": {
+      "version": "3.996.43",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4-multi-region/-/signature-v4-multi-region-3.996.43.tgz",
+      "integrity": "sha512-lKekx8bLBXSv4O+cslk9Zfnw2XKSkWBs3uWL5QGhH2ZAQfNS7FE0vcSSN2vD/AhxX54ZTywWxR4STThoeOXlBA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "^3.974.2",
+        "@smithy/signature-v4": "^5.6.12",
+        "@smithy/types": "^4.16.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/token-providers": {
+      "version": "3.1103.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.1103.0.tgz",
+      "integrity": "sha512-N4wy26MNn31ItGVHYHPrEuCIFY4MBBjC+C5v1lJKqIUSA7OZBdhleCY53zCCrXn27hsk7YNOaTuhQu807S4AfQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.977.6",
+        "@aws-sdk/nested-clients": "^3.997.41",
+        "@aws-sdk/types": "^3.974.2",
+        "@smithy/core": "^3.31.1",
+        "@smithy/types": "^4.16.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/types": {
+      "version": "3.974.2",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.974.2.tgz",
+      "integrity": "sha512-3W6IUtSxFbH6X7Wb7DzGCV5QiFQsd0g8bOfntpmDxQlzBoKWUMBu/JPQR0DwkE+Hpnxd6db1tXbOwdeHddG6cA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^4.16.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/util-dynamodb": {
+      "version": "3.996.7",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-dynamodb/-/util-dynamodb-3.996.7.tgz",
+      "integrity": "sha512-v+WJASG9yaW8qNM7pNSgH1PBYz5mVTf7gzKPi0NqGjLlaCtPdk6EjM1lmv03egA07iXUw6OToGYfW2w8D3kBrg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      },
+      "peerDependencies": {
+        "@aws-sdk/client-dynamodb": "^3.1088.0"
+      }
+    },
+    "node_modules/@aws-sdk/xml-builder": {
+      "version": "3.972.37",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/xml-builder/-/xml-builder-3.972.37.tgz",
+      "integrity": "sha512-zKq4HQum8JwDyEuyfuI4bbiAcU0KxP6qy+9PR/IsR92IyE/DaBAikzAS50tjxip4bqIIANpCcG+Yyj6CVhXupg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^4.16.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws/lambda-invoke-store": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/@aws/lambda-invoke-store/-/lambda-invoke-store-0.3.0.tgz",
+      "integrity": "sha512-sl4Bm6yiMNYrZKkqqDFWN0UfnWhlS8ivKxrYl+6t0gCLrqr8y3B2IqZZbFRkfaVVp7C/baApyh71P+LeE1A2sQ==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@cspotcode/source-map-support": {
+      "version": "0.8.1",
+      "resolved": "https://registry.npmjs.org/@cspotcode/source-map-support/-/source-map-support-0.8.1.tgz",
+      "integrity": "sha512-IchNf6dN4tHoMFIn/7OE8LWZ19Y6q/67Bmf6vnGREv8RSbBVb9LPJxEcnwrcwX6ixSvaiGoomAUvu4YSxXrVgw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/trace-mapping": "0.3.9"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@jridgewell/resolve-uri": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
+      "integrity": "sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@jridgewell/sourcemap-codec": {
+      "version": "1.5.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
+      "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@jridgewell/trace-mapping": {
+      "version": "0.3.9",
+      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.9.tgz",
+      "integrity": "sha512-3Belt6tdc8bPgAtbcmdtNJlirVoTmEb5e2gC94PnkwEW9jI6CAHUeoG85tjWP5WquqfavoMtMwiG4P926ZKKuQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/resolve-uri": "^3.0.3",
+        "@jridgewell/sourcemap-codec": "^1.4.10"
+      }
+    },
+    "node_modules/@smithy/core": {
+      "version": "3.31.1",
+      "resolved": "https://registry.npmjs.org/@smithy/core/-/core-3.31.1.tgz",
+      "integrity": "sha512-CyogUINxvi7C7LDsh8Syo6hVJOT9ckz4rG8dRZfTJ8r91HkMY59PnNooaj7WcHyxEkxPfBAmbgztZU+xTo76lg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^4.16.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/credential-provider-imds": {
+      "version": "4.4.16",
+      "resolved": "https://registry.npmjs.org/@smithy/credential-provider-imds/-/credential-provider-imds-4.4.16.tgz",
+      "integrity": "sha512-QfuLWAkLzptffFW980AFeHZFdqds2B64rpEd3uJ6lgs3xVn9QegGMUgUcj+4d7dRrAsya3r58ZKpku97WcFb4w==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/core": "^3.31.1",
+        "@smithy/types": "^4.16.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/fetch-http-handler": {
+      "version": "5.6.13",
+      "resolved": "https://registry.npmjs.org/@smithy/fetch-http-handler/-/fetch-http-handler-5.6.13.tgz",
+      "integrity": "sha512-4fW86pEUOMbrD5nkbyl/tTvPHHWJFbuB2odl6ps9lWfHoXf9HWh3Q/Smh59qH1g7+c/BSZghX6bbUk4gsiMs8A==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/core": "^3.31.1",
+        "@smithy/types": "^4.16.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/node-http-handler": {
+      "version": "4.9.13",
+      "resolved": "https://registry.npmjs.org/@smithy/node-http-handler/-/node-http-handler-4.9.13.tgz",
+      "integrity": "sha512-Nmd/Nl35zfYrd+a6OO2cDJb3GPh9bgTjIUhcM+JFfjpp8/osCgboDV5nCT1I01Pv6R13eSKDKLSoVa5ZB6Zsfw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/core": "^3.31.1",
+        "@smithy/types": "^4.16.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/signature-v4": {
+      "version": "5.6.12",
+      "resolved": "https://registry.npmjs.org/@smithy/signature-v4/-/signature-v4-5.6.12.tgz",
+      "integrity": "sha512-I6KLtq3H0qqSuV9vLglfi8puHqzygzWHOnI4z/Rdoo+q50vvo18vBRdPAvvEtcaKROz7Zn6qnPa14kRfPH6PcQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/core": "^3.31.1",
+        "@smithy/types": "^4.16.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/types": {
+      "version": "4.16.1",
+      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-4.16.1.tgz",
+      "integrity": "sha512-0JFs3V2y2M9tKW5na/qxe69Zv+uxLMO7QBbhxF/FHu/Gp2NFZAAL9tWl9PU02xxo07pb3G9FTyjNc6D5uZrJIg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@tsconfig/node10": {
+      "version": "1.0.12",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node10/-/node10-1.0.12.tgz",
+      "integrity": "sha512-UCYBaeFvM11aU2y3YPZ//O5Rhj+xKyzy7mvcIoAjASbigy8mHMryP5cK7dgjlz2hWxh1g5pLw084E0a/wlUSFQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@tsconfig/node12": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node12/-/node12-1.0.11.tgz",
+      "integrity": "sha512-cqefuRsh12pWyGsIoBKJA9luFu3mRxCA+ORZvA4ktLSzIuCUtWVxGIuXigEwO5/ywWFMZ2QEGKWvkZG1zDMTag==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@tsconfig/node14": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node14/-/node14-1.0.3.tgz",
+      "integrity": "sha512-ysT8mhdixWK6Hw3i1V2AeRqZ5WfXg1G43mqoYlM2nc6388Fq5jcXyr5mRsqViLx/GJYdoL0bfXD8nmF+Zn/Iow==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@tsconfig/node16": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node16/-/node16-1.0.4.tgz",
+      "integrity": "sha512-vxhUy4J8lyeyinH7Azl1pdd43GJhZH/tP2weN8TntQblOY+A0XbT8DJk1/oCPuOOyg/Ja757rG0CgHcWC8OfMA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/node": {
+      "version": "20.19.43",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.19.43.tgz",
+      "integrity": "sha512-6oYBAi5ikg4Pl+kGsoYtawUMBT2zZMCvPNF7pVLnHZfd1zf38DRiWn/gT01RYCdUqkv7Fhr+C9ot4/tb+2sVvA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~6.21.0"
+      }
+    },
+    "node_modules/acorn": {
+      "version": "8.18.0",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.18.0.tgz",
+      "integrity": "sha512-lGq+9yr1/GuAWaVYIHRjvvySG5/4VfKIvC8EWxStPdcDh/Ka7FG3twP6v4d5BkravUilhIAsG4Qj83t02LWUPQ==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "acorn": "bin/acorn"
+      },
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/acorn-walk": {
+      "version": "8.3.5",
+      "resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-8.3.5.tgz",
+      "integrity": "sha512-HEHNfbars9v4pgpW6SO1KSPkfoS0xVOM/9UzkJltjlsHZmJasxg8aXkuZa7SMf8vKGIBhpUsPluQSqhJFCqebw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "acorn": "^8.11.0"
+      },
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/arg": {
+      "version": "4.1.3",
+      "resolved": "https://registry.npmjs.org/arg/-/arg-4.1.3.tgz",
+      "integrity": "sha512-58S9QDqG0Xx27YwPSt9fJxivjYl432YCwfDMfZ+71RAqUrZef7LrKQZ3LHLOwCS4FLNBplP533Zx895SeOCHvA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/bowser": {
+      "version": "2.14.1",
+      "resolved": "https://registry.npmjs.org/bowser/-/bowser-2.14.1.tgz",
+      "integrity": "sha512-tzPjzCxygAKWFOJP011oxFHs57HzIhOEracIgAePE4pqB3LikALKnSzUyU4MGs9/iCEUuHlAJTjTc5M+u7YEGg==",
+      "license": "MIT"
+    },
+    "node_modules/create-require": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/create-require/-/create-require-1.1.1.tgz",
+      "integrity": "sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/diff": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/diff/-/diff-4.0.4.tgz",
+      "integrity": "sha512-X07nttJQkwkfKfvTPG/KSnE2OMdcUCao6+eXF3wmnIQRn2aPAHH3VxDbDOdegkd6JbPsXqShpvEOHfAT+nCNwQ==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.3.1"
+      }
+    },
+    "node_modules/make-error": {
+      "version": "1.3.6",
+      "resolved": "https://registry.npmjs.org/make-error/-/make-error-1.3.6.tgz",
+      "integrity": "sha512-s8UhlNe7vPKomQhC1qFelMokr/Sc3AgNbso3n74mVPA5LTZwkB9NlXf4XPamLxJE8h0gh73rM94xvwRT2CVInw==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/mnemonist": {
+      "version": "0.38.3",
+      "resolved": "https://registry.npmjs.org/mnemonist/-/mnemonist-0.38.3.tgz",
+      "integrity": "sha512-2K9QYubXx/NAjv4VLq1d1Ly8pWNC5L3BrixtdkyTegXWJIqY+zLNDhhX/A+ZwWt70tB1S8H4BE8FLYEFyNoOBw==",
+      "license": "MIT",
+      "dependencies": {
+        "obliterator": "^1.6.1"
+      }
+    },
+    "node_modules/obliterator": {
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/obliterator/-/obliterator-1.6.1.tgz",
+      "integrity": "sha512-9WXswnqINnnhOG/5SLimUlzuU1hFJUc8zkwyD59Sd+dPOMf05PmnYG/d6Q7HZ+KmgkZJa1PxRso6QdM3sTNHig==",
+      "license": "MIT"
+    },
+    "node_modules/ts-node": {
+      "version": "10.9.2",
+      "resolved": "https://registry.npmjs.org/ts-node/-/ts-node-10.9.2.tgz",
+      "integrity": "sha512-f0FFpIdcHgn8zcPSbf1dRevwt047YMnaiJM3u2w2RewrB+fob/zePZcrOyQoLMMO7aBIddLcQIEK5dYjkLnGrQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@cspotcode/source-map-support": "^0.8.0",
+        "@tsconfig/node10": "^1.0.7",
+        "@tsconfig/node12": "^1.0.7",
+        "@tsconfig/node14": "^1.0.0",
+        "@tsconfig/node16": "^1.0.2",
+        "acorn": "^8.4.1",
+        "acorn-walk": "^8.1.1",
+        "arg": "^4.1.0",
+        "create-require": "^1.1.0",
+        "diff": "^4.0.1",
+        "make-error": "^1.1.1",
+        "v8-compile-cache-lib": "^3.0.1",
+        "yn": "3.1.1"
+      },
+      "bin": {
+        "ts-node": "dist/bin.js",
+        "ts-node-cwd": "dist/bin-cwd.js",
+        "ts-node-esm": "dist/bin-esm.js",
+        "ts-node-script": "dist/bin-script.js",
+        "ts-node-transpile-only": "dist/bin-transpile.js",
+        "ts-script": "dist/bin-script-deprecated.js"
+      },
+      "peerDependencies": {
+        "@swc/core": ">=1.2.50",
+        "@swc/wasm": ">=1.2.50",
+        "@types/node": "*",
+        "typescript": ">=2.7"
+      },
+      "peerDependenciesMeta": {
+        "@swc/core": {
+          "optional": true
+        },
+        "@swc/wasm": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "license": "0BSD"
+    },
+    "node_modules/typescript": {
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/undici-types": {
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
+      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/v8-compile-cache-lib": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/v8-compile-cache-lib/-/v8-compile-cache-lib-3.0.1.tgz",
+      "integrity": "sha512-wa7YjyUGfNZngI/vtK0UHAN+lgDCxBPCylVXGp0zu59Fz5aiGtNXaq3DhIov063MorB+VfufLh3JlF2KdTK3xg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/yn": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/yn/-/yn-3.1.1.tgz",
+      "integrity": "sha512-Ux4ygGWsu2c7isFWe8Yu1YluJmqVhxqK2cLXNQA5AcC3QfbGNpM7fu0Y8b/z16pXLnFxZYvWhd3fhBY9DLmC6Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    }
+  }
+}

--- a/scripts/smoke/release-path/package.json
+++ b/scripts/smoke/release-path/package.json
@@ -1,0 +1,21 @@
+{
+  "name": "release-path-smoke-fixture",
+  "version": "0.0.0",
+  "private": true,
+  "description": "Self-contained, dev-only smoke harness proving cutAgentRelease -> promoteEnvironmentReleasePointer -> dispatch resolve_release end to end. Never run in CI against AWS; see RUNBOOK.md.",
+  "type": "commonjs",
+  "scripts": {
+    "typecheck": "tsc --noEmit",
+    "smoke": "ts-node run-smoke.ts"
+  },
+  "dependencies": {
+    "@aws-sdk/client-cognito-identity-provider": "3.1106.0",
+    "@aws-sdk/client-dynamodb": "3.1106.0",
+    "@aws-sdk/lib-dynamodb": "3.1106.0"
+  },
+  "devDependencies": {
+    "@types/node": "20.19.43",
+    "ts-node": "10.9.2",
+    "typescript": "5.9.3"
+  }
+}

--- a/scripts/smoke/release-path/run-smoke.ts
+++ b/scripts/smoke/release-path/run-smoke.ts
@@ -1,0 +1,319 @@
+/**
+ * run-smoke.ts — exercises the REAL cutAgentRelease then
+ * promoteEnvironmentReleasePointer mutations through AppSync, as the
+ * dedicated fixture Cognito user, and asserts every stage.
+ *
+ * Why through AppSync and not by calling cutAgentRelease()/
+ * promoteEnvironmentReleasePointer() as plain TS functions: the point of
+ * this slice is to prove identity -> org extraction (extractOrgFromEvent
+ * reading the real Cognito `custom:organization` claim) and the
+ * permission gate (hasPermission reading the real `custom:role` claim)
+ * work end-to-end, not just that the inner function's logic is correct
+ * in isolation (that is what release-resolver.test.ts already covers
+ * with mocked identities).
+ *
+ * IDEMPOTENCY (constraint: "re-running must converge, not accumulate"):
+ * cutAgentRelease's constituents (agentConfig content, promptVersions,
+ * modelConfigSnapshots, toolConfigs, policySnapshot, execSpecId/Version,
+ * evalEvidence) are ALL held constant across runs by construction —
+ * every value below is a literal SENTINEL_* constant or is read back from
+ * the arranged fixtures (registryRecordId, execSpecId, evalRunId), none
+ * of which vary run-to-run once arrange() has converged. Because
+ * releaseId = sha256(constituents) (release-store.ts's computeReleaseHash,
+ * excluding volatile fields like createdAt), every rerun of this script
+ * hashes to the IDENTICAL releaseId, so putRelease's
+ * attribute_not_exists(releaseId) conditional Put is a no-op on every run
+ * after the first — see the "exactly one release row" explanation in
+ * README.md. The pointer promotion is NOT content-addressed (it is
+ * explicitly the mutable cursor) — its `version` field increments by
+ * design on every successful promotion, which is the bounded, monitored
+ * growth this fixture's README documents (one row, monotonic version),
+ * not unbounded accumulation.
+ */
+
+import { appsyncRequest } from "./appsync-client";
+import { cognitoAuth, readRequiredEnv } from "./env";
+import {
+  arrange,
+  assertArrangeInvariants,
+  ArrangeResult,
+  SENTINEL_AGENT_TARGET_ID,
+  SENTINEL_ENVIRONMENT,
+  SENTINEL_GIT_SHA,
+  SENTINEL_REGION,
+  SENTINEL_RUN_ID,
+  SENTINEL_SEMVER,
+} from "./fixtures";
+
+const CUT_AGENT_RELEASE = /* GraphQL */ `
+  mutation CutAgentRelease($input: CutAgentReleaseInput!) {
+    cutAgentRelease(input: $input) {
+      releaseId
+      orgId
+      agentTargetId
+      execSpecId
+      execSpecVersion
+      evalEvidence
+    }
+  }
+`;
+
+const PROMOTE_POINTER = /* GraphQL */ `
+  mutation PromotePointer($input: SetEnvironmentReleasePointerInput!) {
+    promoteEnvironmentReleasePointer(input: $input) {
+      orgId
+      agentTargetId
+      environment
+      releaseId
+      previousReleaseId
+      version
+      promotedAt
+    }
+  }
+`;
+
+const GET_CURRENT_POINTER = /* GraphQL */ `
+  query GetCurrentPointer(
+    $agentTargetId: ID!
+    $environment: DeploymentEnvironment!
+  ) {
+    getCurrentEnvironmentReleasePointer(
+      agentTargetId: $agentTargetId
+      environment: $environment
+    ) {
+      releaseId
+      previousReleaseId
+      version
+    }
+  }
+`;
+
+interface CutAgentReleaseResult {
+  releaseId: string;
+  orgId: string;
+  agentTargetId: string;
+  execSpecId: string;
+  execSpecVersion: number;
+  evalEvidence: unknown;
+}
+
+interface PromotePointerResult {
+  orgId: string;
+  agentTargetId: string;
+  environment: string;
+  releaseId: string;
+  previousReleaseId: string | null;
+  version: number;
+  promotedAt: string;
+}
+
+/**
+ * Builds the CutAgentReleaseInput straight from the fixtures' arranged
+ * ids — every Class B "caller-supplied" snapshot field is a constant
+ * SENTINEL_* value so the release stays content-addressed to one row
+ * across reruns (see module doc).
+ */
+function buildCutInput(arranged: ArrangeResult) {
+  return {
+    // input.orgId is intentionally ignored by cutAgentRelease (it derives
+    // orgId from the caller's identity, never from this field) — supplied
+    // here only because the schema marks it required.
+    orgId: arranged.callerOrgId,
+    agentTargetId: SENTINEL_AGENT_TARGET_ID,
+    semver: SENTINEL_SEMVER,
+    registryRecordId: arranged.registryRecordId,
+    execSpecId: arranged.execSpecId,
+    evalRunId: arranged.evalRunId,
+    promptVersions: JSON.stringify({
+      supervisor: {
+        sourceId: "smoke-release-fixture-prompt",
+        content: "SMOKE-RELEASE-FIXTURE prompt content",
+        digest:
+          "0000000000000000000000000000000000000000000000000000000000smoke",
+      },
+    }),
+    modelConfigSnapshots: JSON.stringify([
+      {
+        slot: "supervisor",
+        content: "SMOKE-RELEASE-FIXTURE-MODEL",
+        digest:
+          "1111111111111111111111111111111111111111111111111111111111smoke",
+      },
+    ]),
+    toolConfigs: JSON.stringify([
+      {
+        sourceId: "smoke-release-fixture-tool",
+        content: "{}",
+        digest:
+          "2222222222222222222222222222222222222222222222222222222222smoke",
+      },
+    ]),
+    policySnapshot: JSON.stringify({
+      enforcementMode: "shadow",
+      ruleSetVersion: "smoke-release-fixture-v1",
+      authorityUnitGrantIds: [],
+    }),
+    gitSha: SENTINEL_GIT_SHA,
+    region: SENTINEL_REGION,
+    runId: SENTINEL_RUN_ID,
+  };
+}
+
+async function cutReleaseTwiceAndAssertIdempotent(
+  arranged: ArrangeResult,
+): Promise<string> {
+  const token = await cognitoAuth();
+  const input = buildCutInput(arranged);
+
+  const first = await appsyncRequest<{ cutAgentRelease: CutAgentReleaseResult }>(
+    token,
+    CUT_AGENT_RELEASE,
+    { input },
+  );
+  const firstReleaseId = first.cutAgentRelease.releaseId;
+
+  if (first.cutAgentRelease.orgId !== arranged.callerOrgId) {
+    throw new Error(
+      `cutAgentRelease invariant failed: release.orgId (${first.cutAgentRelease.orgId}) ` +
+        `!= caller org (${arranged.callerOrgId})`,
+    );
+  }
+
+  const second = await appsyncRequest<{ cutAgentRelease: CutAgentReleaseResult }>(
+    token,
+    CUT_AGENT_RELEASE,
+    { input },
+  );
+  if (second.cutAgentRelease.releaseId !== firstReleaseId) {
+    throw new Error(
+      `cutAgentRelease is not idempotent: first releaseId=${firstReleaseId}, ` +
+        `second releaseId=${second.cutAgentRelease.releaseId}. Constituents ` +
+        `must be identical across calls for content-addressing to collide.`,
+    );
+  }
+
+  console.log(
+    `[run-smoke] cutAgentRelease idempotent: releaseId=${firstReleaseId} stable across two calls.`,
+  );
+  return firstReleaseId;
+}
+
+async function promoteAndAssert(releaseId: string): Promise<void> {
+  const token = await cognitoAuth();
+
+  const before = await appsyncRequest<{
+    getCurrentEnvironmentReleasePointer: {
+      releaseId: string;
+      previousReleaseId: string | null;
+      version: number;
+    } | null;
+  }>(token, GET_CURRENT_POINTER, {
+    agentTargetId: SENTINEL_AGENT_TARGET_ID,
+    environment: SENTINEL_ENVIRONMENT,
+  });
+  const versionBefore = before.getCurrentEnvironmentReleasePointer?.version ?? 0;
+
+  const promoted = await appsyncRequest<{
+    promoteEnvironmentReleasePointer: PromotePointerResult;
+  }>(token, PROMOTE_POINTER, {
+    input: {
+      agentTargetId: SENTINEL_AGENT_TARGET_ID,
+      environment: SENTINEL_ENVIRONMENT,
+      releaseId,
+    },
+  });
+  const pointer = promoted.promoteEnvironmentReleasePointer;
+
+  if (pointer.releaseId !== releaseId) {
+    throw new Error(
+      `promoteEnvironmentReleasePointer invariant failed: pointer.releaseId ` +
+        `(${pointer.releaseId}) != cut releaseId (${releaseId})`,
+    );
+  }
+  if (pointer.version !== versionBefore + 1) {
+    throw new Error(
+      `promoteEnvironmentReleasePointer invariant failed: version did not ` +
+        `increment by exactly 1 (before=${versionBefore}, after=${pointer.version})`,
+    );
+  }
+  if (
+    before.getCurrentEnvironmentReleasePointer &&
+    pointer.previousReleaseId !== before.getCurrentEnvironmentReleasePointer.releaseId
+  ) {
+    throw new Error(
+      `promoteEnvironmentReleasePointer invariant failed: previousReleaseId ` +
+        `(${pointer.previousReleaseId}) does not match the pre-promotion ` +
+        `releaseId (${before.getCurrentEnvironmentReleasePointer.releaseId})`,
+    );
+  }
+
+  console.log(
+    `[run-smoke] promoteEnvironmentReleasePointer verified: releaseId=${pointer.releaseId}, ` +
+      `version ${versionBefore} -> ${pointer.version}, previousReleaseId=${pointer.previousReleaseId}.`,
+  );
+
+  // Re-running the promotion against the SAME already-current release is
+  // still a version-incrementing write (this table is deliberately
+  // mutable, unlike AgentReleasesTable) — assert it converges to a
+  // BOUNDED single row (one pointer per org/agent/environment), not that
+  // the version stays fixed. See README.md's "one release row forever,
+  // pointer row grows only its version" explanation.
+  const reproted = await appsyncRequest<{
+    promoteEnvironmentReleasePointer: PromotePointerResult;
+  }>(token, PROMOTE_POINTER, {
+    input: {
+      agentTargetId: SENTINEL_AGENT_TARGET_ID,
+      environment: SENTINEL_ENVIRONMENT,
+      releaseId,
+    },
+  });
+  if (reproted.promoteEnvironmentReleasePointer.releaseId !== releaseId) {
+    throw new Error(
+      "re-promotion invariant failed: releaseId changed on a repeat promotion " +
+        "to the same release",
+    );
+  }
+  if (
+    reproted.promoteEnvironmentReleasePointer.version !==
+    pointer.version + 1
+  ) {
+    throw new Error(
+      "re-promotion invariant failed: version did not increment by exactly 1 " +
+        "on the repeat promotion",
+    );
+  }
+  console.log(
+    `[run-smoke] repeat promotion converges: still exactly one pointer row ` +
+      `for (org, agentTargetId, environment), version now ` +
+      `${reproted.promoteEnvironmentReleasePointer.version}.`,
+  );
+}
+
+async function main(): Promise<void> {
+  console.log("[run-smoke] arranging prerequisites...");
+  const arranged = await arrange();
+  await assertArrangeInvariants(arranged);
+
+  console.log("[run-smoke] cutting release via AppSync cutAgentRelease...");
+  const releaseId = await cutReleaseTwiceAndAssertIdempotent(arranged);
+
+  console.log(
+    "[run-smoke] promoting environment release pointer via AppSync promoteEnvironmentReleasePointer...",
+  );
+  await promoteAndAssert(releaseId);
+
+  console.log(
+    `[run-smoke] DONE. releaseId=${releaseId} agentTargetId=${SENTINEL_AGENT_TARGET_ID} ` +
+      `environment=${SENTINEL_ENVIRONMENT} org=${arranged.callerOrgId}. ` +
+      `Next: run assert_dispatch_resolves.py to verify dispatch-side resolution.`,
+  );
+}
+
+if (require.main === module) {
+  main().catch((err) => {
+    console.error("[run-smoke] FAILED:", err instanceof Error ? err.message : err);
+    process.exitCode = 1;
+  });
+}
+
+export { main, buildCutInput };

--- a/scripts/smoke/release-path/tsconfig.json
+++ b/scripts/smoke/release-path/tsconfig.json
@@ -1,0 +1,16 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "module": "commonjs",
+    "lib": ["es2020"],
+    "strict": true,
+    "noImplicitAny": true,
+    "strictNullChecks": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "resolveJsonModule": true,
+    "types": ["node"]
+  },
+  "include": ["*.ts"]
+}


### PR DESCRIPTION
## test(smoke): end-to-end fixtures for the release path

The release infrastructure is deployed and verified in dev, but nothing has actually cut a release there. This adds a scripted path that exercises the code: arrange what a cut requires, cut and promote through the API as a real caller, then assert dispatch resolves the pointer to that release in a non-blocking mode.

### Why a throwaway suite
Cutting a release marks its evaluation suite referenced, and referenced suites are permanently immutable. Pointing this at a shipped seed suite would freeze it for good and block future seed healing. The fixture authors its own suite — and the isolation is structural, since shipped suites carry the system org and the resolver's cross-org check rejects them before any freeze write.

### Why repeat runs are safe
A release id is the hash of its constituents and excludes creation metadata, so holding the constituents constant means every run derives the same id and the conditional write is a no-op: exactly one release row can ever exist. That matters because releases cannot be deleted and the table has deletion protection. Prerequisites are created only if absent; the pointer is one row whose version advances.

### Operator prerequisite
Requires a one-time dev Cognito user with the architect role and the sentinel org claim. The scripts create no identities and fail loudly when identity or credentials are missing. See the runbook.

### Scope
Prerequisites are seeded directly rather than produced by the evaluation pipeline — this validates the release path, not the eval runner or judge. Not covered: strict blocking, promotion races, cross-org negatives, rollback, grandfathering.

### Verification
lint 0 warnings; tsc clean; jest 6153 tests with no drop; pytest 1453. The release-store choke-point guard is byte-identical to main and was re-proven to bite. Not executed against AWS pending the operator step.