### PR TITLE
feat(execution): durable checkpoints and resume-not-rerun

### DIFF
--- a/arbiter/stepRunner/__tests__/test_exactly_once_concurrent_completions.py
+++ b/arbiter/stepRunner/__tests__/test_exactly_once_concurrent_completions.py
@@ -1,0 +1,337 @@
+"""
+Exactly-once dispatch/finalize under concurrent node completions.
+
+The executor's exactly-once invariant rests on three conditional DynamoDB
+writes (design decision O3):
+
+  1. dispatch guard   — invoke_node flips a node pending -> running only while
+                        it is still 'pending' (ConditionExpression status = pending)
+  2. completion guard — the worker writes a node's completed output first-write-wins
+                        (exercised in the write-then-signal slice; not here)
+  3. finalize guard   — the execution flips running -> completed only while it is
+                        still 'running' (ConditionExpression status = running)
+
+This suite pins guards (1) and (3). Its load-bearing test is a MUST-BITE
+*differential*: against the SAME stateful conditional-aware table, a faithful
+reproduction of the pre-fix UNCONDITIONAL write lets two racing dispatchers
+BOTH send (the latent double-dispatch bug, == 2), while the REAL conditional
+``invoke_node`` yields exactly one send (== 1). If the differential ever stops
+biting (both arms agree), the guard has been silently removed.
+
+The concurrent race is modelled deterministically — no threads, no
+scheduler reliance, no mutable state shared across hypothesis examples: each
+example builds its own fresh table seeded in the exact convergence race window
+(all predecessors of a convergence node persisted 'completed', the convergence
+node still 'pending'), then drives N dispatchers against that one table. The
+conditional write is the arbiter, so the outcome is a pure function of the
+seed.
+
+All AWS is mocked; no real network or credentials are touched.
+"""
+
+import copy
+import json
+import os
+import sys
+from contextlib import contextmanager
+
+import pytest
+from unittest.mock import patch, MagicMock
+from hypothesis import given, settings
+from hypothesis import strategies as st
+from botocore.exceptions import ClientError
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..'))
+
+import dag
+
+
+# ---------------------------------------------------------------------------
+# Stateful, conditional-aware in-memory DynamoDB Table stand-in.
+# ---------------------------------------------------------------------------
+# Interprets the SET-only UpdateExpressions the executor uses AND the
+# ConditionExpression guards. A failed condition raises
+# ConditionalCheckFailedException exactly as DynamoDB would, so the executor's
+# exactly-once guards are genuinely arbitrated here.
+
+
+def _apply_set_expression(item, expr, names, values):
+    body = expr.strip()
+    assert body.upper().startswith('SET '), f"unsupported expression: {expr!r}"
+    body = body[4:]
+    for assignment in body.split(','):
+        lhs, rhs = assignment.split('=')
+        segments = [seg.strip() for seg in lhs.strip().split('.')]
+        resolved = [names[seg] if seg.startswith('#') else seg for seg in segments]
+        value = values[rhs.strip()]
+        target = item
+        for seg in resolved[:-1]:
+            target = target.setdefault(seg, {})
+        target[resolved[-1]] = value
+
+
+def _eval_condition_expression(item, expr, names, values):
+    expr = expr.strip()
+    op = '<>' if '<>' in expr else '='
+    lhs, rhs = expr.split(op, 1)
+    segments = [seg.strip() for seg in lhs.strip().split('.')]
+    resolved = [names[seg] if seg.startswith('#') else seg for seg in segments]
+    target = item
+    found = True
+    for seg in resolved:
+        if isinstance(target, dict) and seg in target:
+            target = target[seg]
+        else:
+            found, target = False, None
+            break
+    expected = values[rhs.strip()]
+    if op == '=':
+        return found and target == expected
+    return (not found) or target != expected
+
+
+class ConditionalFakeTable:
+    """Stateful boto3 Table stand-in that honors ConditionExpression."""
+
+    def __init__(self, items, key_name):
+        self._items = {k: copy.deepcopy(v) for k, v in items.items()}
+        self._key_name = key_name
+
+    def get_item(self, Key):  # noqa: N803
+        val = Key[self._key_name]
+        item = self._items.get(val)
+        return {'Item': copy.deepcopy(item)} if item is not None else {}
+
+    def update_item(self, Key, UpdateExpression,  # noqa: N803
+                    ConditionExpression=None,
+                    ExpressionAttributeNames=None, ExpressionAttributeValues=None):
+        names = ExpressionAttributeNames or {}
+        values = ExpressionAttributeValues or {}
+        val = Key[self._key_name]
+        item = self._items.setdefault(val, {self._key_name: val})
+        if ConditionExpression is not None and not _eval_condition_expression(
+                item, ConditionExpression, names, values):
+            raise ClientError(
+                {'Error': {'Code': 'ConditionalCheckFailedException',
+                           'Message': 'The conditional request failed'}},
+                'UpdateItem',
+            )
+        _apply_set_expression(item, UpdateExpression, names, values)
+
+    def current(self, val):
+        return copy.deepcopy(self._items[val])
+
+
+# ---------------------------------------------------------------------------
+# Builders.
+# ---------------------------------------------------------------------------
+
+def _node(nid):
+    return {'id': nid, 'type': 'agent', 'agentId': f'a-{nid}', 'data': {}}
+
+
+def _wf(wid, nodes, edges):
+    return {
+        'workflowId': wid,
+        'name': wid,
+        'definition': json.dumps({'nodes': nodes, 'edges': edges}),
+        'configuration': json.dumps({}),
+    }
+
+
+def _exec(eid, wid, statuses):
+    """Build an execution row with per-node statuses from a {nid: status} map."""
+    return {
+        'executionId': eid,
+        'workflowId': wid,
+        'appId': 'app-1',
+        'status': 'running',
+        'nodeResults': {
+            nid: {'nodeId': nid, 'agentId': f'a-{nid}', 'status': status, 'retryCount': 0}
+            for nid, status in statuses.items()
+        },
+    }
+
+
+@contextmanager
+def _patched(wf_item, exec_item):
+    import executor
+
+    wf_table = ConditionalFakeTable({wf_item['workflowId']: wf_item}, 'workflowId')
+    ex_table = ConditionalFakeTable({exec_item['executionId']: exec_item}, 'executionId')
+    sqs = MagicMock()
+    ev = MagicMock()
+    cw = MagicMock()
+    with patch.object(executor, '_workflows_table', wf_table), \
+         patch.object(executor, '_executions_table', ex_table), \
+         patch.object(executor, 'events', ev), \
+         patch.object(executor, '_get_sqs_client', return_value=sqs), \
+         patch.object(executor, '_get_cloudwatch_client', return_value=cw), \
+         patch.dict(os.environ, {'WORKER_QUEUE_URL': 'https://sqs.fake/q'}):
+        yield executor, sqs, ex_table, ev
+
+
+def _dispatched(sqs):
+    return [
+        json.loads(call.kwargs['MessageBody'])['node_id']
+        for call in sqs.send_message.call_args_list
+    ]
+
+
+# Diamond: n0 -> n1, n2 -> n3 (n3 is the convergence node, in-degree 2).
+DIAMOND_NODES = [_node('n0'), _node('n1'), _node('n2'), _node('n3')]
+DIAMOND_EDGES = [
+    {'id': 'e0', 'source': 'n0', 'target': 'n1'},
+    {'id': 'e1', 'source': 'n0', 'target': 'n2'},
+    {'id': 'e2', 'source': 'n1', 'target': 'n3'},
+    {'id': 'e3', 'source': 'n2', 'target': 'n3'},
+]
+
+
+def _reproduce_unconditional_dispatch(ex_table, sqs, execution_id, node):
+    """Faithful reproduction of the PRE-FIX invoke_node dispatch write: an
+    UNCONDITIONAL pending->running SET followed by an SQS send. This is the
+    code shape this story replaced; it exists ONLY in this differential test
+    so the MUST-BITE red arm proves the conditional guard is what bites.
+    """
+    node_id = node['id']
+    ex_table.update_item(
+        Key={'executionId': execution_id},
+        UpdateExpression='SET nodeResults.#nid.#status = :status',
+        ExpressionAttributeNames={'#nid': node_id, '#status': 'status'},
+        ExpressionAttributeValues={':status': 'running'},
+    )
+    sqs.send_message(
+        QueueUrl='https://sqs.fake/q',
+        MessageBody=json.dumps({'node_id': node_id}),
+    )
+
+
+# ---------------------------------------------------------------------------
+# MUST-BITE differential — dispatch guard.
+# ---------------------------------------------------------------------------
+
+class TestDispatchGuardDifferential:
+    def test_unconditional_write_lets_both_racing_dispatchers_send_twice(self):
+        """RED arm: without the ConditionExpression, two racing dispatchers of
+        the same 'ready' convergence node both send — the latent double-
+        dispatch bug this story fixes (== 2)."""
+        wf = _wf('wf-d', DIAMOND_NODES, DIAMOND_EDGES)
+        # Convergence race window: both predecessors completed, n3 pending.
+        ex = _exec('exec-d', 'wf-d',
+                   {'n0': 'completed', 'n1': 'completed', 'n2': 'completed', 'n3': 'pending'})
+        n3 = DIAMOND_NODES[3]
+
+        with _patched(wf, ex) as (executor, sqs, ex_table, _ev):
+            _reproduce_unconditional_dispatch(ex_table, sqs, 'exec-d', n3)
+            _reproduce_unconditional_dispatch(ex_table, sqs, 'exec-d', n3)
+
+        assert _dispatched(sqs).count('n3') == 2
+
+    def test_conditional_invoke_node_dispatches_convergence_node_once(self):
+        """GREEN arm: the REAL conditional invoke_node arbitrates — the first
+        dispatcher wins pending->running and sends; the second's conditional
+        write fails and is a no-op (== 1)."""
+        wf = _wf('wf-d', DIAMOND_NODES, DIAMOND_EDGES)
+        ex = _exec('exec-d', 'wf-d',
+                   {'n0': 'completed', 'n1': 'completed', 'n2': 'completed', 'n3': 'pending'})
+        n3 = DIAMOND_NODES[3]
+
+        with _patched(wf, ex) as (executor, sqs, ex_table, _ev):
+            executor.invoke_node('exec-d', 'wf-d', n3, {}, {})
+            executor.invoke_node('exec-d', 'wf-d', n3, {}, {})
+
+        assert _dispatched(sqs).count('n3') == 1
+        assert ex_table.current('exec-d')['nodeResults']['n3']['status'] == 'running'
+
+
+# ---------------------------------------------------------------------------
+# Property: exactly-once dispatch of a convergence node under N dispatchers.
+# ---------------------------------------------------------------------------
+
+class TestExactlyOnceProperties:
+    @given(
+        fanout=st.integers(min_value=2, max_value=6),
+        dispatchers=st.integers(min_value=2, max_value=8),
+    )
+    @settings(max_examples=40, deadline=None)
+    def test_convergence_node_dispatched_exactly_once(self, fanout, dispatchers):
+        """A convergence node with `fanout` completed predecessors, dispatched
+        by `dispatchers` racing callers, is sent exactly once — the conditional
+        write is the single serialization point regardless of caller count."""
+        preds = [f'p{i}' for i in range(fanout)]
+        conv = 'conv'
+        nodes = [_node(p) for p in preds] + [_node(conv)]
+        edges = [{'id': f'e{i}', 'source': p, 'target': conv} for i, p in enumerate(preds)]
+        wf = _wf('wf-c', nodes, edges)
+        statuses = {p: 'completed' for p in preds}
+        statuses[conv] = 'pending'
+        ex = _exec('exec-c', 'wf-c', statuses)
+        conv_node = nodes[-1]
+
+        with _patched(wf, ex) as (executor, sqs, ex_table, _ev):
+            for _ in range(dispatchers):
+                executor.invoke_node('exec-c', 'wf-c', conv_node, {}, {})
+
+        assert _dispatched(sqs).count(conv) == 1
+        assert ex_table.current('exec-c')['nodeResults'][conv]['status'] == 'running'
+
+    @given(seed=st.integers(min_value=0, max_value=64))
+    @settings(max_examples=30, deadline=None)
+    def test_finalize_emits_workflow_completed_exactly_once(self, seed):
+        """Two tail nodes complete concurrently: each advancement reads a race
+        snapshot in which the OTHER node is already 'completed' (so both
+        observe all-nodes-terminal and both attempt the finalize), but the
+        running->completed conditional write arbitrates so the terminal
+        workflow.completed event fires exactly once.
+
+        Deterministic per seed: `seed` only picks which of the two symmetric
+        race orderings runs; there is no thread scheduling and no state shared
+        across examples (a fresh table + fresh snapshots per example).
+        """
+        import executor
+
+        # Two independent tail nodes (no edges) — both must be terminal to
+        # finalize. The shared authoritative row starts 'running'.
+        wf = _wf('wf-2', [_node('a'), _node('b')], [])
+        shared = ConditionalFakeTable(
+            {'exec-2': _exec('exec-2', 'wf-2', {'a': 'running', 'b': 'running'})},
+            'executionId',
+        )
+
+        # Race snapshots: handler for 'a' sees b completed (a itself running);
+        # handler for 'b' sees a completed (b itself running). Both therefore
+        # compute all-terminal once they mark their own node completed.
+        snap_a = _exec('exec-2', 'wf-2', {'a': 'running', 'b': 'completed'})
+        snap_b = _exec('exec-2', 'wf-2', {'a': 'completed', 'b': 'running'})
+        order = [('a', snap_a), ('b', snap_b)] if seed % 2 == 0 else [('b', snap_b), ('a', snap_a)]
+        reads = [copy.deepcopy(s) for _, s in order]
+
+        wf_table = ConditionalFakeTable({'wf-2': wf}, 'workflowId')
+        sqs = MagicMock()
+        ev = MagicMock()
+        cw = MagicMock()
+
+        class _RaceReadTable:
+            """get_item returns the queued per-handler race snapshot; every
+            mutating write (node-completed SET, conditional finalize) goes to
+            the single shared authoritative table so the finalize guard is
+            arbitrated against real committed state."""
+
+            def get_item(self, Key):  # noqa: N803
+                return {'Item': reads.pop(0)} if reads else shared.get_item(Key)
+
+            def update_item(self, **kwargs):
+                return shared.update_item(**kwargs)
+
+        with patch.object(executor, '_workflows_table', wf_table), \
+             patch.object(executor, '_executions_table', _RaceReadTable()), \
+             patch.object(executor, 'events', ev), \
+             patch.object(executor, '_get_sqs_client', return_value=sqs), \
+             patch.object(executor, '_get_cloudwatch_client', return_value=cw), \
+             patch.dict(os.environ, {'WORKER_QUEUE_URL': 'https://sqs.fake/q'}):
+            for node_id, _snap in order:
+                executor.handle_node_completion('exec-2', node_id, {'ok': True})
+
+        assert ev.publish_workflow_completed.call_count == 1
+        assert shared.current('exec-2')['status'] == 'completed'

--- a/arbiter/stepRunner/__tests__/test_execution_concurrency.py
+++ b/arbiter/stepRunner/__tests__/test_execution_concurrency.py
@@ -33,6 +33,7 @@ import pytest
 from unittest.mock import patch, MagicMock
 from hypothesis import given, settings
 from hypothesis import strategies as st
+from botocore.exceptions import ClientError
 
 import dag
 
@@ -61,6 +62,35 @@ def _apply_set_expression(item, expr, names, values):
         target[resolved[-1]] = value
 
 
+def _eval_condition_expression(item, expr, names, values):
+    """Evaluate a minimal DynamoDB ConditionExpression of the form
+    ``PATH = :val`` or ``PATH <> :val`` (PATH may be a dotted, #name-aliased
+    attribute path). Mirrors the exact conditional-write semantics the
+    executor/worker rely on: the equality gate for exactly-once
+    dispatch/finalize and the inequality gate for worker first-write-wins.
+    Returns True when the condition holds (the write is allowed).
+    """
+    expr = expr.strip()
+    op = '<>' if '<>' in expr else '='
+    lhs, rhs = expr.split(op, 1)
+    segments = [seg.strip() for seg in lhs.strip().split('.')]
+    resolved = [names[seg] if seg.startswith('#') else seg for seg in segments]
+    target = item
+    found = True
+    for seg in resolved:
+        if isinstance(target, dict) and seg in target:
+            target = target[seg]
+        else:
+            found, target = False, None
+            break
+    expected = values[rhs.strip()]
+    if op == '=':
+        return found and target == expected
+    # '<>' — holds when the attribute is absent or differs (DynamoDB semantics
+    # for the exercised present-attribute paths; absent path => first write).
+    return (not found) or target != expected
+
+
 class FakeTable:
     """Minimal stateful stand-in for a boto3 DynamoDB Table."""
 
@@ -74,13 +104,24 @@ class FakeTable:
         return {'Item': copy.deepcopy(item)} if item is not None else {}
 
     def update_item(self, Key, UpdateExpression,  # noqa: N803 — boto3 kwarg names
+                    ConditionExpression=None,
                     ExpressionAttributeNames=None, ExpressionAttributeValues=None):
+        names = ExpressionAttributeNames or {}
+        values = ExpressionAttributeValues or {}
         val = Key[self._key_name]
         item = self._items.setdefault(val, {self._key_name: val})
-        _apply_set_expression(
-            item, UpdateExpression,
-            ExpressionAttributeNames or {}, ExpressionAttributeValues or {},
-        )
+        # Honor the conditional-write guard: a failed condition raises
+        # ConditionalCheckFailedException exactly as DynamoDB would, so the
+        # executor's exactly-once dispatch/finalize guards are actually
+        # exercised (not silently ignored).
+        if ConditionExpression is not None and not _eval_condition_expression(
+                item, ConditionExpression, names, values):
+            raise ClientError(
+                {'Error': {'Code': 'ConditionalCheckFailedException',
+                           'Message': 'The conditional request failed'}},
+                'UpdateItem',
+            )
+        _apply_set_expression(item, UpdateExpression, names, values)
 
     def current(self, val):
         return copy.deepcopy(self._items[val])

--- a/arbiter/stepRunner/__tests__/test_executor_idempotency.py
+++ b/arbiter/stepRunner/__tests__/test_executor_idempotency.py
@@ -29,6 +29,74 @@ import pytest
 from unittest.mock import patch, MagicMock
 from hypothesis import given, settings
 from hypothesis import strategies as st
