### PR TITLE
feat(release): per-constituent semantic diff between agent releases

### DIFF
--- a/backend/lib/governance-stack.ts
+++ b/backend/lib/governance-stack.ts
@@ -1186,6 +1186,91 @@ exports.handler = async (event) => {
     cutAgentReleaseResolver.addResourceDependency(agentReleaseLambdaDataSource);
 
     // ============================================================
+    // ReleaseDiff Resolver (releaseDiff query — read-only)
+    // ============================================================
+    //
+    // Deliberately its OWN function, OWN least-privilege role, and OWN
+    // AppSync data source — never reuses agentReleaseWriterRole (that
+    // role's Put/Get/Query-only floor is scoped to being the SOLE
+    // *writer* for AgentReleasesTable per release-store.ts's choke-point
+    // doctrine; a read-only diff query has no business assuming a writer
+    // role) and never reuses environmentReleasePointerWriterRole either
+    // (that role's grant surface is scoped to promotion/canary
+    // mutations, not an arbitrary two-release read). This function's
+    // role carries GetItem-ONLY on AgentReleasesTable and EvalRunsTable
+    // — release-diff-resolver.ts never issues any other DynamoDB action.
+    const releaseDiffResolverFunction = new lambda.Function(
+      this,
+      "ReleaseDiffResolverFunction",
+      {
+        runtime: lambda.Runtime.NODEJS_24_X,
+        handler: "release-diff-resolver.handler",
+        code: lambda.Code.fromAsset("dist/lambda"),
+        environment: {
+          AGENT_RELEASES_TABLE: props.agentReleasesTable.tableName,
+          EVAL_RUNS_TABLE: props.evalRunsTable.tableName,
+        },
+        timeout: cdk.Duration.seconds(30),
+        logGroup: new logs.LogGroup(this, "ReleaseDiffResolverFunctionLogs", {
+          retention: logs.RetentionDays.ONE_WEEK,
+          removalPolicy: cdk.RemovalPolicy.DESTROY,
+        }),
+      },
+    );
+
+    releaseDiffResolverFunction.addToRolePolicy(
+      new iam.PolicyStatement({
+        effect: iam.Effect.ALLOW,
+        actions: ["dynamodb:GetItem"],
+        resources: [props.agentReleasesTable.tableArn],
+      }),
+    );
+    releaseDiffResolverFunction.addToRolePolicy(
+      new iam.PolicyStatement({
+        effect: iam.Effect.ALLOW,
+        actions: ["dynamodb:GetItem"],
+        resources: [props.evalRunsTable.tableArn],
+      }),
+    );
+
+    const releaseDiffDataSourceRole = new iam.Role(
+      this,
+      "ReleaseDiffDataSourceRole",
+      {
+        assumedBy: new iam.ServicePrincipal("appsync.amazonaws.com"),
+      },
+    );
+    releaseDiffResolverFunction.grantInvoke(releaseDiffDataSourceRole);
+
+    const releaseDiffLambdaDataSource = new appsyncCfn.CfnDataSource(
+      this,
+      "ReleaseDiffLambdaDataSource",
+      {
+        apiId: props.appSyncApi.apiId,
+        name: "ReleaseDiffLambdaDataSource",
+        type: "AWS_LAMBDA",
+        serviceRoleArn: releaseDiffDataSourceRole.roleArn,
+        lambdaConfig: {
+          lambdaFunctionArn: releaseDiffResolverFunction.functionArn,
+        },
+      },
+    );
+
+    const releaseDiffResolver = new appsyncCfn.CfnResolver(
+      this,
+      "ReleaseDiffResolver",
+      {
+        apiId: props.appSyncApi.apiId,
+        typeName: "Query",
+        fieldName: "releaseDiff",
+        dataSourceName: releaseDiffLambdaDataSource.attrName,
+        requestMappingTemplate: LAMBDA_REQUEST_MAPPING,
+        responseMappingTemplate: LAMBDA_RESPONSE_MAPPING,
+      },
+    );
+    releaseDiffResolver.addResourceDependency(releaseDiffLambdaDataSource);
+
+    // ============================================================
     // Environment Release Pointer Resolver (mutable per-environment cursor)
     // ============================================================
     //
@@ -1279,6 +1364,13 @@ exports.handler = async (event) => {
           // writer role's PutEvents grant on this bus is added in
           // backend-stack.ts (bus is BackendStack-owned).
           EVENT_BUS_NAME: props.agentEventBus.eventBusName,
+          // Additive candidate-vs-stable diff embedding
+          // (resolveCandidateVsStableDiff in
+          // environment-release-pointer-resolver.ts calls into
+          // release-diff-resolver.ts's releaseDiff, which resolves each
+          // side's score vector from EvalRunsTable). GetItem-only grant
+          // below — the diff path never writes to this table.
+          EVAL_RUNS_TABLE: props.evalRunsTable.tableName,
         },
         timeout: cdk.Duration.seconds(30),
         logGroup: new logs.LogGroup(
@@ -1307,6 +1399,18 @@ exports.handler = async (event) => {
         effect: iam.Effect.ALLOW,
         actions: ["dynamodb:GetItem"],
         resources: [props.agentReleasesTable.tableArn],
+      }),
+    );
+
+    // Additive: resolveCandidateVsStableDiff's best-effort releaseDiff
+    // call reads EvalRunsTable (to resolve each side's score vector) —
+    // GetItem-only, same narrow-statement convention as the
+    // AgentReleasesTable grant directly above.
+    environmentReleasePointerResolverFunction.addToRolePolicy(
+      new iam.PolicyStatement({
+        effect: iam.Effect.ALLOW,
+        actions: ["dynamodb:GetItem"],
+        resources: [props.evalRunsTable.tableArn],
       }),
     );
 

--- a/backend/src/lambda/__tests__/environment-release-pointer-resolver.test.ts
+++ b/backend/src/lambda/__tests__/environment-release-pointer-resolver.test.ts
@@ -1735,6 +1735,324 @@ describe("promoteEnvironmentReleasePointer — approval wiring (decision 8165b7e
   });
 });
 
