### PR TITLE
feat(release): gated environment promotion with atomic pointer history

### DIFF
--- a/backend/bin/app.ts
+++ b/backend/bin/app.ts
@@ -223,6 +223,13 @@ const arbiterStack = new ArbiterStack(app, `citadel-arbiter-${environment}`, {
   // agentReleasesTable/environmentReleasePointersTable prop doc comment).
   agentReleasesTable: backendStack.agentReleasesTable,
   environmentReleasePointersTable: backendStack.environmentReleasePointersTable,
+  // G3 — named org seam for release-aware dispatch. Operator-provisioned
+  // via env or CDK context (never derived), so a deployment opts its
+  // arbiter into resolving a specific org's pointers. Absent → omitted →
+  // resolve_release falls to NO_POINTER (safe no-op).
+  releaseDefaultOrgId:
+    process.env.RELEASE_DEFAULT_ORG_ID ??
+    (app.node.tryGetContext("releaseDefaultOrgId") as string | undefined),
 });
 
 // Telemetry stack — invocation cost ledger + cost query API/budgets

--- a/backend/lib/arbiter-stack.ts
+++ b/backend/lib/arbiter-stack.ts
@@ -102,6 +102,14 @@ interface ArbiterStackProps extends cdk.StackProps {
   // there too).
   agentReleasesTable?: dynamodb.Table;
   environmentReleasePointersTable?: dynamodb.Table;
+  // G3 — the named org seam for release-aware dispatch. resolve_release
+  // resolves pointers for this single org per deployment
+  // (RELEASE_DEFAULT_ORG_ID); the switch itself is RELEASE_DISPATCH_
+  // ENVIRONMENT, derived from `environment` at synth time. Optional and
+  // operator-provisioned (env/CDK context in bin/app.ts): when absent,
+  // RELEASE_DEFAULT_ORG_ID is omitted and every resolve_release lookup
+  // falls to NO_POINTER (see release_resolution.py) — never a crash.
+  releaseDefaultOrgId?: string;
 }
 
 export class ArbiterStack extends cdk.Stack {
@@ -246,18 +254,21 @@ export class ArbiterStack extends cdk.Stack {
         // Release-aware dispatch (this story): table names only, omitted
         // entirely when the tables aren't provisioned (forward-compatible
         // no-op — see ArbiterStackProps's agentReleasesTable/
-        // environmentReleasePointersTable doc comment). RELEASE_DISPATCH_
-        // ENVIRONMENT / RELEASE_DEFAULT_ORG_ID are deliberately NOT set
-        // here — they are the feature switch and the named org seam
-        // respectively, both operator-provisioned per-deployment rather
-        // than CDK-derived, so an operator opts a deployment into the gate
-        // explicitly instead of it turning on the moment the tables exist.
+        // environmentReleasePointersTable doc comment). G3: this stack now
+        // ALSO sets RELEASE_DISPATCH_ENVIRONMENT (the feature switch,
+        // uppercased to match EnvironmentLiteral / pointer SK) and
+        // RELEASE_DEFAULT_ORG_ID (the named org seam) so each env's stack
+        // resolves its OWN pointer set at dispatch time.
         ...(props.agentReleasesTable && {
           AGENT_RELEASES_TABLE: props.agentReleasesTable.tableName,
         }),
         ...(props.environmentReleasePointersTable && {
           ENVIRONMENT_RELEASE_POINTERS_TABLE:
             props.environmentReleasePointersTable.tableName,
+          RELEASE_DISPATCH_ENVIRONMENT: props.environment.toUpperCase(),
+        }),
+        ...(props.releaseDefaultOrgId && {
+          RELEASE_DEFAULT_ORG_ID: props.releaseDefaultOrgId,
         }),
       },
       initialPolicy: [
@@ -932,17 +943,21 @@ export class ArbiterStack extends cdk.Stack {
             // completed/failed events the rules below consume.
             WORKER_QUEUE_URL: workerAgentQueue.queueUrl,
             // Release-aware dispatch (this story): mirrors the Supervisor's
-            // env var wiring above — table names only, omitted when the
-            // tables aren't provisioned. See ArbiterStackProps's doc
-            // comment and the Supervisor's identical block for the
-            // rationale (RELEASE_DISPATCH_ENVIRONMENT / RELEASE_DEFAULT_
-            // ORG_ID are operator-set, not derived here).
+            // env var wiring above — table names, plus G3's
+            // RELEASE_DISPATCH_ENVIRONMENT (feature switch, uppercased) and
+            // RELEASE_DEFAULT_ORG_ID (named org seam). Omitted when the
+            // tables/prop aren't provisioned. See ArbiterStackProps's doc
+            // comment for the rationale.
             ...(props.agentReleasesTable && {
               AGENT_RELEASES_TABLE: props.agentReleasesTable.tableName,
             }),
             ...(props.environmentReleasePointersTable && {
               ENVIRONMENT_RELEASE_POINTERS_TABLE:
                 props.environmentReleasePointersTable.tableName,
+              RELEASE_DISPATCH_ENVIRONMENT: props.environment.toUpperCase(),
+            }),
+            ...(props.releaseDefaultOrgId && {
+              RELEASE_DEFAULT_ORG_ID: props.releaseDefaultOrgId,
             }),
           },
         },

--- a/backend/lib/backend-stack.ts
+++ b/backend/lib/backend-stack.ts
@@ -3462,6 +3462,34 @@ export class BackendStack extends cdk.Stack {
         resources: [governanceLedgerTableArn],
       }),
     );
+
+    // G6 — atomic promotion history. The pointer move + append-only
+    // history row are written in ONE TransactWriteItems by the sole
+    // pointer writer (environment-release-pointer-store.ts), so this role
+    // needs PutItem on the history table for the transactional write,
+    // plus GetItem/Query for the read-only history query
+    // (environment-release-pointer-history-store.ts). The history table
+    // is provisioned in governance-stack.ts, instantiated AFTER
+    // BackendStack, so — like the GOVERNANCE_LEDGER grant above — it is
+    // referenced by deterministic ARN STRING rather than a construct,
+    // avoiding a cyclic stack dependency. PutItem/GetItem/Query only,
+    // never DeleteItem/UpdateItem — the history table is append-only.
+    const environmentReleasePointerHistoryTableArn = `arn:aws:dynamodb:${this.region}:${this.account}:table/citadel-environment-release-pointer-history-${props.environment}`;
+    environmentReleasePointerWriterRole.addToPolicy(
+      new iam.PolicyStatement({
+        effect: iam.Effect.ALLOW,
+        actions: ["dynamodb:PutItem", "dynamodb:GetItem", "dynamodb:Query"],
+        resources: [environmentReleasePointerHistoryTableArn],
+      }),
+    );
+
+    // G5 — best-effort RELEASE_POINTER_MOVED emit (post-commit). The
+    // promotion resolver publishes to the shared bus via publishEvent;
+    // granted here on the sole-writer role rather than in governance-
+    // stack.ts to keep every grant for this role co-located and
+    // cross-stack-cycle-free (agentEventBus is BackendStack-owned).
+    this.agentEventBus.grantPutEventsTo(environmentReleasePointerWriterRole);
+
     this.environmentReleasePointerWriterRole =
       environmentReleasePointerWriterRole;
 

--- a/backend/lib/governance-stack.ts
+++ b/backend/lib/governance-stack.ts
@@ -1194,6 +1194,34 @@ exports.handler = async (event) => {
     // statement anywhere names both tables, which
     // backend-stack-environment-release-pointer-table.test.ts asserts
     // directly.
+    //
+    // G6 — append-only promotion history table (provisioned here per the
+    // design's file-by-file change map). PK orgId, SK historySortKey
+    // (`${agentTargetId}#${environment}#${promotedAt}#${version}`). Same
+    // durable posture as the pointer table (RETAIN + deletionProtection +
+    // PITR): the time-series of every move is deployment history that
+    // must survive stack updates. Written ATOMICALLY with the pointer
+    // move by the sole pointer writer; the writer role's grant lives in
+    // backend-stack.ts (deterministic ARN string, cycle-free — see
+    // there). No construct-based grant is issued here (that would create
+    // a governance→backend→governance cycle via the imported role).
+    const environmentReleasePointerHistoryTable = new dynamodb.Table(
+      this,
+      "EnvironmentReleasePointerHistoryTable",
+      {
+        tableName: `citadel-environment-release-pointer-history-${props.environment}`,
+        partitionKey: { name: "orgId", type: dynamodb.AttributeType.STRING },
+        sortKey: {
+          name: "historySortKey",
+          type: dynamodb.AttributeType.STRING,
+        },
+        billingMode: dynamodb.BillingMode.PAY_PER_REQUEST,
+        removalPolicy: cdk.RemovalPolicy.RETAIN,
+        deletionProtection: true,
+        pointInTimeRecoverySpecification: { pointInTimeRecoveryEnabled: true },
+      },
+    );
+
     const environmentReleasePointerResolverFunction = new lambda.Function(
       this,
       "EnvironmentReleasePointerResolverFunction",
@@ -1205,6 +1233,18 @@ exports.handler = async (event) => {
         environment: {
           ENVIRONMENT_RELEASE_POINTERS_TABLE:
             props.environmentReleasePointersTable.tableName,
+          // G6 — append-only promotion history. Written ATOMICALLY with
+          // the pointer move (TransactWriteItems) by the sole pointer
+          // writer, and read by the environmentReleasePointerHistory
+          // query. The writer role's PutItem/GetItem/Query grant on this
+          // table is added in backend-stack.ts by deterministic ARN
+          // string (the table is provisioned in THIS stack, which is
+          // instantiated after BackendStack — a construct reference from
+          // there would be a cyclic dependency, same pattern as the
+          // GOVERNANCE_LEDGER_TABLE grant). Deterministic name matches
+          // the string ARN backend-stack.ts grants against.
+          ENVIRONMENT_RELEASE_POINTER_HISTORY_TABLE:
+            environmentReleasePointerHistoryTable.tableName,
           AGENT_RELEASES_TABLE: props.agentReleasesTable.tableName,
           // Decision ada70113: validateReleaseGate resolves the
           // per-org/per-agent promotion policy via
@@ -1227,6 +1267,10 @@ exports.handler = async (event) => {
           // grant for why this is a literal string, not a construct
           // reference.
           GOVERNANCE_LEDGER_TABLE: `citadel-governance-ledger-${props.environment}`,
+          // G5 — best-effort RELEASE_POINTER_MOVED emit target. The
+          // writer role's PutEvents grant on this bus is added in
+          // backend-stack.ts (bus is BackendStack-owned).
+          EVENT_BUS_NAME: props.agentEventBus.eventBusName,
         },
         timeout: cdk.Duration.seconds(30),
         logGroup: new logs.LogGroup(
@@ -1309,6 +1353,10 @@ exports.handler = async (event) => {
       {
         id: "ListEnvironmentReleasePointersResolver",
         fieldName: "listEnvironmentReleasePointers",
+      },
+      {
+        id: "EnvironmentReleasePointerHistoryResolver",
+        fieldName: "environmentReleasePointerHistory",
       },
     ];
     for (const { id, fieldName } of environmentReleasePointerQueryFields) {

--- a/backend/src/lambda/__tests__/environment-release-pointer-history-store.test.ts
+++ b/backend/src/lambda/__tests__/environment-release-pointer-history-store.test.ts
@@ -1,0 +1,142 @@
+/**
+ * environment-release-pointer-history-store.test.ts — read-only history
+ * queries (G6). Mocked DDB client; asserts the KeyCondition shape and the
+ * "what ran in PROD on date D" latest-≤-D selection.
+ */
+import { DynamoDBDocumentClient, QueryCommand } from "@aws-sdk/lib-dynamodb";
+import { mockClient } from "aws-sdk-client-mock";
+import type { EnvironmentReleasePointerHistoryEntry } from "../../types";
+
+process.env.ENVIRONMENT_RELEASE_POINTER_HISTORY_TABLE =
+  "citadel-environment-release-pointer-history-test";
+
+const ddbMock = mockClient(DynamoDBDocumentClient);
+
+import {
+  queryEnvironmentReleasePointerHistory,
+  environmentReleaseRunningAt,
+  historySortKeyPrefix,
+} from "../environment-release-pointer-history-store";
+
+function entry(
+  overrides: Partial<EnvironmentReleasePointerHistoryEntry> = {},
+): EnvironmentReleasePointerHistoryEntry {
+  return {
+    orgId: "org-1",
+    agentTargetId: "agent-1",
+    environment: "PROD",
+    releaseId: "release-1",
+    previousReleaseId: null,
+    promotedAt: "2026-01-01T00:00:00.000Z",
+    promotedBy: "user-1",
+    version: 1,
+    ...overrides,
+  };
+}
+
+beforeEach(() => {
+  ddbMock.reset();
+});
+
+describe("historySortKeyPrefix", () => {
+  it("composes the agent#env# prefix used by both writer and reader", () => {
+    expect(historySortKeyPrefix("agent-1", "PROD")).toBe("agent-1#PROD#");
+  });
+});
+
+describe("queryEnvironmentReleasePointerHistory — unbounded", () => {
+  it("queries with a begins_with(agent#env#) KeyCondition, ascending", async () => {
+    const rows = [entry({ version: 1 }), entry({ version: 2 })];
+    ddbMock.on(QueryCommand).resolves({ Items: rows });
+
+    const result = await queryEnvironmentReleasePointerHistory(
+      "org-1",
+      "agent-1",
+      "PROD",
+    );
+
+    expect(result).toEqual(rows);
+    const input = ddbMock.commandCalls(QueryCommand)[0].args[0].input;
+    expect(input.TableName).toBe(
+      "citadel-environment-release-pointer-history-test",
+    );
+    expect(input.KeyConditionExpression).toContain(
+      "begins_with(historySortKey, :prefix)",
+    );
+    expect(input.ExpressionAttributeValues).toMatchObject({
+      ":oid": "org-1",
+      ":prefix": "agent-1#PROD#",
+    });
+    expect(input.ScanIndexForward).toBe(true);
+  });
+
+  it("returns an empty array when nothing has been promoted to that env", async () => {
+    ddbMock.on(QueryCommand).resolves({ Items: [] });
+    const result = await queryEnvironmentReleasePointerHistory(
+      "org-1",
+      "agent-1",
+      "PROD",
+    );
+    expect(result).toEqual([]);
+  });
+});
+
+describe("queryEnvironmentReleasePointerHistory — bounded by `until` (date D)", () => {
+  it("uses a BETWEEN range with a high-sentinel upper bound so an exact-D move is included", async () => {
+    ddbMock.on(QueryCommand).resolves({ Items: [] });
+
+    await queryEnvironmentReleasePointerHistory(
+      "org-1",
+      "agent-1",
+      "PROD",
+      "2026-06-01T00:00:00.000Z",
+    );
+
+    const input = ddbMock.commandCalls(QueryCommand)[0].args[0].input;
+    expect(input.KeyConditionExpression).toContain(
+      "BETWEEN :prefix AND :upper",
+    );
+    expect(input.ExpressionAttributeValues![":upper"]).toBe(
+      "agent-1#PROD#2026-06-01T00:00:00.000Z#\uffff",
+    );
+  });
+});
+
+describe("environmentReleaseRunningAt — what ran in PROD on date D", () => {
+  it("returns the greatest (latest) history row at or before D", async () => {
+    const older = entry({
+      releaseId: "release-old",
+      promotedAt: "2026-01-01T00:00:00.000Z",
+      version: 1,
+    });
+    const newer = entry({
+      releaseId: "release-new",
+      promotedAt: "2026-05-01T00:00:00.000Z",
+      version: 2,
+    });
+    // Store returns ascending; the LAST row is the latest ≤ D.
+    ddbMock.on(QueryCommand).resolves({ Items: [older, newer] });
+
+    const result = await environmentReleaseRunningAt(
+      "org-1",
+      "agent-1",
+      "PROD",
+      "2026-06-01T00:00:00.000Z",
+    );
+
+    expect(result).toEqual(newer);
+  });
+
+  it("returns null when nothing had been promoted to that env by date D", async () => {
+    ddbMock.on(QueryCommand).resolves({ Items: [] });
+
+    const result = await environmentReleaseRunningAt(
+      "org-1",
+      "agent-1",
+      "PROD",
+      "2025-01-01T00:00:00.000Z",
+    );
+
+    expect(result).toBeNull();
+  });
+});

--- a/backend/src/lambda/__tests__/environment-release-pointer-resolver.test.ts
+++ b/backend/src/lambda/__tests__/environment-release-pointer-resolver.test.ts
@@ -15,8 +15,8 @@
 import {
   DynamoDBDocumentClient,
   GetCommand,
-  PutCommand,
   QueryCommand,
+  TransactWriteCommand,
 } from "@aws-sdk/lib-dynamodb";
 import { mockClient } from "aws-sdk-client-mock";
 import type { AuthContext, AgentRelease, EvalSuite } from "../../types";
@@ -24,6 +24,8 @@ import type { AuthContext, AgentRelease, EvalSuite } from "../../types";
 process.env.AGENT_RELEASES_TABLE = "citadel-agent-releases-test";
 process.env.ENVIRONMENT_RELEASE_POINTERS_TABLE =
   "citadel-environment-release-pointers-test";
+process.env.ENVIRONMENT_RELEASE_POINTER_HISTORY_TABLE =
+  "citadel-environment-release-pointer-history-test";
 process.env.EVAL_RUNS_TABLE = "citadel-eval-runs-test";
 process.env.EVAL_SUITES_TABLE = "citadel-eval-suites-test";
 process.env.EVAL_RUN_CASE_RESULTS_TABLE = "citadel-eval-run-case-results-test";
@@ -38,9 +40,11 @@ import {
   promoteEnvironmentReleasePointer,
   getCurrentEnvironmentReleasePointer,
   listEnvironmentReleasePointers,
+  getEnvironmentReleasePointerHistory,
   validateReleaseGate,
   validatePromotionApproval,
   ReleaseApprovalRequiredError,
+  PromotionLadderError,
   handler,
 } from "../environment-release-pointer-resolver";
 import * as governanceFlag from "../../utils/governance-flag";
@@ -48,6 +52,7 @@ import * as releaseGateEvidence from "../utils/release-gate-evidence";
 import * as releaseGateFindingWriter from "../utils/release-gate-finding-writer";
 import * as releasePromotionApprovalWriter from "../utils/release-promotion-approval-writer";
 import * as promotionPolicyStore from "../utils/promotion-policy-store";
+import * as events from "../../utils/events";
 import type { ReleaseGateInputs } from "../utils/release-gate";
 
 function evalSuite(overrides: Partial<EvalSuite> = {}): EvalSuite {
@@ -98,6 +103,64 @@ function release(overrides: Partial<AgentRelease> = {}): AgentRelease {
     runId: "runid-1",
     ...overrides,
   };
+}
+
+const POINTERS_TABLE = "citadel-environment-release-pointers-test";
+const ENV_PREDECESSOR: Record<string, "DEV" | "STAGING" | null> = {
+  DEV: null,
+  STAGING: "DEV",
+  PROD: "STAGING",
+};
+
+/**
+ * Stub the immediately-lower env's CURRENT pointer to reference
+ * `releaseId`, satisfying the G1 ladder adjacency check for a promotion
+ * INTO `environment`. MUST be called AFTER any generic pointers-table
+ * stub in the same test so the specific-key match wins (aws-sdk-client-
+ * mock: the last matching behavior wins). No-op for DEV (ladder entry).
+ */
+function stubLadderPredecessor(
+  environment: "DEV" | "STAGING" | "PROD",
+  releaseId: string,
+  agentTargetId = "agent-1",
+  orgId = "org-1",
+): void {
+  const predecessor = ENV_PREDECESSOR[environment];
+  if (!predecessor) return;
+  ddbMock
+    .on(GetCommand, {
+      TableName: POINTERS_TABLE,
+      Key: {
+        orgId,
+        agentTargetId_environment: `${agentTargetId}#${predecessor}`,
+      },
+    })
+    .resolves({
+      Item: {
+        orgId,
+        agentTargetId,
+        environment: predecessor,
+        releaseId,
+        previousReleaseId: null,
+        promotedAt: "2026-01-01T00:00:00.000Z",
+        promotedBy: "user-x",
+        version: 1,
+      },
+    });
+}
+
+/** Satisfy adjacency for a promotion into EITHER STAGING or PROD by
+ * stubbing BOTH the DEV and STAGING predecessor keys to `releaseId`. A
+ * PROD promote reads only STAGING, a STAGING promote reads only DEV, so
+ * stubbing both is env-agnostic and harmless. Declared AFTER any generic
+ * pointers stub so the specific-key match wins. */
+function stubLadderSatisfied(
+  releaseId = "release-1",
+  agentTargetId = "agent-1",
+  orgId = "org-1",
+): void {
+  stubLadderPredecessor("STAGING", releaseId, agentTargetId, orgId);
+  stubLadderPredecessor("PROD", releaseId, agentTargetId, orgId);
 }
 
 beforeEach(() => {
@@ -440,6 +503,7 @@ describe("promoteEnvironmentReleasePointer — gate wiring position + zero-write
         TableName: "citadel-environment-release-pointers-test",
       })
       .resolves({ Item: undefined });
+    stubLadderSatisfied();
     stubEvidence(failingInputs());
     jest
       .spyOn(governanceFlag, "getGovernanceEnforce")
@@ -460,7 +524,7 @@ describe("promoteEnvironmentReleasePointer — gate wiring position + zero-write
       ),
     ).rejects.toThrow(/ReleaseGateError|quality gate/i);
 
-    expect(ddbMock.commandCalls(PutCommand)).toHaveLength(0);
+    expect(ddbMock.commandCalls(TransactWriteCommand)).toHaveLength(0);
   });
 
   test("shadow FAIL: pointer write STILL proceeds (shadow never blocks)", async () => {
@@ -472,7 +536,8 @@ describe("promoteEnvironmentReleasePointer — gate wiring position + zero-write
         TableName: "citadel-environment-release-pointers-test",
       })
       .resolves({ Item: undefined });
-    ddbMock.on(PutCommand).resolves({});
+    stubLadderSatisfied();
+    ddbMock.on(TransactWriteCommand).resolves({});
     stubEvidence(failingInputs());
     jest
       .spyOn(governanceFlag, "getGovernanceEnforce")
@@ -491,7 +556,7 @@ describe("promoteEnvironmentReleasePointer — gate wiring position + zero-write
       "org-1",
     );
     expect(result.releaseId).toBe("release-1");
-    expect(ddbMock.commandCalls(PutCommand)).toHaveLength(1);
+    expect(ddbMock.commandCalls(TransactWriteCommand)).toHaveLength(1);
   });
 
   test("PASS verdict: pointer write proceeds and a PERMIT finding is written in shadow/strict", async () => {
@@ -503,7 +568,8 @@ describe("promoteEnvironmentReleasePointer — gate wiring position + zero-write
         TableName: "citadel-environment-release-pointers-test",
       })
       .resolves({ Item: undefined });
-    ddbMock.on(PutCommand).resolves({});
+    stubLadderSatisfied();
+    ddbMock.on(TransactWriteCommand).resolves({});
     stubEvidence(passingInputs());
     jest
       .spyOn(governanceFlag, "getGovernanceEnforce")
@@ -556,7 +622,7 @@ describe("promoteEnvironmentReleasePointer — gate wiring position + zero-write
     ).rejects.toThrow(/UnauthorizedError/);
 
     expect(evidenceSpy).not.toHaveBeenCalled();
-    expect(ddbMock.commandCalls(PutCommand)).toHaveLength(0);
+    expect(ddbMock.commandCalls(TransactWriteCommand)).toHaveLength(0);
   });
 
   test("gate runs AFTER existence/org checks — a nonexistent release never reaches evidence resolution", async () => {
@@ -581,7 +647,7 @@ describe("promoteEnvironmentReleasePointer — gate wiring position + zero-write
     ).rejects.toThrow(/ValidationError/);
 
     expect(evidenceSpy).not.toHaveBeenCalled();
-    expect(ddbMock.commandCalls(PutCommand)).toHaveLength(0);
+    expect(ddbMock.commandCalls(TransactWriteCommand)).toHaveLength(0);
   });
 });
 
