### PR TITLE
Feat/promotion-policy-and-approval

### DIFF
--- a/backend/bin/app.ts
+++ b/backend/bin/app.ts
@@ -178,6 +178,14 @@ const governanceStack = new GovernanceStack(
       backendStack.environmentReleasePointersTable,
     environmentReleasePointerWriterRole:
       backendStack.environmentReleasePointerWriterRole,
+    // Decision ada70113 (promotion policy becomes per-org config): the
+    // admin resolver's OWN table + writer role — separate from
+    // environmentReleasePointerWriterRole above, which carries only an
+    // additional scoped GetItem statement for this same table (see
+    // backend-stack.ts's construction site).
+    promotionPolicyConfigTable: backendStack.promotionPolicyConfigTable,
+    promotionPolicyConfigWriterRole:
+      backendStack.promotionPolicyConfigWriterRole,
   },
 );
 

--- a/backend/lib/backend-stack.ts
+++ b/backend/lib/backend-stack.ts
@@ -98,6 +98,33 @@ export class BackendStack extends cdk.Stack {
   // posture rationale as EvalRuns).
   public readonly evalSamplingConfigTable: dynamodb.Table;
   public readonly evalProdSamplesTable: dynamodb.Table;
+  // Decision ada70113 (promotion policy becomes per-org config) — small
+  // admin-authored config table, same posture as EvalSamplingConfigTable
+  // (DESTROY-ok, PITR kept for consistency, no RETAIN/deletionProtection —
+  // re-authored on next admin write, DEFAULT_PROMOTION_POLICY always
+  // available in code as the floor). Two SEPARATE, narrow IAM floors
+  // (mirrors AgentReleasesTable/EnvironmentReleasePointersTable's
+  // separate-role doctrine): the pointer resolver (read path, gates a
+  // promotion) gets GetItem-only; the admin resolver (write path) gets
+  // GetItem+PutItem. Neither role is granted on the other table this
+  // decision touches.
+  public readonly promotionPolicyConfigTable: dynamodb.Table;
+  /** IAM floor for PROMOTION_POLICY_CONFIG_TABLE reads+writes from
+   * promotion-policy-resolver.ts's admin getPromotionPolicy/
+   * setPromotionPolicy — GetItem+PutItem only, explicitly NOT
+   * grantWriteData (which would also confer UpdateItem/DeleteItem/
+   * BatchWriteItem). The READ side consumed by the promotion gate itself
+   * (environment-release-pointer-resolver.ts's validateReleaseGate) is
+   * NOT a separate role here — it is a scoped GetItem-only
+   * PolicyStatement added directly onto the EXISTING
+   * environmentReleasePointerWriterRole below, mirroring how that role
+   * already carries a narrow GetItem-only statement for
+   * AgentReleasesTable (see its construction site for the identical
+   * rationale: a Lambda has exactly one execution role, so a second
+   * table's read access is an additional scoped statement on that same
+   * role, never a second role the function can't actually assume). */
+  public readonly promotionPolicyConfigWriterRole: iam.Role;
+
   // CIT-105: baseline designation pointer + computed comparison verdicts
   // + threshold config — same RETAIN + deletionProtection + PITR posture
   // as EvalRuns for the two evidence tables (EvalBaselines/EvalComparisons);
@@ -3453,6 +3480,61 @@ export class BackendStack extends cdk.Stack {
         removalPolicy: cdk.RemovalPolicy.DESTROY,
         pointInTimeRecoverySpecification: { pointInTimeRecoveryEnabled: true },
       },
+    );
+
+    // Decision ada70113 — PromotionPolicyConfig: admin-authored, one row
+    // per org (PK=orgId). Same small-config-table posture as
+    // EvalSamplingConfigTable above.
+    this.promotionPolicyConfigTable = new dynamodb.Table(
+      this,
+      "PromotionPolicyConfigTable",
+      {
+        tableName: `citadel-promotion-policy-config-${props.environment}`,
+        partitionKey: { name: "orgId", type: dynamodb.AttributeType.STRING },
+        billingMode: dynamodb.BillingMode.PAY_PER_REQUEST,
+        removalPolicy: cdk.RemovalPolicy.DESTROY,
+        pointInTimeRecoverySpecification: { pointInTimeRecoveryEnabled: true },
+      },
+    );
+
+    // Writer role — promotion-policy-resolver.ts's admin
+    // getPromotionPolicy/setPromotionPolicy needs GetItem+PutItem only.
+    // Explicit PolicyStatement, deliberately NOT grantWriteData (which
+    // would also confer UpdateItem/DeleteItem/BatchWriteItem — a wider
+    // floor than this resolver's own two DDB commands ever issue).
+    const promotionPolicyConfigWriterRole = new iam.Role(
+      this,
+      "PromotionPolicyConfigWriterRole",
+      {
+        assumedBy: new iam.ServicePrincipal("lambda.amazonaws.com"),
+      },
+    );
+    promotionPolicyConfigWriterRole.addToPolicy(
+      new iam.PolicyStatement({
+        effect: iam.Effect.ALLOW,
+        actions: ["dynamodb:GetItem", "dynamodb:PutItem"],
+        resources: [this.promotionPolicyConfigTable.tableArn],
+      }),
+    );
+    this.promotionPolicyConfigWriterRole = promotionPolicyConfigWriterRole;
+
+    // Read-only grant for the PROMOTION GATE itself
+    // (environment-release-pointer-resolver.ts's validateReleaseGate,
+    // via promotion-policy-store.ts's resolvePromotionPolicy). A Lambda
+    // has exactly one execution role, and that function already assumes
+    // environmentReleasePointerWriterRole (constructed above) — so this
+    // is an ADDITIONAL scoped GetItem-only statement on that SAME role,
+    // never a second role the function couldn't actually use. Mirrors
+    // that role's existing narrow AgentReleasesTable GetItem grant
+    // (added in governance-stack.ts directly on the resolver function,
+    // which resolves to the same role) — GetItem only, no PutItem: the
+    // promotion gate must never be able to author policy, only read it.
+    environmentReleasePointerWriterRole.addToPolicy(
+      new iam.PolicyStatement({
+        effect: iam.Effect.ALLOW,
+        actions: ["dynamodb:GetItem"],
+        resources: [this.promotionPolicyConfigTable.tableArn],
+      }),
     );
 
     // EvalBaselines (CIT-105) — mutable (orgId, agentTargetId, suiteId)

--- a/backend/lib/governance-stack.ts
+++ b/backend/lib/governance-stack.ts
@@ -98,6 +98,16 @@ export interface GovernanceStackProps extends cdk.StackProps {
   // co-granted on AgentReleasesTable.
   environmentReleasePointersTable: dynamodb.ITable;
   environmentReleasePointerWriterRole: iam.IRole;
+  // Decision ada70113 (promotion policy becomes per-org config) — owned
+  // by BackendStack, consumed here by the new admin
+  // promotion-policy-resolver (getPromotionPolicy/setPromotionPolicy).
+  // The READ side used by validateReleaseGate itself is wired via the
+  // ALREADY-passed environmentReleasePointerWriterRole above (that role
+  // carries an additional scoped GetItem statement for this table — see
+  // backend-stack.ts's construction site); this prop pair is for the
+  // SEPARATE admin resolver Lambda only.
+  promotionPolicyConfigTable: dynamodb.ITable;
+  promotionPolicyConfigWriterRole: iam.IRole;
 }
 
 export class GovernanceStack extends cdk.Stack {
@@ -1196,6 +1206,15 @@ exports.handler = async (event) => {
           ENVIRONMENT_RELEASE_POINTERS_TABLE:
             props.environmentReleasePointersTable.tableName,
           AGENT_RELEASES_TABLE: props.agentReleasesTable.tableName,
+          // Decision ada70113: validateReleaseGate resolves the
+          // per-org/per-agent promotion policy via
+          // promotion-policy-store.ts's resolvePromotionPolicy before
+          // any evidence read. This role (environmentReleasePointerWriterRole)
+          // carries an ADDITIONAL scoped GetItem-only statement for this
+          // table (backend-stack.ts construction site) — no PutItem, the
+          // gate never authors policy.
+          PROMOTION_POLICY_CONFIG_TABLE:
+            props.promotionPolicyConfigTable.tableName,
           // Finding 23971f32: this function calls
           // writeReleaseGateFinding (release-gate-finding-writer.ts) in
           // BOTH shadow and strict mode before the pointer moves — the
@@ -1303,6 +1322,101 @@ exports.handler = async (event) => {
       });
       resolver.addResourceDependency(environmentReleasePointerLambdaDataSource);
     }
+
+    // ============================================================
+    // PromotionPolicy Resolver (decision ada70113 — per-org config)
+    // ============================================================
+    //
+    // Own function, own AppSync data source, own execution role
+    // (promotionPolicyConfigWriterRole — GetItem+PutItem on
+    // PromotionPolicyConfigTable ONLY, see backend-stack.ts's
+    // construction site), mirroring the EnvironmentReleasePointer
+    // resolver's own-role convention above. This role is entirely
+    // separate from environmentReleasePointerWriterRole: the admin write
+    // path (this resolver) and the promotion-gate read path
+    // (environment-release-pointer-resolver.ts, which carries its OWN
+    // scoped GetItem-only statement for this same table, added directly
+    // on its existing role in backend-stack.ts) must never share a role,
+    // so a compromised/buggy admin-resolver deploy can never inherit the
+    // pointer-mutation capability, and vice versa.
+    const promotionPolicyResolverFunction = new lambda.Function(
+      this,
+      "PromotionPolicyResolverFunction",
+      {
+        runtime: lambda.Runtime.NODEJS_24_X,
+        handler: "promotion-policy-resolver.handler",
+        code: lambda.Code.fromAsset("dist/lambda"),
+        role: props.promotionPolicyConfigWriterRole,
+        environment: {
+          PROMOTION_POLICY_CONFIG_TABLE:
+            props.promotionPolicyConfigTable.tableName,
+        },
+        timeout: cdk.Duration.seconds(30),
+        logGroup: new logs.LogGroup(
+          this,
+          "PromotionPolicyResolverFunctionLogs",
+          {
+            retention: logs.RetentionDays.ONE_WEEK,
+            removalPolicy: cdk.RemovalPolicy.DESTROY,
+          },
+        ),
+      },
+    );
+
+    const promotionPolicyDataSourceRole = new iam.Role(
+      this,
+      "PromotionPolicyDataSourceRole",
+      {
+        assumedBy: new iam.ServicePrincipal("appsync.amazonaws.com"),
+      },
+    );
+    promotionPolicyResolverFunction.grantInvoke(promotionPolicyDataSourceRole);
+
+    const promotionPolicyLambdaDataSource = new appsyncCfn.CfnDataSource(
+      this,
+      "PromotionPolicyLambdaDataSource",
+      {
+        apiId: props.appSyncApi.apiId,
+        name: "PromotionPolicyLambdaDataSource",
+        type: "AWS_LAMBDA",
+        serviceRoleArn: promotionPolicyDataSourceRole.roleArn,
+        lambdaConfig: {
+          lambdaFunctionArn: promotionPolicyResolverFunction.functionArn,
+        },
+      },
+    );
+
+    const setPromotionPolicyResolver = new appsyncCfn.CfnResolver(
+      this,
+      "SetPromotionPolicyResolver",
+      {
+        apiId: props.appSyncApi.apiId,
+        typeName: "Mutation",
+        fieldName: "setPromotionPolicy",
+        dataSourceName: promotionPolicyLambdaDataSource.attrName,
+        requestMappingTemplate: LAMBDA_REQUEST_MAPPING,
+        responseMappingTemplate: LAMBDA_RESPONSE_MAPPING,
+      },
+    );
+    setPromotionPolicyResolver.addResourceDependency(
+      promotionPolicyLambdaDataSource,
+    );
+
+    const getPromotionPolicyResolver = new appsyncCfn.CfnResolver(
+      this,
+      "GetPromotionPolicyResolver",
+      {
+        apiId: props.appSyncApi.apiId,
+        typeName: "Query",
+        fieldName: "getPromotionPolicy",
+        dataSourceName: promotionPolicyLambdaDataSource.attrName,
+        requestMappingTemplate: LAMBDA_REQUEST_MAPPING,
+        responseMappingTemplate: LAMBDA_RESPONSE_MAPPING,
+      },
+    );
+    getPromotionPolicyResolver.addResourceDependency(
+      promotionPolicyLambdaDataSource,
+    );
 
     // ============================================================
     // EvalBaseline / EvalComparison Resolver (CIT-105)

--- a/backend/src/lambda/__tests__/environment-release-pointer-resolver.test.ts
+++ b/backend/src/lambda/__tests__/environment-release-pointer-resolver.test.ts
@@ -28,6 +28,8 @@ process.env.EVAL_RUNS_TABLE = "citadel-eval-runs-test";
 process.env.EVAL_SUITES_TABLE = "citadel-eval-suites-test";
 process.env.EVAL_RUN_CASE_RESULTS_TABLE = "citadel-eval-run-case-results-test";
 process.env.GOVERNANCE_LEDGER_TABLE = "citadel-governance-ledger-test";
+process.env.PROMOTION_POLICY_CONFIG_TABLE =
+  "citadel-promotion-policy-config-test";
 process.env.ENVIRONMENT = "test";
 
 const ddbMock = mockClient(DynamoDBDocumentClient);