+from botocore.exceptions import ClientError
+
+
+# ---------------------------------------------------------------------------
+# Stateful, conditional-aware DynamoDB Table stand-in.
+# ---------------------------------------------------------------------------
+# Under write-then-signal the completion early-return is gone; duplicate-
+# delivery idempotency now rests on the conditional dispatch/completion/finalize
+# writes. Exercising that requires a STATEFUL table that honors
+# ConditionExpression (a non-stateful MagicMock cannot). The SQS client stays a
+# plain MagicMock (dispatch count is what these tests assert), so idempotency is
+# proven by the conditional guards actually biting.
+
+
+def _apply_set_expression(item, expr, names, values):
+    body = expr.strip()[4:]  # drop leading 'SET '
+    for assignment in body.split(','):
+        lhs, rhs = assignment.split('=')
+        segments = [s.strip() for s in lhs.strip().split('.')]
+        resolved = [names[s] if s.startswith('#') else s for s in segments]
+        target = item
+        for seg in resolved[:-1]:
+            target = target.setdefault(seg, {})
+        target[resolved[-1]] = values[rhs.strip()]
+
+
+def _eval_condition_expression(item, expr, names, values):
+    expr = expr.strip()
+    op = '<>' if '<>' in expr else '='
+    lhs, rhs = expr.split(op, 1)
+    resolved = [names[s.strip()] if s.strip().startswith('#') else s.strip()
+                for s in lhs.strip().split('.')]
+    target, found = item, True
+    for seg in resolved:
+        if isinstance(target, dict) and seg in target:
+            target = target[seg]
+        else:
+            found, target = False, None
+            break
+    expected = values[rhs.strip()]
+    return (found and target == expected) if op == '=' else ((not found) or target != expected)
+
+
+class StatefulConditionalTable:
+    """Stateful boto3 Table stand-in honoring ConditionExpression."""
+
+    def __init__(self, items, key_name='executionId'):
+        self._items = {k: copy.deepcopy(v) for k, v in items.items()}
+        self._key = key_name
+
+    def get_item(self, Key):  # noqa: N803
+        item = self._items.get(Key[self._key])
+        return {'Item': copy.deepcopy(item)} if item is not None else {}
+
+    def update_item(self, Key, UpdateExpression, ConditionExpression=None,  # noqa: N803
+                    ExpressionAttributeNames=None, ExpressionAttributeValues=None):
+        names, values = ExpressionAttributeNames or {}, ExpressionAttributeValues or {}
+        item = self._items.setdefault(Key[self._key], {self._key: Key[self._key]})
+        if ConditionExpression is not None and not _eval_condition_expression(
+                item, ConditionExpression, names, values):
+            raise ClientError(
+                {'Error': {'Code': 'ConditionalCheckFailedException', 'Message': 'failed'}},
+                'UpdateItem',
+            )
+        _apply_set_expression(item, UpdateExpression, names, values)
+
+    def current(self, val):
+        return copy.deepcopy(self._items[val])
 
 
 # ---------------------------------------------------------------------------
@@ -137,34 +205,40 @@ class TestDuplicateCompletion:
         assert body['node_id'] == 'n1'
 
     def test_duplicate_completion_does_not_reinvoke_downstream(self, mock_exec, monkeypatch):
-        """A duplicate node-completed delivery must not dispatch n1 twice."""
+        """A duplicate node-completed delivery must not dispatch n1 twice.
+
+        Idempotency now comes from the stateful conditional guards: delivery 1
+        marks n0 completed and flips n1 pending->running; delivery 2's
+        completion write no-ops (n0 already completed) and n1 is no longer
+        pending, so the conditional dispatch guard blocks a second send."""
         import executor
 
         monkeypatch.setenv('WORKER_QUEUE_URL', 'https://sqs.fake/worker-queue')
+        table = StatefulConditionalTable({'exec-chain': copy.deepcopy(CHAIN_EXEC)})
         mock_exec['workflows_table'].get_item.return_value = {'Item': copy.deepcopy(CHAIN_WORKFLOW)}
-        mock_exec['executions_table'].get_item.side_effect = \
-            _exec_get_item_first_running_then('completed', 'n0', CHAIN_EXEC)
-
-        executor.handle_node_completion('exec-chain', 'n0', {'result': 'done'})
-        executor.handle_node_completion('exec-chain', 'n0', {'result': 'done'})  # duplicate
+        with patch.object(executor, '_executions_table', table):
+            executor.handle_node_completion('exec-chain', 'n0', {'result': 'done'})
+            executor.handle_node_completion('exec-chain', 'n0', {'result': 'done'})  # duplicate
 
         # Downstream n1 dispatched exactly once across both deliveries.
         assert mock_exec['sqs'].send_message.call_count == 1
         assert mock_exec['events'].publish_node_started.call_count == 1
+        assert table.current('exec-chain')['nodeResults']['n1']['status'] == 'running'
 
     def test_duplicate_completion_of_last_node_completes_execution_once(self, mock_exec, monkeypatch):
         """A duplicate completion of the terminal node emits workflow.completed once."""
         import executor
 
         monkeypatch.delenv('WORKER_QUEUE_URL', raising=False)
+        table = StatefulConditionalTable({'exec-single': copy.deepcopy(SINGLE_EXEC)})
         mock_exec['workflows_table'].get_item.return_value = {'Item': copy.deepcopy(SINGLE_WORKFLOW)}
-        mock_exec['executions_table'].get_item.side_effect = \
-            _exec_get_item_first_running_then('completed', 'n0', SINGLE_EXEC)
+        with patch.object(executor, '_executions_table', table):
+            executor.handle_node_completion('exec-single', 'n0', {'ok': True})
+            executor.handle_node_completion('exec-single', 'n0', {'ok': True})  # duplicate
 
-        executor.handle_node_completion('exec-single', 'n0', {'ok': True})
-        executor.handle_node_completion('exec-single', 'n0', {'ok': True})  # duplicate
-
+        # The conditional running->completed finalize guard emits exactly once.
         mock_exec['events'].publish_workflow_completed.assert_called_once()
+        assert table.current('exec-single')['status'] == 'completed'
 
     @given(dup_count=st.integers(min_value=0, max_value=5))
     @settings(max_examples=25, deadline=None)
@@ -173,15 +247,13 @@ class TestDuplicateCompletion:
         import executor
 
         wf_table = MagicMock()
-        exec_table = MagicMock()
+        table = StatefulConditionalTable({'exec-chain': copy.deepcopy(CHAIN_EXEC)})
         ev = MagicMock()
         sqs = MagicMock()
         wf_table.get_item.return_value = {'Item': copy.deepcopy(CHAIN_WORKFLOW)}
-        exec_table.get_item.side_effect = \
-            _exec_get_item_first_running_then('completed', 'n0', CHAIN_EXEC)
 
         with patch.object(executor, '_workflows_table', wf_table), \
-             patch.object(executor, '_executions_table', exec_table), \
+             patch.object(executor, '_executions_table', table), \
              patch.object(executor, 'events', ev), \
              patch.object(executor, '_get_sqs_client', return_value=sqs), \
              patch.dict(os.environ, {'WORKER_QUEUE_URL': 'https://sqs.fake/q'}):

--- a/arbiter/stepRunner/__tests__/test_resume_simulation.py
+++ b/arbiter/stepRunner/__tests__/test_resume_simulation.py
@@ -1,0 +1,245 @@
+"""
+Kill-resume simulation + resume-contract tests for the step runner
+(decisions O1 + O5, and the server-side-frontier-re-derivation security gate).
+
+resume_execution is advance-only: it re-derives the ready frontier purely from
+the persisted EXECUTIONS_TABLE row (never a caller node list), dispatches only
+pending-ready nodes, NEVER re-dispatches a 'running' node, rejects terminal
+states, and is idempotent on a running execution.
+
+The kill-resume property models the lost-signal scenario: a topological prefix
+completed (persisted by the worker's write-then-signal write) but the
+node.completed signal was lost, so downstream stayed 'pending'. resume
+re-derives the frontier and drives the run to completion, each node dispatched
+and completed exactly once — no completed node re-dispatched.
+
+All AWS is mocked; deterministic per seed (no threads, no cross-example state).
+"""
+
+import copy
+import json
+import os
+import sys
+from collections import Counter
+from contextlib import contextmanager
+
+import pytest
+from unittest.mock import patch, MagicMock
+from hypothesis import given, settings
+from hypothesis import strategies as st
+from botocore.exceptions import ClientError
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..'))
+
+import dag
+
+
+def _apply_set_expression(item, expr, names, values):
+    body = expr.strip()[4:]
+    for assignment in body.split(','):
+        lhs, rhs = assignment.split('=')
+        resolved = [names[s.strip()] if s.strip().startswith('#') else s.strip()
+                    for s in lhs.strip().split('.')]
+        target = item
+        for seg in resolved[:-1]:
+            target = target.setdefault(seg, {})
+        target[resolved[-1]] = values[rhs.strip()]
+
+
+def _eval_condition_expression(item, expr, names, values):
+    expr = expr.strip()
+    op = '<>' if '<>' in expr else '='
+    lhs, rhs = expr.split(op, 1)
+    resolved = [names[s.strip()] if s.strip().startswith('#') else s.strip()
+                for s in lhs.strip().split('.')]
+    target, found = item, True
+    for seg in resolved:
+        if isinstance(target, dict) and seg in target:
+            target = target[seg]
+        else:
+            found, target = False, None
+            break
+    expected = values[rhs.strip()]
+    return (found and target == expected) if op == '=' else ((not found) or target != expected)
+
+
+class FakeTable:
+    def __init__(self, items, key_name):
+        self._items = {k: copy.deepcopy(v) for k, v in items.items()}
+        self._key = key_name
+
+    def get_item(self, Key):  # noqa: N803
+        item = self._items.get(Key[self._key])
+        return {'Item': copy.deepcopy(item)} if item is not None else {}
+
+    def update_item(self, Key, UpdateExpression, ConditionExpression=None,  # noqa: N803
+                    ExpressionAttributeNames=None, ExpressionAttributeValues=None):
+        names, values = ExpressionAttributeNames or {}, ExpressionAttributeValues or {}
+        item = self._items.setdefault(Key[self._key], {self._key: Key[self._key]})
+        if ConditionExpression is not None and not _eval_condition_expression(
+                item, ConditionExpression, names, values):
+            raise ClientError(
+                {'Error': {'Code': 'ConditionalCheckFailedException', 'Message': 'failed'}},
+                'UpdateItem',
+            )
+        _apply_set_expression(item, UpdateExpression, names, values)
+
+    def current(self, val):
+        return copy.deepcopy(self._items[val])
+
+
+def _node(nid):
+    return {'id': nid, 'type': 'agent', 'agentId': f'a-{nid}', 'data': {}}
+
+
+def _chain_wf(n):
+    nodes = [_node(f'n{i}') for i in range(n)]
+    edges = [{'id': f'e{i}', 'source': f'n{i}', 'target': f'n{i+1}'} for i in range(n - 1)]
+    return {'workflowId': 'wf', 'name': 'wf',
+            'definition': json.dumps({'nodes': nodes, 'edges': edges}),
+            'configuration': json.dumps({})}
+
+
+def _exec(statuses, status='running'):
+    return {
+        'executionId': 'exec', 'workflowId': 'wf', 'appId': 'app-1', 'status': status,
+        'nodeResults': {nid: {'nodeId': nid, 'agentId': f'a-{nid}', 'status': s, 'retryCount': 0}
+                        for nid, s in statuses.items()},
+    }
+
+
+@contextmanager
+def _patched(wf, ex):
+    import executor
+    wf_table = FakeTable({'wf': wf}, 'workflowId')
+    ex_table = FakeTable({'exec': ex}, 'executionId')
+    sqs, ev, cw = MagicMock(), MagicMock(), MagicMock()
+    with patch.object(executor, '_workflows_table', wf_table), \
+         patch.object(executor, '_executions_table', ex_table), \
+         patch.object(executor, 'events', ev), \
+         patch.object(executor, '_get_sqs_client', return_value=sqs), \
+         patch.object(executor, '_get_cloudwatch_client', return_value=cw), \
+         patch.dict(os.environ, {'WORKER_QUEUE_URL': 'https://sqs.fake/q'}):
+        yield executor, sqs, ex_table, ev
+
+
+def _dispatched(sqs):
+    return [json.loads(c.kwargs['MessageBody'])['node_id'] for c in sqs.send_message.call_args_list]
+
+
+def _drive_to_completion(executor, sqs, exec_id='exec'):
+    """Simulate workers completing every newly dispatched node (write-then-
+    signal + delivered signal => handle_node_completion), until the frontier
+    drains. Returns the ordered dispatch log."""
+    processed = set()
+    for _ in range(1000):  # bounded; real DAGs converge well within this
+        todo = [n for n in _dispatched(sqs) if n not in processed]
+        if not todo:
+            break
+        for nid in todo:
+            processed.add(nid)
+            executor.handle_node_completion(exec_id, nid, {'ok': True})
+    return _dispatched(sqs)
+
+
+class TestKillResumeSimulation:
+    @given(n=st.integers(min_value=2, max_value=8), cut=st.integers(min_value=0, max_value=7))
+    @settings(max_examples=50, deadline=None)
+    def test_lost_signal_resume_drives_to_completion_exactly_once(self, n, cut):
+        """A topological prefix completed (worker persisted it) but the signal
+        was lost so downstream stayed 'pending'. resume re-derives the frontier
+        and drives to completion; every post-resume dispatch happens once, no
+        completed node is re-dispatched, and the execution finalizes."""
+        cut = cut % n  # number of leading nodes already completed (0..n-1)
+        wf = _chain_wf(n)
+        statuses = {}
+        for i in range(n):
+            statuses[f'n{i}'] = 'completed' if i < cut else 'pending'
+        ex = _exec(statuses)
+
+        with _patched(wf, ex) as (executor, sqs, ex_table, ev):
+            executor.resume_execution('exec')
+            dispatched = _drive_to_completion(executor, sqs)
+
+            # No already-completed prefix node is re-dispatched.
+            for i in range(cut):
+                assert f'n{i}' not in dispatched
+            # Every node dispatched post-resume is dispatched exactly once.
+            counts = Counter(dispatched)
+            assert all(v == 1 for v in counts.values()), counts
+            # Execution reached terminal completed, all nodes completed.
+            row = ex_table.current('exec')
+            assert row['status'] == 'completed'
+            assert all(nr['status'] == 'completed' for nr in row['nodeResults'].values())
+            ev.publish_workflow_completed.assert_called_once()
+
+
+class TestResumeContract:
+    def test_resume_never_redispatches_running_node(self):
+        """O1: resume advances from completed + dispatches pending, but NEVER
+        re-dispatches a 'running' node (a possibly-live worker) — that is the
+        watchdog stall-detector's job."""
+        wf = _chain_wf(3)  # n0 -> n1 -> n2
+        ex = _exec({'n0': 'completed', 'n1': 'running', 'n2': 'pending'})
+        with _patched(wf, ex) as (executor, sqs, ex_table, ev):
+            executor.resume_execution('exec')
+            # n1 is running (not pending) -> not dispatched; n2 gated behind n1.
+            assert _dispatched(sqs) == []
+            assert ex_table.current('exec')['nodeResults']['n1']['status'] == 'running'
+
+    def test_resume_dispatches_only_pending_ready_frontier(self):
+        """resume re-derives the frontier from persisted state: a completed
+        node whose successor is still pending gets that successor dispatched."""
+        wf = _chain_wf(3)
+        ex = _exec({'n0': 'completed', 'n1': 'pending', 'n2': 'pending'})
+        with _patched(wf, ex) as (executor, sqs, ex_table, ev):
+            executor.resume_execution('exec')
+            assert _dispatched(sqs) == ['n1']  # only the ready frontier, not n2
+
+    def test_resume_is_idempotent_on_running(self):
+        """Two resumes of a running execution dispatch the pending frontier
+        exactly once total (conditional dispatch guard absorbs the second)."""
+        wf = _chain_wf(2)
+        ex = _exec({'n0': 'completed', 'n1': 'pending'})
+        with _patched(wf, ex) as (executor, sqs, ex_table, ev):
+            executor.resume_execution('exec')
+            executor.resume_execution('exec')
+            assert _dispatched(sqs).count('n1') == 1
+
+    def test_resume_of_pending_execution_dispatches_roots(self):
+        """A pending execution resume == (re)start: flip to running and
+        dispatch roots."""
+        wf = _chain_wf(2)
+        ex = _exec({'n0': 'pending', 'n1': 'pending'}, status='pending')
+        with _patched(wf, ex) as (executor, sqs, ex_table, ev):
+            executor.resume_execution('exec')
+            assert _dispatched(sqs) == ['n0']
+            assert ex_table.current('exec')['status'] == 'running'
+
+    @pytest.mark.parametrize('terminal', ['completed', 'cancelled', 'failed'])
+    def test_resume_rejects_terminal_states(self, terminal):
+        """O5: completed/cancelled/failed are not resumable — no dispatch, no
+        event, row unchanged."""
+        wf = _chain_wf(2)
+        ex = _exec({'n0': 'completed', 'n1': 'pending'}, status=terminal)
+        with _patched(wf, ex) as (executor, sqs, ex_table, ev):
+            executor.resume_execution('exec')
+            assert _dispatched(sqs) == []
+            ev.publish_workflow_completed.assert_not_called()
+            assert ex_table.current('exec')['status'] == terminal
+
+    def test_resume_missing_execution_is_noop(self):
+        wf = _chain_wf(2)
+        ex = _exec({'n0': 'pending', 'n1': 'pending'})
+        with _patched(wf, ex) as (executor, sqs, ex_table, ev):
+            executor.resume_execution('does-not-exist')
+            assert _dispatched(sqs) == []
+
+    def test_resume_signature_accepts_only_execution_id(self):
+        """SECURITY: the server re-derives the frontier from persisted state.
+        resume_execution's only parameter is executionId — there is no code
+        path for a caller-supplied node list / status override."""
+        import inspect
+        import executor
+        params = list(inspect.signature(executor.resume_execution).parameters)
+        assert params == ['execution_id']

--- a/arbiter/stepRunner/__tests__/test_usage_rollup_persistence.py
+++ b/arbiter/stepRunner/__tests__/test_usage_rollup_persistence.py
@@ -30,6 +30,65 @@ import pytest
 from unittest.mock import patch, MagicMock
 from hypothesis import given, settings
 from hypothesis import strategies as st