+describe("validatePromotionApproval — candidate-vs-stable diff embedding (additive)", () => {
+  const architect = authContextFor("architect");
+
+  test("embeds a diff when a current stable pointer exists and differs from the candidate", async () => {
+    ddbMock.reset();
+    ddbMock
+      .on(GetCommand, {
+        TableName: "citadel-environment-release-pointers-test",
+      })
+      .resolves({
+        Item: {
+          orgId: "org-1",
+          agentTargetId: "agent-1",
+          environment: "PROD",
+          releaseId: "release-stable",
+          previousReleaseId: null,
+          promotedAt: "2026-01-01T00:00:00.000Z",
+          promotedBy: "user-1",
+          version: 1,
+        },
+      });
+    ddbMock
+      .on(GetCommand, {
+        TableName: "citadel-agent-releases-test",
+        Key: { releaseId: "release-stable" },
+      })
+      .resolves({
+        Item: release({ releaseId: "release-stable", execSpecVersion: 1 }),
+      });
+    ddbMock
+      .on(GetCommand, {
+        TableName: "citadel-agent-releases-test",
+        Key: { releaseId: "release-candidate" },
+      })
+      .resolves({
+        Item: release({ releaseId: "release-candidate", execSpecVersion: 2 }),
+      });
+    ddbMock
+      .on(GetCommand, { TableName: "citadel-eval-runs-test" })
+      .resolves({ Item: undefined });
+
+    jest
+      .spyOn(governanceFlag, "getGovernanceEnforce")
+      .mockResolvedValue("strict");
+    let captured: unknown;
+    jest
+      .spyOn(
+        releasePromotionApprovalWriter,
+        "writeReleasePromotionApprovalFinding",
+      )
+      .mockImplementation(async (input) => {
+        captured = input;
+      });
+
+    await validatePromotionApproval(
+      release({ releaseId: "release-candidate", execSpecVersion: 2 }),
+      "PROD",
+      "org-1",
+      architect,
+      { approved: true },
+    );
+
+    expect(captured).toMatchObject({ decision: "permit" });
+    const diff = (
+      captured as {
+        diff?: { releaseIdA: string; releaseIdB: string; changes: unknown[] };
+      }
+    ).diff;
+    expect(diff).toBeDefined();
+    expect(diff!.releaseIdA).toBe("release-stable");
+    expect(diff!.releaseIdB).toBe("release-candidate");
+    expect(diff!.changes.length).toBeGreaterThan(0);
+  });
+
+  test("omits the diff field (never throws) when there is no current stable pointer yet", async () => {
+    ddbMock.reset();
+    ddbMock
+      .on(GetCommand, {
+        TableName: "citadel-environment-release-pointers-test",
+      })
+      .resolves({ Item: undefined });
+
+    jest
+      .spyOn(governanceFlag, "getGovernanceEnforce")
+      .mockResolvedValue("strict");
+    let captured: unknown;
+    jest
+      .spyOn(
+        releasePromotionApprovalWriter,
+        "writeReleasePromotionApprovalFinding",
+      )
+      .mockImplementation(async (input) => {
+        captured = input;
+      });
+
+    await expect(
+      validatePromotionApproval(
+        release({ releaseId: "release-candidate" }),
+        "PROD",
+        "org-1",
+        architect,
+        { approved: true },
+      ),
+    ).resolves.toBeUndefined();
+
+    expect(captured).not.toHaveProperty("diff");
+  });
+
+  test("omits the diff field when the current stable pointer already IS the candidate (no delta)", async () => {
+    ddbMock.reset();
+    ddbMock
+      .on(GetCommand, {
+        TableName: "citadel-environment-release-pointers-test",
+      })
+      .resolves({
+        Item: {
+          orgId: "org-1",
+          agentTargetId: "agent-1",
+          environment: "PROD",
+          releaseId: "release-candidate",
+          previousReleaseId: null,
+          promotedAt: "2026-01-01T00:00:00.000Z",
+          promotedBy: "user-1",
+          version: 1,
+        },
+      });
+
+    jest
+      .spyOn(governanceFlag, "getGovernanceEnforce")
+      .mockResolvedValue("strict");
+    let captured: unknown;
+    jest
+      .spyOn(
+        releasePromotionApprovalWriter,
+        "writeReleasePromotionApprovalFinding",
+      )
+      .mockImplementation(async (input) => {
+        captured = input;
+      });
+
+    await validatePromotionApproval(
+      release({ releaseId: "release-candidate" }),
+      "PROD",
+      "org-1",
+      architect,
+      { approved: true },
+    );
+
+    expect(captured).not.toHaveProperty("diff");
+  });
+
+  test("a diff-computation failure never blocks or fails the approval write", async () => {
+    ddbMock.reset();
+    ddbMock
+      .on(GetCommand, {
+        TableName: "citadel-environment-release-pointers-test",
+      })
+      .resolves({
+        Item: {
+          orgId: "org-1",
+          agentTargetId: "agent-1",
+          environment: "PROD",
+          releaseId: "release-stable",
+          previousReleaseId: null,
+          promotedAt: "2026-01-01T00:00:00.000Z",
+          promotedBy: "user-1",
+          version: 1,
+        },
+      });
+    // Simulate an infra failure resolving the stable release row itself.
+    ddbMock
+      .on(GetCommand, { TableName: "citadel-agent-releases-test" })
+      .rejects(new Error("DynamoDB unavailable"));
+
+    jest
+      .spyOn(governanceFlag, "getGovernanceEnforce")
+      .mockResolvedValue("strict");
+    let captured: unknown;
+    jest
+      .spyOn(
+        releasePromotionApprovalWriter,
+        "writeReleasePromotionApprovalFinding",
+      )
+      .mockImplementation(async (input) => {
+        captured = input;
+      });
+
+    await expect(
+      validatePromotionApproval(
+        release({ releaseId: "release-candidate" }),
+        "PROD",
+        "org-1",
+        architect,
+        { approved: true },
+      ),
+    ).resolves.toBeUndefined();
+
+    expect(captured).not.toHaveProperty("diff");
+    expect(captured).toMatchObject({ decision: "permit" });
+  });
+
+  // Feedback-round-1 finding: the whole-payload MAX_APPROVAL_DIFF_BYTES
+  // (256KB) cap at environment-release-pointer-resolver.ts's
+  // resolveCandidateVsStableDiff was applied but never exercised by a
+  // test — the truncated-stub branch was uncovered.
+  test("caps an oversized serialized diff at the whole-payload boundary and embeds the truncated stub", async () => {
+    ddbMock.reset();
+    // A huge prompt (well past release-diff.ts's own per-constituent
+    // MAX_CONSTITUENT_DIFF_BYTES) drives the FULLY SERIALIZED diff past
+    // this resolver's independent 256KB whole-payload cap even after
+    // per-constituent truncation kicks in, because releaseDiff still
+    // enumerates one changed constituent with a truncated summary —
+    // this test asserts the resolver's OWN cap, not release-diff.ts's.
+    // To be certain the whole-payload cap (not just the per-constituent
+    // one) is what's under test, spread the size across many small
+    // changed prompts instead of one giant one: each prompt is small
+    // enough to dodge per-constituent truncation, but hundreds of them
+    // blow the whole-payload cap.
+    const manyPrompts: Record<
+      string,
+      { sourceId: string; content: string; digest: string }
+    > = {};
+    const manyPromptsAfter: Record<
+      string,
+      { sourceId: string; content: string; digest: string }
+    > = {};
+    for (let i = 0; i < 2000; i++) {
+      manyPrompts[`prompt-${i}`] = {
+        sourceId: `src-${i}`,
+        content: `before-${i}`,
+        digest: `d-before-${i}`,
+      };
+      manyPromptsAfter[`prompt-${i}`] = {
+        sourceId: `src-${i}`,
+        content: `after-${i}-${"x".repeat(80)}`,
+        digest: `d-after-${i}`,
+      };
+    }
+
+    ddbMock
+      .on(GetCommand, {
+        TableName: "citadel-environment-release-pointers-test",
+      })
+      .resolves({
+        Item: {
+          orgId: "org-1",
+          agentTargetId: "agent-1",
+          environment: "PROD",
+          releaseId: "release-stable",
+          previousReleaseId: null,
+          promotedAt: "2026-01-01T00:00:00.000Z",
+          promotedBy: "user-1",
+          version: 1,
+        },
+      });
+    ddbMock
+      .on(GetCommand, {
+        TableName: "citadel-agent-releases-test",
+        Key: { releaseId: "release-stable" },
+      })
+      .resolves({
+        Item: release({
+          releaseId: "release-stable",
+          promptVersions: manyPrompts,
+        }),
+      });
+    ddbMock
+      .on(GetCommand, {
+        TableName: "citadel-agent-releases-test",
+        Key: { releaseId: "release-candidate" },
+      })
+      .resolves({
+        Item: release({
+          releaseId: "release-candidate",
+          promptVersions: manyPromptsAfter,
+        }),
+      });
+    ddbMock
+      .on(GetCommand, { TableName: "citadel-eval-runs-test" })
+      .resolves({ Item: undefined });
+
+    jest
+      .spyOn(governanceFlag, "getGovernanceEnforce")
+      .mockResolvedValue("strict");
+    let captured: unknown;
+    jest
+      .spyOn(
+        releasePromotionApprovalWriter,
+        "writeReleasePromotionApprovalFinding",
+      )
+      .mockImplementation(async (input) => {
+        captured = input;
+      });
+
+    await expect(
+      validatePromotionApproval(
+        release({
+          releaseId: "release-candidate",
+          promptVersions: manyPromptsAfter,
+        }),
+        "PROD",
+        "org-1",
+        architect,
+        { approved: true },
+      ),
+    ).resolves.toBeUndefined();
+
+    // Approval write must succeed regardless of diff size.
+    expect(captured).toMatchObject({ decision: "permit" });
+    const diff = (captured as { diff?: unknown }).diff;
+    expect(diff).toEqual({
+      releaseIdA: "release-stable",
+      releaseIdB: "release-candidate",
+      truncated: true,
+    });
+  });
+});
+
 describe("promoteEnvironmentReleasePointer — ladder adjacency (G1, consensus decision 1)", () => {
   const architect = authContextFor("architect");
 

--- a/backend/src/lambda/__tests__/release-diff-resolver.test.ts
+++ b/backend/src/lambda/__tests__/release-diff-resolver.test.ts
@@ -1,0 +1,288 @@
+/**
+ * release-diff-resolver.test.ts — releaseDiff(releaseIdA, releaseIdB)
+ * query. Mocked DynamoDB client, mirrors release-resolver.test.ts /
+ * environment-release-pointer-resolver.test.ts conventions.
+ */
+import { DynamoDBDocumentClient, GetCommand } from "@aws-sdk/lib-dynamodb";
+import { mockClient } from "aws-sdk-client-mock";
+import type { AgentRelease, EvalRun } from "../../types";
+
+process.env.AGENT_RELEASES_TABLE = "citadel-agent-releases-test";
+process.env.EVAL_RUNS_TABLE = "citadel-eval-runs-test";
+process.env.ENVIRONMENT = "test";
+
+const ddbMock = mockClient(DynamoDBDocumentClient);
+
+import {
+  releaseDiff,
+  ReleaseNotFoundError,
+  CrossOrgReleaseDiffError,
+  handler,
+} from "../release-diff-resolver";
+
+function release(overrides: Partial<AgentRelease> = {}): AgentRelease {
+  return {
+    releaseId: "release-a",
+    orgId: "org-1",
+    agentTargetId: "agent-1",
+    semver: "1.0.0",
+    agentConfig: { sourceId: "reg-1", content: "v1", digest: "d1" },
+    promptVersions: {
+      system: { sourceId: "p-system", content: "hello", digest: "dp1" },
+    },
+    execSpecId: "spec-1",
+    execSpecVersion: 1,
+    modelConfigSnapshots: [],
+    toolConfigs: [],
+    policySnapshot: {
+      enforcementMode: "shadow",
+      ruleSetVersion: "v1",
+      authorityUnitGrantIds: [],
+    },
+    evalEvidence: {
+      evalRunId: "run-a",
+      evalSuiteId: "suite-1",
+      evalSuiteVersion: 1,
+    },
+    createdAt: "2025-01-01T00:00:00.000Z",
+    createdBy: "user-1",
+    gitSha: "abc123",
+    region: "us-east-1",
+    runId: "run-id-1",
+    ...overrides,
+  } as AgentRelease;
+}
+
+function evalRun(overrides: Partial<EvalRun> = {}): EvalRun {
+  return {
+    evalRunId: "run-a",
+    orgId: "org-1",
+    suiteId: "suite-1",
+    suiteVersion: 1,
+    agentTargetId: "agent-1",
+    agentTargetVersion: "1.0.0",
+    status: "COMPLETED",
+    caseCount: 10,
+    pendingCases: 0,
+    startedAt: "2025-01-01T00:00:00.000Z",
+    startedBy: "user-1",
+    idempotencyKey: "key-1",
+    ...overrides,
+  } as EvalRun;
+}
+
+beforeEach(() => {
+  ddbMock.reset();
+});
+
+describe("releaseDiff query", () => {
+  test("returns changes between two same-org releases", async () => {
+    const releaseA = release({ releaseId: "release-a" });
+    const releaseB = release({
+      releaseId: "release-b",
+      execSpecVersion: 2,
+      evalEvidence: {
+        evalRunId: "run-b",
+        evalSuiteId: "suite-1",
+        evalSuiteVersion: 1,
+      },
+    });
+
+    ddbMock
+      .on(GetCommand, {
+        TableName: "citadel-agent-releases-test",
+        Key: { releaseId: "release-a" },
+      })
+      .resolves({ Item: releaseA });
+    ddbMock
+      .on(GetCommand, {
+        TableName: "citadel-agent-releases-test",
+        Key: { releaseId: "release-b" },
+      })
+      .resolves({ Item: releaseB });
+    ddbMock
+      .on(GetCommand, {
+        TableName: "citadel-eval-runs-test",
+        Key: { evalRunId: "run-a" },
+      })
+      .resolves({ Item: evalRun({ evalRunId: "run-a" }) });
+    ddbMock
+      .on(GetCommand, {
+        TableName: "citadel-eval-runs-test",
+        Key: { evalRunId: "run-b" },
+      })
+      .resolves({ Item: evalRun({ evalRunId: "run-b" }) });
+
+    const result = await releaseDiff("release-a", "release-b", "org-1");
+
+    expect(result.releaseIdA).toBe("release-a");
+    expect(result.releaseIdB).toBe("release-b");
+    expect(result.changes.some((c) => c.kind === "execSpec")).toBe(true);
+    expect(result.changes.some((c) => c.kind === "evalEvidence")).toBe(true);
+  });
+
+  test("returns empty changes for a release diffed against itself", async () => {
+    const releaseA = release({ releaseId: "release-a" });
+    ddbMock
+      .on(GetCommand, {
+        TableName: "citadel-agent-releases-test",
+        Key: { releaseId: "release-a" },
+      })
+      .resolves({ Item: releaseA });
+    ddbMock
+      .on(GetCommand, { TableName: "citadel-eval-runs-test" })
+      .resolves({ Item: undefined });
+
+    const result = await releaseDiff("release-a", "release-a", "org-1");
+    expect(result.changes).toEqual([]);
+  });
+
+  test("throws ReleaseNotFoundError when a release does not exist", async () => {
+    ddbMock
+      .on(GetCommand, { TableName: "citadel-agent-releases-test" })
+      .resolves({ Item: undefined });
+
+    await expect(
+      releaseDiff("missing-a", "missing-b", "org-1"),
+    ).rejects.toThrow(ReleaseNotFoundError);
+  });
+
+  test("throws CrossOrgReleaseDiffError when a release belongs to another org", async () => {
+    const releaseA = release({ releaseId: "release-a", orgId: "org-1" });
+    const releaseB = release({ releaseId: "release-b", orgId: "org-2" });
+
+    ddbMock
+      .on(GetCommand, {
+        TableName: "citadel-agent-releases-test",
+        Key: { releaseId: "release-a" },
+      })
+      .resolves({ Item: releaseA });
+    ddbMock
+      .on(GetCommand, {
+        TableName: "citadel-agent-releases-test",
+        Key: { releaseId: "release-b" },
+      })
+      .resolves({ Item: releaseB });
+
+    await expect(
+      releaseDiff("release-a", "release-b", "org-1"),
+    ).rejects.toThrow(CrossOrgReleaseDiffError);
+  });
+
+  test("resolves score vectors from each side's EvalRun.scoreAggregates and reports movement", async () => {
+    const releaseA = release({
+      releaseId: "release-a",
+      evalEvidence: {
+        evalRunId: "run-a",
+        evalSuiteId: "suite-1",
+        evalSuiteVersion: 1,
+      },
+    });
+    const releaseB = release({
+      releaseId: "release-b",
+      evalEvidence: {
+        evalRunId: "run-b",
+        evalSuiteId: "suite-1",
+        evalSuiteVersion: 1,
+      },
+    });
+
+    const scoreA = JSON.stringify([
+      {
+        dimension: "task_success",
+        scoredCount: 10,
+        notApplicableCount: 0,
+        unknownCount: 0,
+        pendingCount: 0,
+        passedCount: 8,
+        passRate: 0.8,
+      },
+    ]);
+    const scoreB = JSON.stringify([
+      {
+        dimension: "task_success",
+        scoredCount: 10,
+        notApplicableCount: 0,
+        unknownCount: 0,
+        pendingCount: 0,
+        passedCount: 9,
+        passRate: 0.9,
+      },
+    ]);
+
+    ddbMock
+      .on(GetCommand, {
+        TableName: "citadel-agent-releases-test",
+        Key: { releaseId: "release-a" },
+      })
+      .resolves({ Item: releaseA });
+    ddbMock
+      .on(GetCommand, {
+        TableName: "citadel-agent-releases-test",
+        Key: { releaseId: "release-b" },
+      })
+      .resolves({ Item: releaseB });
+    ddbMock
+      .on(GetCommand, {
+        TableName: "citadel-eval-runs-test",
+        Key: { evalRunId: "run-a" },
+      })
+      .resolves({
+        Item: evalRun({ evalRunId: "run-a", scoreAggregates: scoreA }),
+      });
+    ddbMock
+      .on(GetCommand, {
+        TableName: "citadel-eval-runs-test",
+        Key: { evalRunId: "run-b" },
+      })
+      .resolves({
+        Item: evalRun({ evalRunId: "run-b", scoreAggregates: scoreB }),
+      });
+
+    const result = await releaseDiff("release-a", "release-b", "org-1");
+    const scoreVectorChange = result.changes.find(
+      (c) => c.kind === "scoreVector",
+    );
+    expect(scoreVectorChange).toBeDefined();
+  });
+
+  test("does not throw when an EvalRun is missing or unscored — omits score-vector movement gracefully", async () => {
+    const releaseA = release({ releaseId: "release-a" });
+    const releaseB = release({
+      releaseId: "release-a-copy",
+      agentConfig: releaseA.agentConfig,
+    });
+
+    ddbMock
+      .on(GetCommand, {
+        TableName: "citadel-agent-releases-test",
+        Key: { releaseId: "release-a" },
+      })
+      .resolves({ Item: releaseA });
+    ddbMock
+      .on(GetCommand, {
+        TableName: "citadel-agent-releases-test",
+        Key: { releaseId: "release-a-copy" },
+      })
+      .resolves({ Item: releaseB });
+    ddbMock
+      .on(GetCommand, { TableName: "citadel-eval-runs-test" })
+      .resolves({ Item: undefined });
+
+    await expect(
+      releaseDiff("release-a", "release-a-copy", "org-1"),
+    ).resolves.toBeDefined();
+  });
+});
+
+describe("releaseDiff-resolver handler dispatch", () => {
+  test("Unsupported field throws", async () => {
+    await expect(
+      handler({
+        info: { fieldName: "somethingElse" },
+        arguments: {},
+        identity: {},
+      } as never),
+    ).rejects.toThrow("Unsupported field");
+  });
+});

--- a/backend/src/lambda/environment-release-pointer-resolver.ts
+++ b/backend/src/lambda/environment-release-pointer-resolver.ts
@@ -114,6 +114,7 @@ import {
 } from "./utils/promotion-ladder";
 import { writeReleaseGateFinding } from "./utils/release-gate-finding-writer";
 import { writeReleasePromotionApprovalFinding } from "./utils/release-promotion-approval-writer";
+import { releaseDiff } from "./release-diff-resolver";
 import { publishEvent, createReleaseEvent, EventTypes } from "../utils/events";
 import {
   getEnvironmentReleasePointer,
@@ -143,6 +144,15 @@ const docClient = DynamoDBDocumentClient.from(dynamoClient);
 function agentReleasesTable(): string {
   return process.env.AGENT_RELEASES_TABLE!;
 }
+
+/** Size cap on the FULLY serialized candidate-vs-stable diff embedded
+ * into a promotion approval finding — mirrors eval-resolver.ts's /
+ * eval-comparison-resolver.ts's MAX_JSON_FIELD_BYTES precedent (256KB),
+ * reused verbatim. Distinct from release-diff.ts's own
+ * MAX_CONSTITUENT_DIFF_BYTES (per-constituent), since this cap is over
+ * the WHOLE diff payload after every constituent has already been
+ * individually truncated. */
+const MAX_APPROVAL_DIFF_BYTES = 256 * 1024;
 
 function requireReleasePromotePermission(authContext: AuthContext): void {
   if (!hasPermission(authContext, "release:promote")) {
@@ -559,6 +569,93 @@ function validatePercentBasisPoints(percentBasisPoints: number): void {
  * threading it through validateReleaseGate's return value, so
  * validateReleaseGate's existing signature and tests are undisturbed.
  */
+/**
+ * Best-effort candidate-vs-current-target-env-stable releaseDiff,
+ * embedded into the promotion approval finding at creation time (task
+ * spec: "Embed the diff (candidate vs current target-env stable) in
+ * the promotion approval request payload at creation"). This is the
+ * ONLY call site in the codebase that computes a releaseDiff eagerly
+ * rather than on-demand via the releaseDiff query — it exists purely to
+ * give the approving human the delta inline with the decision they're
+ * being asked to make.
+ *
+ * ADDITIVE AND NEVER BLOCKING (task spec: "approval must never fail
+ * because a diff is large" — generalized here to "for any reason at
+ * all"): every failure mode — no current stable pointer yet (first-ever
+ * promotion to this environment), the stable release row missing,
+ * EvalRun reads failing, or the diff computation itself throwing —
+ * resolves to `undefined` (diff omitted) rather than propagating. The
+ * approval finding write proceeds identically either way; only the
+ * (optional) `diff` field differs. release-diff.ts's own per-constituent
+ * MAX_CONSTITUENT_DIFF_BYTES truncation already defends against a
+ * single oversized constituent; this function ALSO caps the fully
+ * serialized diff (defense in depth against many-small-changes bloat)
+ * before returning it, again resolving to `undefined` rather than
+ * throwing if even the size check fails unexpectedly.
+ */
+async function resolveCandidateVsStableDiff(
+  candidate: AgentRelease,
+  environment: EnvironmentLiteral,
+  callerOrgId: string,
+): Promise<unknown> {
+  try {
+    const currentPointer = await getEnvironmentReleasePointer(
+      callerOrgId,
+      candidate.agentTargetId,
+      environment,
+    );
+    if (!currentPointer) {
+      // No current stable release for this (org, agent, environment) —
+      // e.g. the very first promotion. Nothing to diff against.
+      return undefined;
+    }
+    if (currentPointer.releaseId === candidate.releaseId) {
+      // Re-approving the release already stable here (e.g. a canary
+      // full-cutover of the release that IS the current stable) — no
+      // delta to show.
+      return undefined;
+    }
+
+    const result = await releaseDiff(
+      currentPointer.releaseId,
+      candidate.releaseId,
+      callerOrgId,
+    );
+
+    // Defense-in-depth size cap on the FULLY serialized diff, on top of
+    // release-diff.ts's own per-constituent truncation — mirrors this
+    // module's own MAX_APPROVAL_DIFF_BYTES doctrine rather than
+    // reusing release-diff.ts's per-constituent constant, since this
+    // cap is over the WHOLE payload, not one constituent.
+    const serialized = JSON.stringify(result);
+    if (
+      serialized !== undefined &&
+      Buffer.byteLength(serialized, "utf8") > MAX_APPROVAL_DIFF_BYTES
+    ) {
+      return {
+        releaseIdA: result.releaseIdA,
+        releaseIdB: result.releaseIdB,
+        truncated: true,
+      };
+    }
+    return result;
+  } catch (err: unknown) {
+    // Best-effort: a diff-computation failure must never abort or even
+    // slow-path the approval decision itself. Logged for observability,
+    // then swallowed.
+    console.error(
+      "environment-release-pointer-resolver: best-effort candidate-vs-stable releaseDiff failed — omitting diff from the approval finding, continuing",
+      {
+        agentTargetId: candidate.agentTargetId,
+        environment,
+        candidateReleaseId: candidate.releaseId,
+        error: err instanceof Error ? err.message : String(err),
+      },
+    );
+    return undefined;
+  }
+}
+
 export async function validatePromotionApproval(
   release: AgentRelease,
   environment: EnvironmentLiteral,
@@ -585,6 +682,11 @@ export async function validatePromotionApproval(
 
   const decision: "permit" | "deny" = approval.approved ? "permit" : "deny";
   const traceContext = getActiveTraceContext();
+  const diff = await resolveCandidateVsStableDiff(
+    release,
+    environment,
+    callerOrgId,
+  );
 
   if (!approval.approved) {
     // Record the denial finding BEFORE throwing (strict) — fail-closed:
@@ -599,6 +701,7 @@ export async function validatePromotionApproval(
       decision,
       justification: approval.justification,
       ...(traceContext?.traceId ? { traceId: traceContext.traceId } : {}),
+      ...(diff !== undefined ? { diff } : {}),
     });
 
     if (disposition.block) {
@@ -618,6 +721,7 @@ export async function validatePromotionApproval(
     decision,
     justification: approval.justification,
     ...(traceContext?.traceId ? { traceId: traceContext.traceId } : {}),
+    ...(diff !== undefined ? { diff } : {}),
   });
 }
 

--- a/backend/src/lambda/release-diff-resolver.ts
+++ b/backend/src/lambda/release-diff-resolver.ts
@@ -1,0 +1,207 @@
+/**
+ * release-diff-resolver.ts — releaseDiff(releaseIdA, releaseIdB) query.
+ *
+ * Read-only. Resolves both AgentRelease rows (release-store.ts's
+ * getRelease — the SOLE reader for AgentReleasesTable, same as
+ * release-resolver.ts / environment-release-pointer-resolver.ts already
+ * do for their own release reads), enforces org-scoped access identical
+ * to every other release read in this codebase (compare
+ * release.orgId === callerOrgId, reject cross-org — see
+ * environment-release-pointer-resolver.ts's promoteEnvironmentReleasePointer
+ * "belongs to a different org" checks), then delegates the actual
+ * semantic diff to the pure release-diff.ts module.
+ *
+ * PERMISSION SCOPE (grounded in existing precedent): there is no
+ * `release:read` permission anywhere in this codebase (auth.ts) — every
+ * existing release READ (getCurrentEnvironmentReleasePointer,
+ * listEnvironmentReleasePointers, environmentReleasePointerHistory in
+ * environment-release-pointer-resolver.ts) is gated by org-membership
+ * ALONE, with no additional permission check. releaseDiff follows that
+ * exact precedent rather than inventing a new permission that nothing
+ * else in the schema requires for a read.
+ *
+ * SCORE-VECTOR RESOLUTION: AgentReleaseConstituents.evalEvidence is a
+ * pointer (evalRunId/evalSuiteId/evalSuiteVersion), not the score
+ * vector itself (see release-diff.ts's module doc). This resolver reads
+ * each side's EvalRun row and parses its `scoreAggregates` (AWSJSON —
+ * serialized DimensionAggregate[], CIT-103) to get the actual vectors,
+ * then calls the pure `releaseDiffWithScoreVectors`. A side whose
+ * EvalRun is missing, or has not yet been scored (scoreAggregates
+ * absent), contributes an EMPTY vector for that side — never a thrown
+ * error and never a fabricated aggregate — so the query still returns
+ * the constituent-level diff even when eval evidence isn't (yet)
+ * scored on one or both sides.
+ */
+import { DynamoDBClient } from "@aws-sdk/client-dynamodb";
+import { DynamoDBDocumentClient, GetCommand } from "@aws-sdk/lib-dynamodb";
+import { extractOrgFromEvent } from "../utils/auth-event";
+import { getRelease } from "./release-store";
+import { releaseDiffWithScoreVectors } from "./utils/release-diff";
+import type { DimensionAggregate } from "./utils/eval-score-aggregate";
+import type { AgentRelease, EvalRun, GovernanceResolverEvent } from "../types";
+
+const dynamoClient = new DynamoDBClient({});
+const docClient = DynamoDBDocumentClient.from(dynamoClient);
+
+function evalRunsTable(): string {
+  return process.env.EVAL_RUNS_TABLE!;
+}
+
+async function getEvalRun(evalRunId: string): Promise<EvalRun | null> {
+  const res = await docClient.send(
+    new GetCommand({ TableName: evalRunsTable(), Key: { evalRunId } }),
+  );
+  return (res.Item as EvalRun | undefined) ?? null;
+}
+
+/** Resolves a release's score vector for diffing. Never throws: missing
+ * run, or a run not yet scored, both resolve to an empty vector — the
+ * diff then reports every dimension present on the OTHER side as
+ * "added"/"removed" rather than failing the whole query. A malformed
+ * (non-JSON) scoreAggregates string is treated the same way (empty),
+ * consistent with this codebase's "absent until scored" doctrine for
+ * that field (see ../types.ts EvalRun.scoreAggregates doc). */
+async function resolveScoreVector(
+  release: AgentRelease,
+): Promise<DimensionAggregate[]> {
+  const run = await getEvalRun(release.evalEvidence.evalRunId);
+  if (!run?.scoreAggregates) {
+    return [];
+  }
+  try {
+    const parsed = JSON.parse(run.scoreAggregates);
+    return Array.isArray(parsed) ? (parsed as DimensionAggregate[]) : [];
+  } catch {
+    return [];
+  }
+}
+
+export class ReleaseNotFoundError extends Error {
+  constructor(public readonly releaseId: string) {
+    super(`ValidationError: release not found: ${releaseId}`);
+    this.name = "ReleaseNotFoundError";
+  }
+}
+
+/** Distinct from the generic ValidationError bucket — mirrors this
+ * codebase's "malformed input" vs "attempted to read another tenant's
+ * data" distinction (release-resolver.ts / environment-release-pointer-
+ * resolver.ts module docs). */
+export class CrossOrgReleaseDiffError extends Error {
+  constructor(public readonly releaseId: string) {
+    super(
+      `SecurityError: release ${releaseId} belongs to a different org — releaseDiff must never compare across tenants`,
+    );
+    this.name = "CrossOrgReleaseDiffError";
+  }
+}
+
+async function getOwnReleaseOrThrow(
+  releaseId: string,
+  callerOrgId: string,
+): Promise<AgentRelease> {
+  const release = await getRelease(releaseId);
+  if (!release) {
+    throw new ReleaseNotFoundError(releaseId);
+  }
+  if (release.orgId !== callerOrgId) {
+    throw new CrossOrgReleaseDiffError(releaseId);
+  }
+  return release;
+}
+
+export interface ReleaseDiffQueryResult {
+  releaseIdA: string;
+  releaseIdB: string;
+  changes: ReturnType<typeof releaseDiffWithScoreVectors>["changes"];
+}
+
+/**
+ * releaseDiff(releaseIdA, releaseIdB) — read-only, org-scoped semantic
+ * diff between two immutable AgentRelease bundles. Both releases must
+ * belong to the caller's org (CrossOrgReleaseDiffError otherwise); both
+ * must exist (ReleaseNotFoundError otherwise). Delegates constituent
+ * diffing to the pure release-diff.ts module; resolves each side's
+ * score vector from its EvalRun row (see resolveScoreVector doc) before
+ * calling releaseDiffWithScoreVectors, so score-vector movement is
+ * included as one additional "scoreVector" entry alongside every other
+ * changed constituent.
+ */
+export async function releaseDiff(
+  releaseIdA: string,
+  releaseIdB: string,
+  callerOrgId: string,
+): Promise<ReleaseDiffQueryResult> {
+  const [releaseA, releaseB] = await Promise.all([
+    getOwnReleaseOrThrow(releaseIdA, callerOrgId),
+    getOwnReleaseOrThrow(releaseIdB, callerOrgId),
+  ]);
+
+  const [scoreVectorA, scoreVectorB] = await Promise.all([
+    resolveScoreVector(releaseA),
+    resolveScoreVector(releaseB),
+  ]);
+
+  const { changes } = releaseDiffWithScoreVectors(
+    releaseA,
+    releaseB,
+    scoreVectorA,
+    scoreVectorB,
+  );
+
+  return { releaseIdA, releaseIdB, changes };
+}
+
+/** Merged view of every argument this resolver's fields receive. */
+interface ReleaseDiffResolverArguments {
+  releaseIdA: string;
+  releaseIdB: string;
+}
+
+type ReleaseDiffResolverEvent =
+  GovernanceResolverEvent<ReleaseDiffResolverArguments>;
+
+/** Truncate long string values in event.arguments for safe error logging
+ * — mirrors release-resolver.ts's / environment-release-pointer-
+ * resolver.ts's sanitizeForLog convention. */
+function sanitizeForLog(input: unknown): unknown {
+  if (!input || typeof input !== "object") return input;
+  const out: Record<string, unknown> = {};
+  for (const [k, v] of Object.entries(input as Record<string, unknown>)) {
+    out[k] =
+      typeof v === "string" && v.length > 200 ? v.slice(0, 200) + "…" : v;
+  }
+  return out;
+}
+
+export const handler = async (
+  event: ReleaseDiffResolverEvent,
+): Promise<unknown> => {
+  const fieldName = event?.info?.fieldName;
+  try {
+    switch (fieldName) {
+      case "releaseDiff": {
+        const callerOrgId = await extractOrgFromEvent(event);
+        if (!callerOrgId) {
+          throw new Error(
+            "ValidationError: caller organization could not be determined",
+          );
+        }
+        return await releaseDiff(
+          event.arguments.releaseIdA,
+          event.arguments.releaseIdB,
+          callerOrgId,
+        );
+      }
+      default:
+        throw new Error(`Unsupported field: ${fieldName}`);
+    }
+  } catch (err: unknown) {
+    console.error("release-diff-resolver error", {
+      fieldName,
+      message: err instanceof Error ? err.message : undefined,
+      args: sanitizeForLog(event?.arguments),
+    });
+    throw err;
+  }
+};

--- a/backend/src/lambda/utils/__tests__/release-diff.test.ts
+++ b/backend/src/lambda/utils/__tests__/release-diff.test.ts
@@ -1,0 +1,666 @@
+import * as fc from "fast-check";
+import {
+  releaseDiff,
+  releaseDiffWithScoreVectors,
+  diffLines,
+  diffScoreVectors,
+  diffScoreVectorChange,
+  assertConstituentKeyCoverage,
+  MAX_CONSTITUENT_DIFF_BYTES,
+  type ReleaseDiffChange,
+} from "../release-diff";
+import type {
+  AgentReleaseConstituents,
+  ContentSnapshot,
+  ModelConfigSnapshot,
+} from "../../../types";
+import type { DimensionAggregate } from "../eval-score-aggregate";
+
+// ---------------------------------------------------------------------
+// Arbitraries
+// ---------------------------------------------------------------------
+
+function contentSnapshotArb(
+  sourceIdArb = fc.stringMatching(/^src-[a-z0-9]{6}$/),
+) {
+  return fc
+    .record({
+      sourceId: sourceIdArb,
+      content: fc.string({ minLength: 0, maxLength: 200 }),
+    })
+    .map(({ sourceId, content }) => ({
+      sourceId,
+      content,
+      digest: `digest-${content.length}-${hashLike(content)}`,
+    }));
+}
+
+// Cheap deterministic stand-in for a real digest — good enough for
+// content-equality tests without importing crypto into the arbitrary.
+function hashLike(s: string): string {
+  let h = 0;
+  for (let i = 0; i < s.length; i++) {
+    h = (h * 31 + s.charCodeAt(i)) | 0;
+  }
+  return String(h);
+}
+
+const modelConfigSnapshotArb: fc.Arbitrary<ModelConfigSnapshot> = fc
+  .record({
+    slot: fc.constantFrom("supervisor", "fabricator", "extraction"),
+    content: fc.string({ minLength: 0, maxLength: 100 }),
+  })
+  .map(({ slot, content }) => ({
+    slot,
+    content,
+    digest: `digest-${hashLike(content)}`,
+  }));
+
+const policySnapshotArb = fc.record({
+  enforcementMode: fc.constantFrom("permissive", "shadow", "strict"),
+  ruleSetVersion: fc.stringMatching(/^v[0-9]{1,3}$/),
+  authorityUnitGrantIds: fc.array(fc.stringMatching(/^au-[a-z0-9]{4}$/), {
+    maxLength: 5,
+  }),
+});
+
+const evalEvidenceArb = fc.record({
+  evalRunId: fc.stringMatching(/^run-[a-z0-9]{6}$/),
+  evalSuiteId: fc.stringMatching(/^suite-[a-z0-9]{6}$/),
+  evalSuiteVersion: fc.integer({ min: 1, max: 50 }),
+});
+
+const promptVersionsArb = fc.dictionary(
+  fc.stringMatching(/^prompt-[a-z]{3,8}$/),
+  contentSnapshotArb(),
+  { maxKeys: 4 },
+);
+
+const agentReleaseConstituentsArb: fc.Arbitrary<AgentReleaseConstituents> =
+  fc.record({
+    agentConfig: contentSnapshotArb(),
+    promptVersions: promptVersionsArb,
+    execSpecId: fc.stringMatching(/^spec-[a-z0-9]{6}$/),
+    execSpecVersion: fc.integer({ min: 1, max: 20 }),
+    modelConfigSnapshots: fc
+      .array(modelConfigSnapshotArb, { maxLength: 3 })
+      .map((arr) => {
+        // dedupe by slot so the arbitrary always represents a valid bundle
+        const seen = new Map<string, ModelConfigSnapshot>();
+        for (const m of arr) seen.set(m.slot, m);
+        return [...seen.values()];
+      }),
+    toolConfigs: fc.array(contentSnapshotArb(), { maxLength: 4 }).map((arr) => {
+      const seen = new Map<string, ContentSnapshot>();
+      for (const t of arr) seen.set(t.sourceId, t);
+      return [...seen.values()];
+    }),
+    policySnapshot: policySnapshotArb,
+    evalEvidence: evalEvidenceArb,
+  });
+
+function swap<T>(
+  change: ReleaseDiffChange,
+  field: "before" | "after",
+): unknown {
+  return change[field];
+}
+
+// ---------------------------------------------------------------------
+// MANDATED property tests
+// ---------------------------------------------------------------------
+
+describe("releaseDiff — property: identity", () => {
+  it("diff(a, a) is always empty for arbitrary bundles", () => {
+    fc.assert(
+      fc.property(agentReleaseConstituentsArb, (bundle) => {
+        const result = releaseDiff(bundle, bundle);
+        expect(result.changes).toEqual([]);
+      }),
+    );
+  });
+});
+
+describe("releaseDiff — property: symmetric-inverse", () => {
+  it("diff(a, b) and diff(b, a) enumerate identical constituents with before/after swapped", () => {
+    fc.assert(
+      fc.property(
+        agentReleaseConstituentsArb,
+        agentReleaseConstituentsArb,
+        (a, b) => {
+          const forward = releaseDiff(a, b);
+          const backward = releaseDiff(b, a);
+
+          const forwardKeys = forward.changes
+            .map((c) => `${c.kind}:${c.key}`)
+            .sort();
+          const backwardKeys = backward.changes
+            .map((c) => `${c.kind}:${c.key}`)
+            .sort();
+          expect(forwardKeys).toEqual(backwardKeys);
+
+          const byKindKey = (changes: ReleaseDiffChange[]) => {
+            const m = new Map<string, ReleaseDiffChange>();
+            for (const c of changes) m.set(`${c.kind}:${c.key}`, c);
+            return m;
+          };
+          const forwardMap = byKindKey(forward.changes);
+          const backwardMap = byKindKey(backward.changes);
+
+          for (const [key, fChange] of forwardMap) {
+            const bChange = backwardMap.get(key)!;
+            if (fChange.truncated || bChange.truncated) {
+              // Truncated summaries are size-only; swap contract
+              // still holds on the truncated flag itself.
+              expect(bChange.truncated).toBe(fChange.truncated);
+              continue;
+            }
+            expect(swap(bChange, "before")).toEqual(swap(fChange, "after"));
+            expect(swap(bChange, "after")).toEqual(swap(fChange, "before"));
+          }
+        },
+      ),
+    );
+  });
+});
+
+describe("releaseDiff — every-constituent-type coverage", () => {
+  const base: AgentReleaseConstituents = {
+    agentConfig: { sourceId: "reg-1", content: "v1", digest: "d1" },
+    promptVersions: {
+      system: { sourceId: "p-system", content: "line1\nline2", digest: "dp1" },
+    },
+    execSpecId: "spec-1",
+    execSpecVersion: 1,
+    modelConfigSnapshots: [
+      { slot: "supervisor", content: "gpt", digest: "dm1" },
+    ],
+    toolConfigs: [{ sourceId: "tool-a", content: "toolA", digest: "dt1" }],
+    policySnapshot: {
+      enforcementMode: "shadow",
+      ruleSetVersion: "v1",
+      authorityUnitGrantIds: ["au-1"],
+    },
+    evalEvidence: {
+      evalRunId: "run-1",
+      evalSuiteId: "suite-1",
+      evalSuiteVersion: 1,
+    },
+  };
+
+  it("detects an agentConfig change", () => {
+    const after: AgentReleaseConstituents = {
+      ...base,
+      agentConfig: { sourceId: "reg-1", content: "v2", digest: "d2" },
+    };
+    const { changes } = releaseDiff(base, after);
+    expect(changes.some((c) => c.kind === "agentConfig")).toBe(true);
+  });
+
+  it("detects a prompt content change with a line-level diff", () => {
+    const after: AgentReleaseConstituents = {
+      ...base,
+      promptVersions: {
+        system: {
+          sourceId: "p-system",
+          content: "line1\nCHANGED",
+          digest: "dp2",
+        },
+      },
+    };
+    const { changes } = releaseDiff(base, after);
+    const promptChange = changes.find(
+      (c) => c.kind === "prompt" && c.key === "system",
+    );
+    expect(promptChange).toBeDefined();
+    expect(promptChange!.lineDiff).toBeDefined();
+    expect(
+      promptChange!.lineDiff!.some(
+        (l) => l.type === "removed" && l.text === "line2",
+      ),
+    ).toBe(true);
+    expect(
+      promptChange!.lineDiff!.some(
+        (l) => l.type === "added" && l.text === "CHANGED",
+      ),
+    ).toBe(true);
+  });
+
+  it("detects a prompt added wholesale (absent -> present)", () => {
+    const after: AgentReleaseConstituents = {
+      ...base,
+      promptVersions: {
+        ...base.promptVersions,
+        greeting: { sourceId: "p-greeting", content: "hi", digest: "dp3" },
+      },
+    };
+    const { changes } = releaseDiff(base, after);
+    const change = changes.find(
+      (c) => c.kind === "prompt" && c.key === "greeting",
+    );
+    expect(change).toBeDefined();
+    expect(change!.before).toBeUndefined();
+    expect(change!.after).toBeDefined();
+    expect(change!.lineDiff).toBeUndefined();
+  });
+
+  it("detects execSpecVersion bump", () => {
+    const after: AgentReleaseConstituents = { ...base, execSpecVersion: 2 };
+    const { changes } = releaseDiff(base, after);
+    const change = changes.find((c) => c.kind === "execSpec");
+    expect(change).toBeDefined();
+    expect(
+      (change!.before as { execSpecVersion: number }).execSpecVersion,
+    ).toBe(1);
+    expect((change!.after as { execSpecVersion: number }).execSpecVersion).toBe(
+      2,
+    );
+  });
+
+  it("detects a model config slot change", () => {
+    const after: AgentReleaseConstituents = {
+      ...base,
+      modelConfigSnapshots: [
+        { slot: "supervisor", content: "claude", digest: "dm2" },
+      ],
+    };
+    const { changes } = releaseDiff(base, after);
+    const change = changes.find(
+      (c) => c.kind === "model" && c.key === "supervisor",
+    );
+    expect(change).toBeDefined();
+  });
+
+  it("detects tool list additions and removals", () => {
+    const after: AgentReleaseConstituents = {
+      ...base,
+      toolConfigs: [{ sourceId: "tool-b", content: "toolB", digest: "dt2" }],
+    };
+    const { changes } = releaseDiff(base, after);
+    const change = changes.find((c) => c.kind === "tools");
+    expect(change).toBeDefined();
+    const before = change!.before as { onlyHere: ContentSnapshot[] };
+    const afterSide = change!.after as { onlyHere: ContentSnapshot[] };
+    expect(before.onlyHere.map((t) => t.sourceId)).toEqual(["tool-a"]);
+    expect(afterSide.onlyHere.map((t) => t.sourceId)).toEqual(["tool-b"]);
+  });
+
+  it("detects a policy field-level delta", () => {
+    const after: AgentReleaseConstituents = {
+      ...base,
+      policySnapshot: { ...base.policySnapshot, enforcementMode: "strict" },
+    };
+    const { changes } = releaseDiff(base, after);
+    const change = changes.find((c) => c.kind === "policy");
+    expect(change).toBeDefined();
+    expect(
+      (change as unknown as { fieldChanges: Record<string, unknown> })
+        .fieldChanges,
+    ).toHaveProperty("enforcementMode");
+  });
+
+  it("detects an evalEvidence pointer change", () => {
+    const after: AgentReleaseConstituents = {
+      ...base,
+      evalEvidence: {
+        evalRunId: "run-2",
+        evalSuiteId: "suite-1",
+        evalSuiteVersion: 1,
+      },
+    };
+    const { changes } = releaseDiff(base, after);
+    expect(changes.some((c) => c.kind === "evalEvidence")).toBe(true);
+  });
+
+  it("omits every unchanged constituent (identity fields only present when changed)", () => {
+    const after: AgentReleaseConstituents = { ...base, execSpecVersion: 2 };
+    const { changes } = releaseDiff(base, after);
+    expect(changes).toHaveLength(1);
+    expect(changes[0].kind).toBe("execSpec");
+  });
+});
+
+describe("diffScoreVectors — score-vector movement", () => {
+  it("reports per-dimension before->after movement, omitting identical dimensions", () => {
+    const before: DimensionAggregate[] = [
+      {
+        dimension: "task_success" as DimensionAggregate["dimension"],
+        scoredCount: 10,
+        notApplicableCount: 0,
+        unknownCount: 0,
+        pendingCount: 0,
+        passedCount: 8,
+        passRate: 0.8,
+      },
+      {
+        dimension: "latency" as DimensionAggregate["dimension"],
+        scoredCount: 10,
+        notApplicableCount: 0,
+        unknownCount: 0,
+        pendingCount: 0,
+        p50: 100,
+        p95: 200,
+      },
+    ];
+    const after: DimensionAggregate[] = [
+      {
+        dimension: "task_success" as DimensionAggregate["dimension"],
+        scoredCount: 10,
+        notApplicableCount: 0,
+        unknownCount: 0,
+        pendingCount: 0,
+        passedCount: 9,
+        passRate: 0.9,
+      },
+      {
+        dimension: "latency" as DimensionAggregate["dimension"],
+        scoredCount: 10,
+        notApplicableCount: 0,
+        unknownCount: 0,
+        pendingCount: 0,
+        p50: 100,
+        p95: 200,
+      },
+    ];
+    const movements = diffScoreVectors(before, after);
+    expect(movements).toHaveLength(1);
+    expect(movements[0].dimension).toBe("task_success");
+    expect(movements[0].before?.passRate).toBe(0.8);
+    expect(movements[0].after?.passRate).toBe(0.9);
+  });
+
+  it("reports a dimension present only on one side with the other side null", () => {
+    const before: DimensionAggregate[] = [];
+    const after: DimensionAggregate[] = [
+      {
+        dimension: "cost" as DimensionAggregate["dimension"],
+        scoredCount: 5,
+        notApplicableCount: 0,
+        unknownCount: 0,
+        pendingCount: 0,
+        sumUsd: 1.5,
+        meanUsd: 0.3,
+      },
+    ];
+    const movements = diffScoreVectors(before, after);
+    expect(movements).toHaveLength(1);
+    expect(movements[0].before).toBeNull();
+    expect(movements[0].after?.sumUsd).toBe(1.5);
+  });
+
+  it("returns no movement for identical vectors regardless of order", () => {
+    const a: DimensionAggregate[] = [
+      {
+        dimension: "cost" as DimensionAggregate["dimension"],
+        scoredCount: 5,
+        notApplicableCount: 0,
+        unknownCount: 0,
+        pendingCount: 0,
+        sumUsd: 1,
+        meanUsd: 0.2,
+      },
+      {
+        dimension: "latency" as DimensionAggregate["dimension"],
+        scoredCount: 5,
+        notApplicableCount: 0,
+        unknownCount: 0,
+        pendingCount: 0,
+        p50: 1,
+        p95: 2,
+      },
+    ];
+    const b = [a[1], a[0]];
+    expect(diffScoreVectors(a, b)).toEqual([]);
+  });
+
+  it("diffScoreVectorChange returns null when there is no movement", () => {
+    const v: DimensionAggregate[] = [
+      {
+        dimension: "cost" as DimensionAggregate["dimension"],
+        scoredCount: 5,
+        notApplicableCount: 0,
+        unknownCount: 0,
+        pendingCount: 0,
+        sumUsd: 1,
+        meanUsd: 0.2,
+      },
+    ];
+    expect(diffScoreVectorChange(v, v)).toBeNull();
+  });
+});
+
+describe("releaseDiffWithScoreVectors", () => {
+  const base: AgentReleaseConstituents = {
+    agentConfig: { sourceId: "reg-1", content: "v1", digest: "d1" },
+    promptVersions: {},
+    execSpecId: "spec-1",
+    execSpecVersion: 1,
+    modelConfigSnapshots: [],
+    toolConfigs: [],
+    policySnapshot: {
+      enforcementMode: "shadow",
+      ruleSetVersion: "v1",
+      authorityUnitGrantIds: [],
+    },
+    evalEvidence: {
+      evalRunId: "run-1",
+      evalSuiteId: "suite-1",
+      evalSuiteVersion: 1,
+    },
+  };
+
+  it("folds score-vector movement into the same ReleaseDiffChange[] shape", () => {
+    const scoreA: DimensionAggregate[] = [
+      {
+        dimension: "cost" as DimensionAggregate["dimension"],
+        scoredCount: 5,
+        notApplicableCount: 0,
+        unknownCount: 0,
+        pendingCount: 0,
+        sumUsd: 1,
+        meanUsd: 0.2,
+      },
+    ];
+    const scoreB: DimensionAggregate[] = [
+      {
+        dimension: "cost" as DimensionAggregate["dimension"],
+        scoredCount: 5,
+        notApplicableCount: 0,
+        unknownCount: 0,
+        pendingCount: 0,
+        sumUsd: 2,
+        meanUsd: 0.4,
+      },
+    ];
+    const result = releaseDiffWithScoreVectors(base, base, scoreA, scoreB);
+    expect(result.changes).toHaveLength(1);
+    expect(result.changes[0].kind).toBe("scoreVector");
+  });
+
+  it("produces no scoreVector entry when constituents AND score vectors are identical", () => {
+    const scoreA: DimensionAggregate[] = [
+      {
+        dimension: "cost" as DimensionAggregate["dimension"],
+        scoredCount: 5,
+        notApplicableCount: 0,
+        unknownCount: 0,
+        pendingCount: 0,
+        sumUsd: 1,
+        meanUsd: 0.2,
+      },
+    ];
+    const result = releaseDiffWithScoreVectors(base, base, scoreA, scoreA);
+    expect(result.changes).toEqual([]);
+  });
+});
+
+describe("releaseDiff — constituent-key exhaustiveness guard", () => {
+  it("accepts every arbitrary AgentReleaseConstituents bundle (full key coverage)", () => {
+    fc.assert(
+      fc.property(agentReleaseConstituentsArb, (bundle) => {
+        // Mirrors the feedback-round-1 concern: verify every key
+        // AgentReleaseConstituents is expected to carry is
+        // actually present, using a real generated bundle
+        // rather than a hand-maintained list. If a field is
+        // ever added to AgentReleaseConstituents without a
+        // corresponding CONSTITUENT_KEY_COVERAGE entry, the
+        // compile-time `satisfies` guard fails to build first;
+        // this runtime check additionally catches a bundle
+        // that is missing a key at the object-shape level
+        // (e.g. constructed via an unsafe cast).
+        expect(() => assertConstituentKeyCoverage(bundle)).not.toThrow();
+        // Also confirms the guard is wired into releaseDiff
+        // itself, not just exposed as a standalone helper.
+        expect(() => releaseDiff(bundle, bundle)).not.toThrow();
+      }),
+    );
+  });
+
+  it("accepts a full AgentRelease row (superset of AgentReleaseConstituents) — real callers pass this shape", () => {
+    // release-diff-resolver.ts and environment-release-pointer-
+    // resolver.ts both call releaseDiff with full AgentRelease rows
+    // (releaseId, orgId, semver, createdAt, ... on top of the pure
+    // constituents). The guard must not reject legitimate extra
+    // fields — only a MISSING constituent key is a real gap.
+    const bundle = {
+      agentConfig: { sourceId: "reg-1", content: "x", digest: "d1" },
+      promptVersions: {},
+      execSpecId: "spec-1",
+      execSpecVersion: 1,
+      modelConfigSnapshots: [],
+      toolConfigs: [],
+      policySnapshot: {
+        enforcementMode: "shadow",
+        ruleSetVersion: "v1",
+        authorityUnitGrantIds: [],
+      },
+      evalEvidence: {
+        evalRunId: "run-1",
+        evalSuiteId: "suite-1",
+        evalSuiteVersion: 1,
+      },
+      releaseId: "release-1",
+      orgId: "org-1",
+      agentTargetId: "agent-1",
+      semver: "1.0.0",
+      createdAt: "2026-01-01T00:00:00.000Z",
+      createdBy: "architect-1",
+      gitSha: "abc123",
+      region: "us-east-1",
+      runId: "runid-1",
+    };
+    expect(() => assertConstituentKeyCoverage(bundle)).not.toThrow();
+  });
+
+  it("rejects a bundle missing a required constituent key", () => {
+    const bundle: AgentReleaseConstituents = {
+      agentConfig: { sourceId: "reg-1", content: "x", digest: "d1" },
+      promptVersions: {},
+      execSpecId: "spec-1",
+      execSpecVersion: 1,
+      modelConfigSnapshots: [],
+      toolConfigs: [],
+      policySnapshot: {
+        enforcementMode: "shadow",
+        ruleSetVersion: "v1",
+        authorityUnitGrantIds: [],
+      },
+      evalEvidence: {
+        evalRunId: "run-1",
+        evalSuiteId: "suite-1",
+        evalSuiteVersion: 1,
+      },
+    };
+    // Simulates a bundle constructed via an unsafe cast that drops
+    // a required constituent — must be caught at runtime rather
+    // than silently producing a diff that omits it.
+    const { policySnapshot: _dropped, ...missingPolicy } = bundle;
+    const withMissingKey = missingPolicy as unknown as AgentReleaseConstituents;
+    expect(() => assertConstituentKeyCoverage(withMissingKey)).toThrow(
+      /policySnapshot/,
+    );
+    expect(() => releaseDiff(withMissingKey, bundle)).toThrow(/policySnapshot/);
+  });
+});
+
+describe("truncation path", () => {
+  it("truncates an oversized constituent and never throws", () => {
+    const hugeContent = "x".repeat(MAX_CONSTITUENT_DIFF_BYTES + 1000);
+    const before: AgentReleaseConstituents = {
+      agentConfig: { sourceId: "reg-1", content: "small", digest: "d1" },
+      promptVersions: {},
+      execSpecId: "spec-1",
+      execSpecVersion: 1,
+      modelConfigSnapshots: [],
+      toolConfigs: [],
+      policySnapshot: {
+        enforcementMode: "shadow",
+        ruleSetVersion: "v1",
+        authorityUnitGrantIds: [],
+      },
+      evalEvidence: {
+        evalRunId: "run-1",
+        evalSuiteId: "suite-1",
+        evalSuiteVersion: 1,
+      },
+    };
+    const after: AgentReleaseConstituents = {
+      ...before,
+      agentConfig: { sourceId: "reg-1", content: hugeContent, digest: "d2" },
+    };
+    expect(() => releaseDiff(before, after)).not.toThrow();
+    const { changes } = releaseDiff(before, after);
+    const change = changes.find((c) => c.kind === "agentConfig")!;
+    expect(change.truncated).toBe(true);
+    expect(change.lineDiff).toBeUndefined();
+  });
+
+  it("does NOT truncate a constituent under the size cap", () => {
+    const before: AgentReleaseConstituents = {
+      agentConfig: { sourceId: "reg-1", content: "small-before", digest: "d1" },
+      promptVersions: {},
+      execSpecId: "spec-1",
+      execSpecVersion: 1,
+      modelConfigSnapshots: [],
+      toolConfigs: [],
+      policySnapshot: {
+        enforcementMode: "shadow",
+        ruleSetVersion: "v1",
+        authorityUnitGrantIds: [],
+      },
+      evalEvidence: {
+        evalRunId: "run-1",
+        evalSuiteId: "suite-1",
+        evalSuiteVersion: 1,
+      },
+    };
+    const after: AgentReleaseConstituents = {
+      ...before,
+      agentConfig: { sourceId: "reg-1", content: "small-after", digest: "d2" },
+    };
+    const { changes } = releaseDiff(before, after);
+    const change = changes.find((c) => c.kind === "agentConfig")!;
+    expect(change.truncated).toBeFalsy();
+  });
+});
+
+describe("diffLines", () => {
+  it("returns pure context entries for identical text", () => {
+    const entries = diffLines("a\nb\nc", "a\nb\nc");
+    expect(entries.every((e) => e.type === "context")).toBe(true);
+  });
+
+  it("detects an added line", () => {
+    const entries = diffLines("a\nb", "a\nb\nc");
+    expect(entries.some((e) => e.type === "added" && e.text === "c")).toBe(
+      true,
+    );
+  });
+
+  it("detects a removed line", () => {
+    const entries = diffLines("a\nb\nc", "a\nc");
+    expect(entries.some((e) => e.type === "removed" && e.text === "b")).toBe(
+      true,
+    );
+  });
+});

--- a/backend/src/lambda/utils/__tests__/release-diff.test.ts
+++ b/backend/src/lambda/utils/__tests__/release-diff.test.ts
@@ -99,10 +99,7 @@ const agentReleaseConstituentsArb: fc.Arbitrary<AgentReleaseConstituents> =
     evalEvidence: evalEvidenceArb,
   });
 
-function swap<T>(
-  change: ReleaseDiffChange,
-  field: "before" | "after",
-): unknown {
+function swap(change: ReleaseDiffChange, field: "before" | "after"): unknown {
   return change[field];
 }
 

--- a/backend/src/lambda/utils/release-diff.ts
+++ b/backend/src/lambda/utils/release-diff.ts
@@ -1,0 +1,662 @@
+/**
+ * release-diff.ts — pure, per-constituent semantic diff between two
+ * AgentRelease bundles (releaseDiff(a, b)).
+ *
+ * Grounded in AgentReleaseConstituents (../../types.ts) and
+ * release-hash.ts's Class A / Class B split:
+ *   - agentConfig (ContentSnapshot)            -> constituent "agentConfig"
+ *   - promptVersions (Record<name, ContentSnapshot>) -> one constituent
+ *     PER PROMPT NAME, "prompt:<name>" — a single prompt edit must not
+ *     force every other prompt into the diff.
+ *   - execSpecId/execSpecVersion (Class A, pinned by reference)
+ *                                               -> constituent "execSpec"
+ *   - modelConfigSnapshots (ModelConfigSnapshot[]) -> one constituent PER
+ *     SLOT, "model:<slot>"
+ *   - toolConfigs (ContentSnapshot[])           -> constituent "tools"
+ *     (list membership ± — see design note below)
+ *   - policySnapshot (PolicySnapshot)           -> constituent "policy"
+ *     (field-level delta)
+ *   - evalEvidence (AgentReleaseEvalEvidence, pointer-only) -> constituent
+ *     "evalEvidence". Score-vector movement is NOT computed here — this
+ *     module is pure and has no I/O, and the score vector lives on the
+ *     (out-of-bundle) EvalRun row, not on AgentReleaseConstituents. The
+ *     resolver layer (release-diff-resolver.ts) resolves each side's
+ *     EvalRun.scoreAggregates and passes them in via `scoreVectorA` /
+ *     `scoreVectorB` on ReleaseDiffOptions — see diffScoreVectors below,
+ *     which IS pure (DimensionAggregate[] in, delta out).
+ *
+ * Semantics (per task spec):
+ *   - Only CHANGED constituents are enumerated; unchanged ones are
+ *     omitted entirely from the result.
+ *   - diff(a, a) === { changes: [] } for ANY bundle (identity).
+ *   - diff(a, b) and diff(b, a) enumerate the IDENTICAL set of changed
+ *     constituent keys, with before/after swapped on every field
+ *     (symmetric-inverse).
+ *
+ * Equality is by content, not by object identity — mirrors
+ * release-hash.ts's own canonicalization discipline (structurally-equal
+ * input, e.g. differently-key-ordered policySnapshot, must never appear
+ * as a spurious diff). Two ContentSnapshot values are equal when their
+ * `digest` is equal (the digest IS the content-equality witness — same
+ * doctrine as release-store.ts's content-addressing).
+ */
+import type {
+  AgentReleaseConstituents,
+  ContentSnapshot,
+  ModelConfigSnapshot,
+  PolicySnapshot,
+  AgentReleaseEvalEvidence,
+} from "../../types";
+import type { DimensionAggregate } from "./eval-score-aggregate";
+import type { DimensionName } from "./eval-scoring";
+
+/** Per-constituent size cap before truncation kicks in (bytes of the
+ * JSON-stringified before/after pair). Mirrors eval-resolver.ts's /
+ * eval-comparison-resolver.ts's MAX_JSON_FIELD_BYTES precedent (256KB) —
+ * reused verbatim rather than inventing a new cap. */
+export const MAX_CONSTITUENT_DIFF_BYTES = 256 * 1024;
+
+export type ReleaseDiffConstituentKind =
+  | "agentConfig"
+  | "prompt"
+  | "execSpec"
+  | "model"
+  | "tools"
+  | "policy"
+  | "evalEvidence"
+  | "scoreVector";
+
+/** Exhaustiveness guard: maps every key of AgentReleaseConstituents to
+ * the ReleaseDiffConstituentKind that covers it (execSpecId and
+ * execSpecVersion both map to the single "execSpec" constituent; every
+ * other field maps 1:1). Compiler-enforced via `satisfies` below — if a
+ * future field is added to AgentReleaseConstituents in ../../types
+ * without a corresponding entry here, this fails to compile, so a new
+ * bundle field can never be silently dropped from releaseDiff (the
+ * feedback-round-1 exhaustiveness finding). Kept next to
+ * ReleaseDiffConstituentKind, not exported — it exists purely as a
+ * compile-time trip-wire and a source for the runtime coverage test. */
+const CONSTITUENT_KEY_COVERAGE = {
+  agentConfig: "agentConfig",
+  promptVersions: "prompt",
+  execSpecId: "execSpec",
+  execSpecVersion: "execSpec",
+  modelConfigSnapshots: "model",
+  toolConfigs: "tools",
+  policySnapshot: "policy",
+  evalEvidence: "evalEvidence",
+} satisfies Record<keyof AgentReleaseConstituents, ReleaseDiffConstituentKind>;
+
+/** Runtime counterpart to the compile-time guard above. Real callers
+ * (release-diff-resolver.ts, environment-release-pointer-resolver.ts)
+ * pass full `AgentRelease` rows — which structurally extend
+ * AgentReleaseConstituents with extra fields like releaseId, orgId,
+ * createdAt, etc. — directly into releaseDiff, so this must NOT reject
+ * a bundle merely for carrying keys beyond AgentReleaseConstituents.
+ * What it guards against is the opposite direction: a bundle that is
+ * MISSING a key CONSTITUENT_KEY_COVERAGE expects (i.e. a future field
+ * added to AgentReleaseConstituents without a matching diff branch
+ * would show up here as an expected key that never appears on any real
+ * bundle key set drift check — see the test suite, which iterates
+ * Object.keys(bundle) filtered to keys AgentReleaseConstituents is
+ * expected to own). Exported so tests can assert coverage directly.
+ * Throws rather than silently ignoring, because a gap here means
+ * releaseDiff's output would otherwise omit a real change. */
+export function assertConstituentKeyCoverage(
+  bundle: AgentReleaseConstituents,
+): void {
+  const expectedKeys = Object.keys(
+    CONSTITUENT_KEY_COVERAGE,
+  ) as (keyof AgentReleaseConstituents)[];
+  const missingKeys = expectedKeys.filter(
+    (k) => !Object.prototype.hasOwnProperty.call(bundle, k),
+  );
+  if (missingKeys.length > 0) {
+    throw new Error(
+      `release-diff: bundle is missing constituent key(s) required for diffing: ${missingKeys.join(", ")}`,
+    );
+  }
+}
+
+export interface DimensionMovement {
+  dimension: DimensionName;
+  before: DimensionAggregate | null;
+  after: DimensionAggregate | null;
+}
+
+/** One line-level diff entry, "context" | "added" | "removed". Used for
+ * prompt text and any other line-oriented content. */
+export interface LineDiffEntry {
+  type: "context" | "added" | "removed";
+  /** 1-based line number in the SIDE this entry's type refers to
+   * (before-side for "removed"/"context", after-side for "added"). */
+  line: number;
+  text: string;
+}
+
+/** A single changed constituent. `before`/`after` are omitted (left
+ * undefined) when the constituent did not exist on that side at all
+ * (e.g. a prompt/model-slot/tool added or removed wholesale) — this is
+ * distinct from an empty-string value, so callers can tell "absent" from
+ * "present but empty". */
+export interface ReleaseDiffChange {
+  kind: ReleaseDiffConstituentKind;
+  /** Stable identifier within `kind` — prompt name, model slot, tool
+   * sourceId, or the constituent kind itself for singleton constituents
+   * (agentConfig, execSpec, policy, evalEvidence, scoreVector). */
+  key: string;
+  before?: unknown;
+  after?: unknown;
+  /** Present only for kind "prompt" — line-level diff of the prompt
+   * text. Absent when either side lacks the prompt (added/removed
+   * wholesale) or when truncated. */
+  lineDiff?: LineDiffEntry[];
+  /** Present only for kind "policy" — precise field-level breakdown
+   * (field name -> {before, after}) so a consumer never has to re-diff
+   * the full before/after PolicySnapshot itself. */
+  fieldChanges?: Record<string, { before: unknown; after: unknown }>;
+  /** Present only for kind "scoreVector" — the full per-dimension
+   * DimensionMovement[] breakdown. */
+  movements?: DimensionMovement[];
+  /** True when this constituent's before/after (and lineDiff, if any)
+   * were large enough to exceed MAX_CONSTITUENT_DIFF_BYTES and were
+   * dropped in favor of a lightweight summary. A truncated entry never
+   * causes the diff computation itself to fail. */
+  truncated?: boolean;
+}
+
+export interface ReleaseDiffResult {
+  changes: ReleaseDiffChange[];
+}
+
+// ---------------------------------------------------------------------
+// Line-level text diff (no external dependency — package.json carries
+// no `diff`/`diff-match-patch`/etc. library; a short, LCS-based
+// line-diff is implemented locally).
+// ---------------------------------------------------------------------
+
+/**
+ * Classic LCS-based line diff, O(n*m) time/space over line counts. Fine
+ * for prompt text (bounded, human-authored) — NOT intended for
+ * arbitrarily large inputs, which is exactly what the truncation path
+ * above guards against before this function is ever reached.
+ */
+export function diffLines(before: string, after: string): LineDiffEntry[] {
+  const beforeLines = before.split("\n");
+  const afterLines = after.split("\n");
+  const n = beforeLines.length;
+  const m = afterLines.length;
+
+  // lcs[i][j] = length of the LCS of beforeLines[i:] and afterLines[j:]
+  const lcs: number[][] = Array.from({ length: n + 1 }, () =>
+    new Array<number>(m + 1).fill(0),
+  );
+  for (let i = n - 1; i >= 0; i--) {
+    for (let j = m - 1; j >= 0; j--) {
+      lcs[i][j] =
+        beforeLines[i] === afterLines[j]
+          ? lcs[i + 1][j + 1] + 1
+          : Math.max(lcs[i + 1][j], lcs[i][j + 1]);
+    }
+  }
+
+  const entries: LineDiffEntry[] = [];
+  let i = 0;
+  let j = 0;
+  let beforeLineNo = 1;
+  let afterLineNo = 1;
+  while (i < n && j < m) {
+    if (beforeLines[i] === afterLines[j]) {
+      entries.push({
+        type: "context",
+        line: beforeLineNo,
+        text: beforeLines[i],
+      });
+      i++;
+      j++;
+      beforeLineNo++;
+      afterLineNo++;
+    } else if (lcs[i + 1][j] >= lcs[i][j + 1]) {
+      entries.push({
+        type: "removed",
+        line: beforeLineNo,
+        text: beforeLines[i],
+      });
+      i++;
+      beforeLineNo++;
+    } else {
+      entries.push({ type: "added", line: afterLineNo, text: afterLines[j] });
+      j++;
+      afterLineNo++;
+    }
+  }
+  while (i < n) {
+    entries.push({ type: "removed", line: beforeLineNo, text: beforeLines[i] });
+    i++;
+    beforeLineNo++;
+  }
+  while (j < m) {
+    entries.push({ type: "added", line: afterLineNo, text: afterLines[j] });
+    j++;
+    afterLineNo++;
+  }
+  return entries;
+}
+
+function byteLength(value: unknown): number {
+  return Buffer.byteLength(JSON.stringify(value) ?? "", "utf8");
+}
+
+/** Applies the truncation contract to a candidate change: if the
+ * before/after (+ lineDiff, when present) payload exceeds
+ * MAX_CONSTITUENT_DIFF_BYTES, replace it with a size-only summary and
+ * set truncated=true. Never throws — a diff must never fail because a
+ * constituent is large (task spec: "approval must never fail because a
+ * diff is large"). */
+function applyTruncation(change: ReleaseDiffChange): ReleaseDiffChange {
+  const payloadBytes = byteLength({
+    before: change.before,
+    after: change.after,
+    lineDiff: change.lineDiff,
+  });
+  if (payloadBytes <= MAX_CONSTITUENT_DIFF_BYTES) {
+    return change;
+  }
+  const summary = (value: unknown): unknown => {
+    if (value === undefined) return undefined;
+    return { truncatedSummaryBytes: byteLength(value) };
+  };
+  return {
+    kind: change.kind,
+    key: change.key,
+    before: summary(change.before),
+    after: summary(change.after),
+    truncated: true,
+  };
+}
+
+// ---------------------------------------------------------------------
+// Per-constituent diffing
+// ---------------------------------------------------------------------
+
+function contentSnapshotEqual(
+  a: ContentSnapshot | undefined,
+  b: ContentSnapshot | undefined,
+): boolean {
+  if (a === undefined && b === undefined) return true;
+  if (a === undefined || b === undefined) return false;
+  return a.digest === b.digest;
+}
+
+function diffAgentConfig(
+  before: ContentSnapshot,
+  after: ContentSnapshot,
+): ReleaseDiffChange | null {
+  if (contentSnapshotEqual(before, after)) return null;
+  return applyTruncation({
+    kind: "agentConfig",
+    key: "agentConfig",
+    before,
+    after,
+    lineDiff: diffLines(before.content, after.content),
+  });
+}
+
+function diffPrompts(
+  before: Record<string, ContentSnapshot>,
+  after: Record<string, ContentSnapshot>,
+): ReleaseDiffChange[] {
+  const names = new Set<string>([
+    ...Object.keys(before ?? {}),
+    ...Object.keys(after ?? {}),
+  ]);
+  const changes: ReleaseDiffChange[] = [];
+  for (const name of names) {
+    const b = before?.[name];
+    const a = after?.[name];
+    if (contentSnapshotEqual(b, a)) continue;
+    changes.push(
+      applyTruncation({
+        kind: "prompt",
+        key: name,
+        before: b,
+        after: a,
+        // lineDiff only makes sense when both sides exist — a wholesale
+        // add/remove has no meaningful before-vs-after text to diff.
+        ...(b !== undefined && a !== undefined
+          ? { lineDiff: diffLines(b.content, a.content) }
+          : {}),
+      }),
+    );
+  }
+  return changes.sort((x, y) => x.key.localeCompare(y.key));
+}
+
+function diffExecSpec(
+  before: AgentReleaseConstituents,
+  after: AgentReleaseConstituents,
+): ReleaseDiffChange | null {
+  if (
+    before.execSpecId === after.execSpecId &&
+    before.execSpecVersion === after.execSpecVersion
+  ) {
+    return null;
+  }
+  return applyTruncation({
+    kind: "execSpec",
+    key: "execSpec",
+    before: {
+      execSpecId: before.execSpecId,
+      execSpecVersion: before.execSpecVersion,
+    },
+    after: {
+      execSpecId: after.execSpecId,
+      execSpecVersion: after.execSpecVersion,
+    },
+  });
+}
+
+function modelSnapshotEqual(
+  a: ModelConfigSnapshot | undefined,
+  b: ModelConfigSnapshot | undefined,
+): boolean {
+  if (a === undefined && b === undefined) return true;
+  if (a === undefined || b === undefined) return false;
+  return a.digest === b.digest;
+}
+
+function diffModelConfigs(
+  before: ModelConfigSnapshot[],
+  after: ModelConfigSnapshot[],
+): ReleaseDiffChange[] {
+  const beforeBySlot = new Map(before.map((m) => [m.slot, m]));
+  const afterBySlot = new Map(after.map((m) => [m.slot, m]));
+  const slots = new Set<string>([
+    ...beforeBySlot.keys(),
+    ...afterBySlot.keys(),
+  ]);
+  const changes: ReleaseDiffChange[] = [];
+  for (const slot of slots) {
+    const b = beforeBySlot.get(slot);
+    const a = afterBySlot.get(slot);
+    if (modelSnapshotEqual(b, a)) continue;
+    changes.push(
+      applyTruncation({ kind: "model", key: slot, before: b, after: a }),
+    );
+  }
+  return changes.sort((x, y) => x.key.localeCompare(y.key));
+}
+
+/** Tool list ± — membership delta keyed by sourceId (a tool's stable
+ * identity per ContentSnapshot), plus a content change for a tool whose
+ * sourceId is present on both sides but whose digest differs. Emitted as
+ * ONE "tools" constituent (task spec: "tool list ±") carrying the full
+ * present/changed breakdown, rather than one entry per tool — a
+ * single-tool add/remove is still one semantic change to "the tool
+ * list".
+ *
+ * SYMMETRIC SHAPE (required for the diff(a,b)/diff(b,a) swap contract):
+ * both `before` and `after` carry the SAME field names —
+ * `{ onlyHere: ContentSnapshot[]; changed: {sourceId, snapshot}[] }` —
+ * where `onlyHere` is "present on this side, absent on the other" (so
+ * before.onlyHere = removed, after.onlyHere = added, and swapping before
+ * <-> after in a reversed diff() call correctly swaps "removed" for
+ * "added"), and `changed` carries THIS side's snapshot for every
+ * sourceId present-but-different on both sides. */
+function diffTools(
+  before: ContentSnapshot[],
+  after: ContentSnapshot[],
+): ReleaseDiffChange | null {
+  const beforeById = new Map(before.map((t) => [t.sourceId, t]));
+  const afterById = new Map(after.map((t) => [t.sourceId, t]));
+
+  const onlyBefore: ContentSnapshot[] = [];
+  const onlyAfter: ContentSnapshot[] = [];
+  const changedBefore: Array<{ sourceId: string; snapshot: ContentSnapshot }> =
+    [];
+  const changedAfter: Array<{ sourceId: string; snapshot: ContentSnapshot }> =
+    [];
+
+  for (const [id, a] of afterById) {
+    const b = beforeById.get(id);
+    if (b === undefined) {
+      onlyAfter.push(a);
+    } else if (!contentSnapshotEqual(b, a)) {
+      changedBefore.push({ sourceId: id, snapshot: b });
+      changedAfter.push({ sourceId: id, snapshot: a });
+    }
+  }
+  for (const [id, b] of beforeById) {
+    if (!afterById.has(id)) {
+      onlyBefore.push(b);
+    }
+  }
+
+  if (
+    onlyBefore.length === 0 &&
+    onlyAfter.length === 0 &&
+    changedBefore.length === 0
+  ) {
+    return null;
+  }
+
+  const sortBySourceId = <T extends { sourceId: string }>(arr: T[]): T[] =>
+    [...arr].sort((x, y) => x.sourceId.localeCompare(y.sourceId));
+
+  return applyTruncation({
+    kind: "tools",
+    key: "tools",
+    before: {
+      onlyHere: sortBySourceId(onlyBefore),
+      changed: sortBySourceId(changedBefore),
+    },
+    after: {
+      onlyHere: sortBySourceId(onlyAfter),
+      changed: sortBySourceId(changedAfter),
+    },
+  });
+}
+
+function diffPolicy(
+  before: PolicySnapshot,
+  after: PolicySnapshot,
+): ReleaseDiffChange | null {
+  const fieldChanges: Record<string, { before: unknown; after: unknown }> = {};
+
+  if (before.enforcementMode !== after.enforcementMode) {
+    fieldChanges.enforcementMode = {
+      before: before.enforcementMode,
+      after: after.enforcementMode,
+    };
+  }
+  if (before.ruleSetVersion !== after.ruleSetVersion) {
+    fieldChanges.ruleSetVersion = {
+      before: before.ruleSetVersion,
+      after: after.ruleSetVersion,
+    };
+  }
+  const beforeGrants = new Set(before.authorityUnitGrantIds ?? []);
+  const afterGrants = new Set(after.authorityUnitGrantIds ?? []);
+  const grantsAdded = [...afterGrants]
+    .filter((g) => !beforeGrants.has(g))
+    .sort();
+  const grantsRemoved = [...beforeGrants]
+    .filter((g) => !afterGrants.has(g))
+    .sort();
+  if (grantsAdded.length > 0 || grantsRemoved.length > 0) {
+    fieldChanges.authorityUnitGrantIds = {
+      before: grantsRemoved,
+      after: grantsAdded,
+    };
+  }
+
+  if (Object.keys(fieldChanges).length === 0) return null;
+
+  return applyTruncation({
+    kind: "policy",
+    key: "policy",
+    before,
+    after,
+    fieldChanges,
+  });
+}
+
+function evalEvidenceEqual(
+  a: AgentReleaseEvalEvidence,
+  b: AgentReleaseEvalEvidence,
+): boolean {
+  return (
+    a.evalRunId === b.evalRunId &&
+    a.evalSuiteId === b.evalSuiteId &&
+    a.evalSuiteVersion === b.evalSuiteVersion
+  );
+}
+
+function diffEvalEvidence(
+  before: AgentReleaseEvalEvidence,
+  after: AgentReleaseEvalEvidence,
+): ReleaseDiffChange | null {
+  if (evalEvidenceEqual(before, after)) return null;
+  return applyTruncation({
+    kind: "evalEvidence",
+    key: "evalEvidence",
+    before,
+    after,
+  });
+}
+
+// ---------------------------------------------------------------------
+// Score-vector movement (I/O-free: takes already-resolved
+// DimensionAggregate[] for each side — the resolver layer is
+// responsible for reading each side's EvalRun.scoreAggregates, since
+// AgentReleaseConstituents.evalEvidence is a pointer, not the vector
+// itself). DimensionMovement is declared earlier in this file (used by
+// ReleaseDiffChange.movements).
+// ---------------------------------------------------------------------
+
+/** Per-dimension before->after movement. A dimension present on only
+ * one side is reported with the other side null (never fabricated as a
+ * zeroed aggregate). Dimensions with byte-identical aggregates on both
+ * sides are omitted, matching the "unchanged constituents omitted"
+ * doctrine used everywhere else in this module. */
+export function diffScoreVectors(
+  before: DimensionAggregate[],
+  after: DimensionAggregate[],
+): DimensionMovement[] {
+  const beforeByDim = new Map<DimensionName, DimensionAggregate>(
+    before.map((d) => [d.dimension, d]),
+  );
+  const afterByDim = new Map<DimensionName, DimensionAggregate>(
+    after.map((d) => [d.dimension, d]),
+  );
+  const dims = new Set<DimensionName>([
+    ...beforeByDim.keys(),
+    ...afterByDim.keys(),
+  ]);
+  const movements: DimensionMovement[] = [];
+  for (const dim of dims) {
+    const b = beforeByDim.get(dim) ?? null;
+    const a = afterByDim.get(dim) ?? null;
+    if (b !== null && a !== null && JSON.stringify(b) === JSON.stringify(a)) {
+      continue;
+    }
+    movements.push({ dimension: dim, before: b, after: a });
+  }
+  return movements.sort((x, y) => x.dimension.localeCompare(y.dimension));
+}
+
+/** Wraps diffScoreVectors's output as a ReleaseDiffChange (kind
+ * "scoreVector") for callers that want score-vector movement folded into
+ * the same ReleaseDiffChange[] shape as every other constituent — e.g.
+ * releaseDiffWithScoreVectors below. Returns null when there is no
+ * movement (mirrors every other diff* function's "unchanged -> null"
+ * contract). */
+export function diffScoreVectorChange(
+  before: DimensionAggregate[],
+  after: DimensionAggregate[],
+): ReleaseDiffChange | null {
+  const movements = diffScoreVectors(before, after);
+  if (movements.length === 0) return null;
+  return applyTruncation({
+    kind: "scoreVector",
+    key: "scoreVector",
+    before: movements.map((m) => m.before),
+    after: movements.map((m) => m.after),
+    movements,
+  });
+}
+
+// ---------------------------------------------------------------------
+// Public entry points
+// ---------------------------------------------------------------------
+
+/**
+ * Pure per-constituent semantic diff between two AgentRelease bundles'
+ * constituents. Does NOT cover score-vector movement (that requires
+ * resolving each side's EvalRun — I/O — see releaseDiffWithScoreVectors
+ * below and the resolver layer). Every changed constituent is
+ * enumerated with before/after (or a truncated summary); unchanged
+ * constituents are omitted entirely.
+ *
+ * diff(a, a) === { changes: [] } for ANY bundle (reflexivity — every
+ * per-constituent comparison above is a content-equality check, so a
+ * bundle diffed against itself produces zero changes regardless of
+ * ordering/content). diff(a, b) and diff(b, a) enumerate the identical
+ * set of (kind, key) pairs with before/after swapped (symmetric-inverse
+ * — every diff* helper above is called with (before, after) in the same
+ * position for both invocations, and every field emitted is exactly one
+ * of {before, after} swapped, or a set-symmetric-difference computation
+ * that is itself symmetric under swap, e.g. tools' added<->removed and
+ * policy's grantsAdded<->grantsRemoved).
+ */
+export function releaseDiff(
+  a: AgentReleaseConstituents,
+  b: AgentReleaseConstituents,
+): ReleaseDiffResult {
+  assertConstituentKeyCoverage(a);
+  assertConstituentKeyCoverage(b);
+
+  const changes: ReleaseDiffChange[] = [];
+
+  const agentConfigChange = diffAgentConfig(a.agentConfig, b.agentConfig);
+  if (agentConfigChange) changes.push(agentConfigChange);
+
+  changes.push(...diffPrompts(a.promptVersions, b.promptVersions));
+
+  const execSpecChange = diffExecSpec(a, b);
+  if (execSpecChange) changes.push(execSpecChange);
+
+  changes.push(
+    ...diffModelConfigs(a.modelConfigSnapshots, b.modelConfigSnapshots),
+  );
+
+  const toolsChange = diffTools(a.toolConfigs, b.toolConfigs);
+  if (toolsChange) changes.push(toolsChange);
+
+  const policyChange = diffPolicy(a.policySnapshot, b.policySnapshot);
+  if (policyChange) changes.push(policyChange);
+
+  const evalEvidenceChange = diffEvalEvidence(a.evalEvidence, b.evalEvidence);
+  if (evalEvidenceChange) changes.push(evalEvidenceChange);
+
+  return { changes };
+}
+
+/** releaseDiff plus score-vector movement folded in as one additional
+ * "scoreVector" constituent — still pure (score vectors are passed in
+ * pre-resolved), for callers (the resolver, the approval-payload
+ * embedder) that want the complete change set in one array. */
+export function releaseDiffWithScoreVectors(
+  a: AgentReleaseConstituents,
+  b: AgentReleaseConstituents,
+  scoreVectorA: DimensionAggregate[],
+  scoreVectorB: DimensionAggregate[],
+): ReleaseDiffResult {
+  const base = releaseDiff(a, b);
+  const scoreVectorChange = diffScoreVectorChange(scoreVectorA, scoreVectorB);
+  return {
+    changes: scoreVectorChange
+      ? [...base.changes, scoreVectorChange]
+      : base.changes,
+  };
+}

--- a/backend/src/lambda/utils/release-promotion-approval-writer.ts
+++ b/backend/src/lambda/utils/release-promotion-approval-writer.ts
@@ -72,6 +72,19 @@ export interface ReleasePromotionApprovalInput {
   justification?: string | null;
   traceId?: string;
   runId?: string;
+  /**
+   * ADDITIVE field (grounded feature: candidate-vs-current-target-env-
+   * stable releaseDiff, embedded at approval-request creation time —
+   * see environment-release-pointer-resolver.ts's
+   * resolveCandidateVsStableDiff). Deliberately OPTIONAL and NEVER
+   * required: the call site computes this best-effort and omits it
+   * entirely on any failure (no current stable pointer yet, EvalRun
+   * read failure, etc.) rather than ever failing the approval write
+   * because a diff could not be computed. Already size-capped by
+   * release-diff.ts's own per-constituent truncation before it reaches
+   * this writer — this field is stored as-is, never re-capped here.
+   */
+  diff?: unknown;
 }
 
 function findingIdFor(input: ReleasePromotionApprovalInput): string {
@@ -135,6 +148,9 @@ export async function writeReleasePromotionApprovalFinding(
   }
   if (input.runId !== undefined) {
     item.runId = input.runId;
+  }
+  if (input.diff !== undefined) {
+    item.diff = input.diff;
   }
 
   try {

--- a/backend/src/schema/schema.graphql
+++ b/backend/src/schema/schema.graphql
@@ -94,6 +94,12 @@ type Query {
   # D". Oldest→newest; `until` (ISO-8601) bounds to promotedAt <= D. orgId
   # is the caller's own org, resolved server-side.
   environmentReleasePointerHistory(agentTargetId: ID!, environment: DeploymentEnvironment!, until: AWSDateTime): [EnvironmentReleasePointerHistoryEntry!]!
+  # releaseDiff — read-only, org-scoped semantic diff between two
+  # immutable AgentRelease bundles (release-diff-resolver.ts). Both
+  # releases must belong to the caller's own org (server-derived, not a
+  # client-supplied value). Per-constituent changes only; unchanged
+  # constituents are omitted (see ReleaseDiff type doc).
+  releaseDiff(releaseIdA: ID!, releaseIdB: ID!): ReleaseDiff!
   getEvalComparison(comparisonId: ID!): EvalComparisonVerdict
   listEvalComparisons(orgId: ID!, suiteId: ID): [EvalComparisonVerdict!]!
   getEvalComparisonThresholdConfig(orgId: ID!, suiteId: ID!): EvalComparisonThresholdConfig
@@ -2404,6 +2410,43 @@ input CutAgentReleaseInput {
   gitSha: String!
   region: String!
   runId: String!
+}
+
+# ReleaseDiff (releaseDiff query, release-diff-resolver.ts /
+# release-diff.ts) — per-constituent semantic diff between two
+# immutable AgentRelease bundles. Only CHANGED constituents appear in
+# `changes`; unchanged constituents are omitted entirely (never a
+# zero-delta entry). `before`/`after` are AWSJSON — their shape varies
+# by `kind` (see release-diff.ts's ReleaseDiffChange doc for the exact
+# per-kind payload: ContentSnapshot for agentConfig/prompt, a
+# {execSpecId, execSpecVersion} pair for execSpec, ModelConfigSnapshot
+# for model, a symmetric {onlyHere, changed} breakdown for tools, the
+# full PolicySnapshot for policy, the evalEvidence pointer for
+# evalEvidence, and a DimensionAggregate[] per side for scoreVector).
+# Either field may be null when the constituent is absent on that side
+# (added/removed wholesale, e.g. a new prompt or tool). `lineDiff`
+# (kind "prompt" only), `fieldChanges` (kind "policy" only), and
+# `movements` (kind "scoreVector" only) carry the precise structured
+# delta for those constituent kinds — all AWSJSON, all null for every
+# other kind. `truncated` is true when a constituent's payload exceeded
+# the size cap and was replaced with a byte-count-only summary — a
+# large diff can truncate individual constituents but never fails the
+# whole query.
+type ReleaseDiffChange {
+  kind: String!
+  key: String!
+  before: AWSJSON
+  after: AWSJSON
+  lineDiff: AWSJSON
+  fieldChanges: AWSJSON
+  movements: AWSJSON
+  truncated: Boolean
+}
+
+type ReleaseDiff {
+  releaseIdA: ID!
+  releaseIdB: ID!
+  changes: [ReleaseDiffChange!]!
 }
 
 # Reuses the CDK deploy-stage literal already threaded through this

--- a/docs/RELEASE_RUNBOOK.md
+++ b/docs/RELEASE_RUNBOOK.md
@@ -427,3 +427,69 @@ lets a later run re-write the finding idempotently.
 | Canary active before deploy never evaluated | Deploy-time GSI backfill gap — reweight it once to materialize the `ActiveCanaryIndex` marker (see above). |
 | `AutoRollbackFindingWriteFailure` alarm firing | An abort committed but its ledger finding write failed. The move is audited via history; re-drive the finding (idempotent id) or investigate the governance-ledger write path. |
 | Auto-rollback fired but stable changed | Should be impossible in v1 (abort-only leaves stable untouched). If observed, treat as a security incident — the auto path must only mint `AUTO_ABORT_CANARY`. |
+
+## 18. Release diff (`releaseDiff`)
+
+`releaseDiff(releaseIdA: ID!, releaseIdB: ID!): ReleaseDiff!` (Query,
+`release-diff-resolver.ts` / `release-diff.ts`) computes a **per-constituent
+semantic diff** between two immutable `AgentRelease` bundles: `agentConfig`,
+one entry per prompt name, `execSpec`, one entry per model slot, `tools`
+(list ±), `policy` (field-level delta), `evalEvidence` (pointer delta), and
+`scoreVector` (per-dimension before→after movement, resolved from each
+side's `EvalRun.scoreAggregates`). **Only changed constituents appear** —
+an unchanged constituent is omitted entirely, never returned as a
+zero-delta entry.
+
+```graphql
+query {
+  releaseDiff(releaseIdA: "release-abc", releaseIdB: "release-xyz") {
+    releaseIdA
+    releaseIdB
+    changes {
+      kind        # agentConfig | prompt | execSpec | model | tools | policy | evalEvidence | scoreVector
+      key         # constituent identity within kind (prompt name, model slot, ...)
+      before
+      after
+      lineDiff    # prompt only
+      fieldChanges # policy only
+      movements   # scoreVector only
+      truncated
+    }
+  }
+}
+```
+
+**Authz.** Read-only, org-scoped like every other release read in this
+codebase — there is no `release:read` permission (none of
+`getCurrentEnvironmentReleasePointer` / `listEnvironmentReleasePointers` /
+`environmentReleasePointerHistory` have one either); both releases must
+belong to the caller's own org or the query throws (`ReleaseNotFoundError`
+/ a distinct cross-org rejection).
+
+**Size safety.** Each changed constituent is independently capped
+(`MAX_CONSTITUENT_DIFF_BYTES`, 256KB) — an oversized constituent (e.g. a
+huge prompt) is replaced with a `truncated: true` byte-count summary
+instead of failing the query. The query itself never throws because a
+diff is large.
+
+**Embedded in the promotion approval finding, additively.** At approval
+time (§7), `validatePromotionApproval` best-effort computes
+`releaseDiff(currentStableReleaseId, candidateReleaseId)` and attaches it
+as an additive `diff` field on the `release-promotion-approval` governance
+finding, so the human approving a promotion sees the delta inline with the
+decision. This is **the only eager releaseDiff call site** in the
+codebase — every other use is on-demand via the query above. It is
+defense-in-depth size-capped a second time over the *whole* serialized
+diff (`MAX_APPROVAL_DIFF_BYTES`, 256KB, distinct from the per-constituent
+cap) and is **never blocking**: no current stable pointer yet (first
+promotion), the stable release already being the candidate (no delta), or
+any read/compute failure all resolve to simply omitting the `diff` field —
+the approval decision and its finding are recorded identically either way.
+
+**UI — API-only interim.** No release-detail surface exists in
+`frontend/src` today (grep confirms it — same interim-pattern acknowledged
+elsewhere in this epic for canary/auto-rollback: ship the API, defer the
+UI). Until a release-detail view is built, consumers read `releaseDiff`
+directly (GraphQL Explorer, or by reading the embedded `diff` field on the
+`release-promotion-approval` finding via the governance UI's existing
+finding views) rather than a dedicated diff screen.


### PR DESCRIPTION
## Summary
Agent releases are immutable, content-addressed bundles - but when an approver signs off on a promotion today, they see the candidate's identity, not what actually changed against the release currently serving the target environment. Answering "what exactly am I approving?" means manually comparing constituents across stores. This adds a first-class semantic diff and puts it in front of the approver.
## What changed
- **Pure diff module** (`utils/release-diff.ts`): per-constituent semantic diff - agent config, prompt text (Line-level LCS diff, implemented locally, no new dependency), model id/params, tool list additions/removals, policy config field deltas, and eval-evidence delta including per-dimension score-vector movement. Enumerates every changed constituent with before/after; unchanged constituents are omitted; per-constituent output is truncated at 256KB with an explicit flag; the function never throws.
- **Exhaustiveness guard**: a `satisfies Record<keyof ...›` coverage map makes any future bundle constituent a compile error if the diff doesn't handle it, backed by a runtime missing-key check - a newly added constituent cannot silently escape the diff while still being covered by the release's content hash.
-***releaseDiff(releaseIdA, releaseIdB) GraphQL query**: read-only, org-scoped (cross-org requests rejected), served by a dedicated Least-privilege Lambda (`GetItem` on two tables, nothing else).
- **Approval embedding**: when a promotion approval is written, the candidate-vs-current-stable diff is embedded additively in the approval record - capped at 256KB for the whole payload with a truncated stub, and strictly best-effort: an approval can never fail because of its diff.
- **UI**: no release-detail surface exists yet, so this is API-only for now (documented in the release runbook, consistent with the epic's interim pattern).
## Testing
- Property-based (fast-check): 'diff(a, a) is empty for arbitrary bundles; diffs are symmetric-inverse - `diff(a, b)` and `diff(b, a)` enumerate the same constituents with before/after swapped (this property caught a real structural asymmetry in the tools diff during development).
- Per-constituent coverage tests including score-vector movement; oversized approval test (2,000 changed prompts pushing past the whole-payload cap - approval still succeeds and embeds the truncated stub); exhaustiveness-guard tests (missing-key rejection, superset-input tolerance); cross-org rejection.
- `tsc --noEmit` clean; full backend suite green (6,548 tests); synth clean for both affected stacks.
## Deployment notes
Adds one read-only Lambda with a two-table `GetItem` role, plus GraphQL schema additions. Light infrastructure delta; the usual pre-merge branch deploy to dev applies.