@@ -612,7 +678,7 @@ describe("promoteEnvironmentReleasePointer — permission gate", () => {
     ).rejects.toThrow(/UnauthorizedError/);
 
     expect(ddbMock.commandCalls(GetCommand)).toHaveLength(0);
-    expect(ddbMock.commandCalls(PutCommand)).toHaveLength(0);
+    expect(ddbMock.commandCalls(TransactWriteCommand)).toHaveLength(0);
   });
 
   test("architect role (release:promote) is allowed through the gate", async () => {
@@ -626,7 +692,8 @@ describe("promoteEnvironmentReleasePointer — permission gate", () => {
         TableName: "citadel-environment-release-pointers-test",
       })
       .resolves({ Item: undefined });
-    ddbMock.on(PutCommand).resolves({});
+    stubLadderSatisfied();
+    ddbMock.on(TransactWriteCommand).resolves({});
 
     const result = await promoteEnvironmentReleasePointer(
       {
@@ -664,7 +731,7 @@ describe("promoteEnvironmentReleasePointer — release existence + org validatio
       ),
     ).rejects.toThrow(/ValidationError/);
 
-    expect(ddbMock.commandCalls(PutCommand)).toHaveLength(0);
+    expect(ddbMock.commandCalls(TransactWriteCommand)).toHaveLength(0);
   });
 
   test("rejects when the target release belongs to a different org", async () => {
@@ -686,7 +753,7 @@ describe("promoteEnvironmentReleasePointer — release existence + org validatio
       ),
     ).rejects.toThrow(/SecurityError/);
 
-    expect(ddbMock.commandCalls(PutCommand)).toHaveLength(0);
+    expect(ddbMock.commandCalls(TransactWriteCommand)).toHaveLength(0);
   });
 
   test("accepts a same-org, existing release and writes the pointer", async () => {
@@ -700,7 +767,8 @@ describe("promoteEnvironmentReleasePointer — release existence + org validatio
         TableName: "citadel-environment-release-pointers-test",
       })
       .resolves({ Item: undefined });
-    ddbMock.on(PutCommand).resolves({});
+    stubLadderSatisfied();
+    ddbMock.on(TransactWriteCommand).resolves({});
 
     const result = await promoteEnvironmentReleasePointer(
       { agentTargetId: "agent-1", environment: "PROD", releaseId: "release-1" },
@@ -741,7 +809,9 @@ describe("promoteEnvironmentReleasePointer — moving an existing pointer", () =
           version: 1,
         },
       });
-    ddbMock.on(PutCommand).resolves({});
+    ddbMock.on(TransactWriteCommand).resolves({});
+    // G1: DEV predecessor must reference the release being promoted to STAGING.
+    stubLadderPredecessor("STAGING", "release-2");
 
     const result = await promoteEnvironmentReleasePointer(
       {
@@ -757,13 +827,13 @@ describe("promoteEnvironmentReleasePointer — moving an existing pointer", () =
     expect(result.releaseId).toBe("release-2");
     expect(result.version).toBe(2);
 
-    const putCall = ddbMock
-      .commandCalls(PutCommand)
-      .find(
-        (call) =>
-          call.args[0].input.TableName ===
-          "citadel-environment-release-pointers-test",
-      )!.args[0].input;
+    const transactInput = ddbMock.commandCalls(TransactWriteCommand)[0].args[0]
+      .input as {
+      TransactItems: { Put: { TableName: string; [k: string]: unknown } }[];
+    };
+    const putCall = transactInput.TransactItems.map((t) => t.Put).find(
+      (p) => p.TableName === "citadel-environment-release-pointers-test",
+    )!;
     expect(putCall.ConditionExpression).toBe(
       "attribute_not_exists(orgId) OR #version = :expectedVersion",
     );
@@ -798,7 +868,10 @@ describe("promoteEnvironmentReleasePointer — moving an existing pointer", () =
       new Error("The conditional request failed"),
       { name: "ConditionalCheckFailedException" },
     );
-    ddbMock.on(PutCommand).rejects(conditionalError);
+    ddbMock.on(TransactWriteCommand).rejects(conditionalError);
+    // G1: DEV predecessor must reference release-2 so the flow reaches
+    // the store's transactional write where the race is surfaced.
+    stubLadderPredecessor("STAGING", "release-2");
 
     await expect(
       promoteEnvironmentReleasePointer(
@@ -888,7 +961,8 @@ describe("handler — AppSync dispatch", () => {
         TableName: "citadel-environment-release-pointers-test",
       })
       .resolves({ Item: undefined });
-    ddbMock.on(PutCommand).resolves({});
+    stubLadderSatisfied();
+    ddbMock.on(TransactWriteCommand).resolves({});
 
     const event = {
       info: { fieldName: "promoteEnvironmentReleasePointer" },
@@ -943,6 +1017,7 @@ describe("validateReleaseGate — decision ada70113 (per-org promotion policy)",
     ddbMock
       .on(GetCommand, { TableName: "citadel-agent-releases-test" })
       .resolves({ Item: release() });
+    stubLadderSatisfied();
     jest
       .spyOn(promotionPolicyStore, "resolvePromotionPolicy")
       .mockResolvedValue({ ok: false, reason: "UNREADABLE" });
@@ -970,7 +1045,7 @@ describe("validateReleaseGate — decision ada70113 (per-org promotion policy)",
     ).rejects.toThrow(/ReleaseGateError|quality gate/i);
 
     expect(evidenceSpy).not.toHaveBeenCalled();
-    expect(ddbMock.commandCalls(PutCommand)).toHaveLength(0);
+    expect(ddbMock.commandCalls(TransactWriteCommand)).toHaveLength(0);
   });
 
   test("unreadable promotion policy fails closed in shadow mode too (finding recorded, decision=deny)", async () => {
@@ -982,7 +1057,8 @@ describe("validateReleaseGate — decision ada70113 (per-org promotion policy)",
         TableName: "citadel-environment-release-pointers-test",
       })
       .resolves({ Item: undefined });
-    ddbMock.on(PutCommand).resolves({});
+    stubLadderSatisfied();
+    ddbMock.on(TransactWriteCommand).resolves({});
     jest
       .spyOn(promotionPolicyStore, "resolvePromotionPolicy")
       .mockResolvedValue({ ok: false, reason: "UNREADABLE" });
@@ -1067,7 +1143,7 @@ describe("validateReleaseGate — decision ada70113 (per-org promotion policy)",
       architect,
     );
 
-    expect(policySpy).toHaveBeenCalledWith("org-9", "agent-42");
+    expect(policySpy).toHaveBeenCalledWith("org-9", "agent-42", "PROD");
   });
 
   test("a config row with a wrong-primitive-type field (string where number expected) refuses promotion BEFORE any pointer write — real resolvePromotionPolicy, not stubbed", async () => {
@@ -1088,6 +1164,7 @@ describe("validateReleaseGate — decision ada70113 (per-org promotion policy)",
           policy: { taskSuccessMin: "0.99" },
         },
       });
+    stubLadderSatisfied();
     const evidenceSpy = jest.spyOn(
       releaseGateEvidence,
       "resolveReleaseGateEvidence",
@@ -1112,7 +1189,7 @@ describe("validateReleaseGate — decision ada70113 (per-org promotion policy)",
     ).rejects.toThrow(/ReleaseGateError|quality gate/i);
 
     expect(evidenceSpy).not.toHaveBeenCalled();
-    expect(ddbMock.commandCalls(PutCommand)).toHaveLength(0);
+    expect(ddbMock.commandCalls(TransactWriteCommand)).toHaveLength(0);
   });
 });
 
@@ -1360,6 +1437,7 @@ describe("promoteEnvironmentReleasePointer — approval wiring (decision 8165b7e
         TableName: "citadel-environment-release-pointers-test",
       })
       .resolves({ Item: undefined });
+    stubLadderSatisfied();
     stubGatePass();
     jest
       .spyOn(governanceFlag, "getGovernanceEnforce")
@@ -1387,7 +1465,7 @@ describe("promoteEnvironmentReleasePointer — approval wiring (decision 8165b7e
     ).rejects.toBeInstanceOf(ReleaseApprovalRequiredError);
 
     expect(approvalWriteSpy).not.toHaveBeenCalled();
-    expect(ddbMock.commandCalls(PutCommand)).toHaveLength(0);
+    expect(ddbMock.commandCalls(TransactWriteCommand)).toHaveLength(0);
   });
 
   test("strict approved=false: denial finding written, then error, zero pointer writes", async () => {
@@ -1399,6 +1477,7 @@ describe("promoteEnvironmentReleasePointer — approval wiring (decision 8165b7e
         TableName: "citadel-environment-release-pointers-test",
       })
       .resolves({ Item: undefined });
+    stubLadderSatisfied();
     stubGatePass();
     jest
       .spyOn(governanceFlag, "getGovernanceEnforce")
@@ -1430,7 +1509,7 @@ describe("promoteEnvironmentReleasePointer — approval wiring (decision 8165b7e
     expect(approvalWriteSpy.mock.calls[0][0]).toMatchObject({
       decision: "deny",
     });
-    expect(ddbMock.commandCalls(PutCommand)).toHaveLength(0);
+    expect(ddbMock.commandCalls(TransactWriteCommand)).toHaveLength(0);
   });
 
   test("strict approved=true: approval finding (category/decision/decidedBy from identity/justification) written, then pointer moves", async () => {
@@ -1442,7 +1521,8 @@ describe("promoteEnvironmentReleasePointer — approval wiring (decision 8165b7e
         TableName: "citadel-environment-release-pointers-test",
       })
       .resolves({ Item: undefined });
-    ddbMock.on(PutCommand).resolves({});
+    stubLadderSatisfied();
+    ddbMock.on(TransactWriteCommand).resolves({});
     stubGatePass();
     jest
       .spyOn(governanceFlag, "getGovernanceEnforce")
@@ -1480,7 +1560,7 @@ describe("promoteEnvironmentReleasePointer — approval wiring (decision 8165b7e
       justification: "approved by release manager",
     });
     expect(result.releaseId).toBe("release-1");
-    expect(ddbMock.commandCalls(PutCommand)).toHaveLength(1);
+    expect(ddbMock.commandCalls(TransactWriteCommand)).toHaveLength(1);
   });
 
   test("shadow with approved=false: deny finding recorded (block:false must NOT block), pointer still moves", async () => {
@@ -1492,7 +1572,8 @@ describe("promoteEnvironmentReleasePointer — approval wiring (decision 8165b7e
         TableName: "citadel-environment-release-pointers-test",
       })
       .resolves({ Item: undefined });
-    ddbMock.on(PutCommand).resolves({});
+    stubLadderSatisfied();
+    ddbMock.on(TransactWriteCommand).resolves({});
     stubGatePass();
     jest
       .spyOn(governanceFlag, "getGovernanceEnforce")
@@ -1526,7 +1607,7 @@ describe("promoteEnvironmentReleasePointer — approval wiring (decision 8165b7e
       decision: "deny",
     });
     expect(result.releaseId).toBe("release-1");
-    expect(ddbMock.commandCalls(PutCommand)).toHaveLength(1);
+    expect(ddbMock.commandCalls(TransactWriteCommand)).toHaveLength(1);
   });
 
   test("permissive: no finding, pointer moves regardless of approved value", async () => {
@@ -1538,7 +1619,8 @@ describe("promoteEnvironmentReleasePointer — approval wiring (decision 8165b7e
         TableName: "citadel-environment-release-pointers-test",
       })
       .resolves({ Item: undefined });
-    ddbMock.on(PutCommand).resolves({});
+    stubLadderSatisfied();
+    ddbMock.on(TransactWriteCommand).resolves({});
     stubGatePass();
     jest
       .spyOn(governanceFlag, "getGovernanceEnforce")
@@ -1563,7 +1645,7 @@ describe("promoteEnvironmentReleasePointer — approval wiring (decision 8165b7e
 
     expect(approvalWriteSpy).not.toHaveBeenCalled();
     expect(result.releaseId).toBe("release-1");
-    expect(ddbMock.commandCalls(PutCommand)).toHaveLength(1);
+    expect(ddbMock.commandCalls(TransactWriteCommand)).toHaveLength(1);
   });
 
   test("approval-finding write failure (AccessDenied mock): promotion aborts, zero pointer writes", async () => {
@@ -1575,6 +1657,7 @@ describe("promoteEnvironmentReleasePointer — approval wiring (decision 8165b7e
         TableName: "citadel-environment-release-pointers-test",
       })
       .resolves({ Item: undefined });
+    stubLadderSatisfied();
     stubGatePass();
     jest
       .spyOn(governanceFlag, "getGovernanceEnforce")
@@ -1604,7 +1687,7 @@ describe("promoteEnvironmentReleasePointer — approval wiring (decision 8165b7e
       ),
     ).rejects.toThrow("AccessDenied");
 