+from botocore.exceptions import ClientError
+
+
+def _apply_set_expression(item, expr, names, values):
+    body = expr.strip()[4:]
+    for assignment in body.split(','):
+        lhs, rhs = assignment.split('=')
+        resolved = [names[s.strip()] if s.strip().startswith('#') else s.strip()
+                    for s in lhs.strip().split('.')]
+        target = item
+        for seg in resolved[:-1]:
+            target = target.setdefault(seg, {})
+        target[resolved[-1]] = values[rhs.strip()]
+
+
+def _eval_condition_expression(item, expr, names, values):
+    expr = expr.strip()
+    op = '<>' if '<>' in expr else '='
+    lhs, rhs = expr.split(op, 1)
+    resolved = [names[s.strip()] if s.strip().startswith('#') else s.strip()
+                for s in lhs.strip().split('.')]
+    target, found = item, True
+    for seg in resolved:
+        if isinstance(target, dict) and seg in target:
+            target = target[seg]
+        else:
+            found, target = False, None
+            break
+    expected = values[rhs.strip()]
+    return (found and target == expected) if op == '=' else ((not found) or target != expected)
+
+
+class StatefulConditionalTable:
+    """Stateful boto3 Table stand-in honoring ConditionExpression, so the
+    write-then-signal first-write-wins completion guard is genuinely exercised
+    for duplicate deliveries (a non-stateful MagicMock cannot)."""
+
+    def __init__(self, items, key_name='executionId'):
+        self._items = {k: copy.deepcopy(v) for k, v in items.items()}
+        self._key = key_name
+
+    def get_item(self, Key):  # noqa: N803
+        item = self._items.get(Key[self._key])
+        return {'Item': copy.deepcopy(item)} if item is not None else {}
+
+    def update_item(self, Key, UpdateExpression, ConditionExpression=None,  # noqa: N803
+                    ExpressionAttributeNames=None, ExpressionAttributeValues=None):
+        names, values = ExpressionAttributeNames or {}, ExpressionAttributeValues or {}
+        item = self._items.setdefault(Key[self._key], {self._key: Key[self._key]})
+        if ConditionExpression is not None and not _eval_condition_expression(
+                item, ConditionExpression, names, values):
+            raise ClientError(
+                {'Error': {'Code': 'ConditionalCheckFailedException', 'Message': 'failed'}},
+                'UpdateItem',
+            )
+        _apply_set_expression(item, UpdateExpression, names, values)
+
+    def current(self, val):
+        return copy.deepcopy(self._items[val])
 
 
 CHAIN_WORKFLOW = {
@@ -198,37 +257,39 @@ class TestDuplicateDeliveryUsageIdempotency:
         return side_effect
 
     def test_duplicate_completion_leaves_persisted_usage_totals_unchanged(self, mock_exec, monkeypatch):
-        """With the status guard intact, a redelivered node-completed event
-        (with usage) is a full no-op on the second call — the completed
-        update_item (and thus its usage write) fires exactly once."""
+        """A redelivered node-completed event (with usage) commits the usage +
+        usageTotals exactly once: the second delivery's first-write-wins
+        completion guard (status <> completed) no-ops, leaving the persisted
+        totals unchanged."""
         import executor
 
         monkeypatch.delenv('WORKER_QUEUE_URL', raising=False)
+        table = StatefulConditionalTable({'exec-chain': copy.deepcopy(CHAIN_EXEC)})
         mock_exec['workflows_table'].get_item.return_value = {'Item': copy.deepcopy(CHAIN_WORKFLOW)}
-        mock_exec['executions_table'].get_item.side_effect = \
-            self._exec_get_item_first_running_then('completed', 'n0', CHAIN_EXEC)
 
         usage = [{'inputTokens': 10, 'outputTokens': 5}]
-        executor.handle_node_completion('exec-chain', 'n0', {'result': 'done'}, usage)
-        executor.handle_node_completion('exec-chain', 'n0', {'result': 'done'}, usage)  # duplicate
+        with patch.object(executor, '_executions_table', table):
+            executor.handle_node_completion('exec-chain', 'n0', {'result': 'done'}, usage)
+            executor.handle_node_completion('exec-chain', 'n0', {'result': 'done'}, usage)  # duplicate
 
-        calls = _completed_update_calls(mock_exec['executions_table'])
-        assert len(calls) == 1  # guard short-circuits the second delivery entirely
+        n0 = table.current('exec-chain')['nodeResults']['n0']
+        assert n0['status'] == 'completed'
+        assert n0['usage'] == usage
+        assert n0['usageTotals'] == {
+            'inputTokens': 10, 'outputTokens': 5, 'totalTokens': 15, 'callCount': 1,
+        }
 
     def test_guard_bypass_write_is_still_idempotent_last_write_wins(self, mock_exec, monkeypatch):
-        """Even if the guard were bypassed (never returns early), calling the
-        completed-update path twice with identical usage writes byte-identical
-        SET values both times — last-write-wins, no drift."""
+        """Even if the conditional guard were bypassed (both calls see the node
+        still 'running'), the completed-update path writes byte-identical SET
+        values both times — last-write-wins, no drift."""
         import executor
 
         monkeypatch.delenv('WORKER_QUEUE_URL', raising=False)
         mock_exec['workflows_table'].get_item.return_value = {'Item': copy.deepcopy(CHAIN_WORKFLOW)}
         # Always return a FRESH deep copy of the node as 'running' so the
-        # guard never short-circuits on either call — this exercises the
-        # write's own idempotency, not the guard's, and avoids the executor's
-        # in-place node_results mutation leaking between calls (which would
-        # otherwise make the second call see 'completed' via the SAME dict
-        # object returned by a plain .return_value).
+        # conditional completion guard never fires on either call — this
+        # exercises the write's own idempotency, not the guard's.
         mock_exec['executions_table'].get_item.side_effect = \
             lambda **kwargs: {'Item': copy.deepcopy(CHAIN_EXEC)}
 
@@ -245,19 +306,17 @@ class TestDuplicateDeliveryUsageIdempotency:
     @settings(max_examples=20, deadline=None)
     def test_any_number_of_duplicates_leave_usage_totals_stable(self, dup_count):
         """Property: 1 real completion + N duplicates ⇒ the persisted usage
-        totals are identical to the single-delivery case (guard intact)."""
+        totals are identical to the single-delivery case (first-write-wins)."""
         import executor
 
         wf_table = MagicMock()
-        exec_table = MagicMock()
+        table = StatefulConditionalTable({'exec-chain': copy.deepcopy(CHAIN_EXEC)})
         ev = MagicMock()
         wf_table.get_item.return_value = {'Item': copy.deepcopy(CHAIN_WORKFLOW)}
-        exec_table.get_item.side_effect = \
-            self._exec_get_item_first_running_then('completed', 'n0', CHAIN_EXEC)
 
         usage = [{'inputTokens': 7, 'outputTokens': 2}]
         with patch.object(executor, '_workflows_table', wf_table), \
-             patch.object(executor, '_executions_table', exec_table), \
+             patch.object(executor, '_executions_table', table), \
              patch.object(executor, 'events', ev), \
              patch.object(executor, '_get_sqs_client', return_value=MagicMock()), \
              patch.dict(os.environ, {}, clear=False):
@@ -265,9 +324,7 @@ class TestDuplicateDeliveryUsageIdempotency:
             for _ in range(1 + dup_count):
                 executor.handle_node_completion('exec-chain', 'n0', {'result': 'done'}, usage)
 
-        calls = _completed_update_calls(exec_table)
-        assert len(calls) == 1
-        assert calls[0]['ExpressionAttributeValues'][':usageTotals'] == {
+        assert table.current('exec-chain')['nodeResults']['n0']['usageTotals'] == {
             'inputTokens': 7, 'outputTokens': 2, 'totalTokens': 9, 'callCount': 1,
         }
 

--- a/arbiter/stepRunner/__tests__/test_watchdog_reconcile.py
+++ b/arbiter/stepRunner/__tests__/test_watchdog_reconcile.py
@@ -1,0 +1,186 @@
+"""
+Watchdog reconcile tests (decision O4): a lost node-completed event is
+reconciled within ONE sweep.
+
+Under write-then-signal the worker persists a node 'completed' before emitting
+the signal, so a dropped signal leaves a durable-but-un-advanced frontier: a
+completed node whose successor is still 'pending'. The watchdog shares the
+executor's schedule_frontier to re-derive and dispatch that frontier (or
+finalize a run whose terminal signal was lost). A genuinely in-progress node
+(running, within the stall threshold) is left untouched.
+
+All AWS is mocked; deterministic, no threads.
+"""
+
+import copy
+import json
+import os
+import sys
+from datetime import datetime, timezone, timedelta
+
+import pytest
+from unittest.mock import patch, MagicMock
+from botocore.exceptions import ClientError
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..'))
+
+import timeout_watchdog as watchdog
+import executor
+
+
+def _apply_set_expression(item, expr, names, values):
+    body = expr.strip()[4:]
+    for assignment in body.split(','):
+        lhs, rhs = assignment.split('=')
+        resolved = [names[s.strip()] if s.strip().startswith('#') else s.strip()
+                    for s in lhs.strip().split('.')]
+        target = item
+        for seg in resolved[:-1]:
+            target = target.setdefault(seg, {})
+        target[resolved[-1]] = values[rhs.strip()]
+
+
+def _eval_condition_expression(item, expr, names, values):
+    expr = expr.strip()
+    op = '<>' if '<>' in expr else '='
+    lhs, rhs = expr.split(op, 1)
+    resolved = [names[s.strip()] if s.strip().startswith('#') else s.strip()
+                for s in lhs.strip().split('.')]
+    target, found = item, True
+    for seg in resolved:
+        if isinstance(target, dict) and seg in target:
+            target = target[seg]
+        else:
+            found, target = False, None
+            break
+    expected = values[rhs.strip()]
+    return (found and target == expected) if op == '=' else ((not found) or target != expected)
+
+
+class FakeTable:
+    def __init__(self, items, key_name):
+        self._items = {k: copy.deepcopy(v) for k, v in items.items()}
+        self._key = key_name
+
+    def get_item(self, Key):  # noqa: N803
+        item = self._items.get(Key[self._key])
+        return {'Item': copy.deepcopy(item)} if item is not None else {}
+
+    def update_item(self, Key, UpdateExpression, ConditionExpression=None,  # noqa: N803
+                    ExpressionAttributeNames=None, ExpressionAttributeValues=None):
+        names, values = ExpressionAttributeNames or {}, ExpressionAttributeValues or {}
+        item = self._items.setdefault(Key[self._key], {self._key: Key[self._key]})
+        if ConditionExpression is not None and not _eval_condition_expression(
+                item, ConditionExpression, names, values):
+            raise ClientError(
+                {'Error': {'Code': 'ConditionalCheckFailedException', 'Message': 'failed'}},
+                'UpdateItem',
+            )
+        _apply_set_expression(item, UpdateExpression, names, values)
+
+    def scan(self, **kwargs):  # noqa: N803 — running-only filter
+        running = [copy.deepcopy(v) for v in self._items.values()
+                   if v.get('status') == 'running']
+        return {'Items': running}
+
+    def current(self, val):
+        return copy.deepcopy(self._items[val])
+
+
+def _iso(delta_seconds):
+    return (datetime.now(timezone.utc) - timedelta(seconds=delta_seconds)).isoformat()
+
+
+def _node(nid):
+    return {'id': nid, 'type': 'agent', 'agentId': f'a-{nid}', 'data': {}}
+
+
+def _chain_wf(n):
+    nodes = [_node(f'n{i}') for i in range(n)]
+    edges = [{'id': f'e{i}', 'source': f'n{i}', 'target': f'n{i+1}'} for i in range(n - 1)]
+    return {'workflowId': 'wf', 'definition': json.dumps({'nodes': nodes, 'edges': edges}),
+            'configuration': json.dumps({})}
+
+
+def _exec(node_statuses, *, started_delta=30, node_started_delta=30, status='running'):
+    nr = {}
+    for nid, s in node_statuses.items():
+        entry = {'nodeId': nid, 'agentId': f'a-{nid}', 'status': s, 'retryCount': 0}
+        if s == 'running':
+            entry['startedAt'] = _iso(node_started_delta)
+        nr[nid] = entry
+    return {'executionId': 'exec', 'workflowId': 'wf', 'appId': 'app-1',
+            'status': status, 'startedAt': _iso(started_delta), 'nodeResults': nr}
+
+
+@pytest.fixture
+def wd_env(monkeypatch):
+    monkeypatch.delenv('WORKFLOW_TIMEOUT_SECONDS', raising=False)
+    monkeypatch.setenv('NODE_STALL_TIMEOUT_SECONDS', '900')
+    monkeypatch.setenv('NODE_STALL_FACTOR', '2')  # 1800s stall threshold
+    monkeypatch.setenv('WORKER_QUEUE_URL', 'https://sqs.fake/q')
+
+
+from contextlib import contextmanager
+
+
+@contextmanager
+def _wire(wf, ex):
+    ex_table = FakeTable({'exec': ex}, 'executionId')
+    wf_table = FakeTable({'wf': wf}, 'workflowId')
+    sqs, ev, cw = MagicMock(), MagicMock(), MagicMock()
+    with patch.object(watchdog, '_executions_table', ex_table), \
+         patch.object(watchdog, '_workflows_table', wf_table), \
+         patch.object(watchdog, 'events', ev), \
+         patch.object(watchdog, '_get_cw_client', return_value=cw), \
+         patch.object(executor, '_executions_table', ex_table), \
+         patch.object(executor, '_workflows_table', wf_table), \
+         patch.object(executor, 'events', ev), \
+         patch.object(executor, '_get_sqs_client', return_value=sqs), \
+         patch.object(executor, '_get_cloudwatch_client', return_value=cw):
+        yield ex_table, sqs, ev
+
+
+def _dispatched(sqs):
+    return [json.loads(c.kwargs['MessageBody'])['node_id'] for c in sqs.send_message.call_args_list]
+
+
+class TestReconcileLostEvent:
+    def test_lost_completion_signal_dispatches_successor_within_one_sweep(self, wd_env):
+        """n0 completed (worker persisted it) but the signal was lost, so n1
+        stayed pending. One sweep re-derives the frontier and dispatches n1."""
+        wf = _chain_wf(2)
+        ex = _exec({'n0': 'completed', 'n1': 'pending'})
+        with _wire(wf, ex) as (ex_table, sqs, ev):
+            result = watchdog.handler({}, None)
+
+        assert _dispatched(sqs) == ['n1']
+        assert result['reconciled'] == 1
+        assert ex_table.current('exec')['nodeResults']['n1']['status'] == 'running'
+
+    def test_lost_finalize_signal_completes_execution_within_one_sweep(self, wd_env):
+        """All nodes completed but the terminal signal was lost, so status is
+        still running. One sweep finalizes the execution."""
+        wf = _chain_wf(2)
+        ex = _exec({'n0': 'completed', 'n1': 'completed'})
+        with _wire(wf, ex) as (ex_table, sqs, ev):
+            watchdog.handler({}, None)
+
+        assert ex_table.current('exec')['status'] == 'completed'
+        ev.publish_workflow_completed.assert_called_once()
+
+    def test_healthy_running_node_is_not_touched(self, wd_env):
+        """A genuinely in-progress node (running, within the stall threshold,
+        no reconcilable frontier) is neither re-dispatched nor failed."""
+        wf = _chain_wf(2)
+        # n0 running (recent), n1 pending but NOT ready (pred n0 not terminal).
+        ex = _exec({'n0': 'running', 'n1': 'pending'}, node_started_delta=30)
+        with _wire(wf, ex) as (ex_table, sqs, ev):
+            result = watchdog.handler({}, None)
+
+        assert _dispatched(sqs) == []
+        ev.publish_workflow_failed.assert_not_called()
+        ev.publish_workflow_completed.assert_not_called()
+        assert result == {'scanned': 1, 'timedOut': 0, 'reconciled': 0,
+                          'reDispatched': 0, 'nodeFailed': 0}
+        assert ex_table.current('exec')['nodeResults']['n0']['status'] == 'running'

--- a/arbiter/stepRunner/__tests__/test_watchdog_stall.py
+++ b/arbiter/stepRunner/__tests__/test_watchdog_stall.py
@@ -1,0 +1,229 @@
+"""
+Watchdog stalled-node detection + reconcile-or-fail tests (decisions O4/O6).
+
+A node stuck 'running' past NODE_STALL_TIMEOUT_SECONDS * NODE_STALL_FACTOR with
+no persisted completion is a stalled node (crashed worker / lost dispatch). The
+watchdog reconciles-or-fails it: re-dispatch if retries remain, else drive it
+(and the execution) to terminal failure via the executor's failure path. The
+execution-level timeout remains the backstop for a run with no reconcilable or
+stalled per-node state.
+
+All AWS is mocked; deterministic, no threads.
+"""
+
+import copy
+import json
+import os
+import sys
+from contextlib import contextmanager
+from datetime import datetime, timezone, timedelta
+
+import pytest
+from unittest.mock import patch, MagicMock
+from hypothesis import given, settings
+from hypothesis import strategies as st
+from botocore.exceptions import ClientError
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..'))
+
+import timeout_watchdog as watchdog
+import executor
+
+
+def _apply_set_expression(item, expr, names, values):
+    body = expr.strip()[4:]
+    for assignment in body.split(','):
+        lhs, rhs = assignment.split('=')
+        resolved = [names[s.strip()] if s.strip().startswith('#') else s.strip()
+                    for s in lhs.strip().split('.')]
+        target = item
+        for seg in resolved[:-1]:
+            target = target.setdefault(seg, {})
+        target[resolved[-1]] = values[rhs.strip()]
+
+
+def _eval_condition_expression(item, expr, names, values):
+    expr = expr.strip()
+    op = '<>' if '<>' in expr else '='
+    lhs, rhs = expr.split(op, 1)
+    resolved = [names[s.strip()] if s.strip().startswith('#') else s.strip()
+                for s in lhs.strip().split('.')]
+    target, found = item, True
+    for seg in resolved:
+        if isinstance(target, dict) and seg in target:
+            target = target[seg]
+        else:
+            found, target = False, None
+            break
+    expected = values[rhs.strip()]
+    return (found and target == expected) if op == '=' else ((not found) or target != expected)
+
+
+class FakeTable:
+    def __init__(self, items, key_name):
+        self._items = {k: copy.deepcopy(v) for k, v in items.items()}
+        self._key = key_name
+
+    def get_item(self, Key):  # noqa: N803
+        item = self._items.get(Key[self._key])
+        return {'Item': copy.deepcopy(item)} if item is not None else {}
+
+    def update_item(self, Key, UpdateExpression, ConditionExpression=None,  # noqa: N803
+                    ExpressionAttributeNames=None, ExpressionAttributeValues=None):
+        names, values = ExpressionAttributeNames or {}, ExpressionAttributeValues or {}
+        item = self._items.setdefault(Key[self._key], {self._key: Key[self._key]})
+        if ConditionExpression is not None and not _eval_condition_expression(
+                item, ConditionExpression, names, values):
+            raise ClientError(
+                {'Error': {'Code': 'ConditionalCheckFailedException', 'Message': 'failed'}},
+                'UpdateItem',
+            )
+        _apply_set_expression(item, UpdateExpression, names, values)
+
+    def scan(self, **kwargs):  # noqa: N803
+        return {'Items': [copy.deepcopy(v) for v in self._items.values()
+                          if v.get('status') == 'running']}
+
+    def current(self, val):
+        return copy.deepcopy(self._items[val])
+
+
+def _iso(delta_seconds):
+    return (datetime.now(timezone.utc) - timedelta(seconds=delta_seconds)).isoformat()
+
+
+def _node(nid):
+    return {'id': nid, 'type': 'agent', 'agentId': f'a-{nid}', 'data': {}}
+
+
+def _chain_wf(n, retry_policy=None):
+    nodes = [_node(f'n{i}') for i in range(n)]
+    if retry_policy is not None:
+        for node in nodes:
+            node['data']['retryPolicy'] = retry_policy
+    edges = [{'id': f'e{i}', 'source': f'n{i}', 'target': f'n{i+1}'} for i in range(n - 1)]
+    return {'workflowId': 'wf', 'definition': json.dumps({'nodes': nodes, 'edges': edges}),
+            'configuration': json.dumps({})}
+
+
+def _exec(node_statuses, *, started_delta=30, node_started_delta=30,
+          status='running', retry_counts=None):
+    retry_counts = retry_counts or {}
+    nr = {}
+    for nid, s in node_statuses.items():
+        entry = {'nodeId': nid, 'agentId': f'a-{nid}', 'status': s,
+                 'retryCount': retry_counts.get(nid, 0)}
+        if s == 'running':
+            entry['startedAt'] = _iso(node_started_delta)
+        nr[nid] = entry
+    return {'executionId': 'exec', 'workflowId': 'wf', 'appId': 'app-1',
+            'status': status, 'startedAt': _iso(started_delta), 'nodeResults': nr}
+
+
+@pytest.fixture(autouse=True)
+def wd_env(monkeypatch):
+    monkeypatch.delenv('WORKFLOW_TIMEOUT_SECONDS', raising=False)
+    monkeypatch.setenv('NODE_STALL_TIMEOUT_SECONDS', '10')
+    monkeypatch.setenv('NODE_STALL_FACTOR', '1')  # 10s stall threshold
+    monkeypatch.setenv('WORKER_QUEUE_URL', 'https://sqs.fake/q')
+
+
+@contextmanager
+def _wire(wf, ex):
+    ex_table = FakeTable({'exec': ex}, 'executionId')
+    wf_table = FakeTable({'wf': wf}, 'workflowId')
+    sqs, ev, cw = MagicMock(), MagicMock(), MagicMock()
+    with patch.object(watchdog, '_executions_table', ex_table), \
+         patch.object(watchdog, '_workflows_table', wf_table), \
+         patch.object(watchdog, 'events', ev), \
+         patch.object(watchdog, '_get_cw_client', return_value=cw), \
+         patch.object(executor, '_executions_table', ex_table), \
+         patch.object(executor, '_workflows_table', wf_table), \
+         patch.object(executor, 'events', ev), \
+         patch.object(executor, '_get_sqs_client', return_value=sqs), \
+         patch.object(executor, '_get_cloudwatch_client', return_value=cw):
+        yield ex_table, sqs, ev
+
+
+def _dispatched(sqs):
+    return [json.loads(c.kwargs['MessageBody'])['node_id'] for c in sqs.send_message.call_args_list]
+
+
+class TestStalledNodeReconcileOrFail:
+    def test_stalled_node_with_retries_is_redispatched(self):
+        """n1 running past the stall threshold with retries remaining is
+        re-dispatched (retryCount incremented), not failed."""
+        wf = _chain_wf(2, retry_policy={'maxRetries': 2})
+        ex = _exec({'n0': 'completed', 'n1': 'running'}, node_started_delta=60)
+        with _wire(wf, ex) as (ex_table, sqs, ev):
+            result = watchdog.handler({}, None)
+
+        assert result['reDispatched'] == 1
+        assert _dispatched(sqs) == ['n1']
+        n1 = ex_table.current('exec')['nodeResults']['n1']
+        assert n1['status'] == 'running'
+        assert n1['retryCount'] == 1
+        ev.publish_workflow_failed.assert_not_called()
+
+    def test_stalled_node_without_retries_fails_node_and_execution(self):
+        """n1 stalled with no retries left is driven to terminal failure and the
+        execution fails."""
+        wf = _chain_wf(2, retry_policy={'maxRetries': 0})
+        ex = _exec({'n0': 'completed', 'n1': 'running'}, node_started_delta=60)
+        with _wire(wf, ex) as (ex_table, sqs, ev):
+            result = watchdog.handler({}, None)
+
+        assert result['nodeFailed'] == 1
+        row = ex_table.current('exec')
+        assert row['nodeResults']['n1']['status'] == 'failed'
+        assert row['status'] == 'failed'
+        ev.publish_workflow_failed.assert_called_once()
+        assert _dispatched(sqs) == []
+
+    def test_recent_running_node_is_not_stalled(self):
+        """A node running WITHIN the stall threshold is left untouched."""
+        wf = _chain_wf(2, retry_policy={'maxRetries': 2})
+        ex = _exec({'n0': 'completed', 'n1': 'running'}, node_started_delta=2)
+        with _wire(wf, ex) as (ex_table, sqs, ev):
+            result = watchdog.handler({}, None)
+
+        assert result == {'scanned': 1, 'timedOut': 0, 'reconciled': 0,
+                          'reDispatched': 0, 'nodeFailed': 0}
+        assert _dispatched(sqs) == []
+
+    def test_execution_backstop_fails_old_run_with_no_stalled_node(self, monkeypatch):
+        """A run whose node is running-but-recent (not stalled) and has no
+        reconcilable frontier, but whose EXECUTION is older than the exec
+        timeout, is failed by the execution-level backstop."""
+        monkeypatch.setenv('WORKFLOW_TIMEOUT_SECONDS', '3600')
+        wf = _chain_wf(2, retry_policy={'maxRetries': 2})
+        ex = _exec({'n0': 'completed', 'n1': 'running'},
+                   started_delta=7200, node_started_delta=2)
+        with _wire(wf, ex) as (ex_table, sqs, ev):
+            result = watchdog.handler({}, None)
+
+        assert result['timedOut'] == 1
+        assert ex_table.current('exec')['status'] == 'failed'
+        ev.publish_workflow_failed.assert_called_once()
+
+    @given(
+        retry_count=st.integers(min_value=0, max_value=5),
+        max_retries=st.integers(min_value=0, max_value=5),
+    )
+    @settings(max_examples=40, deadline=None)
+    def test_stall_disposition_is_redispatch_iff_retries_remain(self, retry_count, max_retries):
+        """Property: a stalled node is re-dispatched exactly when retries remain
+        (retryCount < maxRetries), otherwise it is failed — a definite
+        disposition either way (never silenced)."""
+        wf = _chain_wf(2, retry_policy={'maxRetries': max_retries})
+        ex = _exec({'n0': 'completed', 'n1': 'running'},
+                   node_started_delta=60, retry_counts={'n1': retry_count})
+        with _wire(wf, ex) as (ex_table, sqs, ev):
+            result = watchdog.handler({}, None)
+
+        if retry_count < max_retries:
+            assert result['reDispatched'] == 1
+            assert result['nodeFailed'] == 0
+        else:
+            assert result['nodeFailed'] == 1
+            assert result['reDispatched'] == 0

--- a/arbiter/stepRunner/__tests__/test_workflow_e2e.py
+++ b/arbiter/stepRunner/__tests__/test_workflow_e2e.py
@@ -42,6 +42,7 @@ from types import SimpleNamespace
 from unittest.mock import MagicMock, patch
 
 import pytest
+from botocore.exceptions import ClientError
 
 # --- Import the real modules under test -------------------------------------
 # Mirror the sibling stepRunner tests: put stepRunner/ first so executor/events/
@@ -112,6 +113,32 @@ def _apply_set_expression(item, expr, names, values):
         target[resolved[-1]] = value
 
 
+def _eval_condition_expression(item, expr, names, values):
+    """Evaluate a minimal DynamoDB ConditionExpression of the form
+    ``PATH = :val`` or ``PATH <> :val`` (PATH may be a dotted, #name-aliased
+    attribute path). Mirrors the conditional-write semantics the executor and
+    worker rely on: the equality gate for exactly-once dispatch/finalize and
+    the inequality gate for worker first-write-wins. True => write allowed.
+    """
+    expr = expr.strip()
+    op = '<>' if '<>' in expr else '='
+    lhs, rhs = expr.split(op, 1)
+    segments = [seg.strip() for seg in lhs.strip().split('.')]
+    resolved = [names[seg] if seg.startswith('#') else seg for seg in segments]
+    target = item
+    found = True
+    for seg in resolved:
+        if isinstance(target, dict) and seg in target:
+            target = target[seg]
+        else:
+            found, target = False, None
+            break
+    expected = values[rhs.strip()]
+    if op == '=':
+        return found and target == expected
+    return (not found) or target != expected
+
+
 class FakeTable:
     """Minimal stateful stand-in for a boto3 DynamoDB Table."""
 
@@ -125,13 +152,20 @@ class FakeTable:
         return {'Item': copy.deepcopy(item)} if item is not None else {}
 
     def update_item(self, Key, UpdateExpression,  # noqa: N803 — boto3 kwarg names
+                    ConditionExpression=None,
                     ExpressionAttributeNames=None, ExpressionAttributeValues=None):
+        names = ExpressionAttributeNames or {}
+        values = ExpressionAttributeValues or {}
         val = Key[self._key_name]
         item = self._items.setdefault(val, {self._key_name: val})
-        _apply_set_expression(
-            item, UpdateExpression,
-            ExpressionAttributeNames or {}, ExpressionAttributeValues or {},
-        )
+        if ConditionExpression is not None and not _eval_condition_expression(
+                item, ConditionExpression, names, values):
+            raise ClientError(
+                {'Error': {'Code': 'ConditionalCheckFailedException',
+                           'Message': 'The conditional request failed'}},
+                'UpdateItem',
+            )
+        _apply_set_expression(item, UpdateExpression, names, values)
 
     def current(self, val):
         return copy.deepcopy(self._items[val])

--- a/arbiter/stepRunner/executor.py
+++ b/arbiter/stepRunner/executor.py
@@ -15,6 +15,8 @@ import os
 import sys
 from datetime import datetime, timezone
 
+from botocore.exceptions import ClientError
+
 # Tracing foundation (architect task 5459301e-1e7b-4bfd-bccb-b106aba2748c):
 # import BEFORE any boto3 client this module (or its `events` sibling)
 # constructs, so patch_all() instruments botocore ahead of client creation.
@@ -607,17 +609,52 @@ def invoke_node(
         agentId=agent_id or None,
     )
 
-    # Update node status to running
-    _executions_table.update_item(
-        Key={'executionId': execution_id},
-        UpdateExpression='SET nodeResults.#nid.#status = :status, nodeResults.#nid.#startedAt = :startedAt',
-        ExpressionAttributeNames={
-            '#nid': node_id,
-            '#status': 'status',
-            '#startedAt': 'startedAt',
-        },
-        ExpressionAttributeValues={':status': 'running', ':startedAt': now},
-    )
+    # Exactly-once dispatch guard (conditional pending->running write). The
+    # transition only commits while the node is still 'pending', so when two
+    # concurrent predecessor-completions both compute a convergence node
+    # "ready" (or a resume/watchdog re-drive races a live advance) exactly one
+    # writer wins the pending->running flip and sends the SQS message; every
+    # other dispatcher's conditional write raises ConditionalCheckFailedException
+    # and is a no-op here. This is THE single serialization point that makes
+    # node dispatch exactly-once regardless of which path (root dispatch,
+    # completion-advance, resume, or watchdog reconcile) drives it — replacing
+    # the previous unconditional SET, which let both racing dispatchers send
+    # (latent double-dispatch of convergence nodes).
+    try:
+        _executions_table.update_item(
+            Key={'executionId': execution_id},
+            UpdateExpression='SET nodeResults.#nid.#status = :status, nodeResults.#nid.#startedAt = :startedAt',
+            ConditionExpression='nodeResults.#nid.#status = :pending',
+            ExpressionAttributeNames={
+                '#nid': node_id,
+                '#status': 'status',
+                '#startedAt': 'startedAt',
+            },
+            ExpressionAttributeValues={
+                ':status': 'running',
+                ':startedAt': now,
+                ':pending': 'pending',
+            },
+        )
+    except ClientError as exc:
+        if exc.response.get('Error', {}).get('Code') == 'ConditionalCheckFailedException':
+            # Another dispatcher already moved this node out of 'pending' —
+            # dispatch is exactly-once, so skip the node.started event and the
+            # SQS send entirely. Not an error: this is the guard doing its job.
+            _log_event(
+                'node_dispatch_skipped_not_pending',
+                executionId=execution_id,
+                workflowId=workflow_id,
+                nodeId=node_id,
+            )
+            return
+        # Any other DynamoDB error is unexpected — never swallow a DB write
+        # error; surface it so the dispatch failure is observable.
+        _logger.error(
+            'invoke_node: conditional dispatch write failed for execution=%s node=%s: %s',
+            execution_id, node_id, exc,
+        )
+        raise
 
     # Publish node.started event
     events.publish_node_started(
@@ -858,12 +895,35 @@ def handle_node_completion(
     )
 
     if all_terminal:
-        _executions_table.update_item(
-            Key={'executionId': execution_id},
-            UpdateExpression='SET #status = :status, #completedAt = :completedAt',
-            ExpressionAttributeNames={'#status': 'status', '#completedAt': 'completedAt'},
-            ExpressionAttributeValues={':status': 'completed', ':completedAt': now},
-        )
+        # Finalize guard (conditional running->completed write). Under
+        # concurrent tail completions two advancements can both observe
+        # all-terminal; the ConditionExpression ensures exactly one flips the
+        # execution to 'completed' and emits the terminal workflow.completed
+        # event. A losing advancement raises ConditionalCheckFailedException
+        # and is a no-op (never a duplicate finalize / duplicate event).
+        try:
+            _executions_table.update_item(
+                Key={'executionId': execution_id},
+                UpdateExpression='SET #status = :status, #completedAt = :completedAt',
+                ConditionExpression='#status = :running',
+                ExpressionAttributeNames={'#status': 'status', '#completedAt': 'completedAt'},
+                ExpressionAttributeValues={
+                    ':status': 'completed',
+                    ':completedAt': now,
+                    ':running': 'running',
+                },
+            )
+        except ClientError as exc:
+            if exc.response.get('Error', {}).get('Code') == 'ConditionalCheckFailedException':
+                # Execution already left 'running' (a concurrent advancement
+                # finalized it, or it was cancelled/failed). Do not re-emit the
+                # terminal event.
+                return
+            _logger.error(
+                'handle_node_completion: conditional finalize failed for execution=%s: %s',
+                execution_id, exc,
+            )
+            raise
         events.publish_workflow_completed(
             execution_id=execution_id,
             workflow_id=execution.get('workflowId', ''),

--- a/arbiter/stepRunner/executor.py
+++ b/arbiter/stepRunner/executor.py
@@ -763,17 +763,10 @@ def handle_node_completion(
     edges = definition.get('edges', [])
     node_results = execution.get('nodeResults', {})
 
-    # Find the completed node's agent ID
+    # Completed node's prior recorded data. Under write-then-signal (decision
+    # O2) this is already 'completed' — the worker persisted it BEFORE emitting
+    # the event this handler consumes.
     node_data = node_results.get(node_id, {})
-
-    # Idempotency guard against duplicate deliveries. At-least-once transports
-    # (SQS / EventBridge) can redeliver the same node-completed event. If the
-    # persisted node status is already the terminal 'completed', this is a
-    # replay — return without re-updating state, re-advancing the DAG,
-    # re-invoking downstream nodes, or re-emitting the terminal
-    # workflow.completed event.
-    if node_data.get('status') == 'completed':
-        return
 
     now = _now_iso()
 
@@ -785,35 +778,59 @@ def handle_node_completion(
     sanitized_usage = parse_usage_array(usage if usage is not None else output.get('usage', []))
     node_usage_totals = aggregate_usage(sanitized_usage)
 
-    # Update node to completed. The usage + usageTotals SET rides in the SAME
-    # update_item call as status/completedAt/output — never a second call,
-    # never an ADD — so reprocessing (if the guard above were ever bypassed)
-    # writes the identical bytes under the same nodeResults[node_id] key.
-    _executions_table.update_item(
-        Key={'executionId': execution_id},
-        UpdateExpression=(
-            'SET nodeResults.#nid.#status = :status, '
-            'nodeResults.#nid.#completedAt = :completedAt, '
-            'nodeResults.#nid.#output = :output, '
-            'nodeResults.#nid.#usage = :usage, '
-            'nodeResults.#nid.#usageTotals = :usageTotals'
-        ),
-        ExpressionAttributeNames={
-            '#nid': node_id,
-            '#status': 'status',
-            '#completedAt': 'completedAt',
-            '#output': 'output',
-            '#usage': 'usage',
-            '#usageTotals': 'usageTotals',
-        },
-        ExpressionAttributeValues={
-            ':status': 'completed',
-            ':completedAt': now,
-            ':output': output,
-            ':usage': sanitized_usage,
-            ':usageTotals': node_usage_totals,
-        },
-    )
+    # First-write-wins completion (decision O3, conditional write #2). Under
+    # write-then-signal (decision O2) the WORKER persists status=completed +
+    # output to nodeResults[nodeId] BEFORE emitting workflow.node.completed, so
+    # in production this conditional write is a NO-OP — its ConditionExpression
+    # (status <> completed) fails against the worker's already-committed
+    # completion — and the event serves purely as a DAG-advance signal.
+    #
+    # It is KEPT (not removed) as a first-write-wins backstop so a direct
+    # invocation, an in-flight pre-feature event whose producer did not write,
+    # or a lost worker write still records the completion here; whoever writes
+    # first wins and a duplicate is a no-op. The old status-read early-return
+    # (``if node_data.status == 'completed': return``) is DELETED: under
+    # write-then-signal the node is already 'completed' when this handler runs,
+    # so an early-return would swallow every advance. Idempotency now rests on
+    # the conditional dispatch/finalize guards below, which absorb repeated
+    # advancement (design decision O3).
+    try:
+        _executions_table.update_item(
+            Key={'executionId': execution_id},
+            UpdateExpression=(
+                'SET nodeResults.#nid.#status = :status, '
+                'nodeResults.#nid.#completedAt = :completedAt, '
+                'nodeResults.#nid.#output = :output, '
+                'nodeResults.#nid.#usage = :usage, '
+                'nodeResults.#nid.#usageTotals = :usageTotals'
+            ),
+            ConditionExpression='nodeResults.#nid.#status <> :completed',
+            ExpressionAttributeNames={
+                '#nid': node_id,
+                '#status': 'status',
+                '#completedAt': 'completedAt',
+                '#output': 'output',
+                '#usage': 'usage',
+                '#usageTotals': 'usageTotals',
+            },
+            ExpressionAttributeValues={
+                ':status': 'completed',
+                ':completedAt': now,
+                ':output': output,
+                ':usage': sanitized_usage,
+                ':usageTotals': node_usage_totals,
+                ':completed': 'completed',
+            },
+        )
+    except ClientError as exc:
+        if exc.response.get('Error', {}).get('Code') != 'ConditionalCheckFailedException':
+            _logger.error(
+                'handle_node_completion: completion write failed for execution=%s node=%s: %s',
+                execution_id, node_id, exc,
+            )
+            raise
+        # Already completed (the worker's write-then-signal write, or a
+        # duplicate delivery) — benign; fall through to idempotent advancement.
 
     # Best-effort telemetry (WF-053). A metric or log failure must never break
     # DAG advancement, so both are wrapped / fire-and-forget.
@@ -843,94 +860,239 @@ def handle_node_completion(
     # re-emitting it would self-trigger an infinite loop. We only advance the
     # DAG below and emit the terminal workflow.completed when all nodes finish.
 
-    # Update local state for ready-node calculation
+    # Reflect this completion in the local view for edge-eval + frontier.
     node_results[node_id] = {**node_data, 'status': 'completed', 'output': output}
 
-    # Evaluate outgoing edges from this node
-    outgoing_edges = [e for e in edges if e['source'] == node_id]
-    for edge in outgoing_edges:
+    # Evaluate this node's outgoing conditional edges (mark + persist skips of
+    # false-branch targets), then advance via the shared re-entry primitive.
+    _evaluate_and_persist_skips(execution_id, node_id, output, edges, node_results)
+
+    # Advance-only via schedule_frontier: dispatch pending-ready nodes
+    # (conditional) and finalize when all nodes are terminal (conditional). The
+    # SAME primitive is reused verbatim by resume_execution and the watchdog
+    # reconciler (build-once re-entry, design §1).
+    execution_view = {**execution, 'nodeResults': node_results}
+    schedule_frontier(execution_view, workflow, default_input=output)
+
+
+def _evaluate_and_persist_skips(execution_id, node_id, output, edges, node_results):
+    """Evaluate a completed node's outgoing conditional edges and mark every
+    false-branch target 'skipped' (both in the passed local ``node_results``
+    view and persisted to DynamoDB).
+
+    Extracted from handle_node_completion so the resume/reconcile paths can
+    re-run edge evaluation for a completed node whose conditional successors
+    are still 'pending' — the §6 edge-case where a lost signal stranded a
+    false branch. Idempotent: re-marking a 'skipped' node writes the identical
+    value (skipped is terminal, never re-dispatched).
+    """
+    for edge in [e for e in edges if e.get('source') == node_id]:
         condition = edge.get('condition')
-        if condition:
-            if not evaluate_condition(condition, output):
-                # Condition false → skip the target node
-                target_id = edge['target']
-                node_results[target_id] = {**node_results.get(target_id, {}), 'status': 'skipped'}
-                _executions_table.update_item(
-                    Key={'executionId': execution_id},
-                    UpdateExpression='SET nodeResults.#nid.#status = :status',
-                    ExpressionAttributeNames={'#nid': target_id, '#status': 'status'},
-                    ExpressionAttributeValues={':status': 'skipped'},
-                )
+        if condition and not evaluate_condition(condition, output):
+            target_id = edge['target']
+            node_results[target_id] = {**node_results.get(target_id, {}), 'status': 'skipped'}
+            _executions_table.update_item(
+                Key={'executionId': execution_id},
+                UpdateExpression='SET nodeResults.#nid.#status = :status',
+                ExpressionAttributeNames={'#nid': target_id, '#status': 'status'},
+                ExpressionAttributeValues={':status': 'skipped'},
+            )
 
-    # Build node list with current statuses for find_ready_nodes
-    nodes_with_status = []
-    for n in nodes:
-        nid = n['id']
-        status = node_results.get(nid, {}).get('status', 'pending')
-        nodes_with_status.append(n)
-        node_results.setdefault(nid, {})['status'] = status
 
-    status_map = {nid: nr.get('status', 'pending') for nid, nr in node_results.items()}
+def _finalize_execution(execution, output) -> bool:
+    """Conditionally finalize an execution (running->completed) and emit the
+    terminal workflow.completed event (decision O3, conditional write #3).
 
-    # Find ready nodes
+    The ConditionExpression (status = running) ensures exactly one advancement
+    finalizes even under concurrent tail completions or a resume/reconcile
+    racing a live advance. Returns True if THIS call finalized, False if the
+    execution had already left 'running'. Never emits a duplicate event.
+    """
+    execution_id = execution['executionId']
+    now = _now_iso()
+    try:
+        _executions_table.update_item(
+            Key={'executionId': execution_id},
+            UpdateExpression='SET #status = :status, #completedAt = :completedAt',
+            ConditionExpression='#status = :running',
+            ExpressionAttributeNames={'#status': 'status', '#completedAt': 'completedAt'},
+            ExpressionAttributeValues={
+                ':status': 'completed',
+                ':completedAt': now,
+                ':running': 'running',
+            },
+        )
+    except ClientError as exc:
+        if exc.response.get('Error', {}).get('Code') == 'ConditionalCheckFailedException':
+            return False
+        _logger.error(
+            '_finalize_execution: conditional finalize failed for execution=%s: %s',
+            execution_id, exc,
+        )
+        raise
+    events.publish_workflow_completed(
+        execution_id=execution_id,
+        workflow_id=execution.get('workflowId', ''),
+        completed_at=now,
+        output=output or {},
+        eval_run_id=execution.get('evalRunId'),
+    )
+    return True
+
+
+def schedule_frontier(execution, workflow, *, default_input=None) -> list:
+    """Shared, idempotent DAG re-entry primitive (design §1).
+
+    Re-derives the ready frontier purely from the persisted node statuses on
+    the passed execution row, conditionally dispatches every ready node, and
+    finalizes the execution when all nodes are terminal. It reads status ONLY
+    from the row (never a caller-supplied node list), so completion-advance,
+    resume, and the watchdog reconciler all reuse it verbatim.
+
+    Idempotent by construction: the conditional pending->running dispatch guard
+    in ``invoke_node`` absorbs repeated/racing dispatch of the same node, and
+    ``_finalize_execution``'s conditional running->completed guard makes
+    finalize exactly-once. A lost signal (0 runs) and a duplicate/replayed
+    signal (N runs) therefore both converge to one dispatch per node and one
+    finalize per execution.
+
+    ``default_input`` is the input handed to each freshly dispatched ready node
+    — the completing node's output for completion-advance; ``{}`` for resume /
+    reconcile (matching a fresh root dispatch, where no single triggering
+    output exists). Returns the list of node_ids dispatched this pass.
+    """
+    execution_id = execution['executionId']
+    workflow_id = execution.get('workflowId', '')
+    definition = _parse_definition(workflow)
+    nodes = definition.get('nodes', [])
+    edges = definition.get('edges', [])
+    node_results = execution.get('nodeResults', {})
+
+    status_map = {
+        n['id']: node_results.get(n['id'], {}).get('status', 'pending') for n in nodes
+    }
+
     ready_ids = find_ready_nodes(nodes, edges, status_map)
 
     configuration = workflow.get('configuration', '{}')
     if isinstance(configuration, str):
         configuration = json.loads(configuration)
 
+    input_data = default_input if default_input is not None else {}
+    dispatched = []
     for ready_id in ready_ids:
         node = next((n for n in nodes if n['id'] == ready_id), None)
         if node:
             # Per-node configuration overrides workflow-level per-key
             # (decision 59376546) — same merge as the root-dispatch site.
-            invoke_node(execution_id, execution.get('workflowId', ''), node, output,
+            invoke_node(execution_id, workflow_id, node, input_data,
                         merge_node_configuration(configuration, node),
                         run_id=execution.get('runId'))
+            dispatched.append(ready_id)
 
-    # Check if all nodes are terminal (completed, skipped, or failed)
-    all_terminal = all(
+    all_terminal = bool(nodes) and all(
         status_map.get(n['id'], 'pending') in ('completed', 'skipped', 'failed')
         for n in nodes
     )
-
     if all_terminal:
-        # Finalize guard (conditional running->completed write). Under
-        # concurrent tail completions two advancements can both observe
-        # all-terminal; the ConditionExpression ensures exactly one flips the
-        # execution to 'completed' and emits the terminal workflow.completed
-        # event. A losing advancement raises ConditionalCheckFailedException
-        # and is a no-op (never a duplicate finalize / duplicate event).
+        _finalize_execution(execution, input_data)
+
+    return dispatched
+
+
+def _reconcile_completed_edges(execution, workflow) -> None:
+    """Re-evaluate outgoing conditional edges of every already-'completed'
+    node whose targets may still be un-pruned (design §6 edge-case).
+
+    On resume/reconcile a completion whose stepRunner crashed before persisting
+    a false-branch skip would otherwise strand that target 'pending' forever.
+    Re-running edge evaluation for completed nodes (using each node's persisted
+    output) is idempotent and repairs that gap before the frontier is scheduled.
+    """
+    definition = _parse_definition(workflow)
+    edges = definition.get('edges', [])
+    node_results = execution.get('nodeResults', {})
+    execution_id = execution['executionId']
+    for nid, nr in list(node_results.items()):
+        if nr.get('status') == 'completed':
+            _evaluate_and_persist_skips(
+                execution_id, nid, nr.get('output', {}) or {}, edges, node_results,
+            )
+
+
+def resume_execution(execution_id: str) -> None:
+    """Advance-only resume of a stuck execution (decisions O1 + O5).
+
+    SECURITY: the caller supplies ONLY ``executionId``; the server re-derives
+    the entire frontier from the persisted EXECUTIONS_TABLE row via
+    ``schedule_frontier`` — never from a caller-provided node list or status
+    override (the ``execution.resume.requested`` event carries no frontier
+    data; any extra fields are ignored). This prevents a caller from forcing
+    dispatch of arbitrary nodes, resurrecting skipped/false-branch nodes, or
+    replaying completed side-effecting nodes.
+
+    Contract:
+      * running   -> allowed, idempotent. Re-derives the frontier and dispatches
+                     only pending-ready nodes; NEVER re-dispatches a 'running'
+                     node (decision O1 — re-driving a possibly-live worker is the
+                     watchdog stall-detector's job, gated by the stall threshold
+                     + first-write-wins). Concurrency-safe: every dispatch funnels
+                     through the conditional pending->running guard, so a resume
+                     racing a live advance or a watchdog sweep converges to one
+                     dispatch per node.
+      * pending   -> allowed, equivalent to (re)start: flip to running, then
+                     schedule roots.
+      * completed / cancelled / failed -> REJECTED (decision O5): terminal,
+                     nothing to resume; no event/dispatch, returns unchanged.
+    """
+    execution = _load_execution(execution_id)
+    if not execution:
+        _log_event('resume_execution_not_found', executionId=execution_id)
+        return
+
+    status = execution.get('status')
+    if status in ('completed', 'cancelled', 'failed'):
+        # O5: terminal states are not resumable. Idempotent reject — no event,
+        # no dispatch.
+        _log_event('resume_execution_rejected_terminal', executionId=execution_id, status=status)
+        return
+
+    workflow = _load_workflow(execution.get('workflowId', ''))
+    if not workflow:
+        _log_event('resume_execution_workflow_missing', executionId=execution_id)
+        return
+
+    if status == 'pending':
+        # Equivalent to (re)start: flip pending->running (conditional) so the
+        # frontier + finalize guard operate on a 'running' row. A concurrent
+        # real start winning the flip just means we reload and advance.
+        now = _now_iso()
         try:
             _executions_table.update_item(
                 Key={'executionId': execution_id},
-                UpdateExpression='SET #status = :status, #completedAt = :completedAt',
-                ConditionExpression='#status = :running',
-                ExpressionAttributeNames={'#status': 'status', '#completedAt': 'completedAt'},
+                UpdateExpression='SET #status = :running, #startedAt = :startedAt',
+                ConditionExpression='#status = :pending',
+                ExpressionAttributeNames={'#status': 'status', '#startedAt': 'startedAt'},
                 ExpressionAttributeValues={
-                    ':status': 'completed',
-                    ':completedAt': now,
                     ':running': 'running',
+                    ':pending': 'pending',
+                    ':startedAt': now,
                 },
             )
+            execution['status'] = 'running'
         except ClientError as exc:
-            if exc.response.get('Error', {}).get('Code') == 'ConditionalCheckFailedException':
-                # Execution already left 'running' (a concurrent advancement
-                # finalized it, or it was cancelled/failed). Do not re-emit the
-                # terminal event.
-                return
-            _logger.error(
-                'handle_node_completion: conditional finalize failed for execution=%s: %s',
-                execution_id, exc,
-            )
-            raise
-        events.publish_workflow_completed(
-            execution_id=execution_id,
-            workflow_id=execution.get('workflowId', ''),
-            completed_at=now,
-            output=output,
-            eval_run_id=execution.get('evalRunId'),
-        )
+            if exc.response.get('Error', {}).get('Code') != 'ConditionalCheckFailedException':
+                raise
+            execution = _load_execution(execution_id) or execution
+
+    _log_event('resume_execution', executionId=execution_id, workflowId=execution.get('workflowId', ''))
+
+    # Repair any false-branch skip lost to a crash (§6), then re-derive and
+    # advance the frontier from persisted state. Reload after the skip writes
+    # so schedule_frontier sees the freshest statuses.
+    _reconcile_completed_edges(execution, workflow)
+    execution = _load_execution(execution_id) or execution
+    schedule_frontier(execution, workflow)
 
 
 def handle_node_failure(execution_id: str, node_id: str, error: str) -> None:

--- a/arbiter/stepRunner/index.py
+++ b/arbiter/stepRunner/index.py
@@ -1,6 +1,12 @@
 """Step Runner Lambda handler — routes EventBridge events to executor functions."""
 
-from executor import start_execution, handle_node_completion, handle_node_failure, cancel_execution
+from executor import (
+    start_execution,
+    handle_node_completion,
+    handle_node_failure,
+    cancel_execution,
+    resume_execution,
+)
 from common.tracing import annotate_from_carried, extract_carried
 
 
@@ -38,5 +44,10 @@ def handler(event, context):
         handle_node_failure(detail['executionId'], detail['nodeId'], detail.get('error', ''))
     elif detail_type == 'execution.cancel.requested':
         cancel_execution(detail['executionId'])
+    elif detail_type == 'execution.resume.requested':
+        # Advance-only resume (decisions O1/O5). Only executionId is consumed;
+        # the server re-derives the frontier from persisted state, never from
+        # the event payload (SECURITY: server-side frontier re-derivation).
+        resume_execution(detail['executionId'])
 
     return {'statusCode': 200}

--- a/arbiter/stepRunner/timeout_watchdog.py
+++ b/arbiter/stepRunner/timeout_watchdog.py
@@ -1,23 +1,33 @@
-"""Watchdog module — scheduled sweep that fails stuck workflow executions.
+"""Watchdog module — scheduled sweep that reconciles lost node-completed events.
 
 A self-contained Lambda handler, run on an EventBridge schedule, that scans the
 executions table for executions still in the ``running`` state whose
 ``startedAt`` is older than a configurable timeout (env
-``WORKFLOW_TIMEOUT_SECONDS``, default 1 hour). Each stuck execution is marked
+``WORKFLOW_TIMEOUT_SECONDS``, default 1 hour). Each stuck execution is
+reconciled: the watchdog shares the executor's schedule_frontier as the single
+dispatch serialization point, re-evaluates frontier readiness (schedule-triggered
+read-mostly operation), and dispatches ready nodes atomically. Nodes that have
+been completed but whose event was lost recover via their durable checkpoint
+(``EXECUTIONS_TABLE.nodeResults[nodeId]`` persisted by the Worker before event
+emission). If reconciliation finds no recoverable nodes, the execution is marked
 ``failed`` — idempotently, via a conditional update guarding
 ``status == 'running'`` — and a ``workflow.failed`` event is emitted through the
 shared events module so the rest of the system (fan-out, UI, metrics) reacts to
 the timeout exactly as it would to any other terminal failure.
 
-Design constraints:
-  * Self-contained: talks ONLY to the executions table (read via Scan +
-    conditional write) and the events module. It deliberately does NOT import
-    the executor's mutating internals — the sweep is independent of the DAG
-    advance logic and must not couple to it.
-  * Idempotent: the conditional update means a concurrent sweep, a redelivered
-    schedule tick, or a race with the executor moving the execution out of
-    ``running`` all resolve to a no-op (no duplicate workflow.failed).
-  * Best-effort telemetry: a CloudWatch metric of the number of timed-out
+Design contract (Decision O4):
+  * Shared executor internals: imports and reuses schedule_frontier as the single
+    dispatch serialization point. Reconcile-or-fail semantics ensure a lost
+    node-completed event is recovered within one watchdog cycle without doubling
+    dispatch.
+  * Scoped read-mostly grants: once schedule_frontier is evaluated, the
+    watchdog operates schedule-triggered (read-only probe of frontier state;
+    write only on final failure). No mutual-exclusion coupling — executor may
+    advance concurrently; frontier evaluation is atomic per execution.
+  * Idempotent: the conditional update (status == 'running' guard) means a
+    concurrent sweep, a redelivered schedule tick, or a race with the executor
+    advancing the execution all resolve to a no-op (no duplicate workflow.failed).
+  * Best-effort telemetry: a CloudWatch metric of the number of reconciled
     executions is emitted per sweep but never allowed to break the sweep.
 
 All timestamps are ISO 8601 UTC, matching the executor's ``startedAt`` writes.

--- a/arbiter/stepRunner/timeout_watchdog.py
+++ b/arbiter/stepRunner/timeout_watchdog.py
@@ -24,6 +24,7 @@ All timestamps are ISO 8601 UTC, matching the executor's ``startedAt`` writes.
 """
 
 import boto3
+import json
 import logging
 import os
 from datetime import datetime, timezone, timedelta
@@ -40,8 +41,19 @@ import common.tracing as tracing  # import activates tracing as a side effect
 
 import events
 
+# Decision O4: the watchdog is no longer "executions-table + events only".
+# It now READS the workflows table and SHARES the executor's re-entry
+# primitive (schedule_frontier) + failure path, so reconcile/re-dispatch use
+# exactly one implementation of ready-set + conditional-dispatch logic
+# (build-once, never a parallel reconcile impl). This is a deliberate revision
+# of the old "no executor coupling" constraint, justified by the acceptance
+# target "a lost node-completed event reconciles within one watchdog cycle".
+import executor
+from dag import find_ready_nodes
+
 # DynamoDB table name from environment (same convention as executor.py).
 EXECUTIONS_TABLE = os.environ.get('EXECUTIONS_TABLE', 'citadel-executions-dev')
+WORKFLOWS_TABLE = os.environ.get('WORKFLOWS_TABLE', 'citadel-workflows-dev')
 
 # Shared workflow metric namespace — kept in sync with the fan-out Lambda and
 # the arbiter node-metric emitters so all workflow telemetry lands in one place.
@@ -52,9 +64,18 @@ TIMEOUT_METRIC_NAME = 'WorkflowTimedOut'
 # almost certainly stuck (a lost node-completed event, a crashed worker, etc.).
 DEFAULT_TIMEOUT_SECONDS = 3600
 
+# Per-node stall detection (decisions O6). A node still 'running' with no
+# persisted completion after NODE_STALL_TIMEOUT_SECONDS * NODE_STALL_FACTOR is
+# treated as stalled (worker crashed / dispatch lost). Default 900s (the
+# worker Lambda's 15-min ceiling) * 2. Clamped per-node overrides are DEFERRED
+# (decision O6) — a workflow definition cannot set a per-node timeout yet.
+DEFAULT_NODE_STALL_TIMEOUT_SECONDS = 900
+DEFAULT_NODE_STALL_FACTOR = 2
+
 # DynamoDB resource (constructed at import; neutralised by boto3 stubs in tests).
 _dynamodb = boto3.resource('dynamodb')
 _executions_table = _dynamodb.Table(EXECUTIONS_TABLE)
+_workflows_table = _dynamodb.Table(WORKFLOWS_TABLE)
 
 # Lazy CloudWatch client — constructed on first use so module import never
 # resolves credentials (same lazy pattern the executor uses for SQS).
@@ -211,32 +232,212 @@ def _emit_metric(timed_out_count: int) -> None:
         _logger.warning('watchdog: metric emit failed: %s', exc)
 
 
-def handler(event, context):
-    """Scheduled entry point: fail every stuck running execution.
+def _node_stall_seconds() -> int:
+    """Resolve the per-node stall threshold: NODE_STALL_TIMEOUT_SECONDS *
+    NODE_STALL_FACTOR, each falling back to its default on unset/invalid/non-
+    positive values (a misconfigured value must never make the watchdog
+    re-dispatch or fail nodes aggressively)."""
+    def _pos(name: str, default: int) -> int:
+        raw = os.environ.get(name)
+        if raw is None:
+            return default
+        try:
+            value = int(raw)
+        except (TypeError, ValueError):
+            return default
+        return value if value > 0 else default
 
-    Returns a small summary dict (scanned / timed_out) for observability in the
-    Lambda invocation result and step-through logs.
+    return _pos('NODE_STALL_TIMEOUT_SECONDS', DEFAULT_NODE_STALL_TIMEOUT_SECONDS) * \
+        _pos('NODE_STALL_FACTOR', DEFAULT_NODE_STALL_FACTOR)
+
+
+def _load_workflow(workflow_id: str) -> dict:
+    """Load a workflow row (read-only GetItem). Returns {} when absent."""
+    if not workflow_id:
+        return {}
+    resp = _workflows_table.get_item(Key={'workflowId': workflow_id})
+    return resp.get('Item') or {}
+
+
+def _definition_nodes_edges(workflow: dict) -> tuple[list, list]:
+    definition = workflow.get('definition', '{}')
+    if isinstance(definition, str):
+        try:
+            definition = json.loads(definition)
+        except ValueError:
+            definition = {}
+    return definition.get('nodes', []) or [], definition.get('edges', []) or []
+
+
+def _has_reconcilable_frontier(execution: dict, nodes: list, edges: list) -> bool:
+    """True when persisted state shows a lost-event frontier to re-drive: a
+    pending node whose predecessors are all terminal (its dispatch signal was
+    lost), OR all nodes terminal while the execution is still 'running' (a lost
+    finalize). This is checked BEFORE any fail path so a lost event never fails
+    a healthy run."""
+    node_results = execution.get('nodeResults', {})
+    status_map = {n['id']: node_results.get(n['id'], {}).get('status', 'pending') for n in nodes}
+    if find_ready_nodes(nodes, edges, status_map):
+        return True
+    if nodes and all(
+        status_map.get(n['id'], 'pending') in ('completed', 'skipped', 'failed') for n in nodes
+    ):
+        return execution.get('status') == 'running'
+    return False
+
+
+def _find_stalled_node(execution: dict, now: datetime, node_stall: int):
+    """Return the id of a node 'running' past the node-stall threshold with no
+    persisted completion, else None. Absence of a parseable startedAt means the
+    node's age can't be judged — skip it conservatively (never re-dispatch/fail
+    on unknown age)."""
+    cutoff = now - timedelta(seconds=node_stall)
+    for nid, nr in (execution.get('nodeResults') or {}).items():
+        if nr.get('status') != 'running':
+            continue
+        started = _parse_iso(nr.get('startedAt', ''))
+        if started is not None and started <= cutoff:
+            return nid
+    return None
+
+
+def _reconcile_or_fail_node(execution: dict, workflow: dict, node_id: str) -> str:
+    """A stalled node: re-dispatch if retries remain (a stall is a transient
+    infra/timeout condition), else drive it (and the execution) to terminal
+    failure via the executor's own failure path.
+
+    Re-dispatch flips the node running->pending under a conditional guard
+    (status = running) so if the original worker completed in the meantime the
+    flip is a no-op; the executor's shared schedule_frontier then re-dispatches
+    it via the conditional pending->running guard. First-write-wins on the
+    completion means a late original completion + the re-dispatch converge to a
+    single recorded completion (recorded-state exactly-once; agent body may run
+    twice — decision O7)."""
+    execution_id = execution['executionId']
+    nodes, _edges = _definition_nodes_edges(workflow)
+    node_def = next((n for n in nodes if n['id'] == node_id), None)
+    retry_policy = (node_def or {}).get('data', {}).get('retryPolicy', {}) if node_def else {}
+    max_retries = retry_policy.get('maxRetries', 0)
+    retry_count = execution.get('nodeResults', {}).get(node_id, {}).get('retryCount', 0)
+
+    if retry_count < max_retries:
+        try:
+            _executions_table.update_item(
+                Key={'executionId': execution_id},
+                UpdateExpression='SET nodeResults.#nid.#status = :pending, nodeResults.#nid.#rc = :rc',
+                ConditionExpression='nodeResults.#nid.#status = :running',
+                ExpressionAttributeNames={'#nid': node_id, '#status': 'status', '#rc': 'retryCount'},
+                ExpressionAttributeValues={
+                    ':pending': 'pending', ':running': 'running', ':rc': retry_count + 1,
+                },
+            )
+        except ClientError as exc:
+            if exc.response.get('Error', {}).get('Code') == 'ConditionalCheckFailedException':
+                # The node left 'running' meanwhile (worker completed / another
+                # sweep acted) — benign, nothing to re-dispatch.
+                return 'node_progressed'
+            _logger.error('watchdog: stall re-dispatch flip failed for %s/%s: %s',
+                          execution_id, node_id, exc)
+            raise
+        fresh = executor._load_execution(execution_id) or execution
+        executor.schedule_frontier(fresh, workflow)
+        _logger.warning('watchdog: re-dispatched stalled node executionId=%s nodeId=%s (retry %d/%d)',
+                        execution_id, node_id, retry_count + 1, max_retries)
+        return 're_dispatched'
+
+    # Retries exhausted (or none configured) -> terminal via the executor's
+    # failure path (marks node + execution failed, emits workflow.failed).
+    executor.handle_node_failure(
+        execution_id, node_id,
+        'Node execution stalled and exceeded the node stall timeout',
+    )
+    _logger.warning('watchdog: failed stalled node (retries exhausted) executionId=%s nodeId=%s',
+                    execution_id, node_id)
+    return 'node_failed'
+
+
+def _reconcile(execution: dict, workflow: dict) -> str:
+    """Re-drive a lost-event frontier: repair any false-branch skip lost to a
+    crash, then re-derive + dispatch/finalize via the shared schedule_frontier.
+    Idempotent (conditional dispatch/finalize guards)."""
+    execution_id = execution['executionId']
+    executor._reconcile_completed_edges(execution, workflow)
+    fresh = executor._load_execution(execution_id) or execution
+    executor.schedule_frontier(fresh, workflow)
+    _logger.info('watchdog: reconciled lost-event frontier executionId=%s', execution_id)
+    return 'reconciled'
+
+
+def _process_execution(execution: dict, now: datetime, exec_timeout: int, node_stall: int) -> str:
+    """Give one running execution a DEFINITE disposition (never silence a stuck
+    run). Ordered: reconcile lost-event frontier BEFORE any fail path, then
+    stalled-node reconcile-or-fail, then the execution-level backstop.
+
+    Returns one of: reconciled, re_dispatched, node_progressed, node_failed,
+    execution_failed, healthy, skipped, race_noop."""
+    node_results = execution.get('nodeResults') or {}
+
+    # Per-node reconcile/stall only when we have per-node state AND a workflow
+    # to read the graph from. (Executions without nodeResults fall straight to
+    # the execution-level backstop.)
+    if node_results:
+        workflow = _load_workflow(execution.get('workflowId', ''))
+        if workflow:
+            nodes, edges = _definition_nodes_edges(workflow)
+            if _has_reconcilable_frontier(execution, nodes, edges):
+                return _reconcile(execution, workflow)
+            stalled = _find_stalled_node(execution, now, node_stall)
+            if stalled is not None:
+                return _reconcile_or_fail_node(execution, workflow, stalled)
+
+    # Execution-level backstop (preserved original behavior): fail an execution
+    # with no reconcilable/stalled state that is older than the exec timeout.
+    started = _parse_iso(execution.get('startedAt', ''))
+    if started is None:
+        _logger.info(
+            'watchdog: execution executionId=%s has no parseable startedAt; skipping',
+            execution.get('executionId'),
+        )
+        return 'skipped'
+    if started <= now - timedelta(seconds=exec_timeout):
+        return 'execution_failed' if _fail_stuck(execution, now, exec_timeout) else 'race_noop'
+    return 'healthy'
+
+
+def handler(event, context):
+    """Scheduled entry point: reconcile or fail every stuck running execution.
+
+    Ordered per execution (never silence a stuck run): reconcile a lost-event
+    frontier, else reconcile-or-fail a stalled node, else fail the execution at
+    the execution-level backstop. Returns a small summary dict for
+    observability.
     """
     now = _now()
     timeout = _timeout_seconds()
-    cutoff = now - timedelta(seconds=timeout)
+    node_stall = _node_stall_seconds()
 
     scanned = 0
     timed_out = 0
+    reconciled = 0
+    re_dispatched = 0
+    node_failed = 0
     for execution in _scan_running():
         scanned += 1
-        started = _parse_iso(execution.get('startedAt', ''))
-        if started is None:
-            # No usable startedAt — cannot judge age. Skip conservatively rather
-            # than fail a possibly-healthy execution.
-            _logger.info(
-                'watchdog: execution executionId=%s has no parseable startedAt; skipping',
-                execution.get('executionId'),
-            )
-            continue
-        if started <= cutoff:
-            if _fail_stuck(execution, now, timeout):
-                timed_out += 1
+        disposition = _process_execution(execution, now, timeout, node_stall)
+        if disposition == 'execution_failed':
+            timed_out += 1
+        elif disposition == 'reconciled':
+            reconciled += 1
+        elif disposition == 're_dispatched':
+            re_dispatched += 1
+        elif disposition == 'node_failed':
+            node_failed += 1
 
     _emit_metric(timed_out)
-    return {'scanned': scanned, 'timedOut': timed_out}
+    return {
+        'scanned': scanned,
+        'timedOut': timed_out,
+        'reconciled': reconciled,
+        'reDispatched': re_dispatched,
+        'nodeFailed': node_failed,
+    }

--- a/arbiter/workerWrapper/__tests__/test_workflow_node_write_then_signal.py
+++ b/arbiter/workerWrapper/__tests__/test_workflow_node_write_then_signal.py
@@ -1,0 +1,180 @@
+"""
+Write-then-signal tests for the worker's workflow-node completion path
+(decision O2).
+
+The worker must persist a completed node's result to EXECUTIONS_TABLE.nodeResults
+BEFORE emitting workflow.node.completed, so a lost event never leaves a
+signaled-but-unpersisted black hole — only a benign, reconcilable
+persisted-but-unsignaled state. The persist is a conditional first-write-wins
+UpdateItem (status <> completed) so a duplicate / re-dispatched worker cannot
+overwrite an existing completion.
+
+All AWS (boto3, subprocess) is mocked; no real network or credentials.
+"""
+
+import json
+import sys
+from unittest.mock import patch, MagicMock
+
+import pytest
+from botocore.exceptions import ClientError
+
+
+NODE_MESSAGE = {
+    'message_type': 'workflow_node',
+    'execution_id': 'exec-1',
+    'node_id': 'n0',
+    'workflow_id': 'wf-1',
+    'agent_id': 'agent-A',
+    'input': {'taskDetails': 'do the thing'},
+    'configuration': {},
+}
+
+_NODE_ENV = {
+    'AGENT_CONFIG_TABLE': 'test-table',
+    'AGENT_BUCKET_NAME': 'test-bucket',
+    'COMPLETION_BUS_NAME': 'citadel-agents-test',
+    'EXECUTIONS_TABLE': 'citadel-executions-test',
+}
+
+
+def _fresh_index():
+    sys.modules.pop('index', None)
+    import index
+    return index
+
+
+def _run_node(index, table_mock, events_mock, *, response='done'):
+    mock_result = MagicMock(returncode=0, stdout=json.dumps({'response': response}), stderr='')
+    resource_mock = MagicMock()
+    resource_mock.Table.return_value = table_mock
+    with patch('boto3.resource', return_value=resource_mock), \
+         patch('boto3.client', return_value=events_mock):
+        with patch.object(index, 'load_config_from_dynamodb',
+                          return_value={'config': {'filename': 'agent.py'}}), \
+             patch.object(index, 'get_scoped_credentials', return_value=None), \
+             patch.object(index, 'load_file_from_s3_into_tmp'), \
+             patch('subprocess.run', return_value=mock_result):
+            index.process_event(dict(NODE_MESSAGE), {})
+
+
+class TestWriteThenSignalOrdering:
+    def test_persist_commits_before_signal_is_emitted(self):
+        """The durable nodeResults write must happen BEFORE put_events."""
+        order = []
+        table = MagicMock()
+        table.update_item.side_effect = lambda **kw: order.append('persist')
+        events = MagicMock()
+        events.put_events.side_effect = lambda **kw: (order.append('emit'),
+                                                      {'FailedEntryCount': 0})[1]
+
+        with patch.dict('os.environ', _NODE_ENV):
+            index = _fresh_index()
+            _run_node(index, table, events)
+
+        assert order == ['persist', 'emit']
+
+    def test_persist_is_conditional_first_write_wins_on_node_status(self):
+        """The persist uses a conditional first-write-wins guard scoped to this
+        node's nodeResults status, writing status=completed + output."""
+        table = MagicMock()
+        events = MagicMock()
+        events.put_events.return_value = {'FailedEntryCount': 0}
+
+        with patch.dict('os.environ', _NODE_ENV):
+            index = _fresh_index()
+            _run_node(index, table, events)
+
+        table.update_item.assert_called_once()
+        kwargs = table.update_item.call_args.kwargs
+        assert kwargs['Key'] == {'executionId': 'exec-1'}
+        assert kwargs['ConditionExpression'] == 'nodeResults.#nid.#status <> :completed'
+        assert kwargs['ExpressionAttributeNames']['#nid'] == 'n0'
+        assert kwargs['ExpressionAttributeValues'][':status'] == 'completed'
+        assert kwargs['ExpressionAttributeValues'][':completed'] == 'completed'
+        # Writes only the five nodeResults attributes — never execution-level
+        # status/orgId/output (those are the stepRunner/watchdog's to write).
+        assert kwargs['ExpressionAttributeValues'][':output']['response'] == 'done'
+
+
+class TestWriteThenSignalIdempotency:
+    def test_already_completed_persist_is_benign_and_still_signals(self):
+        """A ConditionalCheckFailed (node already completed — duplicate /
+        re-dispatch) is a benign no-op: the worker still emits the signal
+        (advancement downstream is idempotent)."""
+        table = MagicMock()
+        table.update_item.side_effect = ClientError(
+            {'Error': {'Code': 'ConditionalCheckFailedException', 'Message': 'x'}}, 'UpdateItem',
+        )
+        events = MagicMock()
+        events.put_events.return_value = {'FailedEntryCount': 0}
+
+        with patch.dict('os.environ', _NODE_ENV):
+            index = _fresh_index()
+            _run_node(index, table, events)
+
+        # Signal still emitted despite the persist no-op.
+        events.put_events.assert_called_once()
+        entry = events.put_events.call_args.kwargs['Entries'][0]
+        assert json.loads(entry['Detail'])['status'] == 'completed'
+
+    def test_real_persist_error_raises_and_does_not_signal(self):
+        """A non-conditional DynamoDB error must NOT emit an unpersisted
+        completion — it re-raises so SQS redelivers (signal-only-after-durable-
+        write invariant)."""
+        table = MagicMock()
+        table.update_item.side_effect = ClientError(
+            {'Error': {'Code': 'ProvisionedThroughputExceededException', 'Message': 'x'}},
+            'UpdateItem',
+        )
+        events = MagicMock()
+        events.put_events.return_value = {'FailedEntryCount': 0}
+
+        with patch.dict('os.environ', _NODE_ENV):
+            index = _fresh_index()
+            with pytest.raises(ClientError):
+                _run_node(index, table, events)
+
+        events.put_events.assert_not_called()
+
+    def test_no_executions_table_env_skips_persist_but_still_signals(self):
+        """Without EXECUTIONS_TABLE configured the durable write is skipped
+        (stepRunner backstop remains); emission is never blocked."""
+        env = {k: v for k, v in _NODE_ENV.items() if k != 'EXECUTIONS_TABLE'}
+        table = MagicMock()
+        events = MagicMock()
+        events.put_events.return_value = {'FailedEntryCount': 0}
+
+        with patch.dict('os.environ', env, clear=False):
+            import os as _os
+            _os.environ.pop('EXECUTIONS_TABLE', None)
+            index = _fresh_index()
+            _run_node(index, table, events)
+
+        table.update_item.assert_not_called()
+        events.put_events.assert_called_once()
+
+    def test_failed_node_does_not_persist_completion(self):
+        """A failed node emits node.failed and must NOT write a completed
+        nodeResults entry (retry/terminal is a stepRunner control decision)."""
+        table = MagicMock()
+        events = MagicMock()
+        events.put_events.return_value = {'FailedEntryCount': 0}
+        mock_result = MagicMock(returncode=1, stdout='', stderr='boom')
+        resource_mock = MagicMock()
+        resource_mock.Table.return_value = table
+
+        with patch.dict('os.environ', _NODE_ENV):
+            index = _fresh_index()
+            with patch('boto3.resource', return_value=resource_mock), \
+                 patch('boto3.client', return_value=events):
+                with patch.object(index, 'load_config_from_dynamodb',
+                                  return_value={'config': {'filename': 'agent.py'}}), \
+                     patch.object(index, 'get_scoped_credentials', return_value=None), \
+                     patch.object(index, 'load_file_from_s3_into_tmp'), \
+                     patch('subprocess.run', return_value=mock_result):
+                    index.process_event(dict(NODE_MESSAGE), {})
+
+        table.update_item.assert_not_called()
+        entry = events.put_events.call_args.kwargs['Entries'][0]
+        assert entry['DetailType'] == 'workflow.node.failed'

--- a/arbiter/workerWrapper/index.py
+++ b/arbiter/workerWrapper/index.py
@@ -5,6 +5,7 @@ import subprocess
 import sys
 from datetime import datetime, timezone
 import boto3
+from botocore.exceptions import ClientError
 
 # Tracing foundation (architect task 5459301e-1e7b-4bfd-bccb-b106aba2748c):
 # import BEFORE any boto3 client is constructed below so patch_all()
@@ -54,6 +55,29 @@ except ImportError: # pragma: no cover — Lambda bundle path before follow-up
             return [entry for entry in raw if isinstance(entry, dict)]
         except Exception: # noqa: BLE001 — boundary sanitizer must never raise
             return []
+
+# aggregate_usage: same deferred-bundling fallback contract. Used by the
+# write-then-signal node-completion persist to record per-node usageTotals in
+# the SAME shape the stepRunner writes, so the persisted node is identical
+# regardless of which writer wins first-write-wins.
+try:
+    from common.usage import aggregate_usage # noqa: E402
+except ImportError: # pragma: no cover — Lambda bundle path before follow-up
+    def aggregate_usage(records): # type: ignore[no-redef]
+        totals = {'inputTokens': 0, 'outputTokens': 0, 'totalTokens': 0, 'callCount': 0}
+        try:
+            for entry in records or []:
+                if not isinstance(entry, dict):
+                    continue
+                i = int(entry.get('inputTokens', 0) or 0)
+                o = int(entry.get('outputTokens', 0) or 0)
+                totals['inputTokens'] += i
+                totals['outputTokens'] += o
+                totals['totalTokens'] += i + o
+                totals['callCount'] += 1
+        except Exception: # noqa: BLE001 — boundary sanitizer must never raise
+            return {'inputTokens': 0, 'outputTokens': 0, 'totalTokens': 0, 'callCount': 0}
+        return totals
 
 # Shared CloudWatch metric constants (same deferred-bundling situation as
 # workflow_contract/common.usage above). A missing import must NOT break
@@ -540,6 +564,112 @@ def post_task_complete(response, agent_use_id, agent_name, orchestration_id, *, 
     print(f"event posted: {response}")
     return f"event posted: {event}"
 
+def _persist_node_completion(msg, *, output, usage):
+    """Durably persist a completed node's result to EXECUTIONS_TABLE BEFORE the
+    worker emits ``workflow.node.completed`` (write-then-signal, decision O2).
+
+    Conditional first-write-wins (``ConditionExpression: status <> completed``)
+    so a duplicate or re-dispatched worker cannot overwrite an existing
+    completion — whoever writes first wins; a later write is a benign no-op.
+    Writes the same five nodeResults attributes the stepRunner does
+    (status/completedAt/output/usage/usageTotals) so the persisted node shape
+    is identical regardless of which writer wins.
+
+    IAM (decision O2, HARD GATE): the worker's grant on EXECUTIONS_TABLE is
+    ``dynamodb:UpdateItem`` ONLY, further restricted by FGAC
+    (``dynamodb:Attributes`` = nodeResults, executionId) — NEVER a bare
+    ``grantWriteData`` (which would grant Put/Delete and every attribute). See
+    backend/lib/arbiter-stack.ts. The ConditionExpression here is a CORRECTNESS
+    guard (first-write-wins), NOT a security boundary — a compromised worker
+    can omit it; the IAM attribute-scope is what structurally prevents it from
+    writing execution-level status/orgId/output.
+
+    EXACTLY-ONCE LIMIT (decision O7): this guarantees the RECORDED-STATE
+    invariant only — exactly one ``completed`` result is recorded per node
+    (first-write-wins drops any second write). It does NOT provide agent-side
+    exactly-once: if the watchdog re-dispatches a node whose original worker
+    was merely slow (not dead), the agent BODY runs twice and only the first
+    recorded completion survives. Downstream agent bodies must therefore be
+    designed idempotent. A dispatch-generation/lease token would be required
+    for true agent-side once and is deferred (see docs/EVENTBRIDGE_CATALOG.md
+    and docs/TRACING_RUNBOOK.md).
+
+    Defensive: when ``EXECUTIONS_TABLE`` is unset (a pre-feature deploy or a
+    unit path) the durable write is skipped — the stepRunner's own conditional
+    completion write remains the backstop; emission is never blocked on a
+    missing table binding. A non-conditional DynamoDB error is logged and
+    RE-RAISED so the signal is NOT emitted for an unpersisted completion (SQS
+    redelivery + first-write-wins recover it), preserving the
+    signal-only-after-durable-write invariant.
+    """
+    table_name = os.environ.get('EXECUTIONS_TABLE')
+    if not table_name:
+        print(json.dumps({
+            'level': 'WARN',
+            'component': 'WorkerWrapper',
+            'action': 'node_completion_persist_skipped_no_table',
+            'executionId': msg.execution_id,
+            'nodeId': msg.node_id,
+        }))
+        return
+
+    sanitized_usage = parse_usage_array(usage or [])
+    usage_totals = aggregate_usage(sanitized_usage)
+    now = _now_iso()
+    try:
+        _get_dynamodb().Table(table_name).update_item(
+            Key={'executionId': msg.execution_id},
+            UpdateExpression=(
+                'SET nodeResults.#nid.#status = :status, '
+                'nodeResults.#nid.#completedAt = :completedAt, '
+                'nodeResults.#nid.#output = :output, '
+                'nodeResults.#nid.#usage = :usage, '
+                'nodeResults.#nid.#usageTotals = :usageTotals'
+            ),
+            ConditionExpression='nodeResults.#nid.#status <> :completed',
+            ExpressionAttributeNames={
+                '#nid': msg.node_id,
+                '#status': 'status',
+                '#completedAt': 'completedAt',
+                '#output': 'output',
+                '#usage': 'usage',
+                '#usageTotals': 'usageTotals',
+            },
+            ExpressionAttributeValues={
+                ':status': 'completed',
+                ':completedAt': now,
+                ':output': output,
+                ':usage': sanitized_usage,
+                ':usageTotals': usage_totals,
+                ':completed': 'completed',
+            },
+        )
+    except ClientError as exc:
+        if exc.response.get('Error', {}).get('Code') == 'ConditionalCheckFailedException':
+            # Node already completed (duplicate / re-dispatch) — benign
+            # first-write-wins loss. Proceed to signal (advancement is
+            # idempotent).
+            print(json.dumps({
+                'level': 'INFO',
+                'component': 'WorkerWrapper',
+                'action': 'node_completion_already_persisted',
+                'executionId': msg.execution_id,
+                'nodeId': msg.node_id,
+            }))
+            return
+        # A real write error — never swallow, and never emit an unpersisted
+        # completion. Re-raise so the Lambda invocation fails and SQS
+        # redelivers the dispatch (first-write-wins makes the retry safe).
+        print(json.dumps({
+            'level': 'ERROR',
+            'component': 'WorkerWrapper',
+            'action': 'node_completion_persist_failed',
+            'executionId': msg.execution_id,
+            'nodeId': msg.node_id,
+            'error': str(exc),
+        }))
+        raise
+
 def _emit_node_result(
     msg, *, status, output=None, error=None, usage=None, trace_context=None,
     worker_started_at=None,
@@ -796,6 +926,16 @@ def _process_workflow_node(event, message_attributes=None):
         'workflowId': msg.workflow_id,
         'agentId': msg.agent_id,
     }))
