### PR TITLE
audit frontend dependencies in CI and patch nanoid

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -267,9 +267,21 @@ jobs:
       - uses: actions/setup-node@v5
         with:
           node-version: ${{ env.NODE_VERSION }}
+          cache: npm
+          cache-dependency-path: |
+            package-lock.json
+            frontend/package-lock.json
 
       - name: Install workspaces (root lockfile)
         run: npm ci
 
       - name: Audit dependencies (blocking, with justified allowlist)
         run: npx audit-ci --config .audit-ci.json
+
+      - name: Install frontend deps (frontend lockfile)
+        run: npm ci
+        working-directory: frontend
+
+      - name: Audit frontend dependencies (blocking, with justified allowlist)
+        run: npx audit-ci --config .audit-ci.json
+        working-directory: frontend

--- a/audit-ci-allowlist-justifications.md
+++ b/audit-ci-allowlist-justifications.md
@@ -86,41 +86,28 @@ bypass-successor (mh99's mitigation covers `<5.0.8`; rgw5 extends the vulnerable
 3. Re-run `npm audit` to confirm no new unallowlisted advisories land.
 
 
-## GHSA-qwww-vcr4-c8h2 — react-router (HIGH RSC Mode CSRF Bypass Allows Action Execution Before 400 Response)
+## GHSA-qwww-vcr4-c8h2 — react-router (RESOLVED 2026-08-11, no longer fires; vestigial root entry pending cleanup)
 
-**Affected instances:**
-- `frontend/node_modules/react-router@7.18.1` (transitive via react-router-dom)
-- `frontend/node_modules/react-router-dom@7.18.1` (direct; `^7.18.1` in frontend/package.json)
+**Prior claim (now false):** this entry previously asserted no fix version was published for the
+7.x line and that `react-router-dom@latest` topped out at `7.18.1`.
 
-**Why remediation is blocked:**
-1. **No fix version exists on the registry.** The advisory's stated fix (`8.3.0`) does not exist:
-   `npm view react-router-dom versions --json` shows the published line tops out at `7.18.1`;
-   `npm view react-router-dom@latest version` → `7.18.1`; `npm view react-router-dom@8.3.0 peerDependencies`
-   → `404 Not Found`. There is no 8.x release at all yet. Dependabot alert #86 is citing a not-yet-shipped fix version.
-2. **Downgrading within 7.x makes things strictly worse.** `npm audit fix --force` on the installed 7.18.1
-   suggests downgrading to `react-router-dom@7.11.0`. Verified live: 7.11.0 falls into a *different, much wider*
-   advisory range (`react-router` `6.0.0 - 7.17.0`) bundling 14 distinct CVEs (open redirect/XSS, SSR XSS in
-   ScrollRestoration, arbitrary constructor invocation via vendored turbo-stream deserialization → unauth RCE,
-   DoS via unbounded `__manifest` path expansion, stored XSS via unescaped `Location` header, etc.), versus the
-   single CSRF-bypass advisory covering `7.12.0 - 8.2.0` that 7.18.1 sits in. No published 7.x or 8.x version is
-   outside every vulnerable range simultaneously — 7.18.1 (latest available) is the least-exposed option on the
-   registry today.
-3. **App does not use the vulnerable surface.** The CVE requires RSC (React Server Components) mode
-   (`unstable_RSC`, `RSCStaticRouter`, `ServerRouter`, `react-router/rsc` imports). `grep -rn` across
-   `frontend/src` found zero matches for any RSC-mode API. Usage is confined to the classic component API:
-   `BrowserRouter`/`Routes`/`Route`/`useNavigate`/`useParams`/`useSearchParams`/`Link`/`MemoryRouter`
-   (see `frontend/src/App.tsx:2` and route/test files under `frontend/src/pages/__tests__/`). The CSRF-bypass
-   action-execution path this advisory describes is not reachable from this codebase's router configuration.
+**Resolution:** `react-router`/`react-router-dom` **7.18.2** landed via merged PR #67 and is the
+advisory's documented `first_patched_version` for the `>=7.12.0, <7.18.2` vulnerable range
+(GHSA record vulnerable ranges: `>=7.12.0 <7.18.2` and `>=8.0.0 <8.3.0`; first patched `7.18.2`
+and `8.3.0` respectively). `frontend/package.json` declares `"react-router-dom": "^7.18.2"`, and
+`frontend/package-lock.json` already resolved `react-router-dom@7.18.2` / `react-router@7.18.2`
+— `node_modules` was simply stale relative to the lockfile (`npm ls` reported
+`invalid: "^7.18.2"` against an installed `7.18.1`) until `npm install` resynced it on
+2026-08-11. `npm audit --audit-level=low --prefix frontend` no longer reports this advisory (0
+vulnerabilities from react-router).
 
-**Exposure & Risk Acceptance:**
-- Advisory requires RSC mode; this frontend runs classic SPA routing only (Vite + BrowserRouter), no server
-  actions, no RSC. Exploitability in this deployment is effectively nil.
-- Remediation path is registry-blocked, not effort-blocked — there is nothing to upgrade to yet.
-- Acceptance: risk is non-applicable given routing mode in use; no in-range fix exists upstream.
-
-**Recommended follow-ups (revisitBy: 2026-09-01):**
-1. Re-check `npm view react-router-dom versions --json` periodically for the `8.3.0` (or later) release landing.
-2. When `>=8.3.0` publishes, re-verify its peer `react` requirement (unpublished builds referenced `react>=19.2.7`,
-   vs. this app's `react: ^18.3.1`) — a React 19 upgrade may be a co-requirement, not just a router bump.
-3. Re-run `npm audit --prefix frontend` after any bump attempt to confirm the advisory clears without
-   reintroducing the wider pre-7.18.1 CVE set.
+**Allowlist status (accurate as of this edit):** `GHSA-qwww-vcr4-c8h2` was **never added** to the
+new `frontend/.audit-ci.json` (that file was created with an empty allowlist and stays that way —
+frontend's own `npm audit` reports 0 vulnerabilities, so nothing there needs allowlisting). The ID
+**remains present** in the **root** `.audit-ci.json` allowlist and its `_comment` still says "no
+fix version published yet" — that is now stale but is **out of scope** for this change (root
+`.audit-ci.json` is intentionally left byte-identical to keep this change's diff scoped to the
+frontend gate). Removing the vestigial root entry and correcting its `_comment` is a follow-up,
+root-scoped cleanup; the root gate continues to exit 0 either way since audit-ci does not fail on
+an allowlisted-but-non-firing advisory (it only warns "Consider not allowlisting advisory:
+GHSA-qwww-vcr4-c8h2").

--- a/frontend/.audit-ci.json
+++ b/frontend/.audit-ci.json
@@ -1,0 +1,11 @@
+{
+  "$schema": "https://raw.githubusercontent.com/IBM/audit-ci/main/docs/schema.json",
+  "low": true,
+  "moderate": true,
+  "high": true,
+  "critical": true,
+  "allowlist": [],
+  "report": true,
+  "skip-dev": false,
+  "_comment": "Frontend-scoped audit-ci gate (finding 9c287884). Mirrors root .audit-ci.json's severity threshold (low and above, blocking). Empty allowlist: npm audit --prefix frontend currently reports 0 vulnerabilities. If a future advisory is unfixable, add its exact GHSA id here AND a corresponding justification entry in ../audit-ci-allowlist-justifications.md naming that GHSA id."
+}

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -11171,9 +11171,9 @@
                   "license": "MIT"
             },
             "node_modules/nanoid": {
-                  "version": "3.3.16",
-                  "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.16.tgz",
-                  "integrity": "sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==",
+                  "version": "3.3.18",
+                  "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.18.tgz",
+                  "integrity": "sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==",
                   "funding": [
                         {
                               "type": "github",


### PR DESCRIPTION
## Summary
The Security Scan job audited only the root lockfile, so frontend advisories never reached the blocking gate - Dependabot was the sole signal. 
- New blocking `audit-ci` step for `frontend/package-lock json` in the same Security Scan job, with its own config (`frontend/.audit-ci.json`, thresholds mirroring root, allowlist empty - the frontend tree currently audits clean).
- nanoid 3.3.16 → 3.3.18, resolved by the registry within postess's declared `^3.3.16` range; clears the size-zero infinite-loop advisory (GHSA-2v37-7h3g-55p8, HIGH). Closes Dependabot alert #97. Lockfile diff is the nanoid chain only.
- `audit-ci-allowlist-justifications.md` corrected: the react-router entry claimed no fix was published - 7.18.2 shipped and is resolved (PR #67). The vestigial allowlist ID in root `audit-ci.json` is deliberately untouched (root stays byte-identical) and documented as pending root-scoped cleanup.
## Testing
Frontend gate exits 0 as configured. Bite-proven despite the clean tree: the identical config run against a tree with real HIGH advisories fails with exit l naming the GHSAs - thresholds live, exit codes propagate. No `continue-on-error` or soft-fail anywhere in `ci.yml`. Frontend jest 2,041 passed exit 0; vite build exit 0; root gate unchanged, exit 0 as on 'main.
## Notes
No infrastructure or runtime delta - CI config, one dependency patch, and a documentation truth fix. Future frontend advisories without a patch will now need an allowlist entry plus a written justification; the gate enforces that by failing.