-    expect(ddbMock.commandCalls(PutCommand)).toHaveLength(0);
+    expect(ddbMock.commandCalls(TransactWriteCommand)).toHaveLength(0);
   });
 
   test("dedupe ConditionalCheck on approval writer: proceeds, pointer moves", async () => {
@@ -1616,7 +1699,8 @@ describe("promoteEnvironmentReleasePointer — approval wiring (decision 8165b7e
         TableName: "citadel-environment-release-pointers-test",
       })
       .resolves({ Item: undefined });
-    ddbMock.on(PutCommand).resolves({});
+    stubLadderSatisfied();
+    ddbMock.on(TransactWriteCommand).resolves({});
     stubGatePass();
     jest
       .spyOn(governanceFlag, "getGovernanceEnforce")
@@ -1646,6 +1730,400 @@ describe("promoteEnvironmentReleasePointer — approval wiring (decision 8165b7e
     );
 
     expect(result.releaseId).toBe("release-1");
-    expect(ddbMock.commandCalls(PutCommand)).toHaveLength(1);
+    expect(ddbMock.commandCalls(TransactWriteCommand)).toHaveLength(1);
+  });
+});
+
+describe("promoteEnvironmentReleasePointer — ladder adjacency (G1, consensus decision 1)", () => {
+  const architect = authContextFor("architect");
+
+  function stubAgentRelease(releaseId = "release-1") {
+    ddbMock
+      .on(GetCommand, { TableName: "citadel-agent-releases-test" })
+      .resolves({ Item: release({ releaseId }) });
+  }
+
+  function stubPredecessorPointer(
+    predecessor: "DEV" | "STAGING",
+    releaseId: string | null,
+  ) {
+    ddbMock
+      .on(GetCommand, {
+        TableName: POINTERS_TABLE,
+        Key: {
+          orgId: "org-1",
+          agentTargetId_environment: `agent-1#${predecessor}`,
+        },
+      })
+      .resolves({
+        Item:
+          releaseId === null
+            ? undefined
+            : {
+                orgId: "org-1",
+                agentTargetId: "agent-1",
+                environment: predecessor,
+                releaseId,
+                previousReleaseId: null,
+                promotedAt: "2026-01-01T00:00:00.000Z",
+                promotedBy: "user-x",
+                version: 1,
+              },
+      });
+  }
+
+  test("STAGING promotion is refused with PromotionLadderError when DEV's current pointer references a DIFFERENT release", async () => {
+    stubAgentRelease("release-1");
+    stubPredecessorPointer("DEV", "release-OTHER");
+    const evidenceSpy = jest.spyOn(
+      releaseGateEvidence,
+      "resolveReleaseGateEvidence",
+    );
+
+    await expect(
+      promoteEnvironmentReleasePointer(
+        {
+          agentTargetId: "agent-1",
+          environment: "STAGING",
+          releaseId: "release-1",
+        },
+        architect,
+        "org-1",
+      ),
+    ).rejects.toBeInstanceOf(PromotionLadderError);
+
+    // Adjacency runs BEFORE the gate — evidence resolution never reached,
+    // and nothing is written.
+    expect(evidenceSpy).not.toHaveBeenCalled();
+    expect(ddbMock.commandCalls(TransactWriteCommand)).toHaveLength(0);
+  });
+
+  test("STAGING promotion is refused when DEV has no pointer at all", async () => {
+    stubAgentRelease("release-1");
+    stubPredecessorPointer("DEV", null);
+
+    await expect(
+      promoteEnvironmentReleasePointer(
+        {
+          agentTargetId: "agent-1",
+          environment: "STAGING",
+          releaseId: "release-1",
+        },
+        architect,
+        "org-1",
+      ),
+    ).rejects.toBeInstanceOf(PromotionLadderError);
+    expect(ddbMock.commandCalls(TransactWriteCommand)).toHaveLength(0);
+  });
+
+  test("PROD promotion is refused when STAGING's current pointer references a different release", async () => {
+    stubAgentRelease("release-1");
+    stubPredecessorPointer("STAGING", "release-OTHER");
+
+    await expect(
+      promoteEnvironmentReleasePointer(
+        {
+          agentTargetId: "agent-1",
+          environment: "PROD",
+          releaseId: "release-1",
+        },
+        architect,
+        "org-1",
+      ),
+    ).rejects.toBeInstanceOf(PromotionLadderError);
+  });
+
+  test("STAGING promotion PROCEEDS when DEV's current pointer references the same release", async () => {
+    stubAgentRelease("release-1");
+    stubPredecessorPointer("DEV", "release-1");
+    ddbMock
+      .on(GetCommand, {
+        TableName: POINTERS_TABLE,
+        Key: { orgId: "org-1", agentTargetId_environment: "agent-1#STAGING" },
+      })
+      .resolves({ Item: undefined });
+    ddbMock.on(TransactWriteCommand).resolves({});
+    stubEvidence(passingInputs());
+    jest
+      .spyOn(governanceFlag, "getGovernanceEnforce")
+      .mockResolvedValue("permissive");
+
+    const result = await promoteEnvironmentReleasePointer(
+      {
+        agentTargetId: "agent-1",
+        environment: "STAGING",
+        releaseId: "release-1",
+      },
+      architect,
+      "org-1",
+    );
+    expect(result.releaseId).toBe("release-1");
+    expect(ddbMock.commandCalls(TransactWriteCommand)).toHaveLength(1);
+  });
+
+  test("DEV promotion is the ladder entry — NO adjacency required, proceeds with no predecessor pointer", async () => {
+    stubAgentRelease("release-1");
+    ddbMock
+      .on(GetCommand, { TableName: POINTERS_TABLE })
+      .resolves({ Item: undefined });
+    ddbMock.on(TransactWriteCommand).resolves({});
+    stubEvidence(passingInputs());
+    jest
+      .spyOn(governanceFlag, "getGovernanceEnforce")
+      .mockResolvedValue("permissive");
+
+    const result = await promoteEnvironmentReleasePointer(
+      { agentTargetId: "agent-1", environment: "DEV", releaseId: "release-1" },
+      architect,
+      "org-1",
+    );
+    expect(result.environment).toBe("DEV");
+    expect(ddbMock.commandCalls(TransactWriteCommand)).toHaveLength(1);
+  });
+});
+
+describe("validateReleaseGate — gate-time prod≥staging monotonicity (G2, fail-closed)", () => {
+  const architect = authContextFor("architect");
+
+  test("PROD promotion under a per-env policy WEAKER than STAGING fails closed (synthetic FAIL, evidence never reached)", async () => {
+    // Real resolvePromotionPolicy over a config row whose PROD floor is
+    // LOWER than STAGING's — a monotonicity inversion. taskSuccessMin
+    // STAGING=0.95 vs PROD=0.80.
+    ddbMock
+      .on(GetCommand, { TableName: "citadel-promotion-policy-config-test" })
+      .resolves({
+        Item: {
+          orgId: "org-1",
+          perEnvironmentPolicyOverrides: {
+            STAGING: { taskSuccessMin: 0.95 },
+            PROD: { taskSuccessMin: 0.8 },
+          },
+        },
+      });
+    const evidenceSpy = jest.spyOn(
+      releaseGateEvidence,
+      "resolveReleaseGateEvidence",
+    );
+    jest
+      .spyOn(governanceFlag, "getGovernanceEnforce")
+      .mockResolvedValue("strict");
+    const writeSpy = jest
+      .spyOn(releaseGateFindingWriter, "writeReleaseGateFinding")
+      .mockResolvedValue(undefined);
+
+    await expect(
+      validateReleaseGate(release(), "PROD", "org-1", architect),
+    ).rejects.toThrow(/ReleaseGateError|quality gate/i);
+
+    // Monotonicity is evaluated over the resolved policies BEFORE any
+    // evidence read — fail-closed short-circuit.
+    expect(evidenceSpy).not.toHaveBeenCalled();
+    // The refusal is recorded as a deny finding.
+    expect(writeSpy).toHaveBeenCalledTimes(1);
+    expect(writeSpy.mock.calls[0][0]).toMatchObject({ decision: "deny" });
+  });
+
+  test("PROD promotion under a per-env policy STRICTER than STAGING passes monotonicity and reaches evidence resolution", async () => {
+    ddbMock
+      .on(GetCommand, { TableName: "citadel-promotion-policy-config-test" })
+      .resolves({
+        Item: {
+          orgId: "org-1",
+          perEnvironmentPolicyOverrides: {
+            STAGING: { taskSuccessMin: 0.9 },
+            PROD: { taskSuccessMin: 0.95 },
+          },
+        },
+      });
+    const evidenceSpy = jest
+      .spyOn(releaseGateEvidence, "resolveReleaseGateEvidence")
+      .mockResolvedValue({ ok: true, inputs: passingInputs() });
+    jest
+      .spyOn(governanceFlag, "getGovernanceEnforce")
+      .mockResolvedValue("permissive");
+
+    await validateReleaseGate(release(), "PROD", "org-1", architect);
+
+    // Monotonicity held, so evidence resolution proceeds; the PROD floor
+    // (0.95) is the resolved policy passed to the evidence resolver.
+    expect(evidenceSpy).toHaveBeenCalledTimes(1);
+    expect(evidenceSpy.mock.calls[0][3]).toMatchObject({
+      taskSuccessMin: 0.95,
+    });
+  });
+
+  test("DEV promotion has no predecessor, so monotonicity is skipped entirely", async () => {
+    ddbMock
+      .on(GetCommand, { TableName: "citadel-promotion-policy-config-test" })
+      .resolves({
+        Item: {
+          orgId: "org-1",
+          perEnvironmentPolicyOverrides: {
+            // A deliberately inverted ladder — must be irrelevant for DEV.
+            STAGING: { taskSuccessMin: 0.99 },
+            DEV: { taskSuccessMin: 0.5 },
+          },
+        },
+      });
+    const evidenceSpy = jest
+      .spyOn(releaseGateEvidence, "resolveReleaseGateEvidence")
+      .mockResolvedValue({ ok: true, inputs: passingInputs() });
+    jest
+      .spyOn(governanceFlag, "getGovernanceEnforce")
+      .mockResolvedValue("permissive");
+
+    await validateReleaseGate(release(), "DEV", "org-1", architect);
+    expect(evidenceSpy).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe("promoteEnvironmentReleasePointer — RELEASE_POINTER_MOVED event (G5, best-effort post-commit)", () => {
+  const architect = authContextFor("architect");
+
+  function stubHappyPromotion() {
+    ddbMock
+      .on(GetCommand, { TableName: "citadel-agent-releases-test" })
+      .resolves({ Item: release() });
+    ddbMock
+      .on(GetCommand, { TableName: POINTERS_TABLE })
+      .resolves({ Item: undefined });
+    ddbMock.on(TransactWriteCommand).resolves({});
+    stubEvidence(passingInputs());
+    jest
+      .spyOn(governanceFlag, "getGovernanceEnforce")
+      .mockResolvedValue("permissive");
+  }
+
+  test("emits RELEASE_POINTER_MOVED with the moved-pointer payload AFTER a successful move", async () => {
+    stubHappyPromotion();
+    const publishSpy = jest
+      .spyOn(events, "publishEvent")
+      .mockResolvedValue(undefined);
+
+    const result = await promoteEnvironmentReleasePointer(
+      { agentTargetId: "agent-1", environment: "DEV", releaseId: "release-1" },
+      architect,
+      "org-1",
+    );
+
+    expect(result.releaseId).toBe("release-1");
+    expect(publishSpy).toHaveBeenCalledTimes(1);
+    const emitted = publishSpy.mock.calls[0][0];
+    expect(emitted.eventType).toBe(events.EventTypes.RELEASE_POINTER_MOVED);
+    expect(emitted.agentId).toBe("agent-1");
+    expect(emitted.payload).toMatchObject({
+      orgId: "org-1",
+      agentTargetId: "agent-1",
+      environment: "DEV",
+      releaseId: "release-1",
+      version: 1,
+    });
+  });
+
+  test("a publish failure is swallowed — the committed move is still returned (never blocking)", async () => {
+    stubHappyPromotion();
+    jest
+      .spyOn(events, "publishEvent")
+      .mockRejectedValue(new Error("EventBridge unavailable"));
+
+    const result = await promoteEnvironmentReleasePointer(
+      { agentTargetId: "agent-1", environment: "DEV", releaseId: "release-1" },
+      architect,
+      "org-1",
+    );
+
+    // The move succeeded and is returned despite the emit failure.
+    expect(result.releaseId).toBe("release-1");
+    expect(result.version).toBe(1);
+    expect(ddbMock.commandCalls(TransactWriteCommand)).toHaveLength(1);
+  });
+
+  test("the event is emitted only AFTER the pointer write commits (post-commit ordering)", async () => {
+    const order: string[] = [];
+    ddbMock
+      .on(GetCommand, { TableName: "citadel-agent-releases-test" })
+      .resolves({ Item: release() });
+    ddbMock
+      .on(GetCommand, { TableName: POINTERS_TABLE })
+      .resolves({ Item: undefined });
+    ddbMock.on(TransactWriteCommand).callsFake(() => {
+      order.push("write");
+      return {};
+    });
+    stubEvidence(passingInputs());
+    jest
+      .spyOn(governanceFlag, "getGovernanceEnforce")
+      .mockResolvedValue("permissive");
+    jest.spyOn(events, "publishEvent").mockImplementation(async () => {
+      order.push("emit");
+    });
+
+    await promoteEnvironmentReleasePointer(
+      { agentTargetId: "agent-1", environment: "DEV", releaseId: "release-1" },
+      architect,
+      "org-1",
+    );
+
+    expect(order).toEqual(["write", "emit"]);
+  });
+});
+
+describe("handler — environmentReleasePointerHistory query (G6)", () => {
+  test("routes to the history reader and returns rows, scoped to the caller's org", async () => {
+    const historyRows = [
+      {
+        orgId: "org-1",
+        agentTargetId: "agent-1",
+        environment: "PROD",
+        releaseId: "release-1",
+        previousReleaseId: null,
+        promotedAt: "2026-01-01T00:00:00.000Z",
+        promotedBy: "user-1",
+        version: 1,
+      },
+    ];
+    ddbMock
+      .on(QueryCommand, {
+        TableName: "citadel-environment-release-pointer-history-test",
+      })
+      .resolves({ Items: historyRows });
+
+    const event = {
+      info: { fieldName: "environmentReleasePointerHistory" },
+      identity: {
+        sub: "user-1",
+        "custom:role": "architect",
+        "custom:organization": "org-1",
+      },
+      arguments: {
+        agentTargetId: "agent-1",
+        environment: "PROD",
+        until: "2026-06-01T00:00:00.000Z",
+      },
+    };
+
+    const result = await handler(event as never);
+    expect(result).toEqual(historyRows);
+  });
+
+  test("getEnvironmentReleasePointerHistory passes `until` through to the reader", async () => {
+    const querySpy = ddbMock
+      .on(QueryCommand, {
+        TableName: "citadel-environment-release-pointer-history-test",
+      })
+      .resolves({ Items: [] });
+
+    await getEnvironmentReleasePointerHistory(
+      "org-1",
+      "agent-1",
+      "PROD",
+      "2026-06-01T00:00:00.000Z",
+    );
+
+    const input = ddbMock.commandCalls(QueryCommand)[0].args[0].input;
+    expect(input.KeyConditionExpression).toContain(
+      "BETWEEN :prefix AND :upper",
+    );
+    void querySpy;
   });
 });

--- a/backend/src/lambda/__tests__/environment-release-pointer-store.test.ts
+++ b/backend/src/lambda/__tests__/environment-release-pointer-store.test.ts
@@ -16,14 +16,16 @@
 import {
   DynamoDBDocumentClient,
   GetCommand,
-  PutCommand,
   QueryCommand,
+  TransactWriteCommand,
 } from "@aws-sdk/lib-dynamodb";
 import { mockClient } from "aws-sdk-client-mock";
 import type { EnvironmentReleasePointer } from "../../types";
 
 process.env.ENVIRONMENT_RELEASE_POINTERS_TABLE =
   "citadel-environment-release-pointers-test";
+process.env.ENVIRONMENT_RELEASE_POINTER_HISTORY_TABLE =
+  "citadel-environment-release-pointer-history-test";
 
 const ddbMock = mockClient(DynamoDBDocumentClient);
 
@@ -127,9 +129,31 @@ describe("listEnvironmentReleasePointersForAgent", () => {
   });
 });
 
+// ─────────────────────────────────────────────────────────────────────
+// Transactional write (pointer move + atomic history row) — G6.
+// setEnvironmentReleasePointer now issues ONE TransactWriteCommand with
+// two Put items: the version-gated pointer Put + the append-only history
+// Put. These tests assert on TransactWriteCommand, not PutCommand.
+// ─────────────────────────────────────────────────────────────────────
+
+const POINTERS_TABLE = "citadel-environment-release-pointers-test";
+const HISTORY_TABLE = "citadel-environment-release-pointer-history-test";
+
+/** Extract the two Put items from the sole TransactWriteCommand call. */
+function transactPuts(callIndex = 0) {
+  const input = ddbMock.commandCalls(TransactWriteCommand)[callIndex].args[0]
+    .input as {
+    TransactItems: { Put: { TableName: string; [k: string]: unknown } }[];
+  };
+  const puts = input.TransactItems.map((t) => t.Put);
+  const pointer = puts.find((p) => p.TableName === POINTERS_TABLE)!;
+  const history = puts.find((p) => p.TableName === HISTORY_TABLE)!;
+  return { pointer, history, puts };
+}
+
 describe("setEnvironmentReleasePointer — first promotion (no existing row)", () => {
-  test("Puts a new row at version 1 with previousReleaseId null, guarded by attribute_not_exists", async () => {
-    ddbMock.on(PutCommand).resolves({});
+  test("writes pointer + history atomically at version 1, guarded by attribute_not_exists", async () => {
+    ddbMock.on(TransactWriteCommand).resolves({});
 
     const result = await setEnvironmentReleasePointer({
       orgId: "org-1",
@@ -142,52 +166,36 @@ describe("setEnvironmentReleasePointer — first promotion (no existing row)", (
 
     expect(result.version).toBe(1);
     expect(result.previousReleaseId).toBeNull();
-    expect(result.releaseId).toBe("release-new");
+    expect(ddbMock.commandCalls(TransactWriteCommand)).toHaveLength(1);
 
-    const call = ddbMock.commandCalls(PutCommand)[0].args[0].input;
-    expect(call.TableName).toBe("citadel-environment-release-pointers-test");
-    expect(call.ConditionExpression).toBe("attribute_not_exists(orgId)");
-    expect(call.Item).toMatchObject({
+    const { pointer, history } = transactPuts();
+    expect(pointer.ConditionExpression).toBe("attribute_not_exists(orgId)");
+    expect(pointer.Item).toMatchObject({
       orgId: "org-1",
       agentTargetId_environment: "agent-1#DEV",
       environment: "DEV",
       releaseId: "release-new",
       previousReleaseId: null,
       version: 1,
-      promotedBy: "user-architect",
     });
+    // History row lands in the SAME transaction, with the composite SK.
+    expect(history.Item).toMatchObject({
+      orgId: "org-1",
+      environment: "DEV",
+      releaseId: "release-new",
+      version: 1,
+    });
+    expect((history.Item as { historySortKey: string }).historySortKey).toMatch(
+      /^agent-1#DEV#.*#1$/,
+    );
+    // History Put is unconditional (SK uniqueness via version).
+    expect(history.ConditionExpression).toBeUndefined();
   });
 });
 
 describe("setEnvironmentReleasePointer — subsequent promotion (existing row)", () => {
-  test("moves the pointer, retaining the prior releaseId as previousReleaseId, bumping version, guarded by a version-match ConditionExpression", async () => {
-    ddbMock.on(PutCommand).resolves({});
-
-    const result = await setEnvironmentReleasePointer({
-      orgId: "org-1",
-      agentTargetId: "agent-1",
-      environment: "STAGING",
-      releaseId: "release-new",
-      expectedVersion: 1,
-      promotedBy: "user-architect-2",
-    });
-
-    expect(result.version).toBe(2);
-    expect(result.previousReleaseId).toBe(null);
-    expect(result.releaseId).toBe("release-new");
-
-    const call = ddbMock.commandCalls(PutCommand)[0].args[0].input;
-    expect(call.ConditionExpression).toBe(
-      "attribute_not_exists(orgId) OR #version = :expectedVersion",
-    );
-    expect(call.ExpressionAttributeNames).toEqual({ "#version": "version" });
-    expect(call.ExpressionAttributeValues).toMatchObject({
-      ":expectedVersion": 1,
-    });
-  });
-
-  test("carries the CALLER-SUPPLIED prior releaseId forward as previousReleaseId when moving from a known current release", async () => {
-    ddbMock.on(PutCommand).resolves({});
+  test("moves the pointer under a version-match condition and appends a v2 history row", async () => {
+    ddbMock.on(TransactWriteCommand).resolves({});
 
     const result = await setEnvironmentReleasePointer({
       orgId: "org-1",
@@ -199,17 +207,54 @@ describe("setEnvironmentReleasePointer — subsequent promotion (existing row)",
       promotedBy: "user-architect-2",
     });
 
+    expect(result.version).toBe(2);
     expect(result.previousReleaseId).toBe("release-old");
-    const call = ddbMock.commandCalls(PutCommand)[0].args[0].input;
-    expect(call.Item).toMatchObject({ previousReleaseId: "release-old" });
+
+    const { pointer, history } = transactPuts();
+    expect(pointer.ConditionExpression).toBe(
+      "attribute_not_exists(orgId) OR #version = :expectedVersion",
+    );
+    expect(pointer.ExpressionAttributeNames).toEqual({ "#version": "version" });
+    expect(pointer.ExpressionAttributeValues).toMatchObject({
+      ":expectedVersion": 1,
+    });
+    expect((history.Item as { historySortKey: string }).historySortKey).toMatch(
+      /^agent-1#STAGING#.*#2$/,
+    );
+    expect(history.Item).toMatchObject({
+      previousReleaseId: "release-old",
+      version: 2,
+    });
   });
 
-  test("throws ConcurrentPromotionError (not a generic error) when the ConditionExpression fails — two concurrent promotions must not silently lose one", async () => {
+  test("throws ConcurrentPromotionError when the transaction is cancelled with a ConditionalCheckFailed reason", async () => {
+    const cancelled = Object.assign(new Error("Transaction cancelled"), {
+      name: "TransactionCanceledException",
+      CancellationReasons: [
+        { Code: "ConditionalCheckFailed" },
+        { Code: "None" },
+      ],
+    });
+    ddbMock.on(TransactWriteCommand).rejects(cancelled);
+
+    await expect(
+      setEnvironmentReleasePointer({
+        orgId: "org-1",
+        agentTargetId: "agent-1",
+        environment: "STAGING",
+        releaseId: "release-new",
+        expectedVersion: 1,
+        promotedBy: "user-architect-2",
+      }),
+    ).rejects.toThrow(ConcurrentPromotionError);
+  });
+
+  test("still maps a bare ConditionalCheckFailedException to ConcurrentPromotionError", async () => {
     const conditionalError = Object.assign(
       new Error("The conditional request failed"),
       { name: "ConditionalCheckFailedException" },
     );
-    ddbMock.on(PutCommand).rejects(conditionalError);
+    ddbMock.on(TransactWriteCommand).rejects(conditionalError);
 
     await expect(
       setEnvironmentReleasePointer({
@@ -227,7 +272,7 @@ describe("setEnvironmentReleasePointer — subsequent promotion (existing row)",
     const otherError = Object.assign(new Error("throttled"), {
       name: "ProvisionedThroughputExceededException",
     });
-    ddbMock.on(PutCommand).rejects(otherError);
+    ddbMock.on(TransactWriteCommand).rejects(otherError);
 
     await expect(
       setEnvironmentReleasePointer({
@@ -239,5 +284,202 @@ describe("setEnvironmentReleasePointer — subsequent promotion (existing row)",
         promotedBy: "user-architect-2",
       }),
     ).rejects.toThrow("throttled");
+  });
+
+  test("a transaction cancelled for a NON-conditional reason propagates unchanged", async () => {
+    const cancelled = Object.assign(new Error("Transaction cancelled"), {
+      name: "TransactionCanceledException",
+      CancellationReasons: [
+        { Code: "None" },
+        { Code: "ProvisionedThroughputExceeded" },
+      ],
+    });
+    ddbMock.on(TransactWriteCommand).rejects(cancelled);
+
+    await expect(
+      setEnvironmentReleasePointer({
+        orgId: "org-1",
+        agentTargetId: "agent-1",
+        environment: "STAGING",
+        releaseId: "release-new",
+        expectedVersion: 1,
+        promotedBy: "user-architect-2",
+      }),
+    ).rejects.toThrow(/Transaction cancelled/);
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────
+// MANDATED (design §10, finding d4e76981): two successive chained moves
+// over a STATEFUL transactional mock, asserting the version chain AND
+// that BOTH history rows land; plus a non-stubbed conditional race that
+// proves the version guard BITES (exactly one move + one history row).
+// ─────────────────────────────────────────────────────────────────────
+
+interface StatefulStore {
+  pointer: Map<string, Record<string, unknown>>;
+  history: Record<string, unknown>[];
+}
+
+/** Wire the ddbMock to behave like a real transactional DDB for the
+ * pointer + history tables: the pointer Put's version condition is
+ * evaluated against the live item map; a violation cancels the WHOLE
+ * transaction (no history row lands), exactly as DynamoDB would. */
+function installStatefulTransactMock(): StatefulStore {
+  const store: StatefulStore = { pointer: new Map(), history: [] };
+
+  ddbMock.on(TransactWriteCommand).callsFake((input) => {
+    const items = (
+      input as {
+        TransactItems: {
+          Put: {
+            TableName: string;
+            Item: Record<string, unknown>;
+            ConditionExpression?: string;
+            ExpressionAttributeValues?: Record<string, unknown>;
+          };
+        }[];
+      }
+    ).TransactItems.map((t) => t.Put);
+
+    const pointerPut = items.find((p) => p.TableName === POINTERS_TABLE)!;
+    const historyPut = items.find((p) => p.TableName === HISTORY_TABLE)!;
+
+    const key = `${pointerPut.Item.orgId}#${pointerPut.Item.agentTargetId_environment}`;
+    const existing = store.pointer.get(key);
+
+    // Evaluate the OR'd condition exactly as the store composed it.
+    const cond = pointerPut.ConditionExpression ?? "";
+    const expected = pointerPut.ExpressionAttributeValues?.[":expectedVersion"];
+    const attributeNotExistsSatisfied = existing === undefined;
+    const versionMatchSatisfied =
+      expected !== undefined && existing?.version === expected;
+    const conditionHolds =
+      cond === "" ? true : attributeNotExistsSatisfied || versionMatchSatisfied;
+
+    if (!conditionHolds) {
+      const err = Object.assign(new Error("Transaction cancelled"), {
+        name: "TransactionCanceledException",
+        CancellationReasons: [{ Code: "ConditionalCheckFailed" }],
+      });
+      throw err;
+    }
+
+    store.pointer.set(key, { ...pointerPut.Item });
+    store.history.push({ ...historyPut.Item });
+    return {};
+  });
+
+  return store;
+}
+
+describe("setEnvironmentReleasePointer — chained moves over a stateful transactional mock (finding d4e76981)", () => {
+  test("two successive moves bump version 1→2, chain previousReleaseId, and land BOTH history rows", async () => {
+    const store = installStatefulTransactMock();
+
+    const first = await setEnvironmentReleasePointer({
+      orgId: "org-1",
+      agentTargetId: "agent-1",
+      environment: "STAGING",
+      releaseId: "release-A",
+      expectedVersion: null,
+      promotedBy: "user-1",
+    });
+    expect(first.version).toBe(1);
+    expect(first.previousReleaseId).toBeNull();
+
+    const second = await setEnvironmentReleasePointer({
+      orgId: "org-1",
+      agentTargetId: "agent-1",
+      environment: "STAGING",
+      releaseId: "release-B",
+      expectedVersion: first.version,
+      currentReleaseId: first.releaseId,
+      promotedBy: "user-2",
+    });
+    expect(second.version).toBe(2);
+    expect(second.previousReleaseId).toBe("release-A");
+
+    // Exactly two history rows, in order, with the version chain.
+    expect(store.history).toHaveLength(2);
+    expect(store.history[0]).toMatchObject({
+      releaseId: "release-A",
+      version: 1,
+    });
+    expect(store.history[1]).toMatchObject({
+      releaseId: "release-B",
+      previousReleaseId: "release-A",
+      version: 2,
+    });
+  });
+
+  test("chains across the ladder DEV=R→STAGING=R→PROD=R, one history row per env", async () => {
+    const store = installStatefulTransactMock();
+
+    for (const environment of ["DEV", "STAGING", "PROD"] as const) {
+      await setEnvironmentReleasePointer({
+        orgId: "org-1",
+        agentTargetId: "agent-1",
+        environment,
+        releaseId: "release-R",
+        expectedVersion: null,
+        promotedBy: "user-1",
+      });
+    }
+
+    expect(store.history).toHaveLength(3);
+    expect(store.history.map((h) => h.environment)).toEqual([
+      "DEV",
+      "STAGING",
+      "PROD",
+    ]);
+    expect(store.pointer.size).toBe(3);
+  });
+
+  test("a racing stale-version move is rejected — exactly one move + one history row, the loser writes NOTHING", async () => {
+    const store = installStatefulTransactMock();
+
+    // Establish v1.
+    const v1 = await setEnvironmentReleasePointer({
+      orgId: "org-1",
+      agentTargetId: "agent-1",
+      environment: "STAGING",
+      releaseId: "release-A",
+      expectedVersion: null,
+      promotedBy: "user-1",
+    });
+
+    // Two promotions both read v1 and race. The first wins (v1→v2).
+    await setEnvironmentReleasePointer({
+      orgId: "org-1",
+      agentTargetId: "agent-1",
+      environment: "STAGING",
+      releaseId: "release-B",
+      expectedVersion: v1.version,
+      currentReleaseId: v1.releaseId,
+      promotedBy: "user-2",
+    });
+
+    // The loser also read v1 — its transaction must be cancelled.
+    await expect(
+      setEnvironmentReleasePointer({
+        orgId: "org-1",
+        agentTargetId: "agent-1",
+        environment: "STAGING",
+        releaseId: "release-C",
+        expectedVersion: v1.version,
+        currentReleaseId: v1.releaseId,
+        promotedBy: "user-3",
+      }),
+    ).rejects.toThrow(ConcurrentPromotionError);
+
+    // Exactly one winning move beyond v1, and NO history row for the
+    // loser (release-C never lands anywhere — atomic).
+    expect(store.history).toHaveLength(2);
+    expect(store.history.map((h) => h.releaseId)).toEqual([
+      "release-A",
+      "release-B",
+    ]);
+    expect(store.history.some((h) => h.releaseId === "release-C")).toBe(false);
   });
 });

--- a/backend/src/lambda/__tests__/promotion-policy-resolver.test.ts
+++ b/backend/src/lambda/__tests__/promotion-policy-resolver.test.ts
@@ -192,3 +192,76 @@ describe("handler — AppSync dispatch", () => {
     await expect(handler(event as never)).rejects.toThrow(/Unknown field/);
   });
 });
+
+describe("setPromotionPolicy — G2 write-time prod≥staging monotonicity", () => {
+  test("accepts a monotonic per-env ladder (floors rise DEV→STAGING→PROD)", async () => {
+    ddbMock.on(PutCommand).resolves({});
+
+    const result = await setPromotionPolicy(
+      "org-1",
+      {
+        perEnvironmentPolicyOverrides: {
+          DEV: { taskSuccessMin: 0.8 },
+          STAGING: { taskSuccessMin: 0.9 },
+          PROD: { taskSuccessMin: 0.95 },
+        },
+      },
+      adminAuth,
+    );
+
+    expect(result.perEnvironmentPolicyOverrides.PROD).toEqual({
+      taskSuccessMin: 0.95,
+    });
+    expect(ddbMock.commandCalls(PutCommand)).toHaveLength(1);
+  });
+
+  test("rejects a non-monotonic ladder (PROD floor lower than STAGING) BEFORE persisting", async () => {
+    ddbMock.on(PutCommand).resolves({});
+
+    await expect(
+      setPromotionPolicy(
+        "org-1",
+        {
+          perEnvironmentPolicyOverrides: {
+            STAGING: { taskSuccessMin: 0.95 },
+            PROD: { taskSuccessMin: 0.8 },
+          },
+        },
+        adminAuth,
+      ),
+    ).rejects.toThrow(/ValidationError.*monotonic/i);
+
+    expect(ddbMock.commandCalls(PutCommand)).toHaveLength(0);
+  });
+
+  test("rejects a non-monotonic ceiling (PROD latency budget looser than STAGING)", async () => {
+    ddbMock.on(PutCommand).resolves({});
+
+    await expect(
+      setPromotionPolicy(
+        "org-1",
+        {
+          perEnvironmentPolicyOverrides: {
+            STAGING: { latencyP95TargetMs: 3000 },
+            PROD: { latencyP95TargetMs: 6000 },
+          },
+        },
+        adminAuth,
+      ),
+    ).rejects.toThrow(/ValidationError.*monotonic/i);
+    expect(ddbMock.commandCalls(PutCommand)).toHaveLength(0);
+  });
+
+  test("an org-wide policy with no per-env overrides is trivially monotonic (all envs share the same base)", async () => {
+    ddbMock.on(PutCommand).resolves({});
+
+    await expect(
+      setPromotionPolicy(
+        "org-1",
+        { policy: { taskSuccessMin: 0.95 } },
+        adminAuth,
+      ),
+    ).resolves.toMatchObject({ orgId: "org-1" });
+    expect(ddbMock.commandCalls(PutCommand)).toHaveLength(1);
+  });
+});

--- a/backend/src/lambda/environment-release-pointer-history-store.ts
+++ b/backend/src/lambda/environment-release-pointer-history-store.ts
@@ -1,0 +1,120 @@
+/**
+ * environment-release-pointer-history-store.ts — READ-ONLY queries over
+ * EnvironmentReleasePointerHistoryTable (G6 — "what ran in PROD on date
+ * D").
+ *
+ * This module is the reader half of a deliberate writer/reader split,
+ * mirroring release-store.ts (writer) vs release-gate-evidence.ts
+ * (reader): the ONLY writer of the history table is
+ * environment-release-pointer-store.ts, which appends a history row
+ * inside the SAME TransactWriteItems as every pointer move (so the
+ * time-series is gap-free and atomic with the authoritative pointer
+ * state). This module issues NO writes — only Query — and must never
+ * import a Put/Update/Delete command.
+ *
+ * Sort-key shape (set by the writer): PK orgId, SK
+ * `${agentTargetId}#${environment}#${promotedAt}#${version}`, stored
+ * under the `historySortKey` attribute. A `begins_with(historySortKey,
+ * "${agentTargetId}#${environment}#")` KeyCondition plus a `<= "${...}#${D}"`
+ * upper bound selects every move for that (agent, env) at or before D;
+ * the greatest such row (latest promotedAt/version) is what was running
+ * at D.
+ */
+import { DynamoDBClient } from "@aws-sdk/client-dynamodb";
+import { DynamoDBDocumentClient, QueryCommand } from "@aws-sdk/lib-dynamodb";
+import type {
+  EnvironmentLiteral,
+  EnvironmentReleasePointerHistoryEntry,
+} from "../types";
+
+const dynamoClient = new DynamoDBClient({});
+const docClient = DynamoDBDocumentClient.from(dynamoClient);
+
+function tableName(): string {
+  return process.env.ENVIRONMENT_RELEASE_POINTER_HISTORY_TABLE!;
+}
+
+/** SK attribute name — kept in lock-step with the writer
+ * (environment-release-pointer-store.ts's historySortKey). */
+export const HISTORY_SORT_KEY_ATTR = "historySortKey";
+
+/** The `${agentTargetId}#${environment}#` prefix every history row for
+ * one (agent, env) shares — exported so the writer and reader compose
+ * the identical prefix. */
+export function historySortKeyPrefix(
+  agentTargetId: string,
+  environment: EnvironmentLiteral,
+): string {
+  return `${agentTargetId}#${environment}#`;
+}
+
+/**
+ * Every history row for one (org, agent, environment), oldest→newest.
+ * Optionally bounded to rows with promotedAt <= `until` (an ISO-8601
+ * timestamp): the "what ran on date D" query.
+ *
+ * The `<= until#\uffff` upper bound (rather than `<= until#`) ensures a
+ * row promoted exactly at `until` — whose SK is
+ * `agent#env#until#<version>` — is INCLUDED, since any version suffix
+ * sorts before `\uffff`. Without the sentinel, `agent#env#until#3` would
+ * sort AFTER `agent#env#until` and be excluded on an exact-boundary
+ * match.
+ */
+export async function queryEnvironmentReleasePointerHistory(
+  orgId: string,
+  agentTargetId: string,
+  environment: EnvironmentLiteral,
+  until?: string,
+): Promise<EnvironmentReleasePointerHistoryEntry[]> {
+  const prefix = historySortKeyPrefix(agentTargetId, environment);
+
+  const expressionAttributeValues: Record<string, unknown> = {
+    ":oid": orgId,
+    ":prefix": prefix,
+  };
+  let keyConditionExpression =
+    "orgId = :oid AND begins_with(historySortKey, :prefix)";
+
+  if (until !== undefined) {
+    // Range from the prefix (inclusive lower) up to `until` plus a
+    // high-sentinel version suffix (inclusive of any move AT `until`).
+    keyConditionExpression =
+      "orgId = :oid AND historySortKey BETWEEN :prefix AND :upper";
+    expressionAttributeValues[":upper"] = `${prefix}${until}#\uffff`;
+  }
+
+  const res = await docClient.send(
+    new QueryCommand({
+      TableName: tableName(),
+      KeyConditionExpression: keyConditionExpression,
+      ExpressionAttributeValues: expressionAttributeValues,
+      // Ascending SK order — the caller takes the LAST element for the
+      // "latest ≤ D" answer.
+      ScanIndexForward: true,
+    }),
+  );
+  return (
+    (res.Items as EnvironmentReleasePointerHistoryEntry[] | undefined) ?? []
+  );
+}
+
+/**
+ * "What release was running in `environment` at date `until`" — the
+ * greatest (latest promotedAt/version) history row at or before `until`,
+ * or null when nothing had been promoted to that env by then.
+ */
+export async function environmentReleaseRunningAt(
+  orgId: string,
+  agentTargetId: string,
+  environment: EnvironmentLiteral,
+  until: string,
+): Promise<EnvironmentReleasePointerHistoryEntry | null> {
+  const rows = await queryEnvironmentReleasePointerHistory(
+    orgId,
+    agentTargetId,
+    environment,
+    until,
+  );
+  if (rows.length === 0) return null;
+  return rows[rows.length - 1];
+}

--- a/backend/src/lambda/environment-release-pointer-resolver.ts
+++ b/backend/src/lambda/environment-release-pointer-resolver.ts
@@ -107,18 +107,25 @@ import { governanceDisposition } from "./utils/governance-disposition";
 import { evaluateReleaseGate } from "./utils/release-gate";
 import { resolveReleaseGateEvidence } from "./utils/release-gate-evidence";
 import { resolvePromotionPolicy } from "./utils/promotion-policy-store";
+import {
+  predecessorEnvironment,
+  comparePolicyStrictness,
+} from "./utils/promotion-ladder";
 import { writeReleaseGateFinding } from "./utils/release-gate-finding-writer";
 import { writeReleasePromotionApprovalFinding } from "./utils/release-promotion-approval-writer";
+import { publishEvent, createReleaseEvent, EventTypes } from "../utils/events";
 import {
   getEnvironmentReleasePointer,
   listEnvironmentReleasePointersForAgent,
   setEnvironmentReleasePointer,
 } from "./environment-release-pointer-store";
+import { queryEnvironmentReleasePointerHistory } from "./environment-release-pointer-history-store";
 import type {
   AgentRelease,
   AuthContext,
   EnvironmentLiteral,
   EnvironmentReleasePointer,
+  EnvironmentReleasePointerHistoryEntry,
   GovernanceEventIdentity,
   GovernanceResolverEvent,
   PromotionApproval,
@@ -153,6 +160,30 @@ export class ReleaseGateError extends Error {
       `ReleaseGateError: release quality gate refused promotion of ${releaseId} — reasons=[${reasons.join(", ")}]`,
     );
     this.name = "ReleaseGateError";
+  }
+}
+
+/** Thrown when a promotion violates the dev→staging→prod ladder (G1):
+ * the immediately-lower environment's CURRENT pointer does not reference
+ * the release being promoted. Distinct class (like ReleaseGateError) so
+ * callers can surface a precise "promote to <predecessor> first" message
+ * rather than string-matching a generic Error. Consensus decision 1:
+ * adjacency is the predecessor's CURRENT pointer, NOT a history-based
+ * "was ever there" — promoting a release that has since been superseded
+ * in the lower env is a distinct ROLLBACK operation, not built here.
+ * Promotion INTO DEV (the ladder entry) is unconstrained and never
+ * throws this. */
+export class PromotionLadderError extends Error {
+  constructor(
+    public readonly releaseId: string,
+    public readonly targetEnvironment: EnvironmentLiteral,
+    public readonly predecessorEnvironment: EnvironmentLiteral,
+    public readonly predecessorReleaseId: string | null,
+  ) {
+    super(
+      `PromotionLadderError: release ${releaseId} cannot be promoted to ${targetEnvironment} — the ladder requires ${predecessorEnvironment}'s current pointer to reference it, but ${predecessorEnvironment} currently points at ${predecessorReleaseId ?? "no release"}. Promote it to ${predecessorEnvironment} first.`,
+    );
+    this.name = "PromotionLadderError";
   }
 }
 
@@ -217,23 +248,66 @@ export async function validateReleaseGate(
   const policyResolution = await resolvePromotionPolicy(
     callerOrgId,
     release.agentTargetId,
+    environment,
   );
 
-  // evidence is only resolved when the policy itself resolved OK — an
-  // UNREADABLE policy short-circuits before any evidence read, and the
-  // synthetic FAIL verdict below carries the SAME
-  // `reasons: [<failure-reason>]` shape resolveReleaseGateEvidence's own
-  // ok:false branch produces, so downstream consumers (the ledger
-  // finding, isFailStatus) treat the two failure sources identically.
-  const evidence = policyResolution.ok
-    ? await resolveReleaseGateEvidence(
-        release,
-        environment,
+  // G2 gate-time monotonicity (AUTHORITATIVE, fail-closed): the TARGET
+  // env's fully-resolved policy must be at least as strict as the
+  // immediately-LOWER env's, for the SAME (org, agent). This sees
+  // per-agent overrides that the write-time check in
+  // promotion-policy-resolver.ts cannot, so an inversion introduced after
+  // the write can never let a prod promotion run under a policy weaker
+  // than staging. Skipped for DEV (no predecessor). A violation — or an
+  // UNREADABLE predecessor policy — becomes a synthetic FAIL verdict of
+  // the SAME shape as the UNREADABLE branch below, so downstream
+  // consumers (ledger finding, isFailStatus) treat it identically.
+  let monotonicityFailure: string | null = null;
+  if (policyResolution.ok) {
+    const predecessor = predecessorEnvironment(environment);
+    if (predecessor !== null) {
+      const predecessorResolution = await resolvePromotionPolicy(
         callerOrgId,
-        policyResolution.policy,
-        now,
-      )
-    : ({ ok: false, reason: policyResolution.reason } as const);
+        release.agentTargetId,
+        predecessor,
+      );
+      if (!predecessorResolution.ok) {
+        // Fail-closed: can't prove monotonicity against an unreadable
+        // lower-env policy, so refuse rather than assume it holds.
+        monotonicityFailure = `MONOTONICITY_PREDECESSOR_${predecessorResolution.reason}`;
+      } else {
+        const comparison = comparePolicyStrictness(
+          policyResolution.policy,
+          predecessorResolution.policy,
+        );
+        if (!comparison.monotonic) {
+          monotonicityFailure = `MONOTONICITY_VIOLATION: ${comparison.violations
+            .map((v) => v.field)
+            .join(", ")}`;
+        }
+      }
+    }
+  }
+
+  // evidence is only resolved when the policy itself resolved OK AND the
+  // per-env monotonicity ladder holds — either failure short-circuits
+  // before any evidence read, and the synthetic FAIL verdict below
+  // carries the SAME `reasons: [<failure-reason>]` shape
+  // resolveReleaseGateEvidence's own ok:false branch produces, so
+  // downstream consumers treat every failure source identically.
+  const gateBlockingReason: string | null = !policyResolution.ok
+    ? policyResolution.reason
+    : monotonicityFailure;
+
+  const evidence =
+    policyResolution.ok && monotonicityFailure === null
+      ? await resolveReleaseGateEvidence(
+          release,
+          environment,
+          callerOrgId,
+          policyResolution.policy,
+          now,
+        )
+      : ({ ok: false, reason: gateBlockingReason as string } as const);
 
   const verdict = evidence.ok
     ? evaluateReleaseGate(evidence.inputs)
@@ -446,6 +520,33 @@ export async function promoteEnvironmentReleasePointer(
     );
   }
 
+  // G1 — ladder adjacency (consensus decision 1): promotion INTO a
+  // non-DEV environment requires the immediately-lower env's CURRENT
+  // pointer to reference this exact release. DEV is the ladder entry and
+  // is unconstrained. Positioned AFTER permission/existence/org checks
+  // and BEFORE the quality gate — a ladder violation refuses the
+  // promotion before any evidence read or pointer write (tests assert
+  // zero writes on refusal).
+  const predecessor = predecessorEnvironment(input.environment);
+  if (predecessor !== null) {
+    const predecessorPointer = await getEnvironmentReleasePointer(
+      callerOrgId,
+      input.agentTargetId,
+      predecessor,
+    );
+    if (
+      !predecessorPointer ||
+      predecessorPointer.releaseId !== input.releaseId
+    ) {
+      throw new PromotionLadderError(
+        input.releaseId,
+        input.environment,
+        predecessor,
+        predecessorPointer?.releaseId ?? null,
+      );
+    }
+  }
+
   await validateReleaseGate(
     targetRelease,
     input.environment,
@@ -467,7 +568,7 @@ export async function promoteEnvironmentReleasePointer(
     input.environment,
   );
 
-  return setEnvironmentReleasePointer({
+  const moved = await setEnvironmentReleasePointer({
     orgId: callerOrgId,
     agentTargetId: input.agentTargetId,
     environment: input.environment,
@@ -476,6 +577,56 @@ export async function promoteEnvironmentReleasePointer(
     currentReleaseId: currentPointer?.releaseId ?? null,
     promotedBy: authContext.userId,
   });
+
+  // G5 — RELEASE_POINTER_MOVED, best-effort POST-commit (consensus
+  // decision 2). The move is already durably audited by the atomic
+  // history row + the fail-closed ledger finding; making this
+  // NOTIFICATION fail-closed would let a transient EventBridge blip abort
+  // an already-committed, already-audited move — strictly worse. So a
+  // publish failure is logged and swallowed here, never propagated: the
+  // caller still receives the successfully-moved pointer.
+  await emitReleasePointerMovedEvent(moved);
+
+  return moved;
+}
+
+/**
+ * Best-effort emit of the RELEASE_POINTER_MOVED event (G5). Deliberately
+ * NOT fail-closed — see the call site. Any error is logged and swallowed
+ * so a downstream notification failure can never roll back or hide an
+ * already-committed, already-audited pointer move.
+ */
+async function emitReleasePointerMovedEvent(
+  moved: EnvironmentReleasePointer,
+): Promise<void> {
+  try {
+    await publishEvent(
+      createReleaseEvent(
+        EventTypes.RELEASE_POINTER_MOVED,
+        moved.agentTargetId,
+        {
+          orgId: moved.orgId,
+          agentTargetId: moved.agentTargetId,
+          environment: moved.environment,
+          releaseId: moved.releaseId,
+          previousReleaseId: moved.previousReleaseId,
+          version: moved.version,
+          promotedBy: moved.promotedBy,
+          promotedAt: moved.promotedAt,
+        },
+      ),
+    );
+  } catch (err: unknown) {
+    console.error(
+      "environment-release-pointer-resolver: best-effort RELEASE_POINTER_MOVED emit failed — move is already committed and audited, continuing",
+      {
+        agentTargetId: moved.agentTargetId,
+        environment: moved.environment,
+        releaseId: moved.releaseId,
+        error: err instanceof Error ? err.message : String(err),
+      },
+    );
+  }
 }
 
 /** Read: the current pointer for one agent+environment. Returns null when
@@ -496,11 +647,30 @@ export async function listEnvironmentReleasePointers(
   return listEnvironmentReleasePointersForAgent(orgId, agentTargetId);
 }
 
+/** Read: the append-only promotion history for one agent+environment
+ * (G6). Oldest→newest; optionally bounded to promotedAt <= `until` — the
+ * "what ran in <env> on date D" query. Read-only: delegates to the
+ * dedicated history reader module, never the pointer writer. */
+export async function getEnvironmentReleasePointerHistory(
+  orgId: string,
+  agentTargetId: string,
+  environment: SetEnvironmentReleasePointerInput["environment"],
+  until?: string | null,
+): Promise<EnvironmentReleasePointerHistoryEntry[]> {
+  return queryEnvironmentReleasePointerHistory(
+    orgId,
+    agentTargetId,
+    environment,
+    until ?? undefined,
+  );
+}
+
 /** Merged view of every argument this resolver's fields receive. */
 interface EnvironmentReleasePointerResolverArguments {
   input: SetEnvironmentReleasePointerInput;
   agentTargetId: string;
   environment: SetEnvironmentReleasePointerInput["environment"];
+  until?: string | null;
 }
 
 type EnvironmentReleasePointerResolverEvent =
@@ -574,6 +744,20 @@ export const handler = async (
         return await listEnvironmentReleasePointers(
           callerOrgId,
           event.arguments.agentTargetId,
+        );
+      }
+      case "environmentReleasePointerHistory": {
+        const callerOrgId = await extractOrgFromEvent(event);
+        if (!callerOrgId) {
+          throw new Error(
+            "ValidationError: caller organization could not be determined",
+          );
+        }
+        return await getEnvironmentReleasePointerHistory(
+          callerOrgId,
+          event.arguments.agentTargetId,
+          event.arguments.environment,
+          event.arguments.until,
         );
       }
       default:

--- a/backend/src/lambda/environment-release-pointer-store.ts
+++ b/backend/src/lambda/environment-release-pointer-store.ts
@@ -27,16 +27,25 @@ import { DynamoDBClient } from "@aws-sdk/client-dynamodb";
 import {
   DynamoDBDocumentClient,
   GetCommand,
-  PutCommand,
   QueryCommand,
+  TransactWriteCommand,
 } from "@aws-sdk/lib-dynamodb";
-import type { EnvironmentLiteral, EnvironmentReleasePointer } from "../types";
+import type {
+  EnvironmentLiteral,
+  EnvironmentReleasePointer,
+  EnvironmentReleasePointerHistoryEntry,
+} from "../types";
+import { historySortKeyPrefix } from "./environment-release-pointer-history-store";
 
 const dynamoClient = new DynamoDBClient({});
 const docClient = DynamoDBDocumentClient.from(dynamoClient);
 
 function tableName(): string {
   return process.env.ENVIRONMENT_RELEASE_POINTERS_TABLE!;
+}
+
+function historyTableName(): string {
+  return process.env.ENVIRONMENT_RELEASE_POINTER_HISTORY_TABLE!;
 }
 
 function sortKey(
@@ -66,11 +75,26 @@ export class ConcurrentPromotionError extends Error {
 }
 
 function isConditionalCheckFailed(err: unknown): boolean {
-  return (
-    !!err &&
-    typeof err === "object" &&
-    (err as { name?: string }).name === "ConditionalCheckFailedException"
-  );
+  if (!err || typeof err !== "object") return false;
+  const name = (err as { name?: string }).name;
+  // Direct conditional Put failure (kept for callers/tests that still
+  // surface a bare ConditionalCheckFailedException) AND the
+  // TransactWriteItems form: a cancelled transaction whose pointer-Put
+  // condition failed surfaces as TransactionCanceledException carrying a
+  // CancellationReasons entry with Code "ConditionalCheckFailed". Either
+  // shape means "another promotion won the race".
+  if (name === "ConditionalCheckFailedException") return true;
+  if (name === "TransactionCanceledException") {
+    const reasons = (err as { CancellationReasons?: { Code?: string }[] })
+      .CancellationReasons;
+    if (Array.isArray(reasons)) {
+      return reasons.some((r) => r?.Code === "ConditionalCheckFailed");
+    }
+    // Some SDK/runtime combinations only embed the reason in the message.
+    const message = (err as { message?: string }).message ?? "";
+    return /ConditionalCheckFailed/.test(message);
+  }
+  return false;
 }
 
 /** Point read for the current pointer of one (org, agent, environment). */
@@ -130,19 +154,34 @@ export interface SetEnvironmentReleasePointerParams {
 /**
  * Create-or-move write for the (orgId, agentTargetId, environment)
  * pointer. This is the ONLY function in the codebase permitted to issue a
- * write against EnvironmentReleasePointersTable.
+ * write against EnvironmentReleasePointersTable — AND the ONLY writer of
+ * EnvironmentReleasePointerHistoryTable (G6), by the SAME single-writer
+ * discipline release-store.ts applies to AgentReleasesTable.
  *
- * The single ConditionExpression `attribute_not_exists(orgId) OR
- * #version = :expectedVersion` covers both cases with one write path:
+ * The pointer move and its append-only history row are written ATOMICALLY
+ * in one TransactWriteItems: either both land or neither does. This makes
+ * the history table a gap-free record of every move (invariant I3) — a
+ * refusal or race can never leave a pointer moved without its history row
+ * (or vice versa).
+ *
+ * The pointer Put's single ConditionExpression `attribute_not_exists(orgId)
+ * OR #version = :expectedVersion` covers both cases with one write path:
  *  - First-ever promotion (expectedVersion === null): the row must not
  *    exist yet, mirroring release-store.ts's create-only idempotency
  *    guard structurally, though this table is mutable thereafter.
  *  - Every subsequent move: the row's current `version` must equal what
- *    the caller last read. A stale caller's Put is rejected by DynamoDB
- *    with ConditionalCheckFailedException, surfaced as
- *    ConcurrentPromotionError, BEFORE any data is overwritten — this is
- *    the write-boundary enforcement the optimistic lock exists for, not
- *    a read-then-compare done in this function's own logic.
+ *    the caller last read. A stale caller's transaction is rejected by
+ *    DynamoDB with TransactionCanceledException (CancellationReasons
+ *    carrying ConditionalCheckFailed for the pointer item), surfaced as
+ *    ConcurrentPromotionError, BEFORE any data is written — this is the
+ *    write-boundary enforcement the optimistic lock exists for. Because
+ *    the two Puts share one transaction, the loser's history row never
+ *    lands either.
+ *
+ * The history row carries no ConditionExpression: its SK includes the
+ * monotonic `version`, so a genuine retry cannot double-append (the
+ * pointer item's version condition fails first and cancels the whole
+ * transaction).
  */
 export async function setEnvironmentReleasePointer(
   params: SetEnvironmentReleasePointerParams,
@@ -162,30 +201,54 @@ export async function setEnvironmentReleasePointer(
     version: nextVersion,
   };
 
+  const historyEntry: EnvironmentReleasePointerHistoryEntry = { ...pointer };
+  // SK: `${agentTargetId}#${environment}#${promotedAt}#${version}` — the
+  // prefix is shared with the reader (historySortKeyPrefix) so the two
+  // halves cannot drift; version disambiguates equal-ms timestamps.
+  const historySortKey = `${historySortKeyPrefix(
+    params.agentTargetId,
+    params.environment,
+  )}${promotedAt}#${nextVersion}`;
+
   try {
     const conditionExpression =
       params.expectedVersion === null
         ? "attribute_not_exists(orgId)"
         : "attribute_not_exists(orgId) OR #version = :expectedVersion";
     await docClient.send(
-      new PutCommand({
-        TableName: tableName(),
-        Item: {
-          ...pointer,
-          agentTargetId_environment: sortKey(
-            params.agentTargetId,
-            params.environment,
-          ),
-        },
-        ConditionExpression: conditionExpression,
-        ExpressionAttributeNames:
-          params.expectedVersion === null
-            ? undefined
-            : { "#version": "version" },
-        ExpressionAttributeValues:
-          params.expectedVersion === null
-            ? undefined
-            : { ":expectedVersion": params.expectedVersion },
+      new TransactWriteCommand({
+        TransactItems: [
+          {
+            Put: {
+              TableName: tableName(),
+              Item: {
+                ...pointer,
+                agentTargetId_environment: sortKey(
+                  params.agentTargetId,
+                  params.environment,
+                ),
+              },
+              ConditionExpression: conditionExpression,
+              ExpressionAttributeNames:
+                params.expectedVersion === null
+                  ? undefined
+                  : { "#version": "version" },
+              ExpressionAttributeValues:
+                params.expectedVersion === null
+                  ? undefined
+                  : { ":expectedVersion": params.expectedVersion },
+            },
+          },
+          {
+            Put: {
+              TableName: historyTableName(),
+              Item: {
+                ...historyEntry,
+                historySortKey,
+              },
+            },
+          },
+        ],
       }),
     );
     return pointer;

--- a/backend/src/lambda/promotion-policy-resolver.ts
+++ b/backend/src/lambda/promotion-policy-resolver.ts
@@ -27,7 +27,9 @@ import {
   PutCommand,
 } from "@aws-sdk/lib-dynamodb";
 import type { PromotionPolicy } from "./utils/release-gate";
-import type { AuthContext } from "../types";
+import { resolveBaseEnvironmentPolicy } from "./utils/promotion-policy-store";
+import { comparePolicyStrictness } from "./utils/promotion-ladder";
+import type { AuthContext, EnvironmentLiteral } from "../types";
 
 const dynamoClient = new DynamoDBClient({});
 const docClient = DynamoDBDocumentClient.from(dynamoClient);
@@ -45,6 +47,11 @@ export interface PromotionPolicyConfig {
   orgId: string;
   policy: Partial<PromotionPolicy>;
   perAgentPolicyOverrides: Record<string, Partial<PromotionPolicy>>;
+  // G2 — per-target-env threshold overrides (DeploymentEnvironment ->
+  // Partial<PromotionPolicy>). Layered highest-precedence at gate time
+  // (promotion-policy-store.ts) and validated for prod≥staging
+  // monotonicity at write time below.
+  perEnvironmentPolicyOverrides: Record<string, Partial<PromotionPolicy>>;
   updatedAt?: string;
   updatedBy?: string;
 }
@@ -52,6 +59,51 @@ export interface PromotionPolicyConfig {
 export interface PromotionPolicyConfigInput {
   policy?: Partial<PromotionPolicy>;
   perAgentPolicyOverrides?: Record<string, Partial<PromotionPolicy>>;
+  perEnvironmentPolicyOverrides?: Record<string, Partial<PromotionPolicy>>;
+}
+
+/** The ladder, lowest→highest. Write-time monotonicity asserts each
+ * higher env's AGENTLESS base policy is at least as strict as the
+ * immediately-lower one's. */
+const WRITE_TIME_LADDER: EnvironmentLiteral[] = ["DEV", "STAGING", "PROD"];
+
+/**
+ * Write-time prod≥staging monotonicity (G2, catch-the-common-misconfig
+ * layer). Resolves the AGENTLESS per-env base policy
+ * (DEFAULT←org←perEnv) for each ladder rung and rejects a non-monotonic
+ * authored ladder with a ValidationError. This is the friendlier,
+ * eager check; the AUTHORITATIVE, fail-closed enforcement runs at gate
+ * time over the fully-resolved per-agent policy
+ * (environment-release-pointer-resolver.ts's validateReleaseGate), which
+ * sees per-agent overrides this check cannot.
+ */
+function assertMonotonicLadder(config: PromotionPolicyConfig): void {
+  const baseByEnv = new Map<EnvironmentLiteral, PromotionPolicy>();
+  for (const env of WRITE_TIME_LADDER) {
+    baseByEnv.set(
+      env,
+      resolveBaseEnvironmentPolicy(
+        config.policy,
+        config.perEnvironmentPolicyOverrides[env],
+      ),
+    );
+  }
+
+  for (let i = 1; i < WRITE_TIME_LADDER.length; i += 1) {
+    const higher = WRITE_TIME_LADDER[i];
+    const lower = WRITE_TIME_LADDER[i - 1];
+    const comparison = comparePolicyStrictness(
+      baseByEnv.get(higher)!,
+      baseByEnv.get(lower)!,
+    );
+    if (!comparison.monotonic) {
+      throw new Error(
+        `ValidationError: promotion policy is not monotonic — ${higher} must be at least as strict as ${lower}. Violations: ${comparison.violations
+          .map((v) => v.reason)
+          .join("; ")}`,
+      );
+    }
+  }
 }
 
 export async function setPromotionPolicy(
@@ -65,9 +117,13 @@ export async function setPromotionPolicy(
     orgId,
     policy: input.policy ?? {},
     perAgentPolicyOverrides: input.perAgentPolicyOverrides ?? {},
+    perEnvironmentPolicyOverrides: input.perEnvironmentPolicyOverrides ?? {},
     updatedAt: new Date().toISOString(),
     updatedBy: authContext.userId,
   };
+
+  // G2 write-time monotonicity — reject the misconfig BEFORE persisting.
+  assertMonotonicLadder(config);
 
   await docClient.send(
     new PutCommand({ TableName: PROMOTION_POLICY_CONFIG_TABLE, Item: config }),

--- a/backend/src/lambda/utils/__tests__/promotion-ladder.property.test.ts
+++ b/backend/src/lambda/utils/__tests__/promotion-ladder.property.test.ts
@@ -1,0 +1,160 @@
+/**
+ * promotion-ladder.property.test.ts — property-based coverage of the PURE
+ * ladder + monotonicity helpers (design §10 "Property-based" item).
+ *
+ *  (a) predecessorEnvironment totality/acyclicity.
+ *  (b) comparePolicyStrictness reflexivity/antisymmetry/transitivity per
+ *      field direction.
+ *  (c) comparePolicyStrictness/monotonicity is monotonic IFF every field
+ *      satisfies its direction, and never throws.
+ */
+import * as fc from "fast-check";
+import {
+  ENVIRONMENT_ORDER,
+  predecessorEnvironment,
+  comparePolicyStrictness,
+} from "../promotion-ladder";
+import {
+  DEFAULT_PROMOTION_POLICY,
+  type PromotionPolicy,
+} from "../release-gate";
+import type { EnvironmentLiteral } from "../../../types";
+
+const environmentArb: fc.Arbitrary<EnvironmentLiteral> = fc.constantFrom(
+  ...ENVIRONMENT_ORDER,
+);
+
+/** A PromotionPolicy with all-independent, in-range field values so the
+ * comparison exercises each direction rather than always tying. */
+const policyArb: fc.Arbitrary<PromotionPolicy> = fc.record({
+  taskSuccessMin: fc.double({ min: 0, max: 1, noNaN: true }),
+  policyComplianceMin: fc.double({ min: 0, max: 1, noNaN: true }),
+  latencyP95TargetMs: fc.integer({ min: 0, max: 60000 }),
+  avgCostBudgetUsd: fc.double({ min: 0, max: 100, noNaN: true }),
+  minSampleCount: fc.integer({ min: 0, max: 1000 }),
+  requiredGateClasses: fc.uniqueArray(
+    fc.constantFrom("safety", "latency", "cost", "quality"),
+    { maxLength: 4 },
+  ),
+  maxEvidenceAgeDays: fc.integer({ min: 0, max: 365 }),
+  allowNoBaselineOnAbsoluteFloors: fc.boolean(),
+});
+
+describe("predecessorEnvironment — totality and acyclicity", () => {
+  it("is total over every EnvironmentLiteral and returns null or a strictly-lower env", () => {
+    fc.assert(
+      fc.property(environmentArb, (env) => {
+        const predecessor = predecessorEnvironment(env);
+        if (predecessor === null) {
+          // Only the ladder entry (DEV) has no predecessor.
+          expect(env).toBe("DEV");
+          return;
+        }
+        // A predecessor must be strictly lower in the ladder order.
+        expect(ENVIRONMENT_ORDER.indexOf(predecessor)).toBeLessThan(
+          ENVIRONMENT_ORDER.indexOf(env),
+        );
+      }),
+    );
+  });
+
+  it("following predecessors always terminates at DEV (acyclic, no infinite chain)", () => {
+    fc.assert(
+      fc.property(environmentArb, (env) => {
+        let current: EnvironmentLiteral | null = env;
+        let steps = 0;
+        while (current !== null) {
+          current = predecessorEnvironment(current);
+          steps += 1;
+          expect(steps).toBeLessThanOrEqual(ENVIRONMENT_ORDER.length);
+        }
+      }),
+    );
+  });
+});
+
+describe("comparePolicyStrictness — algebraic properties", () => {
+  it("is reflexive: a policy is always monotonic against itself", () => {
+    fc.assert(
+      fc.property(policyArb, (policy) => {
+        expect(comparePolicyStrictness(policy, policy).monotonic).toBe(true);
+      }),
+    );
+  });
+
+  it("never throws for any pair of in-range policies", () => {
+    fc.assert(
+      fc.property(policyArb, policyArb, (higher, lower) => {
+        expect(() => comparePolicyStrictness(higher, lower)).not.toThrow();
+        const result = comparePolicyStrictness(higher, lower);
+        expect(typeof result.monotonic).toBe("boolean");
+        expect(result.monotonic).toBe(result.violations.length === 0);
+      }),
+    );
+  });
+
+  it("antisymmetry: if higher≥lower AND lower≥higher then all comparable fields are equal", () => {
+    fc.assert(
+      fc.property(policyArb, policyArb, (a, b) => {
+        const ab = comparePolicyStrictness(a, b).monotonic;
+        const ba = comparePolicyStrictness(b, a).monotonic;
+        if (ab && ba) {
+          // Both directions monotonic ⇒ every ordered field must be equal.
+          expect(a.taskSuccessMin).toBe(b.taskSuccessMin);
+          expect(a.policyComplianceMin).toBe(b.policyComplianceMin);
+          expect(a.minSampleCount).toBe(b.minSampleCount);
+          expect(a.latencyP95TargetMs).toBe(b.latencyP95TargetMs);
+          expect(a.avgCostBudgetUsd).toBe(b.avgCostBudgetUsd);
+          expect(a.maxEvidenceAgeDays).toBe(b.maxEvidenceAgeDays);
+          expect(a.allowNoBaselineOnAbsoluteFloors).toBe(
+            b.allowNoBaselineOnAbsoluteFloors,
+          );
+          expect([...a.requiredGateClasses].sort()).toEqual(
+            [...b.requiredGateClasses].sort(),
+          );
+        }
+      }),
+    );
+  });
+
+  it("transitivity: higher≥mid and mid≥lower ⇒ higher≥lower", () => {
+    fc.assert(
+      fc.property(policyArb, policyArb, policyArb, (higher, mid, lower) => {
+        const hm = comparePolicyStrictness(higher, mid).monotonic;
+        const ml = comparePolicyStrictness(mid, lower).monotonic;
+        if (hm && ml) {
+          expect(comparePolicyStrictness(higher, lower).monotonic).toBe(true);
+        }
+      }),
+    );
+  });
+
+  it("monotonic IFF every field satisfies its direction (derived oracle)", () => {
+    fc.assert(
+      fc.property(policyArb, policyArb, (higher, lower) => {
+        const expected =
+          higher.taskSuccessMin >= lower.taskSuccessMin &&
+          higher.policyComplianceMin >= lower.policyComplianceMin &&
+          higher.minSampleCount >= lower.minSampleCount &&
+          higher.latencyP95TargetMs <= lower.latencyP95TargetMs &&
+          higher.avgCostBudgetUsd <= lower.avgCostBudgetUsd &&
+          higher.maxEvidenceAgeDays <= lower.maxEvidenceAgeDays &&
+          lower.requiredGateClasses.every((p) =>
+            higher.requiredGateClasses.includes(p),
+          ) &&
+          (!higher.allowNoBaselineOnAbsoluteFloors ||
+            lower.allowNoBaselineOnAbsoluteFloors);
+        expect(comparePolicyStrictness(higher, lower).monotonic).toBe(expected);
+      }),
+    );
+  });
+
+  it("DEFAULT_PROMOTION_POLICY is monotonic against itself (sanity anchor)", () => {
+    expect(
+      comparePolicyStrictness(
+        DEFAULT_PROMOTION_POLICY,
+        DEFAULT_PROMOTION_POLICY,
+      ).monotonic,
+    ).toBe(true);
+  });
+});

--- a/backend/src/lambda/utils/__tests__/promotion-ladder.test.ts
+++ b/backend/src/lambda/utils/__tests__/promotion-ladder.test.ts
@@ -1,0 +1,96 @@
+/**
+ * promotion-ladder.test.ts — explicit-example unit coverage for the pure
+ * ladder helpers, complementing the property suite.
+ */
+import {
+  predecessorEnvironment,
+  comparePolicyStrictness,
+} from "../promotion-ladder";
+import {
+  DEFAULT_PROMOTION_POLICY,
+  type PromotionPolicy,
+} from "../release-gate";
+
+function policy(overrides: Partial<PromotionPolicy> = {}): PromotionPolicy {
+  return { ...DEFAULT_PROMOTION_POLICY, ...overrides };
+}
+
+describe("predecessorEnvironment", () => {
+  it("maps DEV to null (ladder entry point)", () => {
+    expect(predecessorEnvironment("DEV")).toBeNull();
+  });
+
+  it("maps STAGING to DEV", () => {
+    expect(predecessorEnvironment("STAGING")).toBe("DEV");
+  });
+
+  it("maps PROD to STAGING", () => {
+    expect(predecessorEnvironment("PROD")).toBe("STAGING");
+  });
+});
+
+describe("comparePolicyStrictness — per-field directions", () => {
+  it("accepts a strictly-stricter higher policy (floors up, ceilings down, packs superset)", () => {
+    const lower = policy({
+      taskSuccessMin: 0.8,
+      latencyP95TargetMs: 6000,
+      requiredGateClasses: ["safety"],
+    });
+    const higher = policy({
+      taskSuccessMin: 0.95,
+      latencyP95TargetMs: 3000,
+      requiredGateClasses: ["safety", "latency"],
+    });
+    expect(comparePolicyStrictness(higher, lower).monotonic).toBe(true);
+  });
+
+  it("rejects a lower floor at the higher env (taskSuccessMin decreased)", () => {
+    const result = comparePolicyStrictness(
+      policy({ taskSuccessMin: 0.8 }),
+      policy({ taskSuccessMin: 0.9 }),
+    );
+    expect(result.monotonic).toBe(false);
+    expect(result.violations.map((v) => v.field)).toContain("taskSuccessMin");
+  });
+
+  it("rejects a looser ceiling at the higher env (latencyP95TargetMs increased)", () => {
+    const result = comparePolicyStrictness(
+      policy({ latencyP95TargetMs: 8000 }),
+      policy({ latencyP95TargetMs: 5000 }),
+    );
+    expect(result.monotonic).toBe(false);
+    expect(result.violations.map((v) => v.field)).toContain(
+      "latencyP95TargetMs",
+    );
+  });
+
+  it("rejects a missing required pack at the higher env (not a superset)", () => {
+    const result = comparePolicyStrictness(
+      policy({ requiredGateClasses: ["safety"] }),
+      policy({ requiredGateClasses: ["safety", "cost"] }),
+    );
+    expect(result.monotonic).toBe(false);
+    expect(result.violations.map((v) => v.field)).toContain(
+      "requiredGateClasses",
+    );
+  });
+
+  it("rejects higher enabling no-baseline bootstrap while lower disables it", () => {
+    const result = comparePolicyStrictness(
+      policy({ allowNoBaselineOnAbsoluteFloors: true }),
+      policy({ allowNoBaselineOnAbsoluteFloors: false }),
+    );
+    expect(result.monotonic).toBe(false);
+    expect(result.violations.map((v) => v.field)).toContain(
+      "allowNoBaselineOnAbsoluteFloors",
+    );
+  });
+
+  it("reports every violating field at once", () => {
+    const result = comparePolicyStrictness(
+      policy({ taskSuccessMin: 0.5, latencyP95TargetMs: 9000 }),
+      policy({ taskSuccessMin: 0.9, latencyP95TargetMs: 5000 }),
+    );
+    expect(result.violations.length).toBeGreaterThanOrEqual(2);
+  });
+});

--- a/backend/src/lambda/utils/__tests__/promotion-policy-store.test.ts
+++ b/backend/src/lambda/utils/__tests__/promotion-policy-store.test.ts
@@ -280,3 +280,100 @@ describe("resolvePromotionPolicy — merged numerics stay sane", () => {
     expect(Number.isFinite(result.policy.taskSuccessMin)).toBe(true);
   });
 });
+
+describe("resolvePromotionPolicy — perEnvironmentPolicyOverrides (G2)", () => {
+  test("per-environment override wins over per-agent AND org for the SAME field, when an environment is supplied", async () => {
+    ddbMock.on(GetCommand).resolves({
+      Item: {
+        orgId: "org-1",
+        policy: { taskSuccessMin: 0.9 },
+        perAgentPolicyOverrides: { "agent-1": { taskSuccessMin: 0.93 } },
+        perEnvironmentPolicyOverrides: { PROD: { taskSuccessMin: 0.99 } },
+      },
+    });
+
+    const result = await resolvePromotionPolicy("org-1", "agent-1", "PROD");
+
+    expect(result.ok).toBe(true);
+    if (!result.ok) throw new Error("unreachable");
+    expect(result.policy.taskSuccessMin).toBe(0.99);
+  });
+
+  test("a field only the per-env override supplies falls through per-agent/org to the env value", async () => {
+    ddbMock.on(GetCommand).resolves({
+      Item: {
+        orgId: "org-1",
+        policy: {},
+        perAgentPolicyOverrides: {},
+        perEnvironmentPolicyOverrides: {
+          STAGING: { latencyP95TargetMs: 2500 },
+        },
+      },
+    });
+
+    const result = await resolvePromotionPolicy("org-1", "agent-1", "STAGING");
+
+    expect(result.ok).toBe(true);
+    if (!result.ok) throw new Error("unreachable");
+    expect(result.policy.latencyP95TargetMs).toBe(2500);
+  });
+
+  test("the per-env override for a DIFFERENT environment is not applied", async () => {
+    ddbMock.on(GetCommand).resolves({
+      Item: {
+        orgId: "org-1",
+        policy: { taskSuccessMin: 0.9 },
+        perEnvironmentPolicyOverrides: { PROD: { taskSuccessMin: 0.99 } },
+      },
+    });
+
+    const result = await resolvePromotionPolicy("org-1", "agent-1", "DEV");
+
+    expect(result.ok).toBe(true);
+    if (!result.ok) throw new Error("unreachable");
+    // DEV has no override -> org floor 0.9, NOT PROD's 0.99.
+    expect(result.policy.taskSuccessMin).toBe(0.9);
+  });
+
+  test("omitting the environment reproduces the pre-G2 merge (per-env override ignored)", async () => {
+    ddbMock.on(GetCommand).resolves({
+      Item: {
+        orgId: "org-1",
+        policy: { taskSuccessMin: 0.9 },
+        perEnvironmentPolicyOverrides: { PROD: { taskSuccessMin: 0.99 } },
+      },
+    });
+
+    const result = await resolvePromotionPolicy("org-1", "agent-1");
+
+    expect(result.ok).toBe(true);
+    if (!result.ok) throw new Error("unreachable");
+    expect(result.policy.taskSuccessMin).toBe(0.9);
+  });
+
+  test("a wrong-primitive-type field inside a per-env override fails the whole row closed (UNREADABLE)", async () => {
+    ddbMock.on(GetCommand).resolves({
+      Item: {
+        orgId: "org-1",
+        perEnvironmentPolicyOverrides: { PROD: { taskSuccessMin: "0.99" } },
+      },
+    });
+
+    const result = await resolvePromotionPolicy("org-1", "agent-1", "PROD");
+
+    expect(result).toEqual({ ok: false, reason: "UNREADABLE" });
+  });
+
+  test("a non-object per-env override container fails the whole row closed (UNREADABLE)", async () => {
+    ddbMock.on(GetCommand).resolves({
+      Item: {
+        orgId: "org-1",
+        perEnvironmentPolicyOverrides: "not-an-object",
+      },
+    });
+
+    const result = await resolvePromotionPolicy("org-1", "agent-1", "PROD");
+
+    expect(result).toEqual({ ok: false, reason: "UNREADABLE" });
+  });
+});

--- a/backend/src/lambda/utils/promotion-ladder.ts
+++ b/backend/src/lambda/utils/promotion-ladder.ts
@@ -1,0 +1,160 @@
+/**
+ * promotion-ladder.ts — PURE ladder + monotonicity helpers for the
+ * environment promotion path (dev→staging→prod).
+ *
+ * PURE — no I/O, no Date.now(), no Math.random(), no module-level mutable
+ * state, matching release-gate.ts's own purity contract. Every function
+ * here is deterministic: identical inputs always produce byte-identical
+ * output, and none of them throw (failures surface as data —
+ * `{ monotonic, violations }` — mirroring release-gate-evidence.ts's
+ * "every failure is data" discipline).
+ *
+ * Two concerns, both server-enforced (never client-declared):
+ *
+ *  1. LADDER ADJACENCY (G1). `predecessorEnvironment(env)` names the
+ *     single immediately-lower environment a promotion INTO `env` must
+ *     have come from: DEV→null (entry point, unconstrained), STAGING→DEV,
+ *     PROD→STAGING. The resolver reads the predecessor's CURRENT pointer
+ *     and requires it to reference the same release being promoted
+ *     (consensus decision 1: adjacency = "what's in staging NOW is what
+ *     gets promoted to prod", NOT a history-based "was ever in staging" —
+ *     the latter is a weaker guarantee, and promoting a release that has
+ *     since been superseded in the lower env is a distinct ROLLBACK
+ *     operation, not built here).
+ *
+ *  2. prod≥staging MONOTONICITY (G2). `comparePolicyStrictness(higher,
+ *     lower)` decides whether a HIGHER environment's resolved
+ *     PromotionPolicy is at least as strict as the immediately-LOWER
+ *     one's, per-field/per-direction:
+ *       - Floors RISE going up (higher ≥ lower): taskSuccessMin,
+ *         policyComplianceMin, minSampleCount.
+ *       - Ceilings TIGHTEN going up (higher ≤ lower): latencyP95TargetMs,
+ *         avgCostBudgetUsd, maxEvidenceAgeDays.
+ *       - requiredGateClasses: higher ⊇ lower (superset).
+ *       - allowNoBaselineOnAbsoluteFloors: higher allowing ⇒ lower
+ *         allowing (prod no looser than staging).
+ *     Enforced at BOTH write-time (promotion-policy-resolver.ts, reject a
+ *     non-monotonic authored ladder) AND gate-time (validateReleaseGate,
+ *     fail-closed over the fully-resolved per-agent policies) — the
+ *     gate-time check is authoritative because it sees per-agent
+ *     overrides that could create an inversion after the write-time
+ *     check.
+ */
+import type { EnvironmentLiteral } from "../../types";
+import type { PromotionPolicy } from "./release-gate";
+
+/** The promotion ladder, lowest→highest. Index position IS the strictness
+ * ordering: a higher index must run under a policy at least as strict as
+ * every lower index (comparePolicyStrictness). */
+export const ENVIRONMENT_ORDER: readonly EnvironmentLiteral[] = [
+  "DEV",
+  "STAGING",
+  "PROD",
+] as const;
+
+/**
+ * The single immediately-lower environment a promotion INTO `environment`
+ * must originate from, or null for the ladder's entry point (DEV).
+ *
+ * Total over EnvironmentLiteral and acyclic by construction (it only ever
+ * returns an environment strictly lower in ENVIRONMENT_ORDER, or null).
+ */
+export function predecessorEnvironment(
+  environment: EnvironmentLiteral,
+): EnvironmentLiteral | null {
+  const index = ENVIRONMENT_ORDER.indexOf(environment);
+  if (index <= 0) return null;
+  return ENVIRONMENT_ORDER[index - 1];
+}
+
+/** A single monotonicity violation between a higher and a lower env's
+ * resolved policy — machine-readable field + human-readable direction. */
+export interface PolicyStrictnessViolation {
+  field: keyof PromotionPolicy;
+  reason: string;
+}
+
+export interface PolicyStrictnessComparison {
+  monotonic: boolean;
+  violations: PolicyStrictnessViolation[];
+}
+
+/** Fields whose FLOOR must rise (or hold) going up the ladder:
+ * higher ≥ lower. */
+const RISING_FLOOR_FIELDS = [
+  "taskSuccessMin",
+  "policyComplianceMin",
+  "minSampleCount",
+] as const;
+
+/** Fields whose CEILING must tighten (or hold) going up the ladder:
+ * higher ≤ lower. */
+const TIGHTENING_CEILING_FIELDS = [
+  "latencyP95TargetMs",
+  "avgCostBudgetUsd",
+  "maxEvidenceAgeDays",
+] as const;
+
+/**
+ * Whether `higher`'s policy is at least as strict as `lower`'s, per field
+ * and direction (see module doc for the full field/direction table).
+ * Never throws — returns every violating field so the caller (write-time
+ * reject or gate-time fail-closed) can report all of them at once.
+ *
+ * `higher` is the higher-in-ladder environment (e.g. PROD) and `lower`
+ * the immediately-lower one (e.g. STAGING). The comparison is intended
+ * for adjacent pairs but is well-defined for any two policies.
+ */
+export function comparePolicyStrictness(
+  higher: PromotionPolicy,
+  lower: PromotionPolicy,
+): PolicyStrictnessComparison {
+  const violations: PolicyStrictnessViolation[] = [];
+
+  for (const field of RISING_FLOOR_FIELDS) {
+    if (higher[field] < lower[field]) {
+      violations.push({
+        field,
+        reason: `${field} floor must not decrease going up the ladder (higher=${higher[field]} < lower=${lower[field]})`,
+      });
+    }
+  }
+
+  for (const field of TIGHTENING_CEILING_FIELDS) {
+    if (higher[field] > lower[field]) {
+      violations.push({
+        field,
+        reason: `${field} ceiling must not increase going up the ladder (higher=${higher[field]} > lower=${lower[field]})`,
+      });
+    }
+  }
+
+  // requiredGateClasses: higher must be a SUPERSET of lower — every pack
+  // required lower must also be required higher (more packs required as
+  // you climb, never fewer).
+  const higherPacks = new Set(higher.requiredGateClasses);
+  for (const pack of lower.requiredGateClasses) {
+    if (!higherPacks.has(pack)) {
+      violations.push({
+        field: "requiredGateClasses",
+        reason: `requiredGateClasses must be a superset going up the ladder (lower requires "${pack}", higher does not)`,
+      });
+    }
+  }
+
+  // allowNoBaselineOnAbsoluteFloors: prod must be NO LOOSER than staging.
+  // A violation is: higher allows the no-baseline bootstrap but lower
+  // does not (higher looser than lower).
+  if (
+    higher.allowNoBaselineOnAbsoluteFloors &&
+    !lower.allowNoBaselineOnAbsoluteFloors
+  ) {
+    violations.push({
+      field: "allowNoBaselineOnAbsoluteFloors",
+      reason:
+        "allowNoBaselineOnAbsoluteFloors must not be enabled higher up the ladder while disabled lower down (higher looser than lower)",
+    });
+  }
+
+  return { monotonic: violations.length === 0, violations };
+}

--- a/backend/src/lambda/utils/promotion-policy-store.ts
+++ b/backend/src/lambda/utils/promotion-policy-store.ts
@@ -69,6 +69,7 @@
 import { DynamoDBClient } from "@aws-sdk/client-dynamodb";
 import { DynamoDBDocumentClient, GetCommand } from "@aws-sdk/lib-dynamodb";
 import { DEFAULT_PROMOTION_POLICY, type PromotionPolicy } from "./release-gate";
+import type { EnvironmentLiteral } from "../../types";
 
 const dynamoClient = new DynamoDBClient({});
 const docClient = DynamoDBDocumentClient.from(dynamoClient);
@@ -81,6 +82,13 @@ export interface PromotionPolicyConfigRow {
   orgId: string;
   policy?: Partial<PromotionPolicy>;
   perAgentPolicyOverrides?: Record<string, Partial<PromotionPolicy>>;
+  // G2 (per-target-env thresholds + prod≥staging monotonicity): a
+  // Partial<PromotionPolicy> keyed by DeploymentEnvironment. Layered as
+  // the HIGHEST-precedence source when resolvePromotionPolicy is called
+  // with an `environment` (see below) — the target-env floor is the most
+  // authoritative when gating a promotion INTO that env. Same shape and
+  // same field-level fail-closed discipline as perAgentPolicyOverrides.
+  perEnvironmentPolicyOverrides?: Record<string, Partial<PromotionPolicy>>;
   updatedAt?: string;
   updatedBy?: string;
 }
@@ -221,6 +229,21 @@ function isPlainObject(v: unknown): v is Record<string, unknown> {
 }
 
 /**
+ * Pure: the AGENTLESS per-environment BASE policy (DEFAULT ← org policy ←
+ * that environment's override). No I/O, no per-agent layer — used by the
+ * admin write-time prod≥staging monotonicity check
+ * (promotion-policy-resolver.ts). Reuses the SAME field-level merge (with
+ * per-field sanity floors) as resolvePromotionPolicy so the two never
+ * diverge.
+ */
+export function resolveBaseEnvironmentPolicy(
+  policy: Partial<PromotionPolicy> | undefined,
+  environmentOverride: Partial<PromotionPolicy> | undefined,
+): PromotionPolicy {
+  return mergePolicyFields([policy, environmentOverride]);
+}
+
+/**
  * Validates the overall row SHAPE (not individual field RANGES — those
  * are validated per-field during merge, see mergePolicyFields). Returns
  * false for anything that would make the row untrustworthy to merge:
@@ -244,6 +267,13 @@ function isReadableRow(row: unknown): row is PromotionPolicyConfigRow {
       if (hasWrongTypeField(override)) return false;
     }
   }
+  if (row.perEnvironmentPolicyOverrides !== undefined) {
+    if (!isPlainObject(row.perEnvironmentPolicyOverrides)) return false;
+    for (const override of Object.values(row.perEnvironmentPolicyOverrides)) {
+      if (!isPlainObject(override)) return false;
+      if (hasWrongTypeField(override)) return false;
+    }
+  }
   return true;
 }
 
@@ -260,23 +290,34 @@ async function getPromotionPolicyConfigRow(
 }
 
 /**
- * Resolves the effective PromotionPolicy for (orgId, agentTargetId).
+ * Resolves the effective PromotionPolicy for (orgId, agentTargetId) —
+ * optionally scoped to a target `environment` (G2).
+ *
+ * Precedence (low→high, field-level merge):
+ *   DEFAULT ← row.policy ← perAgentPolicyOverrides[agent]
+ *           ← perEnvironmentPolicyOverrides[environment]
+ * The per-env override is layered LAST (highest precedence) and only
+ * when an `environment` is supplied — the target-env floor is the most
+ * authoritative when gating a promotion INTO that env. Omitting
+ * `environment` reproduces the pre-G2 behaviour exactly (DEFAULT ← org ←
+ * agent), so callers that don't need env-scoping are undisturbed.
  *
  * ok:true, policy=DEFAULT_PROMOTION_POLICY  — no config row exists yet.
  * ok:true, policy=<merged>                  — row exists and is readable;
- *   field-level merge floor <- org <- agent, invalid/missing individual
- *   fields fall through rather than failing the whole resolution.
+ *   field-level merge, invalid/missing individual fields fall through
+ *   rather than failing the whole resolution.
  * ok:false, reason:'UNREADABLE'              — thrown GetItem, or a
  *   schema-invalid row (missing/wrong-typed orgId, a non-object
- *   policy/perAgentPolicyOverrides container, or any present field
- *   inside policy/perAgentPolicyOverrides[*] with the wrong PRIMITIVE
- *   TYPE). Callers MUST treat this as fail-closed — never substitute
- *   DEFAULT_PROMOTION_POLICY on this branch (that would silently
- *   downgrade an org's tightened policy).
+ *   policy/perAgentPolicyOverrides/perEnvironmentPolicyOverrides
+ *   container, or any present field inside any of those with the wrong
+ *   PRIMITIVE TYPE). Callers MUST treat this as fail-closed — never
+ *   substitute DEFAULT_PROMOTION_POLICY on this branch (that would
+ *   silently downgrade an org's tightened policy).
  */
 export async function resolvePromotionPolicy(
   orgId: string,
   agentTargetId: string,
+  environment?: EnvironmentLiteral,
 ): Promise<PromotionPolicyResolutionResult> {
   let row: PromotionPolicyConfigRow | undefined;
   try {
@@ -306,6 +347,13 @@ export async function resolvePromotionPolicy(
   }
 
   const agentOverride = row.perAgentPolicyOverrides?.[agentTargetId];
-  const merged = mergePolicyFields([row.policy, agentOverride]);
+  const envOverride =
+    environment !== undefined
+      ? row.perEnvironmentPolicyOverrides?.[environment]
+      : undefined;
+  // Precedence low→high: DEFAULT (baked into mergePolicyFields) ← org ←
+  // per-agent ← per-environment. envOverride is undefined when no
+  // environment was supplied, preserving the pre-G2 merge exactly.
+  const merged = mergePolicyFields([row.policy, agentOverride, envOverride]);
   return { ok: true, policy: merged };
 }

--- a/backend/src/schema/schema.graphql
+++ b/backend/src/schema/schema.graphql
@@ -90,6 +90,10 @@ type Query {
   # resolved server-side, never a client-supplied value here).
   getCurrentEnvironmentReleasePointer(agentTargetId: ID!, environment: DeploymentEnvironment!): EnvironmentReleasePointer
   listEnvironmentReleasePointers(agentTargetId: ID!): [EnvironmentReleasePointer!]!
+  # Promotion history (G6) — "what release ran in <environment> on date
+  # D". Oldest→newest; `until` (ISO-8601) bounds to promotedAt <= D. orgId
+  # is the caller's own org, resolved server-side.
+  environmentReleasePointerHistory(agentTargetId: ID!, environment: DeploymentEnvironment!, until: AWSDateTime): [EnvironmentReleasePointerHistoryEntry!]!
   getEvalComparison(comparisonId: ID!): EvalComparisonVerdict
   listEvalComparisons(orgId: ID!, suiteId: ID): [EvalComparisonVerdict!]!
   getEvalComparisonThresholdConfig(orgId: ID!, suiteId: ID!): EvalComparisonThresholdConfig
@@ -2421,6 +2425,21 @@ type EnvironmentReleasePointer {
   version: Int!
 }
 
+# EnvironmentReleasePointerHistoryEntry — append-only record of one
+# pointer move (G6, "what ran in <env> on date D"). Written ATOMICALLY
+# with the pointer move (TransactWriteItems in the sole pointer writer),
+# so history is a gap-free time-series. Mirrors EnvironmentReleasePointer.
+type EnvironmentReleasePointerHistoryEntry {
+  orgId: ID!
+  agentTargetId: String!
+  environment: DeploymentEnvironment!
+  releaseId: ID!
+  previousReleaseId: ID
+  promotedAt: AWSDateTime!
+  promotedBy: String!
+  version: Int!
+}
+
 input SetEnvironmentReleasePointerInput {
   agentTargetId: String!
   environment: DeploymentEnvironment!
@@ -2723,6 +2742,10 @@ type PromotionPolicyConfig {
   policy: AWSJSON
   # Map<agentTargetId, Partial<PromotionPolicy>> — per-agent floor overrides.
   perAgentPolicyOverrides: AWSJSON
+  # Map<DeploymentEnvironment, Partial<PromotionPolicy>> — per-target-env
+  # floor overrides (G2). Highest-precedence layer at gate time;
+  # prod≥staging monotonic (enforced write-time AND gate-time).
+  perEnvironmentPolicyOverrides: AWSJSON
   updatedAt: AWSDateTime
   updatedBy: String
 }
@@ -2730,6 +2753,7 @@ type PromotionPolicyConfig {
 input PromotionPolicyConfigInput {
   policy: AWSJSON
   perAgentPolicyOverrides: AWSJSON
+  perEnvironmentPolicyOverrides: AWSJSON
 }
 
 # Phase 2 (production sampling) — a captured + scored production sample.

--- a/backend/src/types/index.ts
+++ b/backend/src/types/index.ts
@@ -1014,3 +1014,29 @@ export interface SetEnvironmentReleasePointerInput {
   releaseId: string;
   approval?: PromotionApproval | null;
 }
+
+/**
+ * EnvironmentReleasePointerHistory row (G6 — "what ran in PROD on date
+ * D"). Append-only time-series of every pointer move, written ATOMICALLY
+ * with the pointer move itself (TransactWriteItems inside the sole
+ * pointer writer, environment-release-pointer-store.ts), so history is a
+ * gap-free record of every promotion — an invariant enforced at the
+ * write boundary, matching AgentRelease's own immutability philosophy.
+ * PK orgId, SK `${agentTargetId}#${environment}#${promotedAt}#${version}`
+ * (the composite stored under the `historySortKey` attribute) so a
+ * `begins_with(agent#env#)` Query with a `<= D` range answers "what
+ * release was running in that env at date D" — take the greatest
+ * (latest) row ≤ D. `version` disambiguates equal-millisecond timestamps
+ * and guarantees uniqueness. Every attribute mirrors
+ * EnvironmentReleasePointer.
+ */
+export interface EnvironmentReleasePointerHistoryEntry {
+  orgId: string;
+  agentTargetId: string;
+  environment: EnvironmentLiteral;
+  releaseId: string;
+  previousReleaseId: string | null;
+  promotedAt: string;
+  promotedBy: string;
+  version: number;
+}

--- a/backend/src/utils/__tests__/events.test.ts
+++ b/backend/src/utils/__tests__/events.test.ts
@@ -14,7 +14,7 @@ jest.mock("aws-xray-sdk-core", () => ({
 }));
 
 import * as AWSXRay from "aws-xray-sdk-core";
-import { publishEvent } from "../events";
+import { publishEvent, createReleaseEvent, EventTypes } from "../events";
 
 describe("events.ts traceContext propagation (additive)", () => {
   beforeEach(() => {
@@ -114,5 +114,51 @@ describe("events.ts traceContext propagation (additive)", () => {
     const detail = lastPublishedDetail();
     expect("traceContext" in detail).toBe(false);
     expect(detail.eventType).toBeUndefined();
+  });
+});
+
+describe("createReleaseEvent (G5 — RELEASE_POINTER_MOVED)", () => {
+  beforeEach(() => {
+    mockSend.mockClear();
+    (AWSXRay.getSegment as jest.Mock).mockReset();
+  });
+
+  it("builds an AgentEvent carrying agentTargetId as agentId, with no projectId", () => {
+    const event = createReleaseEvent(
+      EventTypes.RELEASE_POINTER_MOVED,
+      "agent-1",
+      { environment: "PROD", releaseId: "release-1" },
+      "corr-1",
+    );
+    expect(event.eventType).toBe("release.pointer.moved");
+    expect(event.agentId).toBe("agent-1");
+    expect(event.correlationId).toBe("corr-1");
+    expect(
+      (event as unknown as { projectId?: string }).projectId,
+    ).toBeUndefined();
+    expect(typeof event.timestamp).toBe("string");
+  });
+
+  it("publishes with the citadel.backend Source and drops projectId from the Detail body", async () => {
+    (AWSXRay.getSegment as jest.Mock).mockReturnValue(undefined);
+
+    await publishEvent(
+      createReleaseEvent(EventTypes.RELEASE_POINTER_MOVED, "agent-1", {
+        environment: "PROD",
+        releaseId: "release-1",
+      }),
+    );
+
+    const call = mockSend.mock.calls[mockSend.mock.calls.length - 1][0];
+    const entry = call.input.Entries[0];
+    expect(entry.Source).toBe("citadel.backend");
+    expect(entry.DetailType).toBe("release.pointer.moved");
+    const detail = JSON.parse(entry.Detail);
+    expect("projectId" in detail).toBe(false);
+    expect(detail.agentId).toBe("agent-1");
+    expect(detail.payload).toEqual({
+      environment: "PROD",
+      releaseId: "release-1",
+    });
   });
 });

--- a/backend/src/utils/events.ts
+++ b/backend/src/utils/events.ts
@@ -88,6 +88,31 @@ export function createAgentEvent(
   };
 }
 
+/**
+ * Release-lifecycle event helper (G5 — RELEASE_POINTER_MOVED). A release
+ * promotion is scoped to an agent target, not a project, so there is no
+ * projectId: the AgentEvent's projectId is intentionally left undefined,
+ * which publishEvent's JSON.stringify drops from the emitted Detail body
+ * (matching the additive/optional-field convention already used for
+ * traceContext). agentId carries the agentTargetId so
+ * EVENTBRIDGE_CATALOG consumers (governance graph snapshot, dashboards)
+ * can key off the same identifier the pointer table uses.
+ */
+export function createReleaseEvent(
+  eventType: string,
+  agentTargetId: string,
+  payload: unknown,
+  correlationId?: string,
+): AgentEvent {
+  return {
+    eventType,
+    agentId: agentTargetId,
+    payload,
+    timestamp: new Date().toISOString(),
+    correlationId,
+  } as AgentEvent;
+}
+
 // Event type constants
 export const EventTypes = {
   PROJECT_CREATED: "project.created",
@@ -109,6 +134,10 @@ export const EventTypes = {
   MODEL_CONFIG_CHANGED: "model.config.changed",
   MODEL_CATALOG_SYNCED: "model.catalog.synced",
   MODEL_CATALOG_SYNC_REQUESTED: "model.catalog.sync_requested",
+  // G5 — environment release pointer moved (dev→staging→prod promotion).
+  // citadel.* namespace via the Source "citadel.backend" set in
+  // publishEvent. Best-effort, emitted POST-commit only (never blocking).
+  RELEASE_POINTER_MOVED: "release.pointer.moved",
 } as const;
 
 export type EventType = (typeof EventTypes)[keyof typeof EventTypes];

--- a/backend/test/arbiter-stack-release-dispatch.test.ts
+++ b/backend/test/arbiter-stack-release-dispatch.test.ts
@@ -1,0 +1,177 @@
+/**
+ * arbiter-stack-release-dispatch.test.ts — G3 CDK wiring assertions.
+ *
+ * When the release substrate is provisioned (release tables passed +
+ * releaseDefaultOrgId set), the Supervisor and Step Runner Lambdas must
+ * carry BOTH release-aware-dispatch env vars:
+ *  - RELEASE_DISPATCH_ENVIRONMENT = <environment>.toUpperCase() (the
+ *    feature switch, uppercased to match EnvironmentLiteral / pointer SK)
+ *  - RELEASE_DEFAULT_ORG_ID = the named org seam
+ * resolve_release (Python, unchanged) reads both at dispatch time so each
+ * env's stack resolves its OWN pointer set.
+ */
+import * as cdk from "aws-cdk-lib";
+import { Template, Match } from "aws-cdk-lib/assertions";
+import * as dynamodb from "aws-cdk-lib/aws-dynamodb";
+import * as events from "aws-cdk-lib/aws-events";
+import * as lambda from "aws-cdk-lib/aws-lambda";
+import * as appsync from "aws-cdk-lib/aws-appsync";
+import { Bucket } from "aws-cdk-lib/aws-s3";
+import * as path from "path";
+import {
+  scaffoldBackendAssetDirs,
+  scaffoldArbiterStubs,
+} from "./helpers/scaffold-stub-assets";
+
+scaffoldBackendAssetDirs(["dist/lambda", "src/schema"]);
+scaffoldArbiterStubs();
+
+import { ArbiterStack } from "../lib/arbiter-stack";
+
+function mockTable(
+  scope: cdk.Stack,
+  id: string,
+  tableName: string,
+  pk: string,
+): dynamodb.Table {
+  return new dynamodb.Table(scope, id, {
+    tableName,
+    partitionKey: { name: pk, type: dynamodb.AttributeType.STRING },
+    billingMode: dynamodb.BillingMode.PAY_PER_REQUEST,
+    removalPolicy: cdk.RemovalPolicy.DESTROY,
+  });
+}
+
+function synth(withRelease: boolean): Template {
+  const app = new cdk.App();
+  const backendStack = new cdk.Stack(app, "MockBackendStackReleaseDispatch", {
+    env: { account: "123456789012", region: "us-east-1" },
+  });
+  const agentEventBus = new events.EventBus(backendStack, "AgentEventBus", {
+    eventBusName: "citadel-agents-test",
+  });
+  const agentConfigTable = mockTable(
+    backendStack,
+    "AgentConfigTable",
+    "citadel-agents-test",
+    "agentId",
+  );
+  const codeBucket = new Bucket(backendStack, "CodeBucket", {
+    bucketName: "citadel-code-test",
+  });
+  const workflowsTable = mockTable(
+    backendStack,
+    "WorkflowsTable",
+    "citadel-workflows-test",
+    "workflowId",
+  );
+  const executionsTable = mockTable(
+    backendStack,
+    "ExecutionsTable",
+    "citadel-executions-test",
+    "executionId",
+  );
+  const executionSpecificationsTable = mockTable(
+    backendStack,
+    "ExecutionSpecificationsTable",
+    "citadel-execution-specifications-test",
+    "specId",
+  );
+  const fanoutFunction = new lambda.Function(backendStack, "FanoutFunction", {
+    runtime: lambda.Runtime.NODEJS_24_X,
+    handler: "workflow-progress-fanout.handler",
+    code: lambda.Code.fromAsset("dist/lambda"),
+    timeout: cdk.Duration.seconds(30),
+  });
+  const appSyncApi = new appsync.GraphqlApi(backendStack, "MockApi", {
+    name: "mock-api",
+    schema: appsync.SchemaFile.fromAsset(
+      path.resolve(__dirname, "../src/schema/schema.graphql"),
+    ),
+  });
+
+  const releaseProps = withRelease
+    ? {
+        agentReleasesTable: mockTable(
+          backendStack,
+          "AgentReleasesTable",
+          "citadel-agent-releases-test",
+          "releaseId",
+        ),
+        environmentReleasePointersTable: new dynamodb.Table(
+          backendStack,
+          "EnvironmentReleasePointersTable",
+          {
+            tableName: "citadel-environment-release-pointers-test",
+            partitionKey: {
+              name: "orgId",
+              type: dynamodb.AttributeType.STRING,
+            },
+            sortKey: {
+              name: "agentTargetId_environment",
+              type: dynamodb.AttributeType.STRING,
+            },
+            billingMode: dynamodb.BillingMode.PAY_PER_REQUEST,
+            removalPolicy: cdk.RemovalPolicy.DESTROY,
+          },
+        ),
+        releaseDefaultOrgId: "org-default-test",
+      }
+    : {};
+
+  const stack = new ArbiterStack(app, "TestArbiterStackReleaseDispatch", {
+    environment: "staging",
+    env: { account: "123456789012", region: "us-east-1" },
+    agentEventBus,
+    agentConfigTable,
+    codeBucket,
+    workflowsTable,
+    executionsTable,
+    fanoutFunction,
+    appSyncEndpoint: appSyncApi.graphqlUrl,
+    executionSpecificationsTable,
+    ...releaseProps,
+  });
+  return Template.fromStack(stack);
+}
+
+describe("ArbiterStack — G3 release-aware dispatch env wiring", () => {
+  test("Supervisor + Step Runner both carry RELEASE_DISPATCH_ENVIRONMENT (uppercased) + RELEASE_DEFAULT_ORG_ID when the substrate is wired", () => {
+    const template = synth(true);
+
+    // Supervisor (python, EventBridge-driven) and Step Runner both get
+    // the pair. Assert at least two Lambdas carry the uppercased env token.
+    const functions = template.findResources("AWS::Lambda::Function");
+    const withDispatch = Object.values(functions).filter((fn) => {
+      const vars = fn.Properties?.Environment?.Variables ?? {};
+      return (
+        vars.RELEASE_DISPATCH_ENVIRONMENT === "STAGING" &&
+        vars.RELEASE_DEFAULT_ORG_ID === "org-default-test"
+      );
+    });
+    expect(withDispatch.length).toBeGreaterThanOrEqual(2);
+  });
+
+  test("Step Runner (index.handler) carries the uppercased dispatch env + default org", () => {
+    const template = synth(true);
+    template.hasResourceProperties("AWS::Lambda::Function", {
+      Handler: "index.handler",
+      Environment: {
+        Variables: Match.objectLike({
+          RELEASE_DISPATCH_ENVIRONMENT: "STAGING",
+          RELEASE_DEFAULT_ORG_ID: "org-default-test",
+        }),
+      },
+    });
+  });
+
+  test("without the release substrate, neither dispatch env var is set (forward-compatible no-op)", () => {
+    const template = synth(false);
+    const functions = template.findResources("AWS::Lambda::Function");
+    for (const fn of Object.values(functions)) {
+      const vars = fn.Properties?.Environment?.Variables ?? {};
+      expect(vars.RELEASE_DISPATCH_ENVIRONMENT).toBeUndefined();
+      expect(vars.RELEASE_DEFAULT_ORG_ID).toBeUndefined();
+    }
+  });
+});

--- a/backend/test/backend-stack-environment-release-pointer-table.test.ts
+++ b/backend/test/backend-stack-environment-release-pointer-table.test.ts
@@ -308,3 +308,71 @@ describe("BackendStack — EnvironmentReleasePointersTable (environment release 
     });
   });
 });
+
+describe("BackendStack — G5/G6 writer-role grants (history table + event bus)", () => {
+  let template: Template;
+
+  beforeAll(() => {
+    const app = new cdk.App();
+    const stack = new BackendStack(app, "TestBackendStackEnvPointerG5G6", {
+      environment: "test",
+      env: { account: "123456789012", region: "us-east-1" },
+    });
+    template = Template.fromStack(stack);
+  });
+
+  function statementsTargeting(fragment: string) {
+    const policies = template.findResources("AWS::IAM::Policy");
+    const out: Array<{ Action?: string | string[]; Resource?: unknown }> = [];
+    for (const policy of Object.values(policies)) {
+      const stmts: Array<{ Action?: string | string[]; Resource?: unknown }> =
+        policy.Properties?.PolicyDocument?.Statement ?? [];
+      for (const stmt of stmts) {
+        const resources = Array.isArray(stmt.Resource)
+          ? stmt.Resource
+          : [stmt.Resource];
+        if (resources.some((r) => JSON.stringify(r).includes(fragment))) {
+          out.push(stmt);
+        }
+      }
+    }
+    return out;
+  }
+
+  test("G6: writer role grants PutItem/GetItem/Query on the history table (deterministic ARN), never Update/Delete", () => {
+    const stmts = statementsTargeting(
+      "citadel-environment-release-pointer-history-test",
+    );
+    expect(stmts.length).toBeGreaterThan(0);
+
+    const actions = new Set<string>();
+    for (const stmt of stmts) {
+      for (const a of Array.isArray(stmt.Action)
+        ? stmt.Action
+        : [stmt.Action]) {
+        if (typeof a === "string") actions.add(a);
+      }
+    }
+    expect(actions.has("dynamodb:PutItem")).toBe(true);
+    expect(actions.has("dynamodb:GetItem")).toBe(true);
+    expect(actions.has("dynamodb:Query")).toBe(true);
+    expect(actions.has("dynamodb:UpdateItem")).toBe(false);
+    expect(actions.has("dynamodb:DeleteItem")).toBe(false);
+    expect(actions.has("dynamodb:BatchWriteItem")).toBe(false);
+  });
+
+  test("G5: writer role is granted events:PutEvents (for the best-effort RELEASE_POINTER_MOVED emit)", () => {
+    const policies = template.findResources("AWS::IAM::Policy");
+    const grantsPutEvents = Object.values(policies).some((policy) => {
+      const stmts: Array<{ Action?: string | string[] }> =
+        policy.Properties?.PolicyDocument?.Statement ?? [];
+      return stmts.some((stmt) => {
+        const actions = Array.isArray(stmt.Action)
+          ? stmt.Action
+          : [stmt.Action];
+        return actions.includes("events:PutEvents");
+      });
+    });
+    expect(grantsPutEvents).toBe(true);
+  });
+});

--- a/backend/test/governance-stack-environment-release-pointer-ledger.test.ts
+++ b/backend/test/governance-stack-environment-release-pointer-ledger.test.ts
@@ -345,6 +345,35 @@ describe("GovernanceStack + BackendStack — fail-closed governance ledger recor
     expect(grantsPutItem).toBe(true);
   });
 
+  test("provisions the append-only EnvironmentReleasePointerHistoryTable (PK orgId, SK historySortKey)", () => {
+    template.hasResourceProperties("AWS::DynamoDB::Table", {
+      TableName: "citadel-environment-release-pointer-history-test",
+      KeySchema: Match.arrayWith([
+        Match.objectLike({ AttributeName: "orgId", KeyType: "HASH" }),
+        Match.objectLike({ AttributeName: "historySortKey", KeyType: "RANGE" }),
+      ]),
+    });
+  });
+
+  test("EnvironmentReleasePointerResolverFunction's env carries the history table + EVENT_BUS_NAME (G6/G5)", () => {
+    template.hasResourceProperties("AWS::Lambda::Function", {
+      Handler: "environment-release-pointer-resolver.handler",
+      Environment: {
+        Variables: Match.objectLike({
+          ENVIRONMENT_RELEASE_POINTER_HISTORY_TABLE: Match.anyValue(),
+          EVENT_BUS_NAME: Match.anyValue(),
+        }),
+      },
+    });
+  });
+
+  test("wires the environmentReleasePointerHistory query resolver (G6)", () => {
+    template.hasResourceProperties("AWS::AppSync::Resolver", {
+      TypeName: "Query",
+      FieldName: "environmentReleasePointerHistory",
+    });
+  });
+
   test("no statement targeting the governance ledger table also grants UpdateItem/DeleteItem/BatchWriteItem (PutItem-only, never grantWriteData)", () => {
     const policies = policiesTargetingLedgerTable();
     expect(policies.length).toBeGreaterThan(0);

--- a/docs/RELEASE_RUNBOOK.md
+++ b/docs/RELEASE_RUNBOOK.md
@@ -1,0 +1,215 @@
+# Release Promotion Runbook
+
+How an agent release moves through environments (dev → staging → prod) in
+Citadel, who may do it, what gates it, and how to answer "what ran in prod
+on date D". Sibling to [GOVERNANCE_ROLLOUT_RUNBOOK.md](GOVERNANCE_ROLLOUT_RUNBOOK.md).
+
+> **Name mapping.** The product concept "promoteRelease" is implemented by
+> the GraphQL mutation **`promoteEnvironmentReleasePointer`**. There is no
+> second `promoteRelease` mutation — a duplicate promote path would be a
+> security/consistency hazard. All gating hangs off this one mutation.
+
+## 1. Overview & lifecycle
+
+A release is **cut once** and **promoted many times**:
+
+1. **Cut** — `cutAgentRelease` produces an immutable, content-addressed
+   `AgentRelease` (`releaseId = sha256(constituents)`, `release-store.ts`).
+   The bytes never change afterward.
+2. **Promote** — `promoteEnvironmentReleasePointer` moves a per-environment
+   *pointer* (`EnvironmentReleasePointersTable`) to reference that release.
+   Promotion **never re-cuts or rebuilds** — the same immutable `releaseId`
+   moves across DEV → STAGING → PROD. (Acceptance A1 is satisfied by
+   construction.)
+
+The pointer is a **mutable cursor**; the release it points at is immutable.
+
+## 2. Roles / RBAC
+
+| Action | Permission |
+|---|---|
+| Cut a release | `release:cut` |
+| Promote a release (move a pointer) | `release:promote` |
+| Author promotion policy | `admin` (platform-wide) |
+
+The caller's org is derived from the `custom:organization` claim, never
+from input. A release belonging to another org can never be pointed at
+(`SecurityError`).
+
+## 3. Cutting a release (prerequisite)
+
+Use `cutAgentRelease`. A release bundles the agent config, prompt
+versions, exec-spec, model/tool snapshots, policy snapshot, and eval
+evidence. Only a successfully-cut release can be promoted.
+
+## 4. Promotion ladder (G1 — adjacency)
+
+Promotion is **strictly adjacent**: DEV → STAGING → PROD, one hop at a
+time, via a separate `promoteEnvironmentReleasePointer` call per hop.
+
+- **DEV** is the ladder entry — promotion into DEV is unconstrained.
+- **STAGING** requires DEV's **current** pointer to reference the exact
+  release being promoted.
+- **PROD** requires STAGING's **current** pointer to reference it.
+
+The invariant is the **predecessor's CURRENT pointer**, not "was ever
+there": *what is running in staging now is what gets promoted to prod.*
+Trying to promote a release that has since been **superseded** in the
+lower environment fails with `PromotionLadderError` — that scenario is a
+**rollback**, a distinct operation not performed by this mutation (§12).
+
+## 5. Promotion policy — per-org / per-agent / per-env thresholds (G2)
+
+Admins author a `PromotionPolicyConfig` (`setPromotionPolicy`, admin-only)
+that sets the quality **floor** every promotion is gated against.
+Resolution precedence (low → high, field-by-field merge):
+
+```
+DEFAULT_PROMOTION_POLICY
+  ← policy (org-wide)
+  ← perAgentPolicyOverrides[agentTargetId]
+  ← perEnvironmentPolicyOverrides[environment]     (most authoritative)
+```
+
+An unreadable/malformed policy **fails closed** (never silently falls
+back to defaults).
+
+### prod ≥ staging monotonicity
+
+The policy ladder must get **stricter** going up, per field/direction:
+
+| Field | Direction going up the ladder |
+|---|---|
+| `taskSuccessMin`, `policyComplianceMin`, `minSampleCount` | floors **rise** (≥) |
+| `latencyP95TargetMs`, `avgCostBudgetUsd`, `maxEvidenceAgeDays` | ceilings **tighten** (≤) |
+| `requiredGateClasses` | **superset** (⊇) |
+| `allowNoBaselineOnAbsoluteFloors` | prod **no looser** than staging |
+
+Enforced at **two** points:
+
+1. **Write-time** (`setPromotionPolicy`) — a non-monotonic authored
+   ladder is rejected with a `ValidationError` before persisting (catches
+   the common misconfig early).
+2. **Gate-time (authoritative, fail-closed)** — at promotion, the target
+   env's fully-resolved policy is compared against the immediately-lower
+   env's for the same (org, agent). A violation becomes a synthetic gate
+   FAIL, which strict mode blocks. This sees per-agent overrides that
+   could create an inversion after the write-time check.
+
+## 6. Enforcement modes per environment
+
+Mode comes from SSM `/citadel/governance/enforce/{env}`:
+
+- **permissive** — evaluate + telemetry only, never block, no finding.
+- **shadow** — evaluate, **record** a finding, do not block.
+- **strict** — evaluate, record, **block** on a FAIL verdict.
+
+Modes progress permissive → shadow → strict, per environment, mirroring
+the governance rollout runbook. Mode-lookup failure falls back to
+**shadow** (matches the Python dispatch path).
+
+## 7. Interim human approval (strict)
+
+In **strict** mode a promotion also requires an explicit
+`approval: { approved: true }` on the mutation input
+(`ReleaseApprovalRequiredError` otherwise). `approved: false` records a
+denial finding and refuses. `decidedBy` is server-derived from the
+caller's identity, never from input. In shadow, a supplied approval is
+recorded but not required; in permissive it is ignored.
+
+## 8. Reading history — "what ran in PROD on date D" (G6)
+
+Every pointer move appends an **atomic** row to
+`EnvironmentReleasePointerHistoryTable` (written in the SAME
+`TransactWriteItems` as the pointer move, so history is gap-free). Query:
+
+```graphql
+query {
+  environmentReleasePointerHistory(
+    agentTargetId: "agent-123"
+    environment: PROD
+    until: "2026-06-01T00:00:00.000Z"   # date D (optional)
+  ) {
+    releaseId
+    promotedAt
+    promotedBy
+    version
+  }
+}
+```
+
+Rows are returned oldest → newest, bounded to `promotedAt <= until`. The
+release running **at date D** is the **last** row (greatest
+`promotedAt`/`version`) in the result.
+
+## 9. Audit trail
+
+Every promotion produces, durably:
+
+- a **governance ledger finding** (`release-promotion`,
+  `release-promotion-approval`) with the deciding `traceId` (fail-closed
+  in shadow and strict);
+- an **atomic history row** (§8);
+- a best-effort **`citadel.*` event** `release.pointer.moved` (§10).
+
+## 10. `release.pointer.moved` event (G5)
+
+After a successful move, a best-effort `release.pointer.moved` event is
+published to the shared bus (`Source: citadel.backend`), carrying
+`{orgId, agentTargetId, environment, releaseId, previousReleaseId,
+version, promotedBy, promotedAt}` plus trace context. It is **post-commit
+and never blocking**: the move is already durably audited by the history
+row + ledger finding, so a transient EventBridge failure is logged and
+swallowed rather than aborting an already-committed move. Consumers:
+governance graph snapshot, dashboards. See
+[EVENTBRIDGE_CATALOG.md](EVENTBRIDGE_CATALOG.md).
+
+## 11. Arbiter env-scoped dispatch (G3)
+
+Each environment's Supervisor and Step Runner Lambdas read
+`RELEASE_DISPATCH_ENVIRONMENT` (the feature switch, uppercased —
+`DEV`/`STAGING`/`PROD`) and `RELEASE_DEFAULT_ORG_ID` (the named org seam),
+set per-env stack via CDK (`arbiter-stack.ts`). `resolve_release`
+(Python, unchanged) resolves that env's own pointer set at dispatch time,
+returning `RESOLVED` / `NO_POINTER` / `LOOKUP_FAILED` (a lookup failure is
+**not** the same as no pointer). Grandfathering and shadow-fallback are
+inherited from the governance path. When the env vars are unset the gate
+is a forward-compatible no-op (every lookup → `NO_POINTER`).
+
+> **Known constraint (follow-up, not this story):** the arbiter resolves
+> for a single `RELEASE_DEFAULT_ORG_ID` per deployment. True multi-tenant
+> per-env dispatch needs the org from the dispatch/orchestration context.
+
+## 12. Bootstrapping a new environment's first pointer
+
+The first promotion into an empty target env has **no baseline** to
+compare against. Under the default policy, `NO_BASELINE` is a fail state
+(`allowNoBaselineOnAbsoluteFloors = false`). To bootstrap, either set
+`allowNoBaselineOnAbsoluteFloors = true` (pass on absolute floors alone)
+or perform the first move in **shadow** mode.
+
+## 13. Rollback (distinct operation — not built here)
+
+Rolling back = promoting the `previousReleaseId` back into the
+environment. The gate still applies. Because adjacency uses the
+predecessor's **current** pointer, a plain rollback of a superseded
+release is intentionally blocked by `PromotionLadderError`; a break-glass
+rollback path is a separate operation and is **not** part of
+`promoteEnvironmentReleasePointer`.
+
+## 14. Incident triage
+
+| Symptom | Likely cause / action |
+|---|---|
+| `PromotionLadderError` | Predecessor env's current pointer ≠ this release. Promote the lower env first, or confirm you are not trying to rollback a superseded release. |
+| `ReleaseGateError` | Quality gate FAIL (regression, threshold, stale evidence) **or** a prod<staging monotonicity inversion. Inspect the ledger finding's `reasons`. |
+| `ReleaseApprovalRequiredError` | Strict mode; supply `approval: { approved: true }`. |
+| `ConcurrentPromotionError` | Two promotions raced; the loser's transaction (pointer + history) was atomically rejected. Reload and retry. |
+| Dangling pointer / unexpected release live | Read `environmentReleasePointerHistory` (§8) to reconstruct the move sequence. |
+
+## 15. Metrics / alarms
+
+Promotion outcomes are observable via the governance ledger findings and
+the `release.pointer.moved` event stream; wire dashboards/alarms off
+those (deny-rate, gate-refusal-rate, monotonicity-refusal-rate) alongside
+the platform-health SLO alarms in [OBSERVABILITY.md](OBSERVABILITY.md).


### PR DESCRIPTION
## Summary
Agent releases are already immutable and content-addressed, with per-environment release pointers and a fail-closed quality gate evaluated before any pointer move. What was missing: nothing enforced the dev → staging → prod path, gate thresholds could not differ per target environment, and there was no authoritative history of which release ran in which environment at a given time.

## What changed
- **Promotion Ladder** (`utils/promotion-ladder.ts`, pure): promoting release R to an environment requires the predecessor environment's *current* pointer to be R (dev is the entry environment). Promoting a superseded release is deliberately rejected - rollback/pin is a distinct operation, not a promotion. Checked before the gate runs.
- **Per-environment policy overrides**: `perEnvironmentPolicyOverrides` as the top layer of the existing policy precedence chain (default * org ‹ per-agent + per-env), with prod ≥ staging monotonicity enforced twice: rejected at policy write time and re-validated fail-closed at gate time over resolved values (floors rise, ceilings tighten, required gate classes are supersets going up).
- **Atomic pointer history**: every pointer move writes an append-only history row in the same `TransactWriteItems` as the move itself (new table, written only by the existing sole pointer writer). "What ran in prod on date D" is answered from durable history - latest row at or before end-of-day D, with same-day multiple moves disambiguated.
- **`RELEASE_POINTER_MOVED` event**: emitted best-effort, strictly post-commit. Durable audit remains the governance-ledger finding plus the history row, so a messaging failure can never abort or contradict a committed move.
- **Environment-scoped dispatch wiring**: supervisor and stepRunner functions now receive `RELEASE_DISPATCH_ENVIRONMENT` (and where provisioned) so each environment resolves its own pointer set. CDK-only - no Python changes.
- **`docs/RELEASE_RUNBOOK.md`**: promotion model, bootstrap (`NO_BASELINE`) caveat, and rollback guidance. GraphQL schema/type additions support the policy and history surfaces.
## Testing
- `tsc --noEmit' clean` full backend Jest suite green. (Three arbiter-stack suites needed a serialized re-run after a transient PyPI 502 during Docker asset bundling - environmental, not code; they pass 50/50 warm.)
- Concurrency and safety coverage: two successive chained pointer moves with history assertions; a non-stubbed optimistic-lock race test (stateful mock evaluating the real `ConditionExpression` - exactly one of two concurrent promotions wins); strict-mode prod gate refusal proving zero writes plus a deny finding; property-based promotion-ladder tests; write-time monotonicity rejection.
- `cdk synth` exits 0 for the backend and arbiter stacks; the history-table grant is least-privilege (review removed an unusable index wildcard).
## Deployment notes
Adds a DynamoDB table (pointer history) and IAM grants. Deploys are manual in this repo; a pre-merge branch deploy against dev is recommended to validate the changeset. Dispatch defaults preserve current behavior until environments are explicitly wired.