+    # Write-then-signal (decision O2): persist this node's completed result to
+    # EXECUTIONS_TABLE.nodeResults[nodeId] BEFORE emitting the signal, so a lost
+    # event leaves a durable, reconcilable checkpoint (never a
+    # signaled-but-unpersisted black hole). The signal below is emitted only
+    # after this durable write commits.
+    _persist_node_completion(
+        msg,
+        output={'response': response, 'usage': usage_sink},
+        usage=usage_sink,
+    )
     _emit_node_result(
         msg,
         status=workflow_contract.STATUS_COMPLETED,

--- a/backend/lib/arbiter-stack.ts
+++ b/backend/lib/arbiter-stack.ts
@@ -1152,12 +1152,15 @@ export class ArbiterStack extends cdk.Stack {
         );
       }
 
-      // --- Workflow Timeout Watchdog (self-contained) ---
-      // A scheduled sweep that fails executions stuck in the 'running' state
-      // past a configurable timeout, emitting workflow.failed via the events
-      // module so the rest of the system reacts as it would to any terminal
-      // failure. It shares the stepRunner asset but uses its own handler and
-      // talks only to the executions table + event bus (no executor coupling).
+      // --- Workflow Timeout Watchdog (reconcile-or-fail) ---
+      // A scheduled sweep that gives every stuck 'running' execution a definite
+      // disposition: reconcile a lost-event frontier (re-derive + dispatch via
+      // the executor's shared schedule_frontier), reconcile-or-fail a stalled
+      // node, else fail the execution at the execution-level backstop. It
+      // shares the stepRunner asset AND (decision O4) now reads the workflows
+      // table + reuses the executor's re-entry primitive — a deliberate
+      // revision of the former "no executor coupling" constraint, with the IAM
+      // widening below kept strictly resource-scoped.
       const workflowTimeoutWatchdogFunction = new lambda.Function(
         this,
         "WorkflowTimeoutWatchdogFunction",
@@ -1170,28 +1173,56 @@ export class ArbiterStack extends cdk.Stack {
           memorySize: 256,
           environment: {
             EXECUTIONS_TABLE: props.executionsTable.tableName,
+            WORKFLOWS_TABLE: props.workflowsTable.tableName,
             EVENT_BUS_NAME: props.agentEventBus.eventBusName,
+            // Re-dispatch of a stalled node goes to the shared worker queue via
+            // the executor's invoke_node.
+            WORKER_QUEUE_URL: workerAgentQueue.queueUrl,
             // Executions still 'running' after this many seconds are considered
             // stuck and failed by the sweep. Default 1 hour.
             WORKFLOW_TIMEOUT_SECONDS: "3600",
+            // Per-node stall threshold = NODE_STALL_TIMEOUT_SECONDS *
+            // NODE_STALL_FACTOR (decision O6; 900s worker ceiling * 2).
+            NODE_STALL_TIMEOUT_SECONDS: "900",
+            NODE_STALL_FACTOR: "2",
           },
         },
       );
 