@@ -42,6 +44,7 @@ import {
 import * as governanceFlag from "../../utils/governance-flag";
 import * as releaseGateEvidence from "../utils/release-gate-evidence";
 import * as releaseGateFindingWriter from "../utils/release-gate-finding-writer";
+import * as promotionPolicyStore from "../utils/promotion-policy-store";
 import type { ReleaseGateInputs } from "../utils/release-gate";
 
 function evalSuite(overrides: Partial<EvalSuite> = {}): EvalSuite {
@@ -98,6 +101,15 @@ beforeEach(() => {
   ddbMock.reset();
   jest.restoreAllMocks();
   governanceFlag.__resetGovernanceFlagCacheForTest();
+  // Default: no promotion-policy config row exists for any org, so
+  // resolvePromotionPolicy resolves ok:true/DEFAULT_PROMOTION_POLICY for
+  // every test that doesn't explicitly stub/mock policy resolution
+  // itself — preserves this suite's pre-existing behaviour (every test
+  // written before decision ada70113 implicitly assumed
+  // DEFAULT_PROMOTION_POLICY).
+  ddbMock
+    .on(GetCommand, { TableName: "citadel-promotion-policy-config-test" })
+    .resolves({ Item: undefined });
 });
 
 /** Convenience: stub the evidence resolver to return a fixed
@@ -907,5 +919,185 @@ describe("handler — AppSync dispatch", () => {
       arguments: {},
     };
     await expect(handler(event as never)).rejects.toThrow(/Unsupported field/);
+  });
+});
+
+describe("validateReleaseGate — decision ada70113 (per-org promotion policy)", () => {
+  const architect = authContextFor("architect");
+
+  test("unreadable promotion policy refuses promotion BEFORE any pointer write — zero PutCommands, evidence resolution never reached", async () => {
+    ddbMock
+      .on(GetCommand, { TableName: "citadel-agent-releases-test" })
+      .resolves({ Item: release() });
+    jest
+      .spyOn(promotionPolicyStore, "resolvePromotionPolicy")
+      .mockResolvedValue({ ok: false, reason: "UNREADABLE" });
+    const evidenceSpy = jest.spyOn(
+      releaseGateEvidence,
+      "resolveReleaseGateEvidence",
+    );
+    jest
+      .spyOn(governanceFlag, "getGovernanceEnforce")
+      .mockResolvedValue("strict");
+    jest
+      .spyOn(releaseGateFindingWriter, "writeReleaseGateFinding")
+      .mockResolvedValue(undefined);
+
+    await expect(
+      promoteEnvironmentReleasePointer(
+        {
+          agentTargetId: "agent-1",
+          environment: "PROD",
+          releaseId: "release-1",
+        },
+        architect,
+        "org-1",
+      ),
+    ).rejects.toThrow(/ReleaseGateError|quality gate/i);
+
+    expect(evidenceSpy).not.toHaveBeenCalled();
+    expect(ddbMock.commandCalls(PutCommand)).toHaveLength(0);
+  });
+
+  test("unreadable promotion policy fails closed in shadow mode too (finding recorded, decision=deny)", async () => {
+    ddbMock
+      .on(GetCommand, { TableName: "citadel-agent-releases-test" })
+      .resolves({ Item: release() });
+    ddbMock
+      .on(GetCommand, {
+        TableName: "citadel-environment-release-pointers-test",
+      })
+      .resolves({ Item: undefined });
+    ddbMock.on(PutCommand).resolves({});
+    jest
+      .spyOn(promotionPolicyStore, "resolvePromotionPolicy")
+      .mockResolvedValue({ ok: false, reason: "UNREADABLE" });
+    jest
+      .spyOn(governanceFlag, "getGovernanceEnforce")
+      .mockResolvedValue("shadow");
+    const writeSpy = jest
+      .spyOn(releaseGateFindingWriter, "writeReleaseGateFinding")
+      .mockResolvedValue(undefined);
+
+    // Shadow never blocks, but the finding must still record a deny
+    // decision derived from the UNREADABLE policy resolution.
+    await expect(
+      validateReleaseGate(release(), "PROD", "org-1", architect),
+    ).resolves.toBeUndefined();
+    expect(writeSpy).toHaveBeenCalledTimes(1);
+    expect(writeSpy.mock.calls[0][0]).toMatchObject({
+      decision: "deny",
+      reasons: ["UNREADABLE"],
+    });
+  });
+
+  test("absent promotion policy config preserves today's behaviour byte-identically on the gate inputs (real resolvePromotionPolicy, no stub)", async () => {
+    // Deliberately does NOT stub promotionPolicyStore.resolvePromotionPolicy
+    // — the real module runs, issues a real GetCommand against
+    // PROMOTION_POLICY_CONFIG_TABLE, and the shared ddbMock has no
+    // matching stub for that table, so aws-sdk-client-mock resolves an
+    // empty response ({}), i.e. Item: undefined -> absent row ->
+    // DEFAULT_PROMOTION_POLICY. This is the exact PromotionPolicy value
+    // validateReleaseGate always passed to resolveReleaseGateEvidence
+    // before this change, so evidence resolution — and therefore the
+    // gate's downstream inputs — are unchanged when no config row exists.
+    ddbMock
+      .on(GetCommand, { TableName: "citadel-agent-releases-test" })
+      .resolves({ Item: release() });
+    const evidenceSpy = jest
+      .spyOn(releaseGateEvidence, "resolveReleaseGateEvidence")
+      .mockResolvedValue({ ok: true, inputs: passingInputs() });
+    jest
+      .spyOn(governanceFlag, "getGovernanceEnforce")
+      .mockResolvedValue("strict");
+    jest
+      .spyOn(releaseGateFindingWriter, "writeReleaseGateFinding")
+      .mockResolvedValue(undefined);
+
+    await expect(
+      validateReleaseGate(release(), "PROD", "org-1", architect),
+    ).resolves.toBeUndefined();
+
+    expect(evidenceSpy).toHaveBeenCalledTimes(1);
+    const policyArg = evidenceSpy.mock.calls[0][3];
+    expect(policyArg).toEqual({
+      taskSuccessMin: 0.9,
+      policyComplianceMin: 1.0,
+      latencyP95TargetMs: 5000,
+      avgCostBudgetUsd: 1.0,
+      minSampleCount: 5,
+      requiredGateClasses: [],
+      maxEvidenceAgeDays: 7,
+      allowNoBaselineOnAbsoluteFloors: false,
+    });
+  });
+
+  test("resolvePromotionPolicy is called with (callerOrgId, release.agentTargetId), not orgId alone", async () => {
+    ddbMock
+      .on(GetCommand, { TableName: "citadel-agent-releases-test" })
+      .resolves({ Item: release({ agentTargetId: "agent-42" }) });
+    const policySpy = jest
+      .spyOn(promotionPolicyStore, "resolvePromotionPolicy")
+      .mockResolvedValue({ ok: true, policy: passingInputs().policy });
+    jest
+      .spyOn(releaseGateEvidence, "resolveReleaseGateEvidence")
+      .mockResolvedValue({ ok: true, inputs: passingInputs() });
+    jest
+      .spyOn(governanceFlag, "getGovernanceEnforce")
+      .mockResolvedValue("permissive");
+
+    await validateReleaseGate(
+      release({ agentTargetId: "agent-42" }),
+      "PROD",
+      "org-9",
+      architect,
+    );
+
+    expect(policySpy).toHaveBeenCalledWith("org-9", "agent-42");
+  });
+
+  test("a config row with a wrong-primitive-type field (string where number expected) refuses promotion BEFORE any pointer write — real resolvePromotionPolicy, not stubbed", async () => {
+    // Command-layer probe per verify_policy_config feedback: exercises
+    // the REAL resolvePromotionPolicy (no spy/mock on the store module)
+    // against a config row shaped exactly like the failing repro
+    // ({orgId:"org-1", policy:{taskSuccessMin:"0.99"}}) to prove the
+    // org's tightened floor can never be silently bypassed by a
+    // type-mismatched field falling through to the default.
+    ddbMock
+      .on(GetCommand, { TableName: "citadel-agent-releases-test" })
+      .resolves({ Item: release() });
+    ddbMock
+      .on(GetCommand, { TableName: "citadel-promotion-policy-config-test" })
+      .resolves({
+        Item: {
+          orgId: "org-1",
+          policy: { taskSuccessMin: "0.99" },
+        },
+      });
+    const evidenceSpy = jest.spyOn(
+      releaseGateEvidence,
+      "resolveReleaseGateEvidence",
+    );
+    jest
+      .spyOn(governanceFlag, "getGovernanceEnforce")
+      .mockResolvedValue("strict");
+    jest
+      .spyOn(releaseGateFindingWriter, "writeReleaseGateFinding")
+      .mockResolvedValue(undefined);
+
+    await expect(
+      promoteEnvironmentReleasePointer(
+        {
+          agentTargetId: "agent-1",
+          environment: "PROD",
+          releaseId: "release-1",
+        },
+        architect,
+        "org-1",
+      ),
+    ).rejects.toThrow(/ReleaseGateError|quality gate/i);
+
+    expect(evidenceSpy).not.toHaveBeenCalled();
+    expect(ddbMock.commandCalls(PutCommand)).toHaveLength(0);
   });
 });

--- a/backend/src/lambda/__tests__/environment-release-pointer-resolver.test.ts
+++ b/backend/src/lambda/__tests__/environment-release-pointer-resolver.test.ts
@@ -39,11 +39,14 @@ import {
   getCurrentEnvironmentReleasePointer,
   listEnvironmentReleasePointers,
   validateReleaseGate,
+  validatePromotionApproval,
+  ReleaseApprovalRequiredError,
   handler,
 } from "../environment-release-pointer-resolver";
 import * as governanceFlag from "../../utils/governance-flag";
 import * as releaseGateEvidence from "../utils/release-gate-evidence";
 import * as releaseGateFindingWriter from "../utils/release-gate-finding-writer";
+import * as releasePromotionApprovalWriter from "../utils/release-promotion-approval-writer";
 import * as promotionPolicyStore from "../utils/promotion-policy-store";
 import type { ReleaseGateInputs } from "../utils/release-gate";
 
@@ -508,12 +511,23 @@ describe("promoteEnvironmentReleasePointer — gate wiring position + zero-write
     const writeSpy = jest
       .spyOn(releaseGateFindingWriter, "writeReleaseGateFinding")
       .mockResolvedValue(undefined);
+    // Strict mode requires an explicit approval (decision 8165b7e5) —
+    // supply one so this PASS-verdict test exercises the gate-write
+    // assertion below without tripping the (separately tested) approval
+    // requirement.
+    jest
+      .spyOn(
+        releasePromotionApprovalWriter,
+        "writeReleasePromotionApprovalFinding",
+      )
+      .mockResolvedValue(undefined);
 
     const result = await promoteEnvironmentReleasePointer(
       {
         agentTargetId: "agent-1",
         environment: "PROD",
         releaseId: "release-1",
+        approval: { approved: true },
       },
       architect,
       "org-1",
@@ -1099,5 +1113,539 @@ describe("validateReleaseGate — decision ada70113 (per-org promotion policy)",
 
     expect(evidenceSpy).not.toHaveBeenCalled();
     expect(ddbMock.commandCalls(PutCommand)).toHaveLength(0);
+  });
+});
+
+describe("validatePromotionApproval — decision 8165b7e5 (interim human approval)", () => {
+  const architect = authContextFor("architect");
+
+  test("strict, approval absent: throws ReleaseApprovalRequiredError, no finding written", async () => {
+    jest
+      .spyOn(governanceFlag, "getGovernanceEnforce")
+      .mockResolvedValue("strict");
+    const writeSpy = jest
+      .spyOn(
+        releasePromotionApprovalWriter,
+        "writeReleasePromotionApprovalFinding",
+      )
+      .mockResolvedValue(undefined);
+
+    await expect(
+      validatePromotionApproval(
+        release(),
+        "PROD",
+        "org-1",
+        architect,
+        undefined,
+      ),
+    ).rejects.toBeInstanceOf(ReleaseApprovalRequiredError);
+    expect(writeSpy).not.toHaveBeenCalled();
+  });
+
+  test("strict, approved=false: denial finding written THEN error thrown", async () => {
+    jest
+      .spyOn(governanceFlag, "getGovernanceEnforce")
+      .mockResolvedValue("strict");
+    const calls: string[] = [];
+    const writeSpy = jest
+      .spyOn(
+        releasePromotionApprovalWriter,
+        "writeReleasePromotionApprovalFinding",
+      )
+      .mockImplementation(async () => {
+        calls.push("write");
+      });
+
+    await expect(
+      validatePromotionApproval(release(), "PROD", "org-1", architect, {
+        approved: false,
+        justification: "not ready",
+      }),
+    ).rejects.toBeInstanceOf(ReleaseApprovalRequiredError);
+
+    expect(writeSpy).toHaveBeenCalledTimes(1);
+    expect(writeSpy.mock.calls[0][0]).toMatchObject({
+      decision: "deny",
+      decidedBy: "user-architect",
+      justification: "not ready",
+    });
+    expect(calls).toEqual(["write"]);
+  });
+
+  test("strict, approved=true: approval finding recorded (category/decision/decidedBy from identity/justification), does not throw", async () => {
+    jest
+      .spyOn(governanceFlag, "getGovernanceEnforce")
+      .mockResolvedValue("strict");
+    let captured: unknown;
+    jest
+      .spyOn(
+        releasePromotionApprovalWriter,
+        "writeReleasePromotionApprovalFinding",
+      )
+      .mockImplementation(async (input) => {
+        captured = input;
+      });
+
+    await expect(
+      validatePromotionApproval(release(), "PROD", "org-1", architect, {
+        approved: true,
+        justification: "reviewed by ops",
+      }),
+    ).resolves.toBeUndefined();
+
+    expect(captured).toMatchObject({
+      decision: "permit",
+      decidedBy: "user-architect", // from identity, NOT from input
+      justification: "reviewed by ops",
+      orgId: "org-1",
+      releaseId: "release-1",
+      environment: "PROD",
+    });
+  });
+
+  test("shadow, approved=false: finding recorded (deny) but does NOT block (block:false)", async () => {
+    jest
+      .spyOn(governanceFlag, "getGovernanceEnforce")
+      .mockResolvedValue("shadow");
+    const writeSpy = jest
+      .spyOn(
+        releasePromotionApprovalWriter,
+        "writeReleasePromotionApprovalFinding",
+      )
+      .mockResolvedValue(undefined);
+
+    await expect(
+      validatePromotionApproval(release(), "PROD", "org-1", architect, {
+        approved: false,
+        justification: "still evaluating",
+      }),
+    ).resolves.toBeUndefined();
+
+    expect(writeSpy).toHaveBeenCalledTimes(1);
+    expect(writeSpy.mock.calls[0][0]).toMatchObject({ decision: "deny" });
+  });
+
+  test("shadow, approved=true: finding recorded (permit), does not block", async () => {
+    jest
+      .spyOn(governanceFlag, "getGovernanceEnforce")
+      .mockResolvedValue("shadow");
+    const writeSpy = jest
+      .spyOn(
+        releasePromotionApprovalWriter,
+        "writeReleasePromotionApprovalFinding",
+      )
+      .mockResolvedValue(undefined);
+
+    await expect(
+      validatePromotionApproval(release(), "PROD", "org-1", architect, {
+        approved: true,
+      }),
+    ).resolves.toBeUndefined();
+
+    expect(writeSpy).toHaveBeenCalledTimes(1);
+    expect(writeSpy.mock.calls[0][0]).toMatchObject({ decision: "permit" });
+  });
+
+  test("shadow, approval absent: not required, nothing recorded", async () => {
+    jest
+      .spyOn(governanceFlag, "getGovernanceEnforce")
+      .mockResolvedValue("shadow");
+    const writeSpy = jest
+      .spyOn(
+        releasePromotionApprovalWriter,
+        "writeReleasePromotionApprovalFinding",
+      )
+      .mockResolvedValue(undefined);
+
+    await expect(
+      validatePromotionApproval(
+        release(),
+        "PROD",
+        "org-1",
+        architect,
+        undefined,
+      ),
+    ).resolves.toBeUndefined();
+
+    expect(writeSpy).not.toHaveBeenCalled();
+  });
+
+  test("permissive: approval ignored entirely — no finding, regardless of approved value", async () => {
+    jest
+      .spyOn(governanceFlag, "getGovernanceEnforce")
+      .mockResolvedValue("permissive");
+    const writeSpy = jest
+      .spyOn(
+        releasePromotionApprovalWriter,
+        "writeReleasePromotionApprovalFinding",
+      )
+      .mockResolvedValue(undefined);
+
+    await expect(
+      validatePromotionApproval(release(), "PROD", "org-1", architect, {
+        approved: false,
+        justification: "irrelevant in permissive",
+      }),
+    ).resolves.toBeUndefined();
+    await expect(
+      validatePromotionApproval(
+        release(),
+        "PROD",
+        "org-1",
+        architect,
+        undefined,
+      ),
+    ).resolves.toBeUndefined();
+
+    expect(writeSpy).not.toHaveBeenCalled();
+  });
+
+  test("approval-finding write failure (AccessDenied) propagates uncaught — fail-closed", async () => {
+    jest
+      .spyOn(governanceFlag, "getGovernanceEnforce")
+      .mockResolvedValue("strict");
+    const accessDenied = new Error("AccessDenied");
+    accessDenied.name = "AccessDeniedException";
+    jest
+      .spyOn(
+        releasePromotionApprovalWriter,
+        "writeReleasePromotionApprovalFinding",
+      )
+      .mockRejectedValue(accessDenied);
+
+    await expect(
+      validatePromotionApproval(release(), "PROD", "org-1", architect, {
+        approved: true,
+      }),
+    ).rejects.toThrow("AccessDenied");
+  });
+
+  test("dedupe ConditionalCheckFailedException from the writer proceeds without throwing", async () => {
+    jest
+      .spyOn(governanceFlag, "getGovernanceEnforce")
+      .mockResolvedValue("strict");
+    // The real writer swallows ConditionalCheckFailedException itself
+    // (release-promotion-approval-writer.ts) — validatePromotionApproval
+    // only needs to not re-throw when the writer resolves normally after
+    // its own internal dedupe swallow, which we simulate here by simply
+    // resolving.
+    jest
+      .spyOn(
+        releasePromotionApprovalWriter,
+        "writeReleasePromotionApprovalFinding",
+      )
+      .mockResolvedValue(undefined);
+
+    await expect(
+      validatePromotionApproval(release(), "PROD", "org-1", architect, {
+        approved: true,
+      }),
+    ).resolves.toBeUndefined();
+  });
+});
+
+describe("promoteEnvironmentReleasePointer — approval wiring (decision 8165b7e5)", () => {
+  const architect = authContextFor("architect");
+
+  function stubGatePass() {
+    stubEvidence(passingInputs());
+  }
+
+  test("strict without approval: ReleaseApprovalRequiredError, zero pointer PutCommands", async () => {
+    ddbMock
+      .on(GetCommand, { TableName: "citadel-agent-releases-test" })
+      .resolves({ Item: release() });
+    ddbMock
+      .on(GetCommand, {
+        TableName: "citadel-environment-release-pointers-test",
+      })
+      .resolves({ Item: undefined });
+    stubGatePass();
+    jest
+      .spyOn(governanceFlag, "getGovernanceEnforce")
+      .mockResolvedValue("strict");
+    jest
+      .spyOn(releaseGateFindingWriter, "writeReleaseGateFinding")
+      .mockResolvedValue(undefined);
+    const approvalWriteSpy = jest
+      .spyOn(
+        releasePromotionApprovalWriter,
+        "writeReleasePromotionApprovalFinding",
+      )
+      .mockResolvedValue(undefined);
+
+    await expect(
+      promoteEnvironmentReleasePointer(
+        {
+          agentTargetId: "agent-1",
+          environment: "PROD",
+          releaseId: "release-1",
+        },
+        architect,
+        "org-1",
+      ),
+    ).rejects.toBeInstanceOf(ReleaseApprovalRequiredError);
+
+    expect(approvalWriteSpy).not.toHaveBeenCalled();
+    expect(ddbMock.commandCalls(PutCommand)).toHaveLength(0);
+  });
+
+  test("strict approved=false: denial finding written, then error, zero pointer writes", async () => {
+    ddbMock
+      .on(GetCommand, { TableName: "citadel-agent-releases-test" })
+      .resolves({ Item: release() });
+    ddbMock
+      .on(GetCommand, {
+        TableName: "citadel-environment-release-pointers-test",
+      })
+      .resolves({ Item: undefined });
+    stubGatePass();
+    jest
+      .spyOn(governanceFlag, "getGovernanceEnforce")
+      .mockResolvedValue("strict");
+    jest
+      .spyOn(releaseGateFindingWriter, "writeReleaseGateFinding")
+      .mockResolvedValue(undefined);
+    const approvalWriteSpy = jest
+      .spyOn(
+        releasePromotionApprovalWriter,
+        "writeReleasePromotionApprovalFinding",
+      )
+      .mockResolvedValue(undefined);
+
+    await expect(
+      promoteEnvironmentReleasePointer(
+        {
+          agentTargetId: "agent-1",
+          environment: "PROD",
+          releaseId: "release-1",
+          approval: { approved: false, justification: "blocked by ops" },
+        },
+        architect,
+        "org-1",
+      ),
+    ).rejects.toBeInstanceOf(ReleaseApprovalRequiredError);
+
+    expect(approvalWriteSpy).toHaveBeenCalledTimes(1);
+    expect(approvalWriteSpy.mock.calls[0][0]).toMatchObject({
+      decision: "deny",
+    });
+    expect(ddbMock.commandCalls(PutCommand)).toHaveLength(0);
+  });
+
+  test("strict approved=true: approval finding (category/decision/decidedBy from identity/justification) written, then pointer moves", async () => {
+    ddbMock
+      .on(GetCommand, { TableName: "citadel-agent-releases-test" })
+      .resolves({ Item: release() });
+    ddbMock
+      .on(GetCommand, {
+        TableName: "citadel-environment-release-pointers-test",
+      })
+      .resolves({ Item: undefined });
+    ddbMock.on(PutCommand).resolves({});
+    stubGatePass();
+    jest
+      .spyOn(governanceFlag, "getGovernanceEnforce")
+      .mockResolvedValue("strict");
+    jest
+      .spyOn(releaseGateFindingWriter, "writeReleaseGateFinding")
+      .mockResolvedValue(undefined);
+    let capturedApprovalItem: unknown;
+    jest
+      .spyOn(
+        releasePromotionApprovalWriter,
+        "writeReleasePromotionApprovalFinding",
+      )
+      .mockImplementation(async (input) => {
+        capturedApprovalItem = input;
+      });
+
+    const result = await promoteEnvironmentReleasePointer(
+      {
+        agentTargetId: "agent-1",
+        environment: "PROD",
+        releaseId: "release-1",
+        approval: {
+          approved: true,
+          justification: "approved by release manager",
+        },
+      },
+      architect,
+      "org-1",
+    );
+
+    expect(capturedApprovalItem).toMatchObject({
+      decision: "permit",
+      decidedBy: "user-architect", // server-derived identity, not input
+      justification: "approved by release manager",
+    });
+    expect(result.releaseId).toBe("release-1");
+    expect(ddbMock.commandCalls(PutCommand)).toHaveLength(1);
+  });
+
+  test("shadow with approved=false: deny finding recorded (block:false must NOT block), pointer still moves", async () => {
+    ddbMock
+      .on(GetCommand, { TableName: "citadel-agent-releases-test" })
+      .resolves({ Item: release() });
+    ddbMock
+      .on(GetCommand, {
+        TableName: "citadel-environment-release-pointers-test",
+      })
+      .resolves({ Item: undefined });
+    ddbMock.on(PutCommand).resolves({});
+    stubGatePass();
+    jest
+      .spyOn(governanceFlag, "getGovernanceEnforce")
+      .mockResolvedValue("shadow");
+    jest
+      .spyOn(releaseGateFindingWriter, "writeReleaseGateFinding")
+      .mockResolvedValue(undefined);
+    const approvalWriteSpy = jest
+      .spyOn(
+        releasePromotionApprovalWriter,
+        "writeReleasePromotionApprovalFinding",
+      )
+      .mockResolvedValue(undefined);
+
+    const result = await promoteEnvironmentReleasePointer(
+      {
+        agentTargetId: "agent-1",
+        environment: "PROD",
+        releaseId: "release-1",
+        approval: { approved: false, justification: "shadow deny" },
+      },
+      architect,
+      "org-1",
+    );
+
+    // shadow's disposition.block is false — a deny must be RECORDED but
+    // must NOT block. Assert exactly that: the finding was written with
+    // decision=deny, and the promotion still completed (pointer moved).
+    expect(approvalWriteSpy).toHaveBeenCalledTimes(1);
+    expect(approvalWriteSpy.mock.calls[0][0]).toMatchObject({
+      decision: "deny",
+    });
+    expect(result.releaseId).toBe("release-1");
+    expect(ddbMock.commandCalls(PutCommand)).toHaveLength(1);
+  });
+
+  test("permissive: no finding, pointer moves regardless of approved value", async () => {
+    ddbMock
+      .on(GetCommand, { TableName: "citadel-agent-releases-test" })
+      .resolves({ Item: release() });
+    ddbMock
+      .on(GetCommand, {
+        TableName: "citadel-environment-release-pointers-test",
+      })
+      .resolves({ Item: undefined });
+    ddbMock.on(PutCommand).resolves({});
+    stubGatePass();
+    jest
+      .spyOn(governanceFlag, "getGovernanceEnforce")
+      .mockResolvedValue("permissive");
+    const approvalWriteSpy = jest
+      .spyOn(
+        releasePromotionApprovalWriter,
+        "writeReleasePromotionApprovalFinding",
+      )
+      .mockResolvedValue(undefined);
+
+    const result = await promoteEnvironmentReleasePointer(
+      {
+        agentTargetId: "agent-1",
+        environment: "PROD",
+        releaseId: "release-1",
+        approval: { approved: false },
+      },
+      architect,
+      "org-1",
+    );
+
+    expect(approvalWriteSpy).not.toHaveBeenCalled();
+    expect(result.releaseId).toBe("release-1");
+    expect(ddbMock.commandCalls(PutCommand)).toHaveLength(1);
+  });
+
+  test("approval-finding write failure (AccessDenied mock): promotion aborts, zero pointer writes", async () => {
+    ddbMock
+      .on(GetCommand, { TableName: "citadel-agent-releases-test" })
+      .resolves({ Item: release() });
+    ddbMock
+      .on(GetCommand, {
+        TableName: "citadel-environment-release-pointers-test",
+      })
+      .resolves({ Item: undefined });
+    stubGatePass();
+    jest
+      .spyOn(governanceFlag, "getGovernanceEnforce")
+      .mockResolvedValue("strict");
+    jest
+      .spyOn(releaseGateFindingWriter, "writeReleaseGateFinding")
+      .mockResolvedValue(undefined);
+    const accessDenied = new Error("AccessDenied");
+    accessDenied.name = "AccessDeniedException";
+    jest
+      .spyOn(
+        releasePromotionApprovalWriter,
+        "writeReleasePromotionApprovalFinding",
+      )
+      .mockRejectedValue(accessDenied);
+
+    await expect(
+      promoteEnvironmentReleasePointer(
+        {
+          agentTargetId: "agent-1",
+          environment: "PROD",
+          releaseId: "release-1",
+          approval: { approved: true },
+        },
+        architect,
+        "org-1",
+      ),
+    ).rejects.toThrow("AccessDenied");
+
+    expect(ddbMock.commandCalls(PutCommand)).toHaveLength(0);
+  });
+
+  test("dedupe ConditionalCheck on approval writer: proceeds, pointer moves", async () => {
+    ddbMock
+      .on(GetCommand, { TableName: "citadel-agent-releases-test" })
+      .resolves({ Item: release() });
+    ddbMock
+      .on(GetCommand, {
+        TableName: "citadel-environment-release-pointers-test",
+      })
+      .resolves({ Item: undefined });
+    ddbMock.on(PutCommand).resolves({});
+    stubGatePass();
+    jest
+      .spyOn(governanceFlag, "getGovernanceEnforce")
+      .mockResolvedValue("strict");
+    jest
+      .spyOn(releaseGateFindingWriter, "writeReleaseGateFinding")
+      .mockResolvedValue(undefined);
+    // The real writer swallows ConditionalCheckFailedException itself —
+    // simulate the writer's post-swallow resolved state so the resolver
+    // is exercised on the "proceeds" branch.
+    jest
+      .spyOn(
+        releasePromotionApprovalWriter,
+        "writeReleasePromotionApprovalFinding",
+      )
+      .mockResolvedValue(undefined);
+
+    const result = await promoteEnvironmentReleasePointer(
+      {
+        agentTargetId: "agent-1",
+        environment: "PROD",
+        releaseId: "release-1",
+        approval: { approved: true },
+      },
+      architect,
+      "org-1",
+    );
+
+    expect(result.releaseId).toBe("release-1");
+    expect(ddbMock.commandCalls(PutCommand)).toHaveLength(1);
   });
 });

--- a/backend/src/lambda/__tests__/promotion-policy-resolver.test.ts
+++ b/backend/src/lambda/__tests__/promotion-policy-resolver.test.ts
@@ -1,0 +1,194 @@
+/**
+ * promotion-policy-resolver.test.ts — decision ada70113 (promotion
+ * policy becomes per-org config). Admin-only gate:
+ * `roles.includes("admin")` directly, mirroring
+ * eval-sampling-config-resolver.test.ts's structure.
+ */
+import { mockClient } from "aws-sdk-client-mock";
+import {
+  DynamoDBDocumentClient,
+  GetCommand,
+  PutCommand,
+} from "@aws-sdk/lib-dynamodb";
+import type { AuthContext } from "../../types";
+
+process.env.PROMOTION_POLICY_CONFIG_TABLE =
+  "citadel-promotion-policy-config-test";
+
+const ddbMock = mockClient(DynamoDBDocumentClient);
+
+import {
+  getPromotionPolicy,
+  setPromotionPolicy,
+  handler,
+} from "../promotion-policy-resolver";
+
+beforeEach(() => {
+  ddbMock.reset();
+});
+
+const adminAuth: AuthContext = {
+  userId: "admin-1",
+  groups: [],
+  roles: ["admin"],
+};
+const nonAdminAuth: AuthContext = {
+  userId: "user-1",
+  groups: [],
+  roles: ["project_manager"],
+};
+
+describe("setPromotionPolicy — admin-only gate", () => {
+  test("rejects a non-admin caller", async () => {
+    await expect(
+      setPromotionPolicy(
+        "org-1",
+        { policy: { taskSuccessMin: 0.95 } },
+        nonAdminAuth,
+      ),
+    ).rejects.toThrow(/UnauthorizedError/);
+    expect(ddbMock.commandCalls(PutCommand)).toHaveLength(0);
+  });
+
+  test("allows an admin caller and writes the row", async () => {
+    ddbMock.on(PutCommand).resolves({});
+
+    const result = await setPromotionPolicy(
+      "org-1",
+      {
+        policy: { taskSuccessMin: 0.95 },
+        perAgentPolicyOverrides: { "agent-1": { taskSuccessMin: 0.99 } },
+      },
+      adminAuth,
+    );
+
+    expect(result.orgId).toBe("org-1");
+    expect(result.policy).toEqual({ taskSuccessMin: 0.95 });
+    expect(result.perAgentPolicyOverrides).toEqual({
+      "agent-1": { taskSuccessMin: 0.99 },
+    });
+    const putArgs = ddbMock.commandCalls(PutCommand)[0].args[0].input;
+    expect(putArgs.TableName).toBe("citadel-promotion-policy-config-test");
+    expect((putArgs.Item as Record<string, unknown>).orgId).toBe("org-1");
+  });
+
+  test("updatedBy is server-derived from authContext.userId, never accepted from input", async () => {
+    ddbMock.on(PutCommand).resolves({});
+
+    const result = await setPromotionPolicy(
+      "org-1",
+      // Input has no updatedBy field at all (the type doesn't even allow
+      // one) — this test documents that the resolver derives it from the
+      // authenticated caller, matching eval-sampling-config-resolver's
+      // doctrine.
+      { policy: { taskSuccessMin: 0.95 } },
+      adminAuth,
+    );
+
+    expect(result.updatedBy).toBe("admin-1");
+    const putArgs = ddbMock.commandCalls(PutCommand)[0].args[0].input;
+    expect((putArgs.Item as Record<string, unknown>).updatedBy).toBe("admin-1");
+  });
+
+  test("a different admin caller's userId is reflected, proving it is not hardcoded", async () => {
+    ddbMock.on(PutCommand).resolves({});
+
+    const result = await setPromotionPolicy(
+      "org-1",
+      { policy: {} },
+      { userId: "admin-2", groups: [], roles: ["admin"] },
+    );
+
+    expect(result.updatedBy).toBe("admin-2");
+  });
+
+  test("defaults policy/perAgentPolicyOverrides to empty objects when omitted", async () => {
+    ddbMock.on(PutCommand).resolves({});
+
+    const result = await setPromotionPolicy("org-1", {}, adminAuth);
+
+    expect(result.policy).toEqual({});
+    expect(result.perAgentPolicyOverrides).toEqual({});
+  });
+});
+
+describe("getPromotionPolicy — admin-only gate", () => {
+  test("rejects a non-admin caller", async () => {
+    await expect(getPromotionPolicy("org-1", nonAdminAuth)).rejects.toThrow(
+      /UnauthorizedError/,
+    );
+  });
+
+  test("returns undefined when no config exists", async () => {
+    ddbMock.on(GetCommand).resolves({ Item: undefined });
+    const result = await getPromotionPolicy("org-1", adminAuth);
+    expect(result).toBeUndefined();
+  });
+
+  test("returns the stored config for an admin", async () => {
+    ddbMock.on(GetCommand).resolves({
+      Item: {
+        orgId: "org-1",
+        policy: { taskSuccessMin: 0.95 },
+        perAgentPolicyOverrides: {},
+      },
+    });
+    const result = await getPromotionPolicy("org-1", adminAuth);
+    expect(result?.policy).toEqual({ taskSuccessMin: 0.95 });
+  });
+});
+
+describe("handler — AppSync dispatch", () => {
+  function eventFor(fieldName: string, args: Record<string, unknown>) {
+    return {
+      info: { fieldName },
+      identity: {
+        sub: "admin-1",
+        "custom:role": "admin",
+      },
+      arguments: args,
+    };
+  }
+
+  test("routes setPromotionPolicy for an admin", async () => {
+    ddbMock.on(PutCommand).resolves({});
+
+    const result = (await handler(
+      eventFor("setPromotionPolicy", {
+        orgId: "org-1",
+        input: { policy: { taskSuccessMin: 0.95 } },
+      }) as never,
+    )) as { orgId: string };
+
+    expect(result.orgId).toBe("org-1");
+  });
+
+  test("routes getPromotionPolicy for an admin", async () => {
+    ddbMock.on(GetCommand).resolves({ Item: undefined });
+
+    const result = await handler(
+      eventFor("getPromotionPolicy", { orgId: "org-1" }) as never,
+    );
+
+    expect(result).toBeUndefined();
+  });
+
+  test("rejects setPromotionPolicy for a non-admin caller via the handler", async () => {
+    const event = {
+      info: { fieldName: "setPromotionPolicy" },
+      identity: { sub: "user-1", "custom:role": "developer" },
+      arguments: { orgId: "org-1", input: { policy: {} } },
+    };
+
+    await expect(handler(event as never)).rejects.toThrow(/UnauthorizedError/);
+  });
+
+  test("throws for an unsupported field name", async () => {
+    const event = {
+      info: { fieldName: "somethingElse" },
+      identity: {},
+      arguments: {},
+    };
+    await expect(handler(event as never)).rejects.toThrow(/Unknown field/);
+  });
+});

--- a/backend/src/lambda/environment-release-pointer-resolver.ts
+++ b/backend/src/lambda/environment-release-pointer-resolver.ts
@@ -108,6 +108,7 @@ import { evaluateReleaseGate } from "./utils/release-gate";
 import { resolveReleaseGateEvidence } from "./utils/release-gate-evidence";
 import { resolvePromotionPolicy } from "./utils/promotion-policy-store";
 import { writeReleaseGateFinding } from "./utils/release-gate-finding-writer";
+import { writeReleasePromotionApprovalFinding } from "./utils/release-promotion-approval-writer";
 import {
   getEnvironmentReleasePointer,
   listEnvironmentReleasePointersForAgent,
@@ -120,6 +121,7 @@ import type {
   EnvironmentReleasePointer,
   GovernanceEventIdentity,
   GovernanceResolverEvent,
+  PromotionApproval,
   SetEnvironmentReleasePointerInput,
 } from "../types";
 
@@ -151,6 +153,25 @@ export class ReleaseGateError extends Error {
       `ReleaseGateError: release quality gate refused promotion of ${releaseId} — reasons=[${reasons.join(", ")}]`,
     );
     this.name = "ReleaseGateError";
+  }
+}
+
+/** Thrown when strict-mode governance requires an explicit human
+ * approval (approved=true) before a promotion may proceed, and the
+ * caller's `approval` input is absent or `approved=false`. Distinct from
+ * ReleaseGateError — this is a MISSING-DECISION refusal (no operator has
+ * approved this promotion yet), not a quality-evidence refusal, so
+ * callers must be able to tell the two apart and surface a clear,
+ * distinct operator message ("get this approved" vs. "the release
+ * failed the quality gate"). Decision 8165b7e5: interim human approval
+ * rides this existing mutation — there is no separate CIT-030 approval
+ * substrate. */
+export class ReleaseApprovalRequiredError extends Error {
+  constructor(public readonly releaseId: string) {
+    super(
+      `ReleaseApprovalRequiredError: strict-mode governance requires an explicit approved=true PromotionApproval before promoting release ${releaseId} — none was supplied, or approval was denied. Obtain approval and retry with { approval: { approved: true } }.`,
+    );
+    this.name = "ReleaseApprovalRequiredError";
   }
 }
 
@@ -295,6 +316,103 @@ async function getAgentRelease(
 }
 
 /**
+ * Interim human-approval seam (decision 8165b7e5 — rides this existing
+ * mutation; the CIT-030 approval substrate does not exist).
+ *
+ * Uses the SAME `governanceDisposition(mode)` mapper validateReleaseGate
+ * already consults — `disposition.block` selects whether an approval is
+ * REQUIRED, `disposition.recordFinding` selects whether a supplied
+ * approval (or its absence, in the deny case) is recorded at all:
+ *
+ *   - strict (block:true): approval with approved=true is REQUIRED.
+ *     Absent input, or approved=false, throws
+ *     ReleaseApprovalRequiredError. On approved=false specifically, the
+ *     denial finding is recorded FIRST (fail-closed — a failed write
+ *     aborts the promotion here too), THEN the error is thrown, so the
+ *     denial is never lost even though the promotion is refused either
+ *     way.
+ *   - shadow (block:false, recordFinding:true): approval is NOT
+ *     required. If the caller supplied one, it is recorded (permit OR
+ *     deny) but never blocks — mirrors validateReleaseGate's own
+ *     shadow-mode telemetry-only disposition for the quality gate.
+ *   - permissive (recordFinding:false): approval is ignored entirely —
+ *     no recording, no requirement, no read of the input at all beyond
+ *     this early return.
+ *
+ * Called AFTER validateReleaseGate and BEFORE
+ * getEnvironmentReleasePointer/setEnvironmentReleasePointer — same
+ * "everything before the store's conditional write" ordering
+ * validateReleaseGate itself documents. The store write remains the
+ * LAST statement in promoteEnvironmentReleasePointer.
+ *
+ * Resolves mode itself via `getGovernanceEnforce(environment)` — the
+ * SAME per-environment reader validateReleaseGate uses — rather than
+ * threading it through validateReleaseGate's return value, so
+ * validateReleaseGate's existing signature and tests are undisturbed.
+ */
+export async function validatePromotionApproval(
+  release: AgentRelease,
+  environment: EnvironmentLiteral,
+  callerOrgId: string,
+  authContext: AuthContext,
+  approval: PromotionApproval | null | undefined,
+): Promise<void> {
+  const mode = await getGovernanceEnforce(environment);
+  const disposition = governanceDisposition(mode);
+
+  if (!disposition.recordFinding) {
+    // permissive: approval is ignored entirely.
+    return;
+  }
+
+  if (!approval) {
+    // No approval supplied.
+    if (disposition.block) {
+      throw new ReleaseApprovalRequiredError(release.releaseId);
+    }
+    // shadow: nothing to record when nothing was supplied.
+    return;
+  }
+
+  const decision: "permit" | "deny" = approval.approved ? "permit" : "deny";
+  const traceContext = getActiveTraceContext();
+
+  if (!approval.approved) {
+    // Record the denial finding BEFORE throwing (strict) — fail-closed:
+    // a failed write here aborts the promotion, same as the gate
+    // finding. In shadow, this records the deny without blocking.
+    await writeReleasePromotionApprovalFinding({
+      orgId: callerOrgId,
+      agentTargetId: release.agentTargetId,
+      environment,
+      releaseId: release.releaseId,
+      decidedBy: authContext.userId,
+      decision,
+      justification: approval.justification,
+      ...(traceContext?.traceId ? { traceId: traceContext.traceId } : {}),
+    });
+
+    if (disposition.block) {
+      throw new ReleaseApprovalRequiredError(release.releaseId);
+    }
+    return;
+  }
+
+  // approved=true: record the permit finding (strict and shadow both
+  // record; only strict required it to reach here at all when absent).
+  await writeReleasePromotionApprovalFinding({
+    orgId: callerOrgId,
+    agentTargetId: release.agentTargetId,
+    environment,
+    releaseId: release.releaseId,
+    decidedBy: authContext.userId,
+    decision,
+    justification: approval.justification,
+    ...(traceContext?.traceId ? { traceId: traceContext.traceId } : {}),
+  });
+}
+
+/**
  * promoteEnvironmentReleasePointer — validates the target release EXISTS
  * and belongs to the caller's org, runs the quality gate
  * (validateReleaseGate), then moves the (org, agentTargetId,
@@ -333,6 +451,14 @@ export async function promoteEnvironmentReleasePointer(
     input.environment,
     callerOrgId,
     authContext,
+  );
+
+  await validatePromotionApproval(
+    targetRelease,
+    input.environment,
+    callerOrgId,
+    authContext,
+    input.approval,
   );
 
   const currentPointer = await getEnvironmentReleasePointer(

--- a/backend/src/lambda/environment-release-pointer-resolver.ts
+++ b/backend/src/lambda/environment-release-pointer-resolver.ts
@@ -104,11 +104,9 @@ import { extractOrgFromEvent } from "../utils/auth-event";
 import { getGovernanceEnforce } from "../utils/governance-flag";
 import { getActiveTraceContext } from "../utils/trace-context";
 import { governanceDisposition } from "./utils/governance-disposition";
-import {
-  evaluateReleaseGate,
-  DEFAULT_PROMOTION_POLICY,
-} from "./utils/release-gate";
+import { evaluateReleaseGate } from "./utils/release-gate";
 import { resolveReleaseGateEvidence } from "./utils/release-gate-evidence";
+import { resolvePromotionPolicy } from "./utils/promotion-policy-store";
 import { writeReleaseGateFinding } from "./utils/release-gate-finding-writer";
 import {
   getEnvironmentReleasePointer,
@@ -184,16 +182,37 @@ export async function validateReleaseGate(
   callerOrgId: string,
   authContext: AuthContext,
 ): Promise<void> {
-  const policy = DEFAULT_PROMOTION_POLICY;
   const now = new Date().toISOString();
 
-  const evidence = await resolveReleaseGateEvidence(
-    release,
-    environment,
+  // Decision ada70113: promotion policy is per-org config, resolved
+  // (org, agentTargetId)-scoped via promotion-policy-store.ts (field-level
+  // merge floor<-org<-agent; absent config -> DEFAULT_PROMOTION_POLICY).
+  // A resolution failure (thrown GetItem or a schema-invalid row) is
+  // UNREADABLE and MUST fail the gate closed exactly like a
+  // resolveReleaseGateEvidence UNREADABLE_RECORD — never fall back to
+  // DEFAULT_PROMOTION_POLICY on this branch, which would silently
+  // downgrade an org's intentionally-tightened policy on an
+  // infrastructure blip.
+  const policyResolution = await resolvePromotionPolicy(
     callerOrgId,
-    policy,
-    now,
+    release.agentTargetId,
   );
+
+  // evidence is only resolved when the policy itself resolved OK — an
+  // UNREADABLE policy short-circuits before any evidence read, and the
+  // synthetic FAIL verdict below carries the SAME
+  // `reasons: [<failure-reason>]` shape resolveReleaseGateEvidence's own
+  // ok:false branch produces, so downstream consumers (the ledger
+  // finding, isFailStatus) treat the two failure sources identically.
+  const evidence = policyResolution.ok
+    ? await resolveReleaseGateEvidence(
+        release,
+        environment,
+        callerOrgId,
+        policyResolution.policy,
+        now,
+      )
+    : ({ ok: false, reason: policyResolution.reason } as const);
 
   const verdict = evidence.ok
     ? evaluateReleaseGate(evidence.inputs)

--- a/backend/src/lambda/promotion-policy-resolver.ts
+++ b/backend/src/lambda/promotion-policy-resolver.ts
@@ -1,0 +1,141 @@
+/**
+ * promotion-policy-resolver.ts — admin-only GraphQL resolver for
+ * PromotionPolicyConfig storage/reads. Mirrors
+ * eval-sampling-config-resolver.ts's structure and admin-gate doctrine
+ * exactly: `authContext.roles.includes("admin")` directly, deliberately
+ * stricter than any eval:author/eval:approve/release:promote permission
+ * — this toggle controls the FLOOR every promotion quality gate in the
+ * org evaluates against (decision ada70113: promotion policy becomes
+ * per-org config), a platform-wide governance-policy decision, not a
+ * per-release action.
+ *
+ * updatedBy is SERVER-DERIVED from authContext.userId, never accepted
+ * from caller input — same doctrine as
+ * eval-sampling-config-resolver.ts's setEvalSamplingConfig.
+ *
+ * This resolver only ever issues GetCommand/PutCommand against
+ * PROMOTION_POLICY_CONFIG_TABLE (by orgId) — the read side used by the
+ * promotion gate itself (promotion-policy-store.ts's
+ * resolvePromotionPolicy) is a SEPARATE, dependency-light module; this
+ * resolver is not on that read path and never imports it, so a change
+ * here cannot alter the gate's fail-closed contract.
+ */
+import { DynamoDBClient } from "@aws-sdk/client-dynamodb";
+import {
+  DynamoDBDocumentClient,
+  GetCommand,
+  PutCommand,
+} from "@aws-sdk/lib-dynamodb";
+import type { PromotionPolicy } from "./utils/release-gate";
+import type { AuthContext } from "../types";
+
+const dynamoClient = new DynamoDBClient({});
+const docClient = DynamoDBDocumentClient.from(dynamoClient);
+
+const PROMOTION_POLICY_CONFIG_TABLE =
+  process.env.PROMOTION_POLICY_CONFIG_TABLE!;
+
+function requireAdmin(authContext: AuthContext, action: string): void {
+  if (!authContext.roles?.includes("admin")) {
+    throw new Error(`UnauthorizedError: admin role required to ${action}`);
+  }
+}
+
+export interface PromotionPolicyConfig {
+  orgId: string;
+  policy: Partial<PromotionPolicy>;
+  perAgentPolicyOverrides: Record<string, Partial<PromotionPolicy>>;
+  updatedAt?: string;
+  updatedBy?: string;
+}
+
+export interface PromotionPolicyConfigInput {
+  policy?: Partial<PromotionPolicy>;
+  perAgentPolicyOverrides?: Record<string, Partial<PromotionPolicy>>;
+}
+
+export async function setPromotionPolicy(
+  orgId: string,
+  input: PromotionPolicyConfigInput,
+  authContext: AuthContext,
+): Promise<PromotionPolicyConfig> {
+  requireAdmin(authContext, "modify promotion policy configuration");
+
+  const config: PromotionPolicyConfig = {
+    orgId,
+    policy: input.policy ?? {},
+    perAgentPolicyOverrides: input.perAgentPolicyOverrides ?? {},
+    updatedAt: new Date().toISOString(),
+    updatedBy: authContext.userId,
+  };
+
+  await docClient.send(
+    new PutCommand({ TableName: PROMOTION_POLICY_CONFIG_TABLE, Item: config }),
+  );
+
+  return config;
+}
+
+export async function getPromotionPolicy(
+  orgId: string,
+  authContext: AuthContext,
+): Promise<PromotionPolicyConfig | undefined> {
+  requireAdmin(authContext, "read promotion policy configuration");
+
+  const res = await docClient.send(
+    new GetCommand({
+      TableName: PROMOTION_POLICY_CONFIG_TABLE,
+      Key: { orgId },
+    }),
+  );
+  return res.Item as PromotionPolicyConfig | undefined;
+}
+
+interface PromotionPolicyResolverArguments {
+  orgId: string;
+  input: PromotionPolicyConfigInput;
+}
+
+interface PromotionPolicyResolverEvent {
+  info?: { fieldName?: string };
+  identity?: {
+    sub?: string;
+    username?: string;
+    ["cognito:groups"]?: string[];
+    claims?: Record<string, string>;
+    ["custom:role"]?: string;
+  };
+  arguments: PromotionPolicyResolverArguments;
+}
+
+function authContextFromEvent(
+  event: PromotionPolicyResolverEvent,
+): AuthContext {
+  const identity = event?.identity || {};
+  const claimRole = identity["custom:role"] ?? identity.claims?.["custom:role"];
+  return {
+    userId: identity.sub || identity.username || "anonymous",
+    username: identity.username,
+    groups: identity["cognito:groups"] || [],
+    roles: claimRole ? [claimRole] : [],
+  };
+}
+
+export const handler = async (
+  event: PromotionPolicyResolverEvent,
+): Promise<unknown> => {
+  const fieldName = event?.info?.fieldName;
+  const authContext = authContextFromEvent(event);
+  switch (fieldName) {
+    case "setPromotionPolicy":
+      return await setPromotionPolicy(
+        event.arguments.orgId,
+        event.arguments.input,
+        authContext,
+      );
+    case "getPromotionPolicy":
+      return await getPromotionPolicy(event.arguments.orgId, authContext);
+    default:
+      throw new Error(`Unknown field: ${fieldName}`);
+  }
+};

--- a/backend/src/lambda/utils/__tests__/promotion-policy-store.test.ts
+++ b/backend/src/lambda/utils/__tests__/promotion-policy-store.test.ts
@@ -1,0 +1,282 @@
+/**
+ * promotion-policy-store.test.ts — decision ada70113 (promotion policy
+ * becomes per-org config). Mocked DDB client, structural mirror of
+ * eval-sampling-config.test.ts's conventions.
+ */
+import { mockClient } from "aws-sdk-client-mock";
+import { DynamoDBDocumentClient, GetCommand } from "@aws-sdk/lib-dynamodb";
+
+process.env.PROMOTION_POLICY_CONFIG_TABLE =
+  "citadel-promotion-policy-config-test";
+
+const ddbMock = mockClient(DynamoDBDocumentClient);
+
+import { resolvePromotionPolicy } from "../promotion-policy-store";
+import { DEFAULT_PROMOTION_POLICY } from "../release-gate";
+
+beforeEach(() => {
+  ddbMock.reset();
+});
+
+describe("resolvePromotionPolicy — absent row", () => {
+  test("resolves to DEFAULT_PROMOTION_POLICY when no config row exists", async () => {
+    ddbMock.on(GetCommand).resolves({ Item: undefined });
+
+    const result = await resolvePromotionPolicy("org-1", "agent-1");
+
+    expect(result).toEqual({ ok: true, policy: DEFAULT_PROMOTION_POLICY });
+  });
+});
+
+describe("resolvePromotionPolicy — org-only override", () => {
+  test("applies org-level policy fields over the default floor", async () => {
+    ddbMock.on(GetCommand).resolves({
+      Item: {
+        orgId: "org-1",
+        policy: { taskSuccessMin: 0.99, latencyP95TargetMs: 2000 },
+        perAgentPolicyOverrides: {},
+      },
+    });
+
+    const result = await resolvePromotionPolicy("org-1", "agent-1");
+
+    expect(result.ok).toBe(true);
+    if (!result.ok) throw new Error("unreachable");
+    expect(result.policy.taskSuccessMin).toBe(0.99);
+    expect(result.policy.latencyP95TargetMs).toBe(2000);
+    // Untouched fields still come from the default floor.
+    expect(result.policy.policyComplianceMin).toBe(
+      DEFAULT_PROMOTION_POLICY.policyComplianceMin,
+    );
+    expect(result.policy.avgCostBudgetUsd).toBe(
+      DEFAULT_PROMOTION_POLICY.avgCostBudgetUsd,
+    );
+  });
+});
+
+describe("resolvePromotionPolicy — agent-level override", () => {
+  test("agent override wins over org policy for the SAME field", async () => {
+    ddbMock.on(GetCommand).resolves({
+      Item: {
+        orgId: "org-1",
+        policy: { taskSuccessMin: 0.9 },
+        perAgentPolicyOverrides: {
+          "agent-1": { taskSuccessMin: 0.99 },
+        },
+      },
+    });
+
+    const result = await resolvePromotionPolicy("org-1", "agent-1");
+
+    expect(result.ok).toBe(true);
+    if (!result.ok) throw new Error("unreachable");
+    expect(result.policy.taskSuccessMin).toBe(0.99);
+  });
+
+  test("agent override for a DIFFERENT agentTargetId does not apply", async () => {
+    ddbMock.on(GetCommand).resolves({
+      Item: {
+        orgId: "org-1",
+        policy: { taskSuccessMin: 0.9 },
+        perAgentPolicyOverrides: {
+          "agent-2": { taskSuccessMin: 0.99 },
+        },
+      },
+    });
+
+    const result = await resolvePromotionPolicy("org-1", "agent-1");
+
+    expect(result.ok).toBe(true);
+    if (!result.ok) throw new Error("unreachable");
+    expect(result.policy.taskSuccessMin).toBe(0.9);
+  });
+
+  test("merge is FIELD-LEVEL, not whole-object: org supplies fields the agent override omits", async () => {
+    ddbMock.on(GetCommand).resolves({
+      Item: {
+        orgId: "org-1",
+        policy: {
+          taskSuccessMin: 0.9,
+          latencyP95TargetMs: 3000,
+          avgCostBudgetUsd: 0.5,
+        },
+        perAgentPolicyOverrides: {
+          // Only overrides ONE field — the other org-level fields must
+          // still apply, proving this is not a whole-object replace.
+          "agent-1": { taskSuccessMin: 0.99 },
+        },
+      },
+    });
+
+    const result = await resolvePromotionPolicy("org-1", "agent-1");
+
+    expect(result.ok).toBe(true);
+    if (!result.ok) throw new Error("unreachable");
+    expect(result.policy.taskSuccessMin).toBe(0.99); // from agent
+    expect(result.policy.latencyP95TargetMs).toBe(3000); // from org
+    expect(result.policy.avgCostBudgetUsd).toBe(0.5); // from org
+    expect(result.policy.policyComplianceMin).toBe(
+      DEFAULT_PROMOTION_POLICY.policyComplianceMin,
+    ); // from default floor
+  });
+});
+
+describe("resolvePromotionPolicy — malformed row -> UNREADABLE", () => {
+  test("missing orgId on the row resolves to UNREADABLE", async () => {
+    ddbMock.on(GetCommand).resolves({
+      Item: { policy: { taskSuccessMin: 0.9 } },
+    });
+
+    const result = await resolvePromotionPolicy("org-1", "agent-1");
+
+    expect(result).toEqual({ ok: false, reason: "UNREADABLE" });
+  });
+
+  test("non-object policy container resolves to UNREADABLE", async () => {
+    ddbMock.on(GetCommand).resolves({
+      Item: { orgId: "org-1", policy: "not-an-object" },
+    });
+
+    const result = await resolvePromotionPolicy("org-1", "agent-1");
+
+    expect(result).toEqual({ ok: false, reason: "UNREADABLE" });
+  });
+
+  test("non-object perAgentPolicyOverrides container resolves to UNREADABLE", async () => {
+    ddbMock.on(GetCommand).resolves({
+      Item: { orgId: "org-1", perAgentPolicyOverrides: ["not", "a", "map"] },
+    });
+
+    const result = await resolvePromotionPolicy("org-1", "agent-1");
+
+    expect(result).toEqual({ ok: false, reason: "UNREADABLE" });
+  });
+
+  test("a single malformed FIELD (NaN) is dropped, not fatal — falls through to default", async () => {
+    ddbMock.on(GetCommand).resolves({
+      Item: {
+        orgId: "org-1",
+        policy: { taskSuccessMin: Number.NaN, latencyP95TargetMs: 2000 },
+        perAgentPolicyOverrides: {},
+      },
+    });
+
+    const result = await resolvePromotionPolicy("org-1", "agent-1");
+
+    expect(result.ok).toBe(true);
+    if (!result.ok) throw new Error("unreachable");
+    // NaN dropped -> falls back to the default floor for this field only.
+    expect(result.policy.taskSuccessMin).toBe(
+      DEFAULT_PROMOTION_POLICY.taskSuccessMin,
+    );
+    // The sibling valid field still applies.
+    expect(result.policy.latencyP95TargetMs).toBe(2000);
+  });
+
+  test("a negative value for a rate-like field is dropped, not fatal", async () => {
+    ddbMock.on(GetCommand).resolves({
+      Item: {
+        orgId: "org-1",
+        policy: { policyComplianceMin: -0.5 },
+        perAgentPolicyOverrides: {},
+      },
+    });
+
+    const result = await resolvePromotionPolicy("org-1", "agent-1");
+
+    expect(result.ok).toBe(true);
+    if (!result.ok) throw new Error("unreachable");
+    expect(result.policy.policyComplianceMin).toBe(
+      DEFAULT_PROMOTION_POLICY.policyComplianceMin,
+    );
+  });
+
+  test("a present field with the WRONG PRIMITIVE TYPE (string where number expected) resolves to UNREADABLE for the whole row, not a per-field drop", async () => {
+    ddbMock.on(GetCommand).resolves({
+      Item: {
+        orgId: "org-1",
+        policy: { taskSuccessMin: "0.99" },
+        perAgentPolicyOverrides: {},
+      },
+    });
+
+    const result = await resolvePromotionPolicy("org-1", "agent-1");
+
+    expect(result).toEqual({ ok: false, reason: "UNREADABLE" });
+  });
+
+  test("a wrong-primitive-type field inside a per-agent override resolves to UNREADABLE for the whole row", async () => {
+    ddbMock.on(GetCommand).resolves({
+      Item: {
+        orgId: "org-1",
+        policy: { taskSuccessMin: 0.9 },
+        perAgentPolicyOverrides: {
+          "agent-1": { latencyP95TargetMs: "2000" },
+        },
+      },
+    });
+
+    const result = await resolvePromotionPolicy("org-1", "agent-1");
+
+    expect(result).toEqual({ ok: false, reason: "UNREADABLE" });
+  });
+
+  test("boolean field with wrong primitive type (number instead of boolean) resolves to UNREADABLE", async () => {
+    ddbMock.on(GetCommand).resolves({
+      Item: {
+        orgId: "org-1",
+        policy: { allowNoBaselineOnAbsoluteFloors: 1 },
+        perAgentPolicyOverrides: {},
+      },
+    });
+
+    const result = await resolvePromotionPolicy("org-1", "agent-1");
+
+    expect(result).toEqual({ ok: false, reason: "UNREADABLE" });
+  });
+});
+
+describe("resolvePromotionPolicy — thrown GetItem -> UNREADABLE", () => {
+  test("a thrown SDK error resolves to UNREADABLE, never falls back to defaults", async () => {
+    ddbMock.on(GetCommand).rejects(new Error("DynamoDB unavailable"));
+
+    const result = await resolvePromotionPolicy("org-1", "agent-1");
+
+    expect(result).toEqual({ ok: false, reason: "UNREADABLE" });
+  });
+});
+
+describe("resolvePromotionPolicy — merged numerics stay sane", () => {
+  test("merged policy numerics are always finite and within their documented floors", async () => {
+    ddbMock.on(GetCommand).resolves({
+      Item: {
+        orgId: "org-1",
+        policy: {
+          taskSuccessMin: 0.95,
+          policyComplianceMin: 1.0,
+          latencyP95TargetMs: 4000,
+          avgCostBudgetUsd: 2.0,
+          minSampleCount: 10,
+          maxEvidenceAgeDays: 3,
+        },
+        perAgentPolicyOverrides: {
+          "agent-1": { taskSuccessMin: 0.97 },
+        },
+      },
+    });
+
+    const result = await resolvePromotionPolicy("org-1", "agent-1");
+
+    expect(result.ok).toBe(true);
+    if (!result.ok) throw new Error("unreachable");
+    expect(result.policy.taskSuccessMin).toBeGreaterThanOrEqual(0);
+    expect(result.policy.taskSuccessMin).toBeLessThanOrEqual(1);
+    expect(result.policy.policyComplianceMin).toBeGreaterThanOrEqual(0);
+    expect(result.policy.policyComplianceMin).toBeLessThanOrEqual(1);
+    expect(result.policy.latencyP95TargetMs).toBeGreaterThanOrEqual(0);
+    expect(result.policy.avgCostBudgetUsd).toBeGreaterThanOrEqual(0);
+    expect(result.policy.minSampleCount).toBeGreaterThanOrEqual(0);
+    expect(result.policy.maxEvidenceAgeDays).toBeGreaterThanOrEqual(0);
+    expect(Number.isFinite(result.policy.taskSuccessMin)).toBe(true);
+  });
+});

--- a/backend/src/lambda/utils/promotion-policy-store.ts
+++ b/backend/src/lambda/utils/promotion-policy-store.ts
@@ -1,0 +1,311 @@
+/**
+ * promotion-policy-store.ts — per-org PromotionPolicy config (decision
+ * ada70113: promotion policy becomes per-org config), cloning the
+ * eval-sampling-config.ts convention: a single, dependency-light READ
+ * module the promotion gate consumes, admin-authored via a separate
+ * resolver (promotion-policy-resolver.ts).
+ *
+ * Table: PROMOTION_POLICY_CONFIG_TABLE, PK=orgId. One row per org:
+ *   { orgId, policy: Partial<PromotionPolicy>,
+ *     perAgentPolicyOverrides: Record<agentTargetId, Partial<PromotionPolicy>>,
+ *     updatedAt, updatedBy }
+ *
+ * Resolution order (field-level merge, NOT whole-object replace):
+ *   DEFAULT_PROMOTION_POLICY  <-  row.policy  <-  row.perAgentPolicyOverrides[agentTargetId]
+ * Each PromotionPolicy field is taken from the highest-precedence source
+ * that actually supplies it (and passes the per-field sanity check below);
+ * a field a higher-precedence source omits, or supplies invalid, falls
+ * through to the next-lower source rather than blanking the whole
+ * object — mirrors release-gate-evidence.ts's "every failure is data"
+ * discipline applied at the individual-field level instead of the
+ * whole-resolution level.
+ *
+ * Fail-closed contract, matching eval-sampling-config.ts's
+ * getEvalSamplingConfig AND release-gate-evidence.ts's UNREADABLE_RECORD
+ * discipline simultaneously:
+ *   - Absent row -> ok:true with DEFAULT_PROMOTION_POLICY (no config
+ *     authored yet is NOT a failure — same "opt-in gate" precedent as
+ *     eval-sampling-config.ts's absent-config-is-not-an-error stance,
+ *     applied here to policy floors instead of a sampling opt-in flag).
+ *   - Thrown GetItem (SDK error) -> ok:false, reason:'UNREADABLE'. A
+ *     transient DynamoDB error must never silently fall back to
+ *     DEFAULT_PROMOTION_POLICY, because that would let an org-tightened
+ *     policy (e.g. a stricter taskSuccessMin) get silently bypassed by
+ *     an infrastructure blip — the opposite failure mode from
+ *     eval-sampling-config's "fail closed toward NOT sampling", but the
+ *     same "never treat an unreadable governance record as safe to
+ *     ignore" doctrine as release-gate-evidence.ts.
+ *   - Schema-invalid row (orgId missing/wrong type, policy/
+ *     perAgentPolicyOverrides present but not a plain object) -> ok:false,
+ *     reason:'UNREADABLE'. A malformed governance record is
+ *     indistinguishable, for fail-closed purposes, from an unreadable one.
+ *   - A malformed INDIVIDUAL field inside policy/perAgentPolicyOverrides
+ *     whose PRIMITIVE TYPE is wrong (e.g. a string where PromotionPolicy
+ *     declares a number, or vice versa) is treated as schema-invalid for
+ *     the WHOLE ROW -> ok:false, reason:'UNREADABLE'. A present field of
+ *     the wrong primitive type is indistinguishable, for fail-closed
+ *     purposes, from a malformed policy/perAgentPolicyOverrides container:
+ *     both mean the record cannot be trusted to represent the org's
+ *     intended policy, so silently falling through to
+ *     DEFAULT_PROMOTION_POLICY for that field would risk bypassing a
+ *     tightened org floor (e.g. taskSuccessMin: "0.99" as a string must
+ *     refuse, not silently resolve to the default 0.9).
+ *   - A field that IS the correct primitive type but fails its
+ *     RANGE/sanity floor (NaN, negative where nonsensical, out-of-[0,1]
+ *     for a rate) does NOT fail the whole resolution — it is dropped from
+ *     that source and the merge falls through to the next-lower-
+ *     precedence source for that field only. This is deliberately
+ *     narrower than the whole-row UNREADABLE case: a single
+ *     out-of-range-but-correctly-typed numeric in an otherwise-valid
+ *     per-agent override must not blank the entire org policy — only a
+ *     type mismatch does.
+ *
+ * Never re-implements PromotionPolicy's own numeric semantics — every
+ * sanity floor here (0..1 for rate-like fields, >=0 for
+ * ms/usd/count-like fields, non-negative integer array length is
+ * trivially satisfied by `string[]`) mirrors the field comments on
+ * PromotionPolicy (release-gate.ts) exactly.
+ */
+import { DynamoDBClient } from "@aws-sdk/client-dynamodb";
+import { DynamoDBDocumentClient, GetCommand } from "@aws-sdk/lib-dynamodb";
+import { DEFAULT_PROMOTION_POLICY, type PromotionPolicy } from "./release-gate";
+
+const dynamoClient = new DynamoDBClient({});
+const docClient = DynamoDBDocumentClient.from(dynamoClient);
+
+function promotionPolicyConfigTable(): string {
+  return process.env.PROMOTION_POLICY_CONFIG_TABLE!;
+}
+
+export interface PromotionPolicyConfigRow {
+  orgId: string;
+  policy?: Partial<PromotionPolicy>;
+  perAgentPolicyOverrides?: Record<string, Partial<PromotionPolicy>>;
+  updatedAt?: string;
+  updatedBy?: string;
+}
+
+export type PromotionPolicyResolutionFailureReason = "UNREADABLE";
+
+export type PromotionPolicyResolutionResult =
+  | { ok: true; policy: PromotionPolicy }
+  | { ok: false; reason: PromotionPolicyResolutionFailureReason };
+
+// ─────────────────────────────────────────────────────────────────────────
+// Per-field sanity floors — mirrors PromotionPolicy's own doc comments
+// (release-gate.ts). A field failing its floor is treated as ABSENT from
+// that source (falls through to the next-lower-precedence source), never
+// as a whole-row failure.
+// ─────────────────────────────────────────────────────────────────────────
+
+function isFiniteNumber(v: unknown): v is number {
+  return typeof v === "number" && Number.isFinite(v);
+}
+
+/** Rate-like fields: must resolve within [0,1]. */
+function isSaneRate(v: unknown): v is number {
+  return isFiniteNumber(v) && v >= 0 && v <= 1;
+}
+
+/** Non-negative magnitude fields (ms/usd/count) — no sensible upper
+ * bound to enforce here (policy authors may legitimately set a very
+ * high budget/threshold), but negative or NaN is never sane. */
+function isSaneNonNegative(v: unknown): v is number {
+  return isFiniteNumber(v) && v >= 0;
+}
+
+function isSaneStringArray(v: unknown): v is string[] {
+  return Array.isArray(v) && v.every((x) => typeof x === "string");
+}
+
+function isSaneBoolean(v: unknown): v is boolean {
+  return typeof v === "boolean";
+}
+
+/** Field-by-field validators, keyed exactly to PromotionPolicy's own
+ * field set — adding a field to PromotionPolicy without adding a floor
+ * here is a compile error via the Record<keyof PromotionPolicy, ...>
+ * constraint below. */
+const FIELD_VALIDATORS: {
+  [K in keyof PromotionPolicy]: (v: unknown) => v is PromotionPolicy[K];
+} = {
+  taskSuccessMin: isSaneRate,
+  policyComplianceMin: isSaneRate,
+  latencyP95TargetMs: isSaneNonNegative,
+  avgCostBudgetUsd: isSaneNonNegative,
+  minSampleCount: isSaneNonNegative,
+  requiredGateClasses: isSaneStringArray,
+  maxEvidenceAgeDays: isSaneNonNegative,
+  allowNoBaselineOnAbsoluteFloors: isSaneBoolean,
+};
+
+/**
+ * Primitive-TYPE-only checks (no range/sanity floor) — used to
+ * distinguish "wrong primitive type" (whole-row UNREADABLE) from
+ * "correct type but out of range" (per-field drop, handled by
+ * FIELD_VALIDATORS/mergePolicyFields). Deliberately permissive on
+ * range: `typeof v === "number"` accepts NaN/negative/out-of-[0,1] —
+ * those are exactly the values FIELD_VALIDATORS is meant to catch and
+ * drop per-field, not fail the whole row over.
+ */
+const FIELD_TYPE_GUARDS: {
+  [K in keyof PromotionPolicy]: (v: unknown) => boolean;
+} = {
+  taskSuccessMin: (v) => typeof v === "number",
+  policyComplianceMin: (v) => typeof v === "number",
+  latencyP95TargetMs: (v) => typeof v === "number",
+  avgCostBudgetUsd: (v) => typeof v === "number",
+  minSampleCount: (v) => typeof v === "number",
+  requiredGateClasses: (v) =>
+    Array.isArray(v) && v.every((x) => typeof x === "string"),
+  maxEvidenceAgeDays: (v) => typeof v === "number",
+  allowNoBaselineOnAbsoluteFloors: (v) => typeof v === "boolean",
+};
+
+const POLICY_FIELDS = Object.keys(
+  FIELD_VALIDATORS,
+) as (keyof PromotionPolicy)[];
+
+/**
+ * Scans a single Partial<PromotionPolicy>-shaped container (row.policy,
+ * or one entry of row.perAgentPolicyOverrides) for any PRESENT field
+ * whose primitive type is wrong. Range-only problems (NaN, negative,
+ * out-of-[0,1]) are NOT flagged here — those pass their type guard and
+ * are left for mergePolicyFields' per-field drop.
+ */
+function hasWrongTypeField(container: Record<string, unknown>): boolean {
+  for (const field of POLICY_FIELDS) {
+    const value = container[field];
+    if (value === undefined) continue;
+    const typeGuard = FIELD_TYPE_GUARDS[field];
+    if (!typeGuard(value)) return true;
+  }
+  return false;
+}
+
+/**
+ * Field-level merge: for each PromotionPolicy field, take the
+ * highest-precedence source (later entries in `sources` win) that both
+ * supplies the field (not undefined) AND passes its sanity floor.
+ * Sources earlier in the array are lower precedence — pass
+ * [floor, org, agent] in that order.
+ */
+function mergePolicyFields(
+  sources: (Partial<PromotionPolicy> | undefined)[],
+): PromotionPolicy {
+  const result = { ...DEFAULT_PROMOTION_POLICY };
+  for (const field of POLICY_FIELDS) {
+    const validate = FIELD_VALIDATORS[field];
+    for (const source of sources) {
+      if (!source) continue;
+      const candidate = source[field];
+      if (candidate === undefined) continue;
+      if (validate(candidate as never)) {
+        (result as Record<string, unknown>)[field] = candidate;
+      }
+      // An invalid candidate is dropped (falls through to the next
+      // source in iteration order); it never throws and never blanks
+      // a previously-resolved value from a lower-precedence source
+      // that already landed in `result`.
+    }
+  }
+  return result;
+}
+
+/** Loose type guard for "is this a plain, non-array object" — used to
+ * distinguish a genuinely malformed `policy`/`perAgentPolicyOverrides`
+ * shape (schema-invalid row -> UNREADABLE) from a merely-absent one
+ * (fine, defaults apply). */
+function isPlainObject(v: unknown): v is Record<string, unknown> {
+  return typeof v === "object" && v !== null && !Array.isArray(v);
+}
+
+/**
+ * Validates the overall row SHAPE (not individual field RANGES — those
+ * are validated per-field during merge, see mergePolicyFields). Returns
+ * false for anything that would make the row untrustworthy to merge:
+ * missing/wrong-typed orgId, a present-but-non-object
+ * policy/perAgentPolicyOverrides container, OR any present field inside
+ * policy/perAgentPolicyOverrides[*] whose PRIMITIVE TYPE is wrong (see
+ * hasWrongTypeField — range-only problems are NOT shape violations and
+ * do not reach this function's false branch).
+ */
+function isReadableRow(row: unknown): row is PromotionPolicyConfigRow {
+  if (!isPlainObject(row)) return false;
+  if (typeof row.orgId !== "string" || !row.orgId) return false;
+  if (row.policy !== undefined) {
+    if (!isPlainObject(row.policy)) return false;
+    if (hasWrongTypeField(row.policy)) return false;
+  }
+  if (row.perAgentPolicyOverrides !== undefined) {
+    if (!isPlainObject(row.perAgentPolicyOverrides)) return false;
+    for (const override of Object.values(row.perAgentPolicyOverrides)) {
+      if (!isPlainObject(override)) return false;
+      if (hasWrongTypeField(override)) return false;
+    }
+  }
+  return true;
+}
+
+async function getPromotionPolicyConfigRow(
+  orgId: string,
+): Promise<PromotionPolicyConfigRow | undefined> {
+  const res = await docClient.send(
+    new GetCommand({
+      TableName: promotionPolicyConfigTable(),
+      Key: { orgId },
+    }),
+  );
+  return res.Item as PromotionPolicyConfigRow | undefined;
+}
+
+/**
+ * Resolves the effective PromotionPolicy for (orgId, agentTargetId).
+ *
+ * ok:true, policy=DEFAULT_PROMOTION_POLICY  — no config row exists yet.
+ * ok:true, policy=<merged>                  — row exists and is readable;
+ *   field-level merge floor <- org <- agent, invalid/missing individual
+ *   fields fall through rather than failing the whole resolution.
+ * ok:false, reason:'UNREADABLE'              — thrown GetItem, or a
+ *   schema-invalid row (missing/wrong-typed orgId, a non-object
+ *   policy/perAgentPolicyOverrides container, or any present field
+ *   inside policy/perAgentPolicyOverrides[*] with the wrong PRIMITIVE
+ *   TYPE). Callers MUST treat this as fail-closed — never substitute
+ *   DEFAULT_PROMOTION_POLICY on this branch (that would silently
+ *   downgrade an org's tightened policy).
+ */
+export async function resolvePromotionPolicy(
+  orgId: string,
+  agentTargetId: string,
+): Promise<PromotionPolicyResolutionResult> {
+  let row: PromotionPolicyConfigRow | undefined;
+  try {
+    row = await getPromotionPolicyConfigRow(orgId);
+  } catch (err: unknown) {
+    console.error(
+      "promotion-policy-store: resolvePromotionPolicy GetItem failed — resolving to UNREADABLE (fail-closed, never falls back to defaults)",
+      {
+        orgId,
+        agentTargetId,
+        error: err instanceof Error ? err.message : String(err),
+      },
+    );
+    return { ok: false, reason: "UNREADABLE" };
+  }
+
+  if (row === undefined) {
+    return { ok: true, policy: { ...DEFAULT_PROMOTION_POLICY } };
+  }
+
+  if (!isReadableRow(row)) {
+    console.error(
+      "promotion-policy-store: resolvePromotionPolicy encountered a schema-invalid row — resolving to UNREADABLE",
+      { orgId, agentTargetId },
+    );
+    return { ok: false, reason: "UNREADABLE" };
+  }
+
+  const agentOverride = row.perAgentPolicyOverrides?.[agentTargetId];
+  const merged = mergePolicyFields([row.policy, agentOverride]);
+  return { ok: true, policy: merged };
+}

--- a/backend/src/lambda/utils/release-promotion-approval-writer.ts
+++ b/backend/src/lambda/utils/release-promotion-approval-writer.ts
@@ -1,0 +1,164 @@
+/**
+ * release-promotion-approval-writer.ts — write-once GovernanceFinding row
+ * for ONE interim human-approval decision on a release promotion.
+ *
+ * Sibling of release-gate-finding-writer.ts — mirrors its contract
+ * exactly (same GOVERNANCE_LEDGER_TABLE, same key-schema aliases
+ * (camelCase) + dataclass field names (snake_case) dual-write
+ * convention, same write-once dedupe discipline), so
+ * governance-ui-resolver.ts's existing `projectFinding` reads this row
+ * unmodified. Decision 8165b7e5: this is the interim human-approval
+ * substrate riding the existing promote mutation — the CIT-030 approval
+ * substrate does not exist, so this writer + the `PromotionApproval`
+ * input on `promoteEnvironmentReleasePointer` are the whole of it.
+ *
+ * category is `release-promotion-approval` — distinct from the release
+ * gate's `release-promotion` category (release-gate-finding-writer.ts)
+ * — so the two decisions are never conflated when querying findings by
+ * category, even though both write into the same ledger table for the
+ * same release+environment.
+ *
+ * decidedBy is ALWAYS `authContext.userId` (Cognito, server-derived) —
+ * the caller must never be able to author who decided; there is
+ * deliberately no `decidedBy` field on the input type at all (see
+ * ReleasePromotionApprovalInput below), matching the schema-level
+ * doctrine that `PromotionApproval` (schema.graphql) carries no
+ * `decidedBy` field either.
+ *
+ * FAIL-CLOSED, same as release-gate-finding-writer.ts and the SAME
+ * standing user decision (finding 23971f32): a failed write here must
+ * abort the promotion, never be swallowed. Only the expected write-once
+ * dedupe rejection (ConditionalCheckFailedException) is caught; every
+ * other error is rethrown unchanged.
+ *
+ * findingId is derived deterministically from
+ * `{orgId}#{agentTargetId}#{environment}#{releaseId}#approval#{decision}`
+ * — same idempotency discipline as release-gate-finding-writer.ts's
+ * findingIdFor, with an extra `#approval` segment so an approval
+ * decision's findingId can never collide with the gate's own finding
+ * for the same release+environment+decision.
+ */
+import { createHash } from "crypto";
+import { DynamoDBClient } from "@aws-sdk/client-dynamodb";
+import { DynamoDBDocumentClient, PutCommand } from "@aws-sdk/lib-dynamodb";
+import type { EnvironmentLiteral } from "../../types";
+
+const dynamoClient = new DynamoDBClient({});
+const docClient = DynamoDBDocumentClient.from(dynamoClient);
+
+function governanceLedgerTable(): string {
+  return process.env.GOVERNANCE_LEDGER_TABLE!;
+}
+
+const TTL_DAYS = 90; // Same default retention as release-gate-finding-writer.ts.
+const REQUESTING_AGENT = "release-promotion-approval";
+
+/** The two ArbitrationDecision literals an approval decision can
+ * produce, derived from `approved` at the call site. */
+export type ReleasePromotionApprovalDecision = "permit" | "deny";
+
+export interface ReleasePromotionApprovalInput {
+  orgId: string;
+  agentTargetId: string;
+  environment: EnvironmentLiteral;
+  releaseId: string;
+  /** Server-derived caller identity (from Cognito claims via
+   * authContext.userId), never from caller-supplied input. */
+  decidedBy: string;
+  decision: ReleasePromotionApprovalDecision;
+  /** Caller-supplied justification, carried verbatim. Optional — the
+   * `PromotionApproval` schema input's `justification` field is
+   * nullable. */
+  justification?: string | null;
+  traceId?: string;
+  runId?: string;
+}
+
+function findingIdFor(input: ReleasePromotionApprovalInput): string {
+  const raw = `${input.orgId}#${input.agentTargetId}#${input.environment}#${input.releaseId}#approval#${input.decision}`;
+  return createHash("sha256").update(raw).digest("hex");
+}
+
+function workflowIdFor(input: ReleasePromotionApprovalInput): string {
+  return `RELEASE_PROMOTION_APPROVAL#${input.agentTargetId}#${input.environment}`;
+}
+
+function buildReason(input: ReleasePromotionApprovalInput): string {
+  const justificationPart = input.justification
+    ? ` justification="${input.justification}"`
+    : "";
+  return (
+    `Release promotion approval ${input.decision.toUpperCase()} for ` +
+    `release="${input.releaseId}" agent="${input.agentTargetId}" ` +
+    `environment="${input.environment}" decidedBy="${input.decidedBy}".` +
+    justificationPart
+  );
+}
+
+/**
+ * Writes one write-once GovernanceFinding row for a release-promotion
+ * approval decision. Idempotent per (orgId, agentTargetId, environment,
+ * releaseId, decision) — see module doc. Rethrows any error other than
+ * the expected write-once dedupe rejection (ConditionalCheckFailedException).
+ */
+export async function writeReleasePromotionApprovalFinding(
+  input: ReleasePromotionApprovalInput,
+): Promise<void> {
+  const findingId = findingIdFor(input);
+  const workflowId = workflowIdFor(input);
+  const timestamp = Date.now() / 1000;
+  const ttl = timestamp + TTL_DAYS * 86400;
+
+  const item: Record<string, unknown> = {
+    findingId,
+    workflowId,
+    timestamp,
+    workflow_id: workflowId,
+    decision: input.decision,
+    requesting_agent: REQUESTING_AGENT,
+    target_agent: input.agentTargetId,
+    reason: buildReason(input),
+    finding_id: findingId,
+    decided_by: input.decidedBy,
+    category: "release-promotion-approval",
+    org_id: input.orgId,
+    environment: input.environment,
+    release_id: input.releaseId,
+    ttl,
+  };
+
+  if (input.justification !== undefined && input.justification !== null) {
+    item.justification = input.justification;
+  }
+  if (input.traceId !== undefined) {
+    item.traceId = input.traceId;
+  }
+  if (input.runId !== undefined) {
+    item.runId = input.runId;
+  }
+
+  try {
+    await docClient.send(
+      new PutCommand({
+        TableName: governanceLedgerTable(),
+        Item: item,
+        ConditionExpression: "attribute_not_exists(findingId)",
+      }),
+    );
+  } catch (err: unknown) {
+    if (
+      err instanceof Error &&
+      err.name === "ConditionalCheckFailedException"
+    ) {
+      // intentional-empty-catch: expected outcome — a finding for this
+      // exact (org, agent, environment, release, approval, decision)
+      // already exists. Not an error, same dedupe discipline as
+      // release-gate-finding-writer.ts.
+      return;
+    }
+    // Every OTHER error is rethrown — approval recording is FAIL-CLOSED
+    // same as the gate finding (a failed write aborts the promotion;
+    // that is the standing user decision, finding 23971f32).
+    throw err;
+  }
+}

--- a/backend/src/schema/schema.graphql
+++ b/backend/src/schema/schema.graphql
@@ -2425,6 +2425,17 @@ input SetEnvironmentReleasePointerInput {
   agentTargetId: String!
   environment: DeploymentEnvironment!
   releaseId: ID!
+  approval: PromotionApproval
+}
+
+# Interim human-approval input for promoteEnvironmentReleasePointer
+# (decision 8165b7e5 — rides the existing promote mutation; the CIT-030
+# approval substrate does not exist). decidedBy is NEVER part of this
+# input — it is server-derived from the caller's identity in the
+# resolver, same doctrine as every other decidedBy field in this schema.
+input PromotionApproval {
+  approved: Boolean!
+  justification: String
 }
 
 type EvalRunCaseResult {

--- a/backend/src/schema/schema.graphql
+++ b/backend/src/schema/schema.graphql
@@ -98,6 +98,9 @@ type Query {
   # eval-sampling-config-resolver.ts, not by schema visibility).
   getEvalSamplingConfig(orgId: ID!): EvalSamplingConfig
   listEvalProdSamples(orgId: ID!, agentId: ID): [EvalProdSample!]!
+  # Decision ada70113 — admin-only read (enforced in
+  # promotion-policy-resolver.ts, not by schema visibility).
+  getPromotionPolicy(orgId: ID!): PromotionPolicyConfig
   # InterrogationRound
   getInterrogationRound(projectId: ID!, roundN: Int!): InterrogationRound
   listInterrogationRounds(projectId: ID!): [InterrogationRound!]!
@@ -384,6 +387,10 @@ type Mutation {
   # not schema visibility). optIn/rate changes take effect on the NEXT
   # terminal workflow/conversation signal; no retroactive resampling.
   setEvalSamplingConfig(orgId: ID!, input: EvalSamplingConfigInput!): EvalSamplingConfig!
+  # Decision ada70113 — admin-only write (enforced in
+  # promotion-policy-resolver.ts, not by schema visibility). updatedBy is
+  # server-derived from the caller's identity, never accepted from input.
+  setPromotionPolicy(orgId: ID!, input: PromotionPolicyConfigInput!): PromotionPolicyConfig!
   # InterrogationRound
   startInterrogationRound(projectId: ID!, roundN: Int!): InterrogationRound!
   injectConstraints(projectId: ID!, roundN: Int!, constraints: [String!]!): InterrogationRound!
@@ -2689,6 +2696,29 @@ input EvalSamplingConfigInput {
   optIn: Boolean!
   defaultSampleRate: Float!
   perAgentSampleRate: AWSJSON
+}
+
+# Decision ada70113: promotion policy becomes per-org config. Admin-authored
+# floor for environment-release-pointer-resolver.ts's validateReleaseGate
+# (via promotion-policy-store.ts's resolvePromotionPolicy). Mirrors
+# EvalSamplingConfig's structure: `policy` overrides DEFAULT_PROMOTION_POLICY
+# field-by-field, `perAgentPolicyOverrides` further overrides per
+# agentTargetId. Both are AWSJSON since GraphQL has no native map/partial
+# type and PromotionPolicy fields are resolved field-by-field, not as a
+# whole-object replace.
+type PromotionPolicyConfig {
+  orgId: ID!
+  # Partial<PromotionPolicy> — org-wide floor overrides.
+  policy: AWSJSON
+  # Map<agentTargetId, Partial<PromotionPolicy>> — per-agent floor overrides.
+  perAgentPolicyOverrides: AWSJSON
+  updatedAt: AWSDateTime
+  updatedBy: String
+}
+
+input PromotionPolicyConfigInput {
+  policy: AWSJSON
+  perAgentPolicyOverrides: AWSJSON
 }
 
 # Phase 2 (production sampling) — a captured + scored production sample.

--- a/backend/src/types/index.ts
+++ b/backend/src/types/index.ts
@@ -992,11 +992,25 @@ export interface EnvironmentReleasePointer {
   version: number;
 }
 
+/** Interim human-approval input for promoteEnvironmentReleasePointer
+ * (decision 8165b7e5 — rides the existing promote mutation; the CIT-030
+ * approval substrate does not exist). `approved` is caller-supplied;
+ * `decidedBy` is deliberately ABSENT here — it is derived from
+ * authContext.userId in the resolver, never accepted from input. */
+export interface PromotionApproval {
+  approved: boolean;
+  justification?: string | null;
+}
+
 /** Input to set (create-or-move) the pointer for one (agentTargetId,
  * environment) pair. orgId is derived from the caller, never taken from
- * caller-supplied input — same doctrine as CutAgentReleaseInput. */
+ * caller-supplied input — same doctrine as CutAgentReleaseInput.
+ * `approval` is OPTIONAL and its requirement is mode-dependent — see
+ * environment-release-pointer-resolver.ts's promoteEnvironmentReleasePointer
+ * for the strict/shadow/permissive disposition. */
 export interface SetEnvironmentReleasePointerInput {
   agentTargetId: string;
   environment: EnvironmentLiteral;
   releaseId: string;
+  approval?: PromotionApproval | null;
 }

--- a/backend/test/governance-stack-environment-release-pointer-ledger.test.ts
+++ b/backend/test/governance-stack-environment-release-pointer-ledger.test.ts
@@ -223,6 +223,29 @@ function createTestStack(): {
   const registryArn =
     "arn:aws:bedrock-agentcore:us-east-1:123456789012:registry/citadel-test";
 
+  const promotionPolicyConfigTable = new dynamodb.Table(
+    backendStack,
+    "PromotionPolicyConfigTable",
+    {
+      tableName: "citadel-promotion-policy-config-test",
+      partitionKey: { name: "orgId", type: dynamodb.AttributeType.STRING },
+      billingMode: dynamodb.BillingMode.PAY_PER_REQUEST,
+      removalPolicy: cdk.RemovalPolicy.DESTROY,
+    },
+  );
+  const promotionPolicyConfigWriterRole = new iam.Role(
+    backendStack,
+    "PromotionPolicyConfigWriterRole",
+    { assumedBy: new iam.ServicePrincipal("lambda.amazonaws.com") },
+  );
+  promotionPolicyConfigWriterRole.addToPolicy(
+    new iam.PolicyStatement({
+      effect: iam.Effect.ALLOW,
+      actions: ["dynamodb:GetItem", "dynamodb:PutItem"],
+      resources: [promotionPolicyConfigTable.tableArn],
+    }),
+  );
+
   const stack = new GovernanceStack(
     app,
     "TestGovernanceStackEnvPointerLedger",
@@ -254,6 +277,8 @@ function createTestStack(): {
       registryId: "citadel-test",
       environmentReleasePointersTable,
       environmentReleasePointerWriterRole,
+      promotionPolicyConfigTable,
+      promotionPolicyConfigWriterRole,
     },
   );
 

--- a/backend/test/governance-stack-eval-comparison.test.ts
+++ b/backend/test/governance-stack-eval-comparison.test.ts
@@ -109,6 +109,29 @@ function createTestStack(): { stack: GovernanceStack; template: Template } {
     { assumedBy: new iam.ServicePrincipal("lambda.amazonaws.com") },
   );
 
+  const promotionPolicyConfigTable = new dynamodb.Table(
+    backendStack,
+    "PromotionPolicyConfigTable",
+    {
+      tableName: "citadel-promotion-policy-config-test",
+      partitionKey: { name: "orgId", type: dynamodb.AttributeType.STRING },
+      billingMode: dynamodb.BillingMode.PAY_PER_REQUEST,
+      removalPolicy: cdk.RemovalPolicy.DESTROY,
+    },
+  );
+  const promotionPolicyConfigWriterRole = new iam.Role(
+    backendStack,
+    "PromotionPolicyConfigWriterRole",
+    { assumedBy: new iam.ServicePrincipal("lambda.amazonaws.com") },
+  );
+  promotionPolicyConfigWriterRole.addToPolicy(
+    new iam.PolicyStatement({
+      effect: iam.Effect.ALLOW,
+      actions: ["dynamodb:GetItem", "dynamodb:PutItem"],
+      resources: [promotionPolicyConfigTable.tableArn],
+    }),
+  );
+
   const stack = new GovernanceStack(app, "TestGovernanceStackEvalComparison", {
     env: { account: "123456789012", region: "us-east-1" },
     environment: "test",
@@ -194,6 +217,8 @@ function createTestStack(): { stack: GovernanceStack; template: Template } {
     registryId: "citadel-test",
     environmentReleasePointersTable,
     environmentReleasePointerWriterRole,
+    promotionPolicyConfigTable,
+    promotionPolicyConfigWriterRole,
   });
 
   const template = Template.fromStack(stack);

--- a/backend/test/governance-stack-eval-resolver.test.ts
+++ b/backend/test/governance-stack-eval-resolver.test.ts
@@ -194,6 +194,29 @@ function createTestStack(): { stack: GovernanceStack; template: Template } {
     { assumedBy: new iam.ServicePrincipal("lambda.amazonaws.com") },
   );
 
+  const promotionPolicyConfigTable = new dynamodb.Table(
+    backendStack,
+    "PromotionPolicyConfigTable",
+    {
+      tableName: "citadel-promotion-policy-config-test",
+      partitionKey: { name: "orgId", type: dynamodb.AttributeType.STRING },
+      billingMode: dynamodb.BillingMode.PAY_PER_REQUEST,
+      removalPolicy: cdk.RemovalPolicy.DESTROY,
+    },
+  );
+  const promotionPolicyConfigWriterRole = new iam.Role(
+    backendStack,
+    "PromotionPolicyConfigWriterRole",
+    { assumedBy: new iam.ServicePrincipal("lambda.amazonaws.com") },
+  );
+  promotionPolicyConfigWriterRole.addToPolicy(
+    new iam.PolicyStatement({
+      effect: iam.Effect.ALLOW,
+      actions: ["dynamodb:GetItem", "dynamodb:PutItem"],
+      resources: [promotionPolicyConfigTable.tableArn],
+    }),
+  );
+
   const stack = new GovernanceStack(app, "TestGovernanceStackEval", {
     env: { account: "123456789012", region: "us-east-1" },
     environment: "test",
@@ -223,6 +246,8 @@ function createTestStack(): { stack: GovernanceStack; template: Template } {
     registryId: "citadel-test",
     environmentReleasePointersTable,
     environmentReleasePointerWriterRole,
+    promotionPolicyConfigTable,
+    promotionPolicyConfigWriterRole,
   });
 
   const template = Template.fromStack(stack);

--- a/backend/test/governance-stack-eval-run.test.ts
+++ b/backend/test/governance-stack-eval-run.test.ts
@@ -173,6 +173,29 @@ function createTestStack(): { stack: GovernanceStack; template: Template } {
     { assumedBy: new iam.ServicePrincipal("lambda.amazonaws.com") },
   );
 
+  const promotionPolicyConfigTable = new dynamodb.Table(
+    backendStack,
+    "PromotionPolicyConfigTable",
+    {
+      tableName: "citadel-promotion-policy-config-test",
+      partitionKey: { name: "orgId", type: dynamodb.AttributeType.STRING },
+      billingMode: dynamodb.BillingMode.PAY_PER_REQUEST,
+      removalPolicy: cdk.RemovalPolicy.DESTROY,
+    },
+  );
+  const promotionPolicyConfigWriterRole = new iam.Role(
+    backendStack,
+    "PromotionPolicyConfigWriterRole",
+    { assumedBy: new iam.ServicePrincipal("lambda.amazonaws.com") },
+  );
+  promotionPolicyConfigWriterRole.addToPolicy(
+    new iam.PolicyStatement({
+      effect: iam.Effect.ALLOW,
+      actions: ["dynamodb:GetItem", "dynamodb:PutItem"],
+      resources: [promotionPolicyConfigTable.tableArn],
+    }),
+  );
+
   const stack = new GovernanceStack(app, "TestGovernanceStackEvalRun", {
     env: { account: "123456789012", region: "us-east-1" },
     environment: "test",
@@ -202,6 +225,8 @@ function createTestStack(): { stack: GovernanceStack; template: Template } {
     registryId: "citadel-test",
     environmentReleasePointersTable,
     environmentReleasePointerWriterRole,
+    promotionPolicyConfigTable,
+    promotionPolicyConfigWriterRole,
   });
 
   const template = Template.fromStack(stack);

--- a/backend/test/governance-stack-promotion-policy.test.ts
+++ b/backend/test/governance-stack-promotion-policy.test.ts
@@ -1,19 +1,25 @@
 /**
- * governance-stack-agent-release.test.ts — GovernanceStack agent-release
- * wiring assertions (agent release bundles, slice 3: wiring only).
+ * governance-stack-promotion-policy.test.ts — decision ada70113
+ * (promotion policy becomes per-org config). CDK template assertions
+ * for PromotionPolicyConfigTable (BackendStack) and the admin
+ * PromotionPolicyResolverFunction + AppSync wiring (GovernanceStack).
  *
- * Mirrors governance-stack-eval-run.test.ts: one AgentReleaseResolverFunction,
- * one AgentReleaseLambdaDataSource, and a CfnResolver for the
- * Mutation.cutAgentRelease field, bound to that data source.
+ * Mirrors governance-stack-agent-release.test.ts's mock-stack scaffold
+ * pattern: a minimal BackendStack stand-in with just the tables/roles
+ * GovernanceStack actually needs, real GovernanceStack synth on top.
  *
- * The two invariants under test here are the whole risk of this slice:
- *  - The resolver Lambda's role is the EXISTING AgentReleaseWriterRole
- *    (assumed, not a fresh grantReadWriteData call) — so this test also
- *    re-asserts, at the GovernanceStack synth level, that no UpdateItem/
- *    DeleteItem is granted on AgentReleasesTable anywhere in the
- *    template (the IAM immutability floor must survive wiring).
- *  - No new principal picks up broader-than-Put/Get/Query access to the
- *    releases table as a side effect of AppSync/data-source wiring.
+ * Invariants under test:
+ *  - PromotionPolicyConfigTable exists, PAY_PER_REQUEST, PK=orgId.
+ *  - PromotionPolicyResolverFunction has the PROMOTION_POLICY_CONFIG_TABLE
+ *    env var and Node.js 24.x runtime.
+ *  - Its execution role is the EXISTING promotionPolicyConfigWriterRole
+ *    (assumed), not a fresh grantReadWriteData role.
+ *  - IAM floor is narrow: GetItem+PutItem only for the writer role, no
+ *    grantWriteData anywhere (no UpdateItem/DeleteItem/BatchWriteItem on
+ *    this table from any principal).
+ *  - The EXISTING environmentReleasePointerWriterRole additionally has a
+ *    GetItem-only (never PutItem) statement on this table — no single
+ *    statement grants PutItem to that role for this table.
  */
 import * as cdk from "aws-cdk-lib";
 import { Template, Match } from "aws-cdk-lib/assertions";
@@ -43,12 +49,11 @@ function mockTable(
 }
 
 function createTestStack(): {
-  stack: GovernanceStack;
   template: Template;
   backendTemplate: Template;
 } {
   const app = new cdk.App();
-  const backendStack = new cdk.Stack(app, "MockBackendStackAgentRelease", {
+  const backendStack = new cdk.Stack(app, "MockBackendStackPromotionPolicy", {
     env: { account: "123456789012", region: "us-east-1" },
   });
 
@@ -144,11 +149,6 @@ function createTestStack(): {
     "citadel-conversations-test",
   );
 
-  // Slice 1's actual releases table shape (simple PK on releaseId) plus
-  // the pre-existing writer role this slice must ASSUME rather than
-  // grant afresh — mirrors backend-stack.ts's real AgentReleasesTable /
-  // AgentReleaseWriterRole construction exactly (PutItem/GetItem/Query
-  // only, nothing else, ever).
   const agentReleasesTable = new dynamodb.Table(
     backendStack,
     "AgentReleasesTable",
@@ -168,9 +168,7 @@ function createTestStack(): {
   const agentReleaseWriterRole = new iam.Role(
     backendStack,
     "AgentReleaseWriterRole",
-    {
-      assumedBy: new iam.ServicePrincipal("lambda.amazonaws.com"),
-    },
+    { assumedBy: new iam.ServicePrincipal("lambda.amazonaws.com") },
   );
   agentReleaseWriterRole.addToPolicy(
     new iam.PolicyStatement({
@@ -183,11 +181,6 @@ function createTestStack(): {
     }),
   );
 
-  // Environment release pointer — separate table + separate role from
-  // AgentReleasesTable/AgentReleaseWriterRole above, mirroring
-  // backend-stack.ts's real EnvironmentReleasePointersTable /
-  // EnvironmentReleasePointerWriterRole construction. Kept separate on
-  // purpose — this is the invariant this slice guards.
   const environmentReleasePointersTable = new dynamodb.Table(
     backendStack,
     "EnvironmentReleasePointersTable",
@@ -205,9 +198,7 @@ function createTestStack(): {
   const environmentReleasePointerWriterRole = new iam.Role(
     backendStack,
     "EnvironmentReleasePointerWriterRole",
-    {
-      assumedBy: new iam.ServicePrincipal("lambda.amazonaws.com"),
-    },
+    { assumedBy: new iam.ServicePrincipal("lambda.amazonaws.com") },
   );
   environmentReleasePointerWriterRole.addToPolicy(
     new iam.PolicyStatement({
@@ -220,9 +211,11 @@ function createTestStack(): {
     }),
   );
 
-  const registryArn =
-    "arn:aws:bedrock-agentcore:us-east-1:123456789012:registry/citadel-test";
-
+  // Decision ada70113 — the table + two IAM floors under test. Mirrors
+  // backend-stack.ts's real construction: a dedicated writer role for
+  // the admin resolver (GetItem+PutItem), plus an ADDITIONAL scoped
+  // GetItem-only statement on the EXISTING pointer-writer role above
+  // (the promotion gate's read path).
   const promotionPolicyConfigTable = new dynamodb.Table(
     backendStack,
     "PromotionPolicyConfigTable",
@@ -245,8 +238,18 @@ function createTestStack(): {
       resources: [promotionPolicyConfigTable.tableArn],
     }),
   );
+  environmentReleasePointerWriterRole.addToPolicy(
+    new iam.PolicyStatement({
+      effect: iam.Effect.ALLOW,
+      actions: ["dynamodb:GetItem"],
+      resources: [promotionPolicyConfigTable.tableArn],
+    }),
+  );
 
-  const stack = new GovernanceStack(app, "TestGovernanceStackAgentRelease", {
+  const registryArn =
+    "arn:aws:bedrock-agentcore:us-east-1:123456789012:registry/citadel-test";
+
+  const stack = new GovernanceStack(app, "TestGovernanceStackPromotionPolicy", {
     env: { account: "123456789012", region: "us-east-1" },
     environment: "test",
     appSyncApi,
@@ -280,160 +283,100 @@ function createTestStack(): {
 
   const template = Template.fromStack(stack);
   const backendTemplate = Template.fromStack(backendStack);
-  return { stack, template, backendTemplate };
+  return { template, backendTemplate };
 }
 
-describe("GovernanceStack — agent-release wiring (cutAgentRelease reachability)", () => {
-  let template: Template;
+describe("PromotionPolicyConfigTable (decision ada70113)", () => {
   let backendTemplate: Template;
 
   beforeAll(() => {
-    ({ template, backendTemplate } = createTestStack());
+    ({ backendTemplate } = createTestStack());
   });
 
-  test("AgentReleaseResolverFunction exists with Node.js 24.x runtime and the expected table/registry env vars", () => {
+  test("table exists, PAY_PER_REQUEST, PK=orgId", () => {
+    backendTemplate.hasResourceProperties("AWS::DynamoDB::Table", {
+      TableName: "citadel-promotion-policy-config-test",
+      BillingMode: "PAY_PER_REQUEST",
+      KeySchema: [{ AttributeName: "orgId", KeyType: "HASH" }],
+    });
+  });
+
+  test("no single IAM statement grants access to both PromotionPolicyConfigTable and EnvironmentReleasePointersTable's PutItem action", () => {
+    const policies = backendTemplate.findResources("AWS::IAM::Policy");
+    for (const policy of Object.values(policies)) {
+      const stmts: Array<{ Action?: string | string[]; Resource?: unknown }> =
+        policy.Properties?.PolicyDocument?.Statement ?? [];
+      for (const stmt of stmts) {
+        const resources = Array.isArray(stmt.Resource)
+          ? stmt.Resource
+          : [stmt.Resource];
+        const asStrings = resources.map((r) => JSON.stringify(r));
+        const targetsPromotionPolicy = asStrings.some((s) =>
+          s.includes("PromotionPolicyConfigTable"),
+        );
+        const actions = Array.isArray(stmt.Action)
+          ? stmt.Action
+          : [stmt.Action];
+        const grantsPutOnPointers =
+          asStrings.some((s) =>
+            s.includes("EnvironmentReleasePointersTable"),
+          ) && actions.includes("dynamodb:PutItem");
+        // A statement targeting PromotionPolicyConfigTable must never be
+        // the SAME statement that grants PutItem on the pointers table —
+        // that would indicate the two tables' write floors were merged.
+        expect(targetsPromotionPolicy && grantsPutOnPointers).toBe(false);
+      }
+    }
+  });
+});
+
+describe("GovernanceStack — PromotionPolicyResolverFunction wiring", () => {
+  let template: Template;
+
+  beforeAll(() => {
+    ({ template } = createTestStack());
+  });
+
+  test("exists with Node.js 24.x runtime and the PROMOTION_POLICY_CONFIG_TABLE env var", () => {
     template.hasResourceProperties("AWS::Lambda::Function", {
-      Handler: "release-resolver.handler",
+      Handler: "promotion-policy-resolver.handler",
       Runtime: "nodejs24.x",
       Environment: {
         Variables: Match.objectLike({
-          AGENT_RELEASES_TABLE: Match.anyValue(),
-          EXECUTION_SPECS_TABLE: Match.anyValue(),
-          EVAL_RUNS_TABLE: Match.anyValue(),
-          EVAL_SUITES_TABLE: Match.anyValue(),
-          PROJECTS_TABLE: Match.anyValue(),
-          REGISTRY_ID: Match.anyValue(),
+          PROMOTION_POLICY_CONFIG_TABLE: Match.anyValue(),
         }),
       },
     });
   });
 
-  test("AgentReleaseResolverFunction's execution role IS the existing AgentReleaseWriterRole (assumed, not a fresh grantReadWriteData role)", () => {
+  test("its execution role IS the existing promotionPolicyConfigWriterRole (assumed, not a fresh role)", () => {
     const fns = template.findResources("AWS::Lambda::Function");
     const match = Object.values(fns).find(
-      (f) => f.Properties?.Handler === "release-resolver.handler",
+      (f) => f.Properties?.Handler === "promotion-policy-resolver.handler",
     );
     expect(match).toBeDefined();
     const roleProp = JSON.stringify(match!.Properties.Role);
-    // Cross-stack role reference: CDK exports agentReleaseWriterRole's ARN
-    // from BackendStack and imports it here via Fn::ImportValue — proof
-    // this Lambda ASSUMES the existing role rather than getting a
-    // freshly-generated "...ServiceRole..." (which grantReadWriteData
-    // or an implicit default role would produce).
-    expect(roleProp).toContain("AgentReleaseWriterRole");
-    expect(roleProp).not.toContain("ServiceRole");
-  });
-
-  test("no fresh IAM Role named *AgentReleaseResolverFunctionServiceRole* is synthesized (confirms no default/grantReadWriteData role was created)", () => {
-    const roles = template.findResources("AWS::IAM::Role");
-    const freshRoles = Object.keys(roles).filter((id) =>
-      id.startsWith("AgentReleaseResolverFunctionServiceRole"),
+    // Cross-stack role reference: CDK exports promotionPolicyConfigWriterRole's
+    // ARN from the mock BackendStack and imports it here via
+    // Fn::ImportValue — proof this Lambda ASSUMES the existing role
+    // rather than getting a fresh GetAtt'd role of its own.
+    expect(roleProp).toMatch(
+      /Fn::ImportValue|Fn::GetAtt.*PromotionPolicyConfigWriterRole/,
     );
-    expect(freshRoles).toEqual([]);
   });
 
-  test("AgentReleaseLambdaDataSource exists as an AWS_LAMBDA AppSync data source", () => {
+  test("AppSync data source + resolvers exist for setPromotionPolicy (Mutation) and getPromotionPolicy (Query)", () => {
     template.hasResourceProperties("AWS::AppSync::DataSource", {
-      Name: "AgentReleaseLambdaDataSource",
+      Name: "PromotionPolicyLambdaDataSource",
       Type: "AWS_LAMBDA",
     });
-  });
-
-  test("has a Mutation.cutAgentRelease CfnResolver bound to AgentReleaseLambdaDataSource", () => {
     template.hasResourceProperties("AWS::AppSync::Resolver", {
       TypeName: "Mutation",
-      FieldName: "cutAgentRelease",
-      DataSourceName: {
-        "Fn::GetAtt": [
-          Match.stringLikeRegexp("AgentReleaseLambdaDataSource"),
-          "Name",
-        ],
-      },
+      FieldName: "setPromotionPolicy",
     });
-  });
-
-  test("grants read access (via the assumed AgentReleaseWriterRole's policy) to exec-specs/eval-runs/eval-suites/projects tables and the registry", () => {
-    // Because agentReleaseWriterRole is an existing role passed in as a
-    // prop (not created inside GovernanceStack), grantXxx calls against
-    // it attach their statements to a policy owned by the role's own
-    // stack (the mock "backend" stack here), not to a fresh
-    // ServiceRole/DefaultPolicy inside GovernanceStack. This is the
-    // expected cross-stack shape, and it is itself part of what proves
-    // the resolver assumes the existing role rather than getting a new
-    // grantReadWriteData-generated one.
-    const policies = backendTemplate.findResources("AWS::IAM::Policy");
-    const writerRolePolicies = Object.values(policies).filter((p) => {
-      const roles = (p.Properties?.Roles ?? []) as Array<{ Ref?: string }>;
-      return roles.some((r) =>
-        (r.Ref ?? "").startsWith("AgentReleaseWriterRole"),
-      );
-    });
-    expect(writerRolePolicies.length).toBeGreaterThan(0);
-
-    const allStatements = writerRolePolicies.flatMap(
-      (p) =>
-        p.Properties.PolicyDocument.Statement as Array<{
-          Action?: string | string[];
-          Resource?: unknown;
-        }>,
-    );
-    const allActions = allStatements.flatMap((s) =>
-      Array.isArray(s.Action) ? s.Action : [s.Action],
-    );
-    expect(allActions).toEqual(expect.arrayContaining(["dynamodb:GetItem"]));
-    expect(allActions).toEqual(
-      expect.arrayContaining(["bedrock-agentcore:GetRegistryRecord"]),
-    );
-  });
-
-  describe("IAM immutability floor survives wiring", () => {
-    function collectReleaseTableActions(tmpl: Template): string[] {
-      const policies = tmpl.findResources("AWS::IAM::Policy");
-      const actions: string[] = [];
-      for (const policy of Object.values(policies)) {
-        const stmts: Array<{
-          Action?: string | string[];
-          Resource?: unknown;
-        }> = policy.Properties?.PolicyDocument?.Statement ?? [];
-        for (const stmt of stmts) {
-          const resources = Array.isArray(stmt.Resource)
-            ? stmt.Resource
-            : [stmt.Resource];
-          const targetsReleaseTable = resources.some((r) =>
-            JSON.stringify(r).includes("AgentReleasesTable"),
-          );
-          if (!targetsReleaseTable) continue;
-          const stmtActions = Array.isArray(stmt.Action)
-            ? stmt.Action
-            : [stmt.Action];
-          actions.push(...stmtActions.filter((a): a is string => !!a));
-        }
-      }
-      return actions;
-    }
-
-    test("no IAM policy in either the GovernanceStack or the table-owning stack grants UpdateItem or DeleteItem on AgentReleasesTable", () => {
-      const actions = [
-        ...collectReleaseTableActions(template),
-        ...collectReleaseTableActions(backendTemplate),
-      ];
-      expect(actions).not.toContain("dynamodb:UpdateItem");
-      expect(actions).not.toContain("dynamodb:DeleteItem");
-    });
-
-    test("every statement referencing AgentReleasesTable grants only Put/Get/Query — no grantReadWriteData-shaped Allow-all-actions was introduced by wiring", () => {
-      const actions = [
-        ...collectReleaseTableActions(template),
-        ...collectReleaseTableActions(backendTemplate),
-      ];
-      expect(actions.length).toBeGreaterThan(0);
-      for (const action of actions) {
-        expect([
-          "dynamodb:PutItem",
-          "dynamodb:GetItem",
-          "dynamodb:Query",
-        ]).toContain(action);
-      }
+    template.hasResourceProperties("AWS::AppSync::Resolver", {
+      TypeName: "Query",
+      FieldName: "getPromotionPolicy",
     });
   });
 });


### PR DESCRIPTION
## Summary

Promotion thresholds as per-org config, human approval in strict mode. Completes quality-gated promotion. 

- `093e1da` — thresholds move from a hardcoded constant to a per-org `PromotionPolicyConfig` table with field-level per-agent overrides, authored by an admin-only mutation. Absent row = today's behaviour; an unreadable or type-invalid row refuses promotion rather than silently evaluating looser
defaults. Gate reader gets `GetItem` only; admin resolver `GetItem`+`PutItem`.
- `ef0f2d0` — the promote mutation takes an optional approval. Strict refuses without one (denials recorded, then refused); shadow records without blocking; permissive ignores. Each decision is its own write-once ledger finding, fail-closed like the gate verdict, `decidedBy` server-derived from Cognito — a smuggled `decidedBy` input was proven inert. No infra delta for this commit.

## Testing

Backend jest 6,330 passed exit 0; lint, tsc, `cdk synth` (9 stacks) all clean. Behavioural proofs: full strict/shadow/permissive × approval mode matrix at the DynamoDB-mock layer with the real writers; zero pointer writes on any refusal; fail-closed proven via `AccessDeniedException` through the real approval writer in both modes; template assertions pin table, env vars, and exact grant actions.

## Deploy notes

- `093e1da` adds a table, env vars, and grants (additive template delta) — worth a manual branch deploy before merge.
- Flipping enforcement to `strict` now also requires explicit human approval per promotion. Inert today (dev is `shadow`), but the strict flip changes meaning with this PR.