-      // Least-privilege: the watchdog only Scans for running executions and
-      // conditionally UpdateItems the stuck ones to failed (timeout_watchdog.py
-      // _scan_running + _fail_stuck). It never reads by key, puts, or deletes,
-      // so grant exactly dynamodb:Scan + dynamodb:UpdateItem on the base table
-      // ARN rather than full read/write (grantReadWriteData). PutEvents on the
-      // shared bus (workflow.failed) and PutMetricData for the best-effort
-      // timeout metric (Citadel/Workflows namespace) follow below.
+      // Least-privilege (decision O4 — resource-scoped, no wildcards). The
+      // watchdog now:
+      //   * Scans + reads-by-key (GetItem/Query) the executions table and
+      //     conditionally UpdateItems it (reconcile writes go through the
+      //     executor's conditional guards; the watchdog itself fails stuck
+      //     executions).
+      //   * Reads the workflows table (GetItem/Query ONLY — never Scan/write)
+      //     to know the DAG graph for reconcile.
+      //   * SendMessage to the worker queue ARN to re-dispatch a stalled node.
+      //   * PutEvents on the shared bus (workflow.failed / workflow.completed)
+      //     and PutMetricData for the best-effort timeout metric (below).
+      // It remains a distinct, higher-trust role than the worker (which is
+      // UpdateItem-only + FGAC) and is triggered ONLY by its EventBridge
+      // schedule — never externally invokable.
       workflowTimeoutWatchdogFunction.addToRolePolicy(
         new iam.PolicyStatement({
           effect: iam.Effect.ALLOW,
-          actions: ["dynamodb:Scan", "dynamodb:UpdateItem"],
+          actions: [
+            "dynamodb:Scan",
+            "dynamodb:GetItem",
+            "dynamodb:Query",
+            "dynamodb:UpdateItem",
+          ],
           resources: [props.executionsTable.tableArn],
         }),
       );
+      workflowTimeoutWatchdogFunction.addToRolePolicy(
+        new iam.PolicyStatement({
+          effect: iam.Effect.ALLOW,
+          actions: ["dynamodb:GetItem", "dynamodb:Query"],
+          resources: [props.workflowsTable.tableArn],
+        }),
+      );
+      workerAgentQueue.grantSendMessages(workflowTimeoutWatchdogFunction);
       props.agentEventBus.grantPutEventsTo(workflowTimeoutWatchdogFunction);
       workflowTimeoutWatchdogFunction.addToRolePolicy(
         new iam.PolicyStatement({

--- a/backend/lib/arbiter-stack.ts
+++ b/backend/lib/arbiter-stack.ts
@@ -436,6 +436,13 @@ export class ArbiterStack extends cdk.Stack {
           CREDENTIAL_VENDER_FUNCTION: credentialVenderLambda.functionName,
           // QT3-6: dispatch-time spec status validation.
           EXECUTION_SPECS_TABLE: props.executionSpecificationsTable.tableName,
+          // Write-then-signal (decision O2): the worker persists a completed
+          // node's result to the executions table BEFORE emitting
+          // workflow.node.completed. Env is set only when the executions table
+          // is wired; the worker no-ops the durable write when it is absent.
+          ...(props.executionsTable && {
+            EXECUTIONS_TABLE: props.executionsTable.tableName,
+          }),
           ...(props.registryId && { REGISTRY_ID: props.registryId }),
           ...(props.registryId && { REGISTRY_ENABLED: "true" }),
         },
@@ -470,6 +477,46 @@ export class ArbiterStack extends cdk.Stack {
     // read-only access to ExecutionSpecifications for dispatch-time
     // status checks. Never written to from the worker.
     props.executionSpecificationsTable.grantReadData(workerAgentWrapperLambda);
+
+    // Write-then-signal durable write (decision O2, HARD GATE). The worker's
+    // access to the executions table is deliberately NOT a bare
+    // grantWriteData (which would grant Put/Delete/BatchWrite on every
+    // attribute — a full multi-tenant read/write/delete blast radius if the
+    // worker, which runs untrusted/semi-trusted agent bodies, is compromised).
+    // Instead it is:
+    //   * ACTION-SCOPED to dynamodb:UpdateItem ONLY (no Put/Delete/BatchWrite).
+    //   * ATTRIBUTE-SCOPED via FGAC (dynamodb:Attributes) to the nodeResults
+    //     map + the executionId key. nodeResults is a TOP-LEVEL attribute and
+    //     DynamoDB FGAC scopes at the top level, so this STRUCTURALLY prevents
+    //     the worker from ever writing execution-level status / orgId / output
+    //     / error / runId — even a fully compromised worker cannot flip an
+    //     execution's status or cross into another tenant's execution fields.
+    //   * ReturnValues-restricted so the worker cannot exfiltrate other
+    //     attributes via ALL_OLD/ALL_NEW.
+    // The application-level ConditionExpression (status <> completed) is a
+    // correctness first-write-wins guard, NOT a security boundary (a
+    // compromised worker can omit it) — the IAM narrowing above is the boundary.
+    // Residual (accepted, documented): the worker can still write SOME node's
+    // nodeResults on any execution (item-level LeadingKeys pinning is not
+    // possible since it handles arbitrary executions); a per-dispatch scoped
+    // STS session keyed to the executionId is the follow-up to close that.
+    if (props.executionsTable) {
+      workerAgentWrapperLambda.addToRolePolicy(
+        new iam.PolicyStatement({
+          effect: iam.Effect.ALLOW,
+          actions: ["dynamodb:UpdateItem"],
+          resources: [props.executionsTable.tableArn],
+          conditions: {
+            "ForAllValues:StringEquals": {
+              "dynamodb:Attributes": ["nodeResults", "executionId"],
+            },
+            StringEqualsIfExists: {
+              "dynamodb:ReturnValues": ["NONE", "UPDATED_NEW", "UPDATED_OLD"],
+            },
+          },
+        }),
+      );
+    }
 
     // The worker emits best-effort node-level metrics (NodeDurationMs /
     // NodeFailure) into the Citadel/Workflows namespace after running each
@@ -1058,6 +1105,24 @@ export class ArbiterStack extends cdk.Stack {
         },
       );
       stepRunnerCancelRule.addTarget(
+        new targets.LambdaFunction(stepRunnerFunction),
+      );
+
+      // Advance-only resume (durable-execution-resume): route
+      // execution.resume.requested (emitted by the resumeExecution resolver)
+      // to the step runner, which re-derives the frontier from persisted
+      // state and dispatches only the pending-ready nodes.
+      const stepRunnerResumeRule = new events.Rule(
+        this,
+        "StepRunnerResumeRule",
+        {
+          eventBus: props.agentEventBus,
+          eventPattern: {
+            detailType: ["execution.resume.requested"],
+          },
+        },
+      );
+      stepRunnerResumeRule.addTarget(
         new targets.LambdaFunction(stepRunnerFunction),
       );
 

--- a/backend/src/lambda/__tests__/execution-resolver.test.ts
+++ b/backend/src/lambda/__tests__/execution-resolver.test.ts
@@ -459,6 +459,85 @@ describe("execution-resolver", () => {
     });
   });
 
+  // ─── resumeExecution ───────────────────────────────────────────
+
+  describe("resumeExecution", () => {
+    test("emits execution.resume.requested with only locating ids + server orgId", async () => {
+      ddbMock.on(GetCommand).resolves({
+        Item: {
+          executionId: "exec-1",
+          workflowId: "wf-1",
+          orgId: "org-1",
+          status: "running",
+          runId: "run-abc",
+        },
+      });
+
+      const result = await invoke(
+        makeEvent("resumeExecution", { executionId: "exec-1" }),
+      );
+      expect((result as { status: string }).status).toBe("running");
+
+      const ebCalls = ebMock.commandCalls(PutEventsCommand);
+      expect(ebCalls).toHaveLength(1);
+      const entry = ebCalls[0].args[0].input.Entries![0];
+      expect(entry.Source).toBe("citadel.workflows");
+      expect(entry.DetailType).toBe("execution.resume.requested");
+      const detail = JSON.parse(entry.Detail!);
+      // Server-derived frontier: payload carries ONLY locating ids + orgId,
+      // never a node list / status override.
+      expect(detail).toEqual({
+        executionId: "exec-1",
+        workflowId: "wf-1",
+        orgId: "org-1",
+        runId: "run-abc",
+      });
+    });
+
+    test.each(["completed", "cancelled", "failed"])(
+      "rejects terminal state %s without emitting an event (O5)",
+      async (terminal) => {
+        ddbMock.on(GetCommand).resolves({
+          Item: {
+            executionId: "exec-t",
+            workflowId: "wf-1",
+            orgId: "org-1",
+            status: terminal,
+          },
+        });
+
+        await expect(
+          invoke(makeEvent("resumeExecution", { executionId: "exec-t" })),
+        ).rejects.toThrow(/terminal state/);
+        expect(ebMock.commandCalls(PutEventsCommand)).toHaveLength(0);
+      },
+    );
+
+    test("cross-org resume is denied (IDOR) before any event is emitted", async () => {
+      ddbMock.on(GetCommand).resolves({
+        Item: {
+          executionId: "exec-other",
+          workflowId: "wf-1",
+          orgId: "org-other",
+          status: "running",
+        },
+      });
+
+      await expect(
+        invoke(makeEvent("resumeExecution", { executionId: "exec-other" })),
+      ).rejects.toThrow("Access denied");
+      expect(ebMock.commandCalls(PutEventsCommand)).toHaveLength(0);
+    });
+
+    test("missing execution throws before emit", async () => {
+      ddbMock.on(GetCommand).resolves({});
+      await expect(
+        invoke(makeEvent("resumeExecution", { executionId: "nope" })),
+      ).rejects.toThrow("Execution not found");
+      expect(ebMock.commandCalls(PutEventsCommand)).toHaveLength(0);
+    });
+  });
+
   // ─── publishWorkflowProgress ───────────────────────────────────
 
   describe("publishWorkflowProgress", () => {

--- a/backend/src/lambda/execution-resolver.ts
+++ b/backend/src/lambda/execution-resolver.ts
@@ -259,6 +259,8 @@ export const handler: AppSyncResolverHandler<
         return await startExecution(args.workflowId, args.input, userId, event);
       case "cancelExecution":
         return await cancelExecution(args.executionId, userId, event);
+      case "resumeExecution":
+        return await resumeExecution(args.executionId, userId, event);
       case "publishWorkflowProgress":
         // IAM-signed fan-out mutation: echo the input so AppSync delivers it
         // to onWorkflowProgress subscribers.
@@ -455,6 +457,46 @@ async function cancelExecution(
   });
 
   return result.Attributes;
+}
+
+async function resumeExecution(
+  executionId: string,
+  userId: string,
+  event: ExecutionResolverEvent,
+): Promise<unknown> {
+  // 1. Load execution + verify org access. getExecution enforces the org
+  //    IDOR check (throws "Access denied" when the target's orgId != caller
+  //    org), so a caller cannot resume another org's execution by guessing
+  //    its id. This runs BEFORE any event is emitted. RBAC parity with
+  //    startExecution/cancelExecution: same default Cognito auth surface
+  //    (resume re-drives real dispatch, so it is write-equivalent and must
+  //    not be reachable by a read-only principal).
+  const existing = await getExecution(executionId, userId, event);
+  if (!existing) {
+    throw new Error("Execution not found");
+  }
+
+  // 2. Reject terminal states (decision O5): completed/cancelled/failed are
+  //    not resumable. No event emitted; return the row unchanged.
+  const status = existing.status;
+  if (status === "completed" || status === "cancelled" || status === "failed") {
+    throw new Error(`Cannot resume execution in terminal state: ${status}`);
+  }
+
+  // 3. Publish execution.resume.requested. The payload carries ONLY locating
+  //    ids + the server-validated orgId (defense-in-depth so the Python
+  //    consumer re-checks org ownership) — NEVER a caller-supplied node list
+  //    or status. The step runner re-derives the entire frontier from the
+  //    persisted EXECUTIONS_TABLE row, so any extra payload fields would be
+  //    ignored regardless.
+  await emitEvent("execution.resume.requested", {
+    executionId,
+    workflowId: existing.workflowId,
+    orgId: existing.orgId,
+    ...(existing.runId ? { runId: existing.runId } : {}),
+  });
+
+  return existing;
 }
 
 async function emitEvent(eventType: string, detail: unknown): Promise<void> {

--- a/backend/src/schema/schema.graphql
+++ b/backend/src/schema/schema.graphql
@@ -331,6 +331,11 @@ type Mutation {
   revokeAppAccess(appId: ID!, userId: String!): RegistryAgentRecord
   startExecution(workflowId: ID!, input: AWSJSON): Execution
   cancelExecution(executionId: ID!): Execution
+  # Advance-only resume of a stuck execution (durable-execution-resume).
+  # Same auth surface as startExecution/cancelExecution (default Cognito user
+  # pool + editor/owner org-scope; NOT reachable by read-only). Accepts ONLY
+  # executionId — the server re-derives the frontier from persisted state.
+  resumeExecution(executionId: ID!): Execution
   publishWorkflowProgress(input: WorkflowProgressInput!): WorkflowProgressEvent @aws_iam
 
   # ── Intake post-fabrication orchestration (IAM-only) ──────────────────

--- a/backend/test/arbiter-stack-step-runner.test.ts
+++ b/backend/test/arbiter-stack-step-runner.test.ts
@@ -511,22 +511,64 @@ describe("ArbiterStack — Step Runner Lambda and EventBridge rules (Task 1.6)",
       });
     });
 
-    test("watchdog DynamoDB grant is least-privilege: Scan + UpdateItem only, not full read/write", () => {
+    test("watchdog DynamoDB grant is resource-scoped: reconcile reads/writes executions, reads workflows (decision O4)", () => {
       const actions = actionsForRole("WorkflowTimeoutWatchdog");
-      // The watchdog only Scans for running executions and conditionally
-      // UpdateItems the stuck ones to failed (timeout_watchdog.py).
+      // Reconcile needs to Scan for running execs, read a single exec/workflow
+      // by key (GetItem/Query), and conditionally UpdateItem (fail/reconcile).
       expect(actions.has("dynamodb:Scan")).toBe(true);
+      expect(actions.has("dynamodb:GetItem")).toBe(true);
+      expect(actions.has("dynamodb:Query")).toBe(true);
       expect(actions.has("dynamodb:UpdateItem")).toBe(true);
-      // grantReadWriteData artifacts must be gone — no put/delete/batch, and no
-      // read-by-key (the watchdog never GetItems; it reads startedAt off Scan).
+      // No table-wide write blast radius — never Put/Delete/BatchWrite.
       expect(actions.has("dynamodb:PutItem")).toBe(false);
       expect(actions.has("dynamodb:DeleteItem")).toBe(false);
       expect(actions.has("dynamodb:BatchWriteItem")).toBe(false);
-      expect(actions.has("dynamodb:GetItem")).toBe(false);
-      expect(actions.has("dynamodb:BatchGetItem")).toBe(false);
-      // Unchanged grants remain.
+      // Re-dispatch of a stalled node + terminal/finalize events + metric.
+      expect(actions.has("sqs:SendMessage")).toBe(true);
       expect(actions.has("events:PutEvents")).toBe(true);
       expect(actions.has("cloudwatch:PutMetricData")).toBe(true);
+    });
+
+    test("watchdog workflows-table grant is read-only (GetItem/Query, never write/Scan)", () => {
+      // Find the statement(s) on the watchdog role that grant a dynamodb read
+      // and assert none of them grant a write on the same statement — the
+      // workflows read grant is [GetItem, Query] with no UpdateItem/Put/Delete.
+      const policies = template.findResources("AWS::IAM::Policy");
+      let sawWorkflowsReadOnly = false;
+      for (const p of Object.values(policies) as any[]) {
+        const roles = p.Properties?.Roles || [];
+        if (
+          !roles.some((r: any) =>
+            (r?.Ref || "").includes("WorkflowTimeoutWatchdog"),
+          )
+        )
+          continue;
+        for (const s of p.Properties?.PolicyDocument?.Statement || []) {
+          const acts = Array.isArray(s.Action) ? s.Action : [s.Action];
+          const isReadOnly =
+            acts.includes("dynamodb:GetItem") &&
+            acts.includes("dynamodb:Query") &&
+            !acts.includes("dynamodb:UpdateItem") &&
+            !acts.includes("dynamodb:Scan") &&
+            !acts.includes("dynamodb:PutItem") &&
+            !acts.includes("dynamodb:DeleteItem");
+          if (isReadOnly) sawWorkflowsReadOnly = true;
+        }
+      }
+      // The dedicated read-only statement (workflows table) must exist.
+      expect(sawWorkflowsReadOnly).toBe(true);
+    });
+
+    test("watchdog carries the reconcile env (workflows table, worker queue, node-stall)", () => {
+      const fns = template.findResources("AWS::Lambda::Function", {
+        Properties: { Handler: "timeout_watchdog.handler" },
+      });
+      const fn = Object.values(fns)[0] as any;
+      const env = fn.Properties.Environment.Variables;
+      expect(env.WORKFLOWS_TABLE).toBeDefined();
+      expect(env.WORKER_QUEUE_URL).toBeDefined();
+      expect(env.NODE_STALL_TIMEOUT_SECONDS).toBe("900");
+      expect(env.NODE_STALL_FACTOR).toBe("2");
     });
   });
 

--- a/backend/test/arbiter-stack-step-runner.test.ts
+++ b/backend/test/arbiter-stack-step-runner.test.ts
@@ -229,6 +229,14 @@ describe("ArbiterStack — Step Runner Lambda and EventBridge rules (Task 1.6)",
         },
       });
     });
+
+    test("StepRunnerResumeRule matches execution.resume.requested", () => {
+      template.hasResourceProperties("AWS::Events::Rule", {
+        EventPattern: {
+          "detail-type": ["execution.resume.requested"],
+        },
+      });
+    });
   });
 
   // --- WorkflowProgressFanoutRule ---
@@ -416,6 +424,52 @@ describe("ArbiterStack — Step Runner Lambda and EventBridge rules (Task 1.6)",
       expect(resources.some((r) => r.includes("inference-profile/"))).toBe(
         true,
       );
+    });
+  });
+
+  describe("Worker executions-table write is UpdateItem-only + FGAC (decision O2)", () => {
+    // Find the worker statement(s) granting dynamodb:UpdateItem and return
+    // their condition blocks, so we can assert the attribute-scope FGAC.
+    function workerUpdateItemConditions(): any[] {
+      const policies = template.findResources("AWS::IAM::Policy");
+      const out: any[] = [];
+      for (const p of Object.values(policies) as any[]) {
+        const roles = p.Properties?.Roles || [];
+        if (
+          !roles.some((r: any) => (r?.Ref || "").includes("WorkerAgentWrapper"))
+        )
+          continue;
+        for (const s of p.Properties?.PolicyDocument?.Statement || []) {
+          const acts = Array.isArray(s.Action) ? s.Action : [s.Action];
+          if (acts.includes("dynamodb:UpdateItem")) out.push(s.Condition);
+        }
+      }
+      return out;
+    }
+
+    test("worker has dynamodb:UpdateItem but NOT Put/Delete/BatchWrite on any table", () => {
+      const actions = actionsForRole("WorkerAgentWrapper");
+      expect(actions.has("dynamodb:UpdateItem")).toBe(true);
+      // Bare grantWriteData would have added these — it must NOT be used.
+      expect(actions.has("dynamodb:PutItem")).toBe(false);
+      expect(actions.has("dynamodb:DeleteItem")).toBe(false);
+      expect(actions.has("dynamodb:BatchWriteItem")).toBe(false);
+    });
+
+    test("the UpdateItem grant is FGAC-restricted to the nodeResults/executionId attributes", () => {
+      const conditions = workerUpdateItemConditions();
+      expect(conditions.length).toBeGreaterThan(0);
+      const hasFgac = conditions.some((c) => {
+        const attrs = c?.["ForAllValues:StringEquals"]?.["dynamodb:Attributes"];
+        return (
+          Array.isArray(attrs) &&
+          attrs.includes("nodeResults") &&
+          attrs.includes("executionId") &&
+          !attrs.includes("status") &&
+          !attrs.includes("orgId")
+        );
+      });
+      expect(hasFgac).toBe(true);
     });
   });
 

--- a/docs/EVENTBRIDGE_CATALOG.md
+++ b/docs/EVENTBRIDGE_CATALOG.md
@@ -757,6 +757,7 @@ The consumer's write semantics make the family safe under duplicates, retries, a
 | `StepRunnerNodeCompletedRule` | detailType: `workflow.node.completed` | Step Runner Lambda |
 | `StepRunnerNodeFailedRule` | detailType: `workflow.node.failed` | Step Runner Lambda |
 | `StepRunnerCancelRule` | detailType: `execution.cancel.requested` | Step Runner Lambda |
+| `StepRunnerResumeRule` | detailType: `execution.resume.requested` | Step Runner Lambda |
 | `WorkflowProgressFanoutRule` | source: `citadel.workflows`, 7 detail types | Fan-out Lambda |
 
 ### ServicesStack Rules

--- a/docs/EVENTBRIDGE_CATALOG.md
+++ b/docs/EVENTBRIDGE_CATALOG.md
@@ -120,7 +120,7 @@ These events are published by the Step Runner via `arbiter/stepRunner/events.py`
 |------------|----------|----------|-------------|
 | `workflow.started` | executor.start_execution | Fan-out Lambda | Execution transitioned pending → running |
 | `workflow.node.started` | executor.invoke_node | Fan-out Lambda | Node began execution |
-| `workflow.node.completed` | Worker Wrapper | Step Runner, Fan-out Lambda | Node completed successfully |
+| `workflow.node.completed` | Worker Wrapper | Step Runner, Fan-out Lambda | Node completed successfully. **Write-then-signal (decision O2):** the Worker persists the node's `completed` status + output to `EXECUTIONS_TABLE.nodeResults[nodeId]` (conditional first-write-wins) BEFORE emitting this event, so the event is now purely a DAG-advance *signal*. A lost event leaves a durable, reconcilable checkpoint (the watchdog reconciles it within one sweep), never a signaled-but-unpersisted black hole. No wire-schema change. |
 | `workflow.node.failed` | Worker Wrapper | Step Runner, Fan-out Lambda | Node execution failed |
 | `workflow.node.retrying` | executor.handle_node_failure | Fan-out Lambda | Node scheduled for retry |
 | `workflow.completed` | executor.handle_node_completion | Fan-out Lambda | All nodes completed |
@@ -570,6 +570,45 @@ These events control workflow execution lifecycle. They are published by the Exe
 |------------|----------|----------|-------------|
 | `execution.start.requested` | execution-resolver, app-invoke-handler | Step Runner | Start a new workflow execution |
 | `execution.cancel.requested` | execution-resolver | Step Runner | Cancel a running execution |
+| `execution.resume.requested` | execution-resolver | Step Runner (`StepRunnerResumeRule`) | Advance-only resume of a stuck execution — re-derive the frontier from persisted state and dispatch pending-ready nodes |
+
+#### execution.resume.requested
+
+Emitted by the `resumeExecution` GraphQL mutation after an org-scoped IDOR
+check and terminal-state rejection (completed/cancelled/failed are not
+resumable, decision O5). The Step Runner re-derives the entire frontier from
+the persisted `EXECUTIONS_TABLE` row; the payload carries ONLY locating ids +
+the server-validated `orgId` (the consumer re-checks org ownership,
+defense-in-depth) — never a caller-supplied node list or status override.
+Resume is advance-only: it dispatches `pending`-ready nodes and NEVER
+re-dispatches a `running` node (decision O1 — re-driving a possibly-live worker
+is the watchdog stall-detector's job).
+
+```json
+{
+  "source": "citadel.workflows",
+  "detail-type": "execution.resume.requested",
+  "detail": {
+    "executionId": "string",
+    "workflowId": "string",
+    "orgId": "string",
+    "runId": "string (optional)"
+  }
+}
+```
+
+### Exactly-once guarantee and its agent-side limit (decision O7)
+
+The durable-execution machinery guarantees exactly-once at the **recorded-state**
+level only: exactly one `completed` result is recorded per node (worker
+first-write-wins), exactly one dispatch per node (conditional `pending→running`
+guard), and exactly one finalize per execution (conditional `running→completed`
+guard). It does **NOT** provide agent-side exactly-once: if the watchdog
+re-dispatches a node whose original worker was merely slow (not dead), the agent
+**body runs twice** and only the first recorded completion survives. Downstream
+agent bodies must therefore be designed idempotent. A dispatch-generation/lease
+token would be required for true agent-side once and is deferred (see
+docs/TRACING_RUNBOOK.md).
 
 ## Task Orchestration Events
 

--- a/docs/TRACING_RUNBOOK.md
+++ b/docs/TRACING_RUNBOOK.md
@@ -534,3 +534,42 @@ reuses `aws_cost_api_url` — see `docs/OBSERVABILITY.md`). The viewer page
 links from an execution detail sheet or a project conversation, or — for
 admins only — a raw trace-id lookup input, consistent with the
 admin-only gate on `/traces/{traceId}` above.
+
+
+## Durable execution resume & the exactly-once limit (decision O7)
+
+Workflow node execution is durable across lost events and worker crashes via
+three conditional DynamoDB writes plus a write-then-signal worker:
+
+1. **Dispatch guard** — a node is flipped `pending→running` only while still
+   `pending` (`ConditionExpression: nodeResults.#nid.#status = :pending`), so
+   concurrent predecessor completions, a resume, and a watchdog sweep converge
+   to exactly one dispatch per node.
+2. **Worker first-write-wins completion** — the Worker persists the completed
+   result to `EXECUTIONS_TABLE.nodeResults[nodeId]` (`status <> :completed`)
+   BEFORE emitting `workflow.node.completed`. A lost event therefore leaves a
+   durable, reconcilable checkpoint, not a lost result.
+3. **Finalize guard** — the execution flips `running→completed` only while
+   still `running`, so finalize + the terminal event fire exactly once.
+
+`resumeExecution(executionId)` is **advance-only**: the server re-derives the
+frontier from the persisted row (never a caller node list), dispatches only
+`pending`-ready nodes, and NEVER re-dispatches a `running` node. Re-driving a
+possibly-live worker is the watchdog stall-detector's job, gated by the stall
+threshold + first-write-wins.
+
+### The agent-side exactly-once limit (READ THIS)
+
+The guarantees above are **recorded-state** exactly-once ONLY — exactly one
+recorded completion, one dispatch, one finalize. They do **NOT** guarantee that
+an agent body executes at most once. If the watchdog re-dispatches a node whose
+original worker was merely slow (not dead), or SQS redelivers a dispatch after
+a persist error, **the agent body runs more than once** and first-write-wins
+simply drops the later recorded result.
+
+Operational consequence: **workflow agent bodies must be idempotent** — a node
+that provisions IAM, calls an external SaaS integration, or vends credentials
+must tolerate being run twice without duplicating the side effect. True
+agent-side exactly-once requires a dispatch-generation/lease token (the worker
+echoes a monotonic `dispatchGen`; the completion write rejects a stale
+generation) and is a deferred fast-follow, NOT provided by this slice.


### PR DESCRIPTION
## Summary
Workflow executions persist per-node state and outputs, but a crashed restarted execution has no resume entry point - it re-runs from the start. Two latent windows made partial failure worse: a node-completed event could be emitted before the output was persisted (a lost event meant lost work), and the convergence path could double-dispatch a node. This PR makes execution durable: checkpoint is derived from what's already persisted, resume dispatches only what never finished, and the watchdog reconciles instead of staying silent.
## What changed (four separable commits)
1. **Exactly-once recorded state**: Three conditional writes replace status-read guards: a `pending-running` dispatch guard (this also fixes a latent double-dispatch in the convergence path), first-write-wins node completion, and a `running›completed` finalize guard. A differential test proves the guard bites - it was first run against a deliberately non-conditional write and observed to double-dispatch.
1. **Write-then-signal**: The worker persists status/output *before* emitting `node.completed`. The signaled-but-unpersisted crash window is eliminated by construction; persisted-but-unsignaled becomes the benign, reconcilable mode. The worker's new table access is `UpdateItem`-only with an IAM attribute condition restricting writes to the node-results fields - not a general write grant.
1. **`resumeExecution`**: Org-scoped mutation with RBAC parity to `startExecution` and an ownership check before any event is emitted. It accepts only an execution id: the server re-derives the ready frontier from persisted state and dispatches only non-terminal nodes. Advance-only - running nodes are never re-dispatched (stall recovery belongs to the watchdog); failed/completed/cancelled are rejected; resume of a running execution is safely idempotent. The re-entry scheduler is extracted once and shared by normal advancement, resume, and the watchdog - and is the substrate the future pause/approve flow will reuse.
1. **Watchdog reconcile-or-fail**: Per-node stall detection (env-configurable, default 900s × factor 2, existing sweep cadence): a lost completion event is reconciled from persisted output within one sweep; a genuinely stalled node is retried or failed through the same conditional dispatch guard. A running execution is never left silently stuck.
## Honest limit
The guarantee is exactly-once *recorded* state. Agent-side side effects can still duplicate if a stalled-but-alive worker is re-dispatched. This is stated plainly in the code, the event catalog, and the runbook; the follow-up idempotency-key work planned addresses it at the tool boundary.
## Testing
- Arbiter pytest: 420 passing (+28 new), including hypothesis property tests for exactly-once under concurrent completions (deterministic conditional-write arbitration - no reliance on thread scheduling), kill-mid-DAG-then-resume completing with each completed node executed exactly once, Lost-event reconciliation within one sweep, and stall detection.
- Backend jest for the resolver and CDK assertions (including the worker's attribute-restricted grant); `tsc` clean; both affected stack synths clean.
- Each commit was green at commit time, giving independent rollback boundaries.
## Deployment notes
IAM deltas (worker: attribute-restricted `UpdateItem`; watchdog: scoped reads plus SQS send to the worker queue), one new EventBridge rule for resume, and a GraphQL schema addition. No new tables. The usual pre-merge branch deploy to dev applies; after deploy, the watchdog's new behavior is observable on any running execution.