### PR TITLE
feat(tools): fence stale dispatches and offload oversized results

### DIFF
--- a/arbiter/common/workflow_contract.py
+++ b/arbiter/common/workflow_contract.py
@@ -89,6 +89,15 @@ class NodeDispatchMessage:
     # for any pre-runId dispatcher, a pre-runId execution row, or a
     # malformed wire value — best-effort, never fabricated.
     run_id: Optional[str] = None
+    # Additive (PR2 dispatch-generation fence): the per-node dispatch
+    # generation the step runner incremented on this node's pending->running
+    # transition. Carried to the worker so its tool-call reserve can be fenced
+    # against the execution row's current generation — a stale
+    # (re-dispatched-away) worker is refused before any side effect. None for a
+    # pre-fence dispatcher or a malformed wire value; when None the worker's
+    # reserve is unfenced (exactly-once-within-attempt only), preserving
+    # back-compat.
+    dispatch_generation: Optional[int] = None
 
 
 @dataclass
@@ -155,6 +164,7 @@ def build_node_dispatch_message(
     trace_context: Optional[dict[str, Any]] = None,
     dispatched_at: Optional[str] = None,
     run_id: Optional[str] = None,
+    dispatch_generation: Optional[int] = None,
 ) -> dict:
     """Build a JSON-serializable node-dispatch message for the worker queue.
 
@@ -206,6 +216,12 @@ def build_node_dispatch_message(
         raise ValueError(
             "node-dispatch message: 'run_id' must be a string when present"
         )
+    if dispatch_generation is not None and (
+        not isinstance(dispatch_generation, int) or isinstance(dispatch_generation, bool)
+    ):
+        raise ValueError(
+            "node-dispatch message: 'dispatch_generation' must be an int when present"
+        )
 
     message: dict[str, Any] = {
         'message_type': MESSAGE_TYPE_WORKFLOW_NODE,
@@ -224,6 +240,8 @@ def build_node_dispatch_message(
         message['dispatchedAt'] = dispatched_at
     if isinstance(run_id, str) and run_id:
         message['runId'] = run_id
+    if dispatch_generation is not None:
+        message['dispatch_generation'] = dispatch_generation
     return message
 
 
@@ -278,6 +296,12 @@ def parse_node_dispatch_message(body: Any) -> NodeDispatchMessage:
         # mirrors dispatched_at's malformed-wire-value degradation above.
         run_id = None
 
+    dispatch_generation = body.get('dispatch_generation')
+    if isinstance(dispatch_generation, bool) or not isinstance(dispatch_generation, int):
+        # Best-effort, never gates parsing (PR2 fence): a malformed/absent
+        # generation degrades to None -> the worker's reserve is unfenced.
+        dispatch_generation = None
+
     return NodeDispatchMessage(
         execution_id=execution_id,
         node_id=node_id,
@@ -288,6 +312,7 @@ def parse_node_dispatch_message(body: Any) -> NodeDispatchMessage:
         correlation_id=correlation_id,
         dispatched_at=dispatched_at,
         run_id=run_id,
+        dispatch_generation=dispatch_generation,
     )
 
 

--- a/arbiter/governance/__tests__/test_tool_execution_fence.py
+++ b/arbiter/governance/__tests__/test_tool_execution_fence.py
@@ -1,0 +1,309 @@
+"""Tests for the PR2 dispatch-generation fence in tool_execution_ledger.reserve.
+
+The fence closes the inherited O7 commitment: a worker that was re-dispatched
+away (its node's dispatchGeneration was bumped by the watchdog) is REFUSED at
+the reserve step before any side effect. Security condition C2 requires the
+generation guard to be evaluated inside the SAME conditional write as the
+reserve — so it is implemented as a ``ConditionCheck`` on the execution row
+inside the reserve's ``TransactWriteItems``.
+
+The fake ``transact_write_items`` here is FAITHFUL: it unmarshals the real
+marshalled TransactItems (exercising ``_marshal``/``TypeSerializer``),
+evaluates BOTH the ledger ``attribute_not_exists`` Put condition and the
+execution-row generation ``ConditionCheck`` against shared state, and raises a
+real ``TransactionCanceledException`` with per-item ``CancellationReasons`` —
+so the differential RED (unfenced double-execute) and the TOCTOU proof
+(a generation bump interleaved at commit time) both bite for the right reason.
+"""
+from __future__ import annotations
+
+import os
+import sys
+
+import pytest
+from botocore.exceptions import ClientError
+from boto3.dynamodb.types import TypeDeserializer
+
+_PROJECT_ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "..", ".."))
+if _PROJECT_ROOT not in sys.path:
+    sys.path.insert(0, _PROJECT_ROOT)
+
+from arbiter.governance import tool_execution_ledger as ledger  # noqa: E402
+from arbiter.governance.tool_execution_ledger import (  # noqa: E402
+    ReserveOutcome,
+    StaleWorkerFencedError,
+    __reset_ledger_client_for_test,
+    execute_idempotent,
+)
+from arbiter.workerWrapper.tool_idempotency import MODE_LEDGER, build_key  # noqa: E402
+
+LEDGER_TABLE = "citadel-tool-execution-ledger-test"
+EXEC_TABLE = "citadel-executions-test"
+
+_deser = TypeDeserializer()
+
+
+def _unmarshal(marshalled: dict) -> dict:
+    return {k: _deser.deserialize(v) for k, v in marshalled.items()}
+
+
+class _FakeLedgerTable:
+    """Ledger table: (pk, sk) keyed, honours attribute_not_exists / status /
+    createdAt conditions for put/get/update (finalize path)."""
+
+    def __init__(self) -> None:
+        self.store: dict[tuple, dict] = {}
+
+    @staticmethod
+    def _k(d):
+        return (d[ledger.PK_ATTR], d[ledger.SK_ATTR])
+
+    def _cond_ok(self, expr, existing, names, values):
+        if not expr:
+            return True
+        if "attribute_not_exists" in expr:
+            return existing is None
+        for term in expr.split(" AND "):
+            lhs, rhs = [t.strip() for t in term.split("=")]
+            attr = names.get(lhs, lhs) if lhs.startswith("#") else lhs
+            if existing is None or existing.get(attr) != values[rhs]:
+                return False
+        return True
+
+    def put_item(self, Item, ConditionExpression=None, **_kw):  # noqa: N803
+        if not self._cond_ok(ConditionExpression, self.store.get(self._k(Item)), {}, {}):
+            raise _ccf("PutItem")
+        self.store[self._k(Item)] = dict(Item)
+        return {}
+
+    def get_item(self, Key, **_kw):  # noqa: N803
+        item = self.store.get((Key[ledger.PK_ATTR], Key[ledger.SK_ATTR]))
+        return {"Item": dict(item)} if item is not None else {}
+
+    def update_item(self, Key, UpdateExpression, ConditionExpression=None,  # noqa: N803
+                    ExpressionAttributeNames=None, ExpressionAttributeValues=None, **_kw):
+        key = (Key[ledger.PK_ATTR], Key[ledger.SK_ATTR])
+        existing = self.store.get(key)
+        names = ExpressionAttributeNames or {}
+        values = ExpressionAttributeValues or {}
+        if not self._cond_ok(ConditionExpression, existing, names, values):
+            raise _ccf("UpdateItem")
+        target = dict(existing) if existing else {ledger.PK_ATTR: key[0], ledger.SK_ATTR: key[1]}
+        for assignment in UpdateExpression[4:].split(","):
+            lhs, rhs = [t.strip() for t in assignment.split("=")]
+            attr = names.get(lhs, lhs) if lhs.startswith("#") else lhs
+            target[attr] = values[rhs.strip()]
+        self.store[key] = target
+        return {}
+
+
+def _ccf(op):
+    return ClientError({"Error": {"Code": "ConditionalCheckFailedException", "Message": "c"}}, op)
+
+
+class _FakeClient:
+    """Faithful transact_write_items over the shared ledger + executions state.
+
+    ``pre_eval_hook`` runs immediately before the fence ConditionCheck is
+    evaluated — the TOCTOU test uses it to bump the execution generation at
+    commit time and prove the guard reads LIVE state (no read-then-check gap).
+    """
+
+    def __init__(self, ledger_table, exec_store, *, pre_eval_hook=None):
+        self._ledger = ledger_table
+        self._exec = exec_store
+        self.pre_eval_hook = pre_eval_hook
+
+    def transact_write_items(self, TransactItems):  # noqa: N803
+        put = TransactItems[0]["Put"]
+        check = TransactItems[1]["ConditionCheck"]
+        put_item = _unmarshal(put["Item"])
+        put_ok = self._ledger.store.get((put_item[ledger.PK_ATTR], put_item[ledger.SK_ATTR])) is None
+
+        if self.pre_eval_hook is not None:
+            self.pre_eval_hook()
+
+        check_key = _unmarshal(check["Key"])
+        names = check["ExpressionAttributeNames"]
+        gen_value = _deser.deserialize(check["ExpressionAttributeValues"][":gen"])
+        row = self._exec.get(check_key["executionId"], {})
+        node = (row.get("nodeResults") or {}).get(names["#nid"], {})
+        current = node.get(names["#gen"])
+        fence_ok = current is not None and current == gen_value
+
+        if put_ok and fence_ok:
+            self._ledger.store[(put_item[ledger.PK_ATTR], put_item[ledger.SK_ATTR])] = put_item
+            return {}
+        reasons = [
+            {"Code": "None" if put_ok else "ConditionalCheckFailed"},
+            {"Code": "None" if fence_ok else "ConditionalCheckFailed"},
+        ]
+        raise ClientError(
+            {"Error": {"Code": "TransactionCanceledException", "Message": "cancelled"},
+             "CancellationReasons": reasons},
+            "TransactWriteItems",
+        )
+
+
+class _FakeResource:
+    def __init__(self, ledger_table, exec_store, *, pre_eval_hook=None):
+        self._ledger_table = ledger_table
+        self.meta = type("M", (), {})()
+        self.meta.client = _FakeClient(ledger_table, exec_store, pre_eval_hook=pre_eval_hook)
+
+    def Table(self, name):  # noqa: N802
+        return self._ledger_table
+
+
+@pytest.fixture
+def fence_env(monkeypatch):
+    monkeypatch.setenv("TOOL_EXECUTION_LEDGER_TABLE", LEDGER_TABLE)
+    monkeypatch.setenv("EXECUTIONS_TABLE", EXEC_TABLE)
+    __reset_ledger_client_for_test()
+    yield
+    __reset_ledger_client_for_test()
+
+
+def _wire(monkeypatch, exec_store, *, pre_eval_hook=None):
+    lt = _FakeLedgerTable()
+    resource = _FakeResource(lt, exec_store, pre_eval_hook=pre_eval_hook)
+    monkeypatch.setattr(ledger, "_get_dynamodb_resource", lambda: resource)
+    return lt
+
+
+def _exec_store(gen):
+    return {"exec1": {"executionId": "exec1", "nodeResults": {"node1": {"dispatchGeneration": gen}}}}
+
+
+# ---------------------------------------------------------------------------
+# THE RED PROOF (captured, permanent differential)
+# ---------------------------------------------------------------------------
+
+
+class TestFenceDifferentialRedProof:
+    """A stale-generation split-brain: worker A (gen 1) and worker B (gen 2)
+    both run; the node's current generation is 2 (A was re-dispatched away).
+
+    UNFENCED (dispatch_generation=None), nondeterministic re-dispatch yields
+    DIFFERENT keys -> both reserve WON -> BOTH execute (calls == 2, the bug).
+    FENCED -> A is refused at the reserve fence (StaleWorkerFencedError, no
+    execution); only B executes (calls == 1)."""
+
+    def test_unfenced_stale_worker_double_executes_RED(self, fence_env, monkeypatch):
+        _wire(monkeypatch, _exec_store(2))
+        calls = {"n": 0}
+
+        def adapter():
+            calls["n"] += 1
+            return {"status": "success", "ticketId": f"T-{calls['n']}"}
+
+        # Nondeterministic re-dispatch -> different args -> different keys.
+        pk_a, sk_a = build_key("orgA", "exec1", "node1", 0, "createTicket", {"subject": "A"})
+        pk_b, sk_b = build_key("orgA", "exec1", "node1", 0, "createTicket", {"subject": "B"})
+        # Unfenced: no dispatch_generation threaded.
+        execute_idempotent(pk=pk_a, sk=sk_a, tool_name="createTicket", mode=MODE_LEDGER, run_tool=adapter)
+        execute_idempotent(pk=pk_b, sk=sk_b, tool_name="createTicket", mode=MODE_LEDGER, run_tool=adapter)
+
+        assert calls["n"] == 2  # RED: the unfenced path lets the stale worker through
+
+    def test_fenced_stale_worker_refused_single_execute_GREEN(self, fence_env, monkeypatch):
+        _wire(monkeypatch, _exec_store(2))
+        calls = {"n": 0}
+
+        def adapter():
+            calls["n"] += 1
+            return {"status": "success", "ticketId": f"T-{calls['n']}"}
+
+        pk_a, sk_a = build_key("orgA", "exec1", "node1", 0, "createTicket", {"subject": "A"})
+        pk_b, sk_b = build_key("orgA", "exec1", "node1", 0, "createTicket", {"subject": "B"})
+
+        # Worker A carries the STALE generation 1 -> fenced, never executes.
+        with pytest.raises(StaleWorkerFencedError):
+            execute_idempotent(
+                pk=pk_a, sk=sk_a, tool_name="createTicket", mode=MODE_LEDGER,
+                run_tool=adapter, dispatch_generation=1,
+                execution_id="exec1", node_id="node1",
+            )
+        # Worker B carries the CURRENT generation 2 -> wins, executes once.
+        execute_idempotent(
+            pk=pk_b, sk=sk_b, tool_name="createTicket", mode=MODE_LEDGER,
+            run_tool=adapter, dispatch_generation=2,
+            execution_id="exec1", node_id="node1",
+        )
+
+        assert calls["n"] == 1  # GREEN: only the current generation executed
+
+
+# ---------------------------------------------------------------------------
+# TOCTOU: the guard is IN the reserve's conditional write, not a prior read
+# ---------------------------------------------------------------------------
+
+
+class TestFenceTOCTOU:
+    def test_generation_bump_at_commit_time_refuses_stale_worker(self, fence_env, monkeypatch):
+        """A generation bump interleaved BETWEEN a (hypothetical) read and the
+        write must NOT let the stale worker through. The worker carries gen 1,
+        which is current when it starts; a watchdog re-dispatch bumps the
+        execution row to gen 2 at commit time (via pre_eval_hook). Because the
+        guard is a ConditionCheck evaluated atomically WITH the reserve — not a
+        separate read-then-act — the worker is refused. A naive read-then-check
+        would have seen gen 1 and proceeded (the very TOCTOU window C2 forbids).
+        """
+        exec_store = _exec_store(1)  # worker's carried gen (1) IS current at start
+        calls = {"n": 0}
+
+        def bump_generation():
+            # The re-dispatch lands right before the fence condition is evaluated.
+            exec_store["exec1"]["nodeResults"]["node1"]["dispatchGeneration"] = 2
+
+        _wire(monkeypatch, exec_store, pre_eval_hook=bump_generation)
+
+        def adapter():
+            calls["n"] += 1
+            return {"status": "success"}
+
+        pk, sk = build_key("orgA", "exec1", "node1", 0, "createTicket", {"subject": "hi"})
+        with pytest.raises(StaleWorkerFencedError):
+            execute_idempotent(
+                pk=pk, sk=sk, tool_name="createTicket", mode=MODE_LEDGER,
+                run_tool=adapter, dispatch_generation=1,
+                execution_id="exec1", node_id="node1",
+            )
+        assert calls["n"] == 0  # never executed — the guard read live state at write time
+
+    def test_current_generation_worker_wins_and_dedupes_under_fence(self, fence_env, monkeypatch):
+        """The current-generation worker reserves; a redelivery of the SAME key
+        (fence Put fails, fence check passes) resolves to the recorded result —
+        dedupe still works under the fence (exactly-once within the generation)."""
+        lt = _wire(monkeypatch, _exec_store(3))
+        calls = {"n": 0}
+
+        def adapter():
+            calls["n"] += 1
+            return {"status": "success", "ticketId": "T-1"}
+
+        pk, sk = build_key("orgA", "exec1", "node1", 0, "createTicket", {"subject": "hi"})
+        r1 = execute_idempotent(
+            pk=pk, sk=sk, tool_name="createTicket", mode=MODE_LEDGER, run_tool=adapter,
+            dispatch_generation=3, execution_id="exec1", node_id="node1",
+        )
+        r2 = execute_idempotent(
+            pk=pk, sk=sk, tool_name="createTicket", mode=MODE_LEDGER, run_tool=adapter,
+            dispatch_generation=3, execution_id="exec1", node_id="node1",
+        )
+        assert calls["n"] == 1
+        assert r1["ticketId"] == "T-1" and r2["ticketId"] == "T-1"
+        completed = [v for v in lt.store.values() if v.get("status") == "completed"]
+        assert len(completed) == 1
+
+    def test_missing_executions_table_fails_closed(self, fence_env, monkeypatch):
+        """A generation was threaded but EXECUTIONS_TABLE is unset -> fail closed
+        (never silently downgrade to an unfenced reserve)."""
+        _wire(monkeypatch, _exec_store(1))
+        monkeypatch.delenv("EXECUTIONS_TABLE", raising=False)
+        pk, sk = build_key("orgA", "exec1", "node1", 0, "createTicket", {"subject": "hi"})
+        with pytest.raises(ledger.LedgerError):
+            execute_idempotent(
+                pk=pk, sk=sk, tool_name="createTicket", mode=MODE_LEDGER, run_tool=lambda: {},
+                dispatch_generation=1, execution_id="exec1", node_id="node1",
+            )

--- a/arbiter/governance/__tests__/test_tool_execution_ledger.py
+++ b/arbiter/governance/__tests__/test_tool_execution_ledger.py
@@ -217,7 +217,7 @@ class TestConcurrentRace:
             calls["n"] += 1
             return {"status": "success", "ticketId": f"T-{calls['n']}"}
 
-        def nonconditional_reserve(_pk, _sk, *, tool_name, now=None):
+        def nonconditional_reserve(_pk, _sk, *, tool_name, now=None, **_kw):
             _table(_fake_ddb).store[(_pk, _sk)] = {
                 ledger.PK_ATTR: _pk, ledger.SK_ATTR: _sk, "status": "in_flight",
             }

--- a/arbiter/governance/__tests__/test_tool_result_offload.py
+++ b/arbiter/governance/__tests__/test_tool_result_offload.py
@@ -1,0 +1,213 @@
+"""Tests for the PR2 oversized-result S3 offload in tool_execution_ledger.
+
+Replaces PR1's deterministic oversize marker: an oversized result is offloaded
+to a CMK-encrypted, org/execution-prefixed S3 object so a deduped caller gets
+the FULL recorded body (faithful replay). Security condition C3 pieces proven
+here: SSE-KMS is requested on write, the object key is org/execution-prefixed,
+the stored resultRef is re-checked against the caller's prefix on read
+(cross-org refusal), and an oversize result with no bucket fails closed.
+"""
+from __future__ import annotations
+
+import json
+import os
+import sys
+
+import pytest
+from botocore.exceptions import ClientError
+
+_PROJECT_ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "..", ".."))
+if _PROJECT_ROOT not in sys.path:
+    sys.path.insert(0, _PROJECT_ROOT)
+
+from arbiter.governance import tool_execution_ledger as ledger  # noqa: E402
+from arbiter.governance.tool_execution_ledger import (  # noqa: E402
+    CrossOrgResultRefError,
+    LedgerError,
+    __reset_ledger_client_for_test,
+    execute_idempotent,
+    finalize_success,
+    reserve,
+    _recorded_result,
+)
+from arbiter.workerWrapper.tool_idempotency import MODE_LEDGER, build_key  # noqa: E402
+
+LEDGER_TABLE = "citadel-tool-execution-ledger-test"
+BUCKET = "citadel-tool-results-test"
+
+# Module-level alias: a dunder-prefixed name referenced bare inside a class
+# method is name-mangled by Python, so bind a plain name here.
+_reset_ledger_client_for_test = __reset_ledger_client_for_test
+
+
+class _FakeLedgerTable:
+    def __init__(self):
+        self.store: dict[tuple, dict] = {}
+
+    def _cond_ok(self, expr, existing, names, values):
+        if not expr:
+            return True
+        if "attribute_not_exists" in expr:
+            return existing is None
+        for term in expr.split(" AND "):
+            lhs, rhs = [t.strip() for t in term.split("=")]
+            attr = names.get(lhs, lhs) if lhs.startswith("#") else lhs
+            if existing is None or existing.get(attr) != values[rhs]:
+                return False
+        return True
+
+    def put_item(self, Item, ConditionExpression=None, **_kw):  # noqa: N803
+        k = (Item[ledger.PK_ATTR], Item[ledger.SK_ATTR])
+        if not self._cond_ok(ConditionExpression, self.store.get(k), {}, {}):
+            raise ClientError({"Error": {"Code": "ConditionalCheckFailedException"}}, "PutItem")
+        self.store[k] = dict(Item)
+        return {}
+
+    def get_item(self, Key, **_kw):  # noqa: N803
+        item = self.store.get((Key[ledger.PK_ATTR], Key[ledger.SK_ATTR]))
+        return {"Item": dict(item)} if item is not None else {}
+
+    def update_item(self, Key, UpdateExpression, ConditionExpression=None,  # noqa: N803
+                    ExpressionAttributeNames=None, ExpressionAttributeValues=None, **_kw):
+        k = (Key[ledger.PK_ATTR], Key[ledger.SK_ATTR])
+        existing = self.store.get(k)
+        names = ExpressionAttributeNames or {}
+        values = ExpressionAttributeValues or {}
+        if not self._cond_ok(ConditionExpression, existing, names, values):
+            raise ClientError({"Error": {"Code": "ConditionalCheckFailedException"}}, "UpdateItem")
+        target = dict(existing) if existing else {ledger.PK_ATTR: k[0], ledger.SK_ATTR: k[1]}
+        for assignment in UpdateExpression[4:].split(","):
+            lhs, rhs = [t.strip() for t in assignment.split("=")]
+            attr = names.get(lhs, lhs) if lhs.startswith("#") else lhs
+            target[attr] = values[rhs.strip()]
+        self.store[k] = target
+        return {}
+
+
+class _FakeResource:
+    def __init__(self, table):
+        self._t = table
+
+    def Table(self, name):  # noqa: N802
+        return self._t
+
+
+class _FakeS3:
+    def __init__(self):
+        self.objects: dict[tuple, bytes] = {}
+        self.puts: list[dict] = []
+
+    def put_object(self, **kwargs):
+        self.puts.append(kwargs)
+        self.objects[(kwargs["Bucket"], kwargs["Key"])] = kwargs["Body"]
+        return {}
+
+    def get_object(self, Bucket, Key):  # noqa: N803
+        body = self.objects.get((Bucket, Key))
+        if body is None:
+            raise ClientError({"Error": {"Code": "NoSuchKey"}}, "GetObject")
+        return {"Body": _Body(body)}
+
+
+class _Body:
+    def __init__(self, data):
+        self._data = data
+
+    def read(self):
+        return self._data
+
+
+@pytest.fixture
+def offload_env(monkeypatch):
+    monkeypatch.setenv("TOOL_EXECUTION_LEDGER_TABLE", LEDGER_TABLE)
+    monkeypatch.setenv("TOOL_RESULT_BUCKET", BUCKET)
+    monkeypatch.setenv("TOOL_RESULT_KMS_KEY_ID", "arn:aws:kms:region:acct:key/cmk-123")
+    # Force everything above 40 bytes to offload.
+    monkeypatch.setenv("TOOL_RESULT_MAX_INLINE_BYTES", "40")
+    __reset_ledger_client_for_test()
+    table = _FakeLedgerTable()
+    s3 = _FakeS3()
+    monkeypatch.setattr(ledger, "_get_dynamodb_resource", lambda: _FakeResource(table))
+    monkeypatch.setattr(ledger, "_get_s3_client", lambda: s3)
+    yield table, s3
+    __reset_ledger_client_for_test()
+
+
+def _big_result():
+    return {"status": "success", "payload": "x" * 500}
+
+
+class TestOffloadRoundTrip:
+    def test_oversized_result_offloaded_with_sse_kms_and_org_prefix(self, offload_env):
+        table, s3 = offload_env
+        pk, sk = build_key("orgA", "exec1", "node1", 0, "bigTool", {"a": 1})
+        assert reserve(pk, sk, tool_name="bigTool").outcome.value == "won"
+        finalize_success(pk, sk, result=_big_result())
+
+        row = table.store[(pk, sk)]
+        assert row.get("resultOffloaded") is True
+        assert "result" not in row                       # not stored inline
+        ref = row["resultRef"]
+        assert ref["bucket"] == BUCKET
+        assert ref["key"].startswith("tool-results/orgA/exec1/")   # org/exec prefixed
+        # SSE-KMS requested on the write (deny-non-KMS is enforced by the bucket policy).
+        put = s3.puts[0]
+        assert put["ServerSideEncryption"] == "aws:kms"
+        assert put["SSEKMSKeyId"] == "arn:aws:kms:region:acct:key/cmk-123"
+
+    def test_dedupe_returns_full_offloaded_body(self, offload_env):
+        table, s3 = offload_env
+        calls = {"n": 0}
+
+        def adapter():
+            calls["n"] += 1
+            return _big_result()
+
+        pk, sk = build_key("orgA", "exec1", "node1", 0, "bigTool", {"a": 1})
+        r1 = execute_idempotent(pk=pk, sk=sk, tool_name="bigTool", mode=MODE_LEDGER, run_tool=adapter)
+        r2 = execute_idempotent(pk=pk, sk=sk, tool_name="bigTool", mode=MODE_LEDGER, run_tool=adapter)
+        assert calls["n"] == 1
+        # Faithful replay: the deduped caller gets the FULL body, not a marker.
+        assert r1 == _big_result()
+        assert r2 == _big_result()
+        assert len(r2["payload"]) == 500
+
+
+class TestCrossOrgResultRefRefused:
+    def test_result_ref_outside_caller_prefix_is_refused(self, offload_env):
+        table, s3 = offload_env
+        # A completed row for orgA/exec1 whose resultRef points at ANOTHER org's
+        # object (forged / confused-deputy). The read must refuse, not fetch.
+        pk, sk = build_key("orgA", "exec1", "node1", 0, "bigTool", {"a": 1})
+        s3.objects[(BUCKET, "tool-results/orgB/exec9/deadbeef.json")] = b'{"secret":"orgB"}'
+        row = {
+            ledger.PK_ATTR: pk, ledger.SK_ATTR: sk, "status": "completed",
+            "resultOffloaded": True,
+            "resultRef": {"bucket": BUCKET, "key": "tool-results/orgB/exec9/deadbeef.json"},
+        }
+        with pytest.raises(CrossOrgResultRefError):
+            _recorded_result(row, pk)
+
+    def test_valid_ref_within_prefix_reads(self, offload_env):
+        table, s3 = offload_env
+        pk, sk = build_key("orgA", "exec1", "node1", 0, "bigTool", {"a": 1})
+        key = "tool-results/orgA/exec1/abc.json"
+        s3.objects[(BUCKET, key)] = json.dumps({"ok": True}).encode()
+        row = {ledger.PK_ATTR: pk, ledger.SK_ATTR: sk, "status": "completed",
+               "resultRef": {"bucket": BUCKET, "key": key}}
+        assert _recorded_result(row, pk) == {"ok": True}
+
+
+class TestOffloadFailClosed:
+    def test_oversized_without_bucket_fails_closed(self, monkeypatch):
+        monkeypatch.setenv("TOOL_EXECUTION_LEDGER_TABLE", LEDGER_TABLE)
+        monkeypatch.delenv("TOOL_RESULT_BUCKET", raising=False)
+        monkeypatch.setenv("TOOL_RESULT_MAX_INLINE_BYTES", "40")
+        _reset_ledger_client_for_test()
+        table = _FakeLedgerTable()
+        monkeypatch.setattr(ledger, "_get_dynamodb_resource", lambda: _FakeResource(table))
+        pk, sk = build_key("orgA", "exec1", "node1", 0, "bigTool", {"a": 1})
+        reserve(pk, sk, tool_name="bigTool")
+        with pytest.raises(LedgerError):
+            finalize_success(pk, sk, result=_big_result())
+        _reset_ledger_client_for_test()

--- a/arbiter/governance/tool_execution_ledger.py
+++ b/arbiter/governance/tool_execution_ledger.py
@@ -8,19 +8,40 @@ reserve -> execute -> finalize protocol against them.
 
 Guarantee (state it precisely — do NOT collapse to a bare "exactly-once"):
 
-* **Exactly-once execution of the side effect is a GUARANTEE for calls that
+* **Exactly-once execution of the side effect is GUARANTEED for calls that
   resolve to the same key** — redelivery, same-attempt SDK/Strands retries,
   and concurrent split-brain with identical keys. The reservation's
   conditional write is what provides it: exactly one caller wins the reserve
   and executes; every other caller is absorbed (recorded result) or bounced
   with a retryable no-execution error, and NEVER executes.
-* It is **best-effort across nondeterministic re-dispatch** (different keys),
-  which is closed only by the worker ``dispatchGeneration`` fence — DEFERRED
-  to PR2 and REQUIRED for the complete guarantee. Nothing here is the complete
-  guarantee on its own.
+* **Exactly-once across a watchdog re-dispatch is GUARANTEED for
+  workflow-node tool calls once the ``dispatchGeneration`` fence is engaged
+  (PR2, landed).** When the step runner re-dispatches a node it increments a
+  per-node ``dispatchGeneration`` on the execution row; each worker carries
+  the generation it was dispatched under, and the fence — evaluated as a
+  ``ConditionCheck`` inside the SAME ``TransactWriteItems`` that performs the
+  reserve (no read-then-check TOCTOU window) — REFUSES a stale worker
+  (:class:`StaleWorkerFencedError`) before any side effect. So a
+  stalled-but-alive original worker (H2 split-brain) and a nondeterministic
+  re-dispatch body (H1) can no longer both reach an adapter: only the current
+  generation's worker executes.
+* **Residual (still best-effort):** a tool call that runs OUTSIDE the fence
+  envelope — a supervisor task (no execution/node/generation context) or a
+  tool flagged ``idempotency.mode='bypass'`` (skips the ledger, and therefore
+  the fence) — is NOT generation-fenced. For those the guarantee remains
+  exactly-once-within-attempt + reservation-race safety only. The fence is a
+  JOINT property of (reserve-before-execute atomic seam) ∧ (no bypass path)
+  ∧ (a generation was threaded); it does not cover paths that opt out of the
+  ledger.
 * Concurrent-loser *result delivery* is best-effort (a slow/dead holder may
   yield a retryable error instead of the recorded result); side-effect
   *execution* remains exactly-once.
+
+Oversized results are OFFLOADED to a CMK-encrypted, org-prefixed S3 object
+(PR2, landed) so a deduped caller receives the FULL recorded result — a
+faithful replay. The stored ``resultRef`` is re-checked against the caller's
+org/execution prefix on read (:class:`CrossOrgResultRefError`), so a forged or
+confused-deputy ref cannot cross orgs.
 
 NOT an audit artifact: TTL is 48h operational (server-write-time based),
 distinct from the 90-day ``arbiter/governance/ledger.py`` accountability
@@ -39,10 +60,13 @@ import logging
 import os
 import time
 from dataclasses import dataclass
+from decimal import Decimal
 from enum import Enum
+from numbers import Number
 from typing import Any, Callable
 
 import boto3
+from boto3.dynamodb.types import TypeSerializer
 from botocore.exceptions import BotoCoreError, ClientError
 
 from arbiter.workerWrapper.tool_idempotency import MODE_BYPASS
@@ -145,6 +169,34 @@ class RecordedToolFailure(LedgerError):
         self.recorded = recorded or {}
 
 
+class StaleWorkerFencedError(LedgerError):
+    """A re-dispatched-away (stale) worker was refused at the reserve fence.
+
+    The worker carries a ``dispatchGeneration`` older than the execution row's
+    current generation for this node — its node was re-dispatched by the
+    watchdog, so a newer worker owns it. The fence (a ``ConditionCheck`` inside
+    the SAME ``TransactWriteItems`` as the reserve) rejects it atomically
+    BEFORE any adapter call, so no side effect occurred. Non-retryable for THIS
+    worker: its generation can never become current again, and the current
+    generation's worker will perform (and record) the call.
+    """
+
+    retryable = False
+
+
+class CrossOrgResultRefError(LedgerError):
+    """A stored ``resultRef`` does not belong to the reading caller's org.
+
+    Defense-in-depth on the S3 offload read path: the offloaded object key is
+    org/execution-prefixed (``tool-results/{orgId}/{executionId}/…``) and is
+    re-validated on read against the org/execution derived from the ledger PK
+    the caller located the row by. A ref that points outside that prefix (a
+    forged or confused-deputy pointer) is refused rather than fetched.
+    """
+
+    retryable = False
+
+
 class ToolOutcomeError(Exception):
     """Adapter-raised classification of a failed tool call.
 
@@ -218,33 +270,139 @@ def _table() -> Any:
 
 def __reset_ledger_client_for_test() -> None:
     """Test-only: clear the cached boto3 resource."""
-    global _ddb_resource
+    global _ddb_resource, _s3_client
     _ddb_resource = None
+    _s3_client = None
 
 
-# --- Result preparation (inline only in PR1; S3 offload is PR2) -------------
+# --- Lazy DynamoDB client (fenced reserve uses TransactWriteItems) -----------
+
+_serializer = TypeSerializer()
 
 
-def _prepare_result(result: Any) -> tuple[Any, bool, str | None]:
-    """Return ``(inline_result_json, truncated, marker)`` for a tool result.
+def _get_dynamodb_client() -> Any:
+    """The low-level DynamoDB client backing the resource.
 
-    Inline results only in PR1. When the serialized result exceeds
-    ``max_inline_bytes`` it is NOT stored inline and is NOT truncated into a
-    partial body (a partial replay would be unfaithful); instead we record a
-    deterministic content marker (``sha256`` of the canonical JSON) and set
-    ``truncated=True``. Faithful large-result replay via S3 offload is PR2 —
-    do NOT build it here. A caller that gets a truncated record must treat the
-    dedupe hit as "known-completed, body unavailable inline".
+    ``TransactWriteItems`` (the fenced reserve) is a client-level operation
+    with no resource-Table equivalent. Reusing ``resource.meta.client`` keeps
+    a single credential/config source and lets a test that patches
+    :func:`_get_dynamodb_resource` reach a fake client through ``.meta.client``
+    with no second seam.
+    """
+    return _get_dynamodb_resource().meta.client
+
+
+def _to_ddb_number_safe(obj: Any) -> Any:
+    """Recursively convert ``float`` to ``Decimal`` so ``TypeSerializer`` (which
+    rejects floats) can marshal a ledger item for the client-level transaction.
+    Ints/strings/None/bools/containers pass through unchanged."""
+    if isinstance(obj, bool):
+        return obj
+    if isinstance(obj, float):
+        return Decimal(str(obj))
+    if isinstance(obj, dict):
+        return {k: _to_ddb_number_safe(v) for k, v in obj.items()}
+    if isinstance(obj, (list, tuple)):
+        return [_to_ddb_number_safe(v) for v in obj]
+    return obj
+
+
+def _marshal(mapping: dict[str, Any]) -> dict[str, Any]:
+    """Marshal a plain dict to DynamoDB AttributeValue JSON for the client API."""
+    safe = _to_ddb_number_safe(mapping)
+    return {k: _serializer.serialize(v) for k, v in safe.items()}
+
+
+# --- Lazy S3 client (oversized-result offload) -------------------------------
+
+_s3_client: Any = None
+
+
+def _get_s3_client() -> Any:
+    global _s3_client
+    if _s3_client is None:
+        _s3_client = boto3.client("s3")
+    return _s3_client
+
+
+def _result_bucket() -> str | None:
+    bucket = os.environ.get("TOOL_RESULT_BUCKET")
+    return bucket or None
+
+
+def _result_kms_key_id() -> str | None:
+    key_id = os.environ.get("TOOL_RESULT_KMS_KEY_ID")
+    return key_id or None
+
+
+def _split_pk(pk: str) -> tuple[str, str]:
+    """Split a ledger PK ``orgId#executionId`` into ``(orgId, executionId)``.
+
+    ``orgId`` may legitimately be empty (executionId alone is globally unique);
+    the org prefix is defense-in-depth, not the uniqueness guarantee.
+    """
+    org_id, sep, execution_id = pk.partition("#")
+    return (org_id, execution_id if sep else "")
+
+
+def _result_object_key(pk: str, sk: str) -> str:
+    """Org/execution-prefixed S3 key for an offloaded result.
+
+    ``tool-results/{orgId}/{executionId}/{sha256(sk)}.json`` — the org prefix
+    gives structural cross-org isolation and is re-validated on read.
+    """
+    org_id, execution_id = _split_pk(pk)
+    digest = hashlib.sha256(sk.encode("utf-8")).hexdigest()
+    return f"tool-results/{org_id}/{execution_id}/{digest}.json"
+
+
+# --- Result preparation (inline, else CMK-encrypted org-prefixed S3 offload) -
+
+
+def _prepare_result(result: Any, *, pk: str, sk: str) -> tuple[Any, dict[str, Any] | None]:
+    """Return ``(inline_result_json_or_None, result_ref_or_None)`` for a result.
+
+    Small results are stored inline. When the serialized result exceeds
+    ``max_inline_bytes`` it is OFFLOADED to S3 — NOT truncated (a partial
+    replay would be unfaithful) — and a ``resultRef`` pointer is returned so a
+    redelivered caller receives the FULL recorded body. The object is written
+    with SSE-KMS (CMK) under an org/execution-prefixed key
+    (``tool-results/{orgId}/{executionId}/…``); the bucket policy additionally
+    DENIES any non-KMS put, so a mis-encrypted write fails closed.
+
+    Fails closed: if the result is oversized but no ``TOOL_RESULT_BUCKET`` is
+    configured, we raise rather than silently truncate.
     """
     try:
         serialized = json.dumps(result, sort_keys=True, separators=(",", ":"), ensure_ascii=False, default=str)
     except (TypeError, ValueError) as exc:
         raise LedgerError(f"tool result is not JSON-serializable: {exc}") from exc
     encoded = serialized.encode("utf-8")
-    if len(encoded) > max_inline_bytes():
-        marker = hashlib.sha256(encoded).hexdigest()
-        return None, True, marker
-    return serialized, False, None
+    if len(encoded) <= max_inline_bytes():
+        return serialized, None
+
+    bucket = _result_bucket()
+    if not bucket:
+        raise LedgerError(
+            "tool result exceeds the inline cap but TOOL_RESULT_BUCKET is not "
+            "configured — refusing to truncate (fail-closed); S3 offload is required"
+        )
+    key = _result_object_key(pk, sk)
+    put_kwargs: dict[str, Any] = {
+        "Bucket": bucket,
+        "Key": key,
+        "Body": encoded,
+        "ContentType": "application/json",
+        "ServerSideEncryption": "aws:kms",
+    }
+    kms_key_id = _result_kms_key_id()
+    if kms_key_id:
+        put_kwargs["SSEKMSKeyId"] = kms_key_id
+    try:
+        _get_s3_client().put_object(**put_kwargs)
+    except (ClientError, BotoCoreError) as exc:
+        raise LedgerError(f"tool result S3 offload failed for {key!r}: {exc}") from exc
+    return None, {"bucket": bucket, "key": key, "sha256": hashlib.sha256(encoded).hexdigest()}
 
 
 # --- Reserve / get / finalize ------------------------------------------------
@@ -319,46 +477,18 @@ def _reclaim_released(pk: str, sk: str, *, now: float) -> bool:
         raise LedgerError(f"ledger re-reserve transport error for {pk!r}/{sk!r}: {exc}") from exc
 
 
-def reserve(pk: str, sk: str, *, tool_name: str, now: float | None = None) -> ReserveResult:
-    """Attempt to reserve a tool execution with a conditional first-write-wins.
+def _resolve_existing(pk: str, sk: str, now: float) -> ReserveResult:
+    """Resolve the outcome when a reservation row already exists.
 
-    Returns a :class:`ReserveResult`:
-
-    * ``WON`` — this caller holds the reservation and MUST proceed to execute
-      then :func:`finalize_success` / :func:`finalize_failure`.
-    * ``HIT_COMPLETED`` / ``HIT_FAILED`` — a prior terminal record exists;
-      return it, do NOT execute.
-    * ``IN_FLIGHT`` — a live concurrent holder; the caller should poll
-      (:func:`wait_for_terminal`) then raise :class:`RetryableNoExecutionError`
-      without executing. A *stale* in-flight row is reclaimed here (returns
-      ``WON`` with ``reclaimed=True``).
+    Shared by the fenced and non-fenced reserve paths: reads the current row
+    and maps it to HIT_COMPLETED / HIT_FAILED / a released- or stale-reclaim
+    WON / IN_FLIGHT.
     """
-    now = time.time() if now is None else now
-    item = {
-        PK_ATTR: pk,
-        SK_ATTR: sk,
-        "status": STATUS_IN_FLIGHT,
-        "toolName": tool_name,
-        "createdAt": now,
-        "updatedAt": now,
-        # TTL derived from SERVER write-time (not a producer clock), so a
-        # skewed/malicious producer cannot force early expiry.
-        "ttl": int(now) + ttl_seconds(),
-    }
-    try:
-        _table().put_item(Item=item, ConditionExpression=f"attribute_not_exists({PK_ATTR})")
-        return ReserveResult(ReserveOutcome.WON)
-    except ClientError as exc:
-        if exc.response.get("Error", {}).get("Code") != "ConditionalCheckFailedException":
-            raise LedgerError(f"ledger reserve failed for {pk!r}/{sk!r}: {exc}") from exc
-    except BotoCoreError as exc:
-        raise LedgerError(f"ledger reserve transport error for {pk!r}/{sk!r}: {exc}") from exc
-
-    # Reservation exists — resolve its current status.
     row = get(pk, sk)
     if row is None:
-        # Vanished between our failed put and this read (TTL/reclaim race);
-        # treat as retryable rather than executing unprotected.
+        # Vanished between the failed conditional write and this read
+        # (TTL/reclaim race); treat as retryable rather than executing
+        # unprotected.
         return ReserveResult(ReserveOutcome.IN_FLIGHT)
     status = row.get("status")
     if status == STATUS_COMPLETED:
@@ -373,10 +503,157 @@ def reserve(pk: str, sk: str, *, tool_name: str, now: float | None = None) -> Re
         return ReserveResult(ReserveOutcome.IN_FLIGHT, row=row)
     # in_flight — reclaim if the holder looks dead, else report live.
     created_at = row.get("createdAt")
-    if isinstance(created_at, (int, float)) and (now - float(created_at)) > lease_seconds():
+    if isinstance(created_at, (int, float, Decimal)) and (now - float(created_at)) > lease_seconds():
         if _reclaim_stale(pk, sk, seen_created_at=created_at, now=now):
             return ReserveResult(ReserveOutcome.WON, reclaimed=True)
     return ReserveResult(ReserveOutcome.IN_FLIGHT, row=row)
+
+
+def _reserve_fenced(
+    item: dict[str, Any],
+    *,
+    pk: str,
+    sk: str,
+    execution_id: str,
+    node_id: str,
+    dispatch_generation: int,
+    now: float,
+) -> ReserveResult:
+    """Reserve with the dispatch-generation fence in ONE atomic transaction.
+
+    Security condition C2: the generation guard is a ``ConditionCheck`` on the
+    execution row evaluated INSIDE the SAME ``TransactWriteItems`` that performs
+    the reserve ``Put`` — never a separate read-then-check (which would
+    reintroduce a TOCTOU window a re-dispatch could slip through). Either both
+    the reserve and the fence commit, or neither does:
+
+    * fence ``ConditionCheck`` (``nodeResults.<nodeId>.dispatchGeneration =
+      :gen``) fails  -> the worker is stale -> :class:`StaleWorkerFencedError`,
+      no side effect;
+    * reserve ``Put`` (``attribute_not_exists``) fails -> the key already
+      exists for the CURRENT generation -> resolve the existing row (dedupe
+      hit / in-flight / reclaim), exactly as the non-fenced path.
+    """
+    ledger_table = os.environ.get("TOOL_EXECUTION_LEDGER_TABLE")
+    exec_table = os.environ.get("EXECUTIONS_TABLE")
+    if not ledger_table:
+        raise LedgerError(
+            "TOOL_EXECUTION_LEDGER_TABLE not configured — cannot reserve (fail-closed)"
+        )
+    if not exec_table:
+        # A generation was threaded but there is no execution table to fence
+        # against — fail closed rather than silently downgrade to unfenced.
+        raise LedgerError(
+            "dispatch fence requested but EXECUTIONS_TABLE not configured — "
+            "cannot evaluate the generation guard (fail-closed)"
+        )
+    transact_items = [
+        {
+            "Put": {
+                "TableName": ledger_table,
+                "Item": _marshal(item),
+                "ConditionExpression": f"attribute_not_exists({PK_ATTR})",
+            }
+        },
+        {
+            "ConditionCheck": {
+                "TableName": exec_table,
+                "Key": _marshal({"executionId": execution_id}),
+                "ConditionExpression": "nodeResults.#nid.#gen = :gen",
+                "ExpressionAttributeNames": {"#nid": node_id, "#gen": "dispatchGeneration"},
+                "ExpressionAttributeValues": {":gen": _serializer.serialize(int(dispatch_generation))},
+            }
+        },
+    ]
+    try:
+        _get_dynamodb_client().transact_write_items(TransactItems=transact_items)
+        return ReserveResult(ReserveOutcome.WON)
+    except ClientError as exc:
+        code = exc.response.get("Error", {}).get("Code")
+        if code != "TransactionCanceledException":
+            raise LedgerError(f"ledger fenced reserve failed for {pk!r}/{sk!r}: {exc}") from exc
+        reasons = exc.response.get("CancellationReasons") or []
+        fence_failed = len(reasons) > 1 and reasons[1].get("Code") == "ConditionalCheckFailed"
+        put_failed = len(reasons) > 0 and reasons[0].get("Code") == "ConditionalCheckFailed"
+        if fence_failed:
+            raise StaleWorkerFencedError(
+                f"worker dispatchGeneration {dispatch_generation} is stale for node "
+                f"{node_id!r} (execution {execution_id!r}); refused at reserve fence "
+                "before any side effect"
+            ) from exc
+        if put_failed:
+            return _resolve_existing(pk, sk, now)
+        raise LedgerError(
+            f"ledger fenced reserve cancelled for {pk!r}/{sk!r}: {reasons}"
+        ) from exc
+    except BotoCoreError as exc:
+        raise LedgerError(f"ledger fenced reserve transport error for {pk!r}/{sk!r}: {exc}") from exc
+
+
+def reserve(
+    pk: str,
+    sk: str,
+    *,
+    tool_name: str,
+    dispatch_generation: int | None = None,
+    execution_id: str | None = None,
+    node_id: str | None = None,
+    now: float | None = None,
+) -> ReserveResult:
+    """Attempt to reserve a tool execution with a conditional first-write-wins.
+
+    Returns a :class:`ReserveResult`:
+
+    * ``WON`` — this caller holds the reservation and MUST proceed to execute
+      then :func:`finalize_success` / :func:`finalize_failure`.
+    * ``HIT_COMPLETED`` / ``HIT_FAILED`` — a prior terminal record exists;
+      return it, do NOT execute.
+    * ``IN_FLIGHT`` — a live concurrent holder; the caller should poll
+      (:func:`wait_for_terminal`) then raise :class:`RetryableNoExecutionError`
+      without executing. A *stale* in-flight row is reclaimed here (returns
+      ``WON`` with ``reclaimed=True``).
+
+    When ``dispatch_generation`` is provided (a workflow-node tool call), the
+    reserve is fenced: the generation guard is evaluated in the SAME atomic
+    transaction as the reserve (see :func:`_reserve_fenced`), and a stale
+    worker raises :class:`StaleWorkerFencedError`. When it is ``None`` (a
+    supervisor task, or a pre-feature caller) the reserve is the unfenced
+    conditional ``PutItem`` — exactly-once-within-attempt only.
+    """
+    now = time.time() if now is None else now
+    item = {
+        PK_ATTR: pk,
+        SK_ATTR: sk,
+        "status": STATUS_IN_FLIGHT,
+        "toolName": tool_name,
+        "createdAt": now,
+        "updatedAt": now,
+        # TTL derived from SERVER write-time (not a producer clock), so a
+        # skewed/malicious producer cannot force early expiry.
+        "ttl": int(now) + ttl_seconds(),
+    }
+    if dispatch_generation is not None:
+        if not (execution_id and node_id):
+            raise LedgerError(
+                "dispatch_generation requires execution_id and node_id to locate "
+                "the fence row (fail-closed)"
+            )
+        item["dispatchGeneration"] = int(dispatch_generation)
+        return _reserve_fenced(
+            item, pk=pk, sk=sk, execution_id=execution_id, node_id=node_id,
+            dispatch_generation=int(dispatch_generation), now=now,
+        )
+    try:
+        _table().put_item(Item=item, ConditionExpression=f"attribute_not_exists({PK_ATTR})")
+        return ReserveResult(ReserveOutcome.WON)
+    except ClientError as exc:
+        if exc.response.get("Error", {}).get("Code") != "ConditionalCheckFailedException":
+            raise LedgerError(f"ledger reserve failed for {pk!r}/{sk!r}: {exc}") from exc
+    except BotoCoreError as exc:
+        raise LedgerError(f"ledger reserve transport error for {pk!r}/{sk!r}: {exc}") from exc
+
+    # Reservation exists — resolve its current status.
+    return _resolve_existing(pk, sk, now)
 
 
 def wait_for_terminal(
@@ -446,12 +723,18 @@ def _finalize(pk: str, sk: str, *, attributes: dict[str, Any], now: float) -> No
 
 
 def finalize_success(pk: str, sk: str, *, result: Any, now: float | None = None) -> None:
-    """Record a successful execution result (in_flight -> completed)."""
+    """Record a successful execution result (in_flight -> completed).
+
+    Small results are stored inline; an oversized result is offloaded to S3
+    (CMK-encrypted, org-prefixed) and only a ``resultRef`` pointer is stored,
+    so a redelivered caller can fetch the FULL body (faithful replay).
+    """
     now = time.time() if now is None else now
-    inline, truncated, marker = _prepare_result(result)
-    attrs: dict[str, Any] = {"status": STATUS_COMPLETED, "resultTruncated": truncated}
-    if truncated:
-        attrs["resultMarker"] = marker
+    inline, result_ref = _prepare_result(result, pk=pk, sk=sk)
+    attrs: dict[str, Any] = {"status": STATUS_COMPLETED, "resultTruncated": False}
+    if result_ref is not None:
+        attrs["resultRef"] = result_ref
+        attrs["resultOffloaded"] = True
     else:
         attrs["result"] = inline
     _finalize(pk, sk, attributes=attrs, now=now)
@@ -512,16 +795,57 @@ def release(pk: str, sk: str) -> None:
         raise LedgerError(f"ledger release transport error for {pk!r}/{sk!r}: {exc}") from exc
 
 
-def _recorded_result(row: dict[str, Any]) -> Any:
-    """Extract the recorded result from a completed row (parse inline JSON)."""
-    if row.get("resultTruncated"):
-        return {
-            "status": "success",
-            "idempotent": True,
-            "resultTruncated": True,
-            "resultMarker": row.get("resultMarker"),
-            "note": "result body exceeded inline cap; faithful replay via S3 is PR2",
-        }
+def _fetch_result_ref(pk: str, result_ref: dict[str, Any]) -> Any:
+    """Fetch an offloaded result from S3 after re-checking its org prefix.
+
+    Defense-in-depth (security condition C3): the stored key MUST live under
+    the ``tool-results/{orgId}/{executionId}/`` prefix derived from the ledger
+    PK the caller located this row by. A ref pointing outside that prefix — a
+    forged or confused-deputy pointer — is refused (:class:`CrossOrgResultRefError`)
+    rather than fetched, so one org can never read another org's object even
+    if a ref were tampered with.
+    """
+    if not isinstance(result_ref, dict):
+        raise CrossOrgResultRefError(f"malformed resultRef on ledger row: {result_ref!r}")
+    key = result_ref.get("key")
+    bucket = result_ref.get("bucket")
+    if not isinstance(key, str) or not isinstance(bucket, str) or not key or not bucket:
+        raise CrossOrgResultRefError(f"incomplete resultRef on ledger row: {result_ref!r}")
+    org_id, execution_id = _split_pk(pk)
+    expected_prefix = f"tool-results/{org_id}/{execution_id}/"
+    if not key.startswith(expected_prefix):
+        raise CrossOrgResultRefError(
+            f"resultRef key {key!r} is outside the caller's org/execution prefix "
+            f"{expected_prefix!r}; refusing cross-org result read"
+        )
+    try:
+        resp = _get_s3_client().get_object(Bucket=bucket, Key=key)
+        body = resp["Body"].read()
+    except (ClientError, BotoCoreError, KeyError) as exc:
+        raise LedgerError(f"offloaded result fetch failed for {key!r}: {exc}") from exc
+    try:
+        return json.loads(body)
+    except (ValueError, TypeError) as exc:
+        raise LedgerError(f"offloaded result at {key!r} is not valid JSON: {exc}") from exc
+
+
+def _recorded_result(row: dict[str, Any], pk: str | None = None) -> Any:
+    """Extract the recorded result from a completed row.
+
+    An offloaded result (``resultRef``) is fetched from S3 with an org-prefix
+    re-check; an inline result is parsed from JSON. ``pk`` is required to fetch
+    an offloaded ref (it carries the org/execution prefix to validate against);
+    if a ref is present but no ``pk`` was supplied, we fail closed rather than
+    trust the ref.
+    """
+    result_ref = row.get("resultRef")
+    if result_ref is not None:
+        if pk is None:
+            raise LedgerError(
+                "cannot resolve an offloaded resultRef without the ledger PK "
+                "for the org-prefix re-check (fail-closed)"
+            )
+        return _fetch_result_ref(pk, result_ref)
     raw = row.get("result")
     if isinstance(raw, str):
         try:
@@ -538,6 +862,9 @@ def execute_idempotent(
     tool_name: str,
     mode: str,
     run_tool: Callable[[], Any],
+    dispatch_generation: int | None = None,
+    execution_id: str | None = None,
+    node_id: str | None = None,
     now: float | None = None,
     wait_kwargs: dict[str, Any] | None = None,
 ) -> Any:
@@ -551,15 +878,23 @@ def execute_idempotent(
     is written and ``run_tool`` runs directly. Any other mode is
     ledger-protected (fail-safe default lives in
     ``tool_idempotency.classify_idempotency_mode``).
+
+    When ``dispatch_generation`` is provided the reserve is FENCED against the
+    execution row's current generation (see :func:`reserve`); a stale
+    re-dispatched-away worker raises :class:`StaleWorkerFencedError` and NEVER
+    executes.
     """
     if mode == MODE_BYPASS:
         return run_tool()
 
     now = time.time() if now is None else now
-    reservation = reserve(pk, sk, tool_name=tool_name, now=now)
+    reservation = reserve(
+        pk, sk, tool_name=tool_name, dispatch_generation=dispatch_generation,
+        execution_id=execution_id, node_id=node_id, now=now,
+    )
 
     if reservation.outcome == ReserveOutcome.HIT_COMPLETED:
-        return _recorded_result(reservation.row or {})
+        return _recorded_result(reservation.row or {}, pk)
     if reservation.outcome == ReserveOutcome.HIT_FAILED:
         row = reservation.row or {}
         raise RecordedToolFailure(
@@ -571,7 +906,7 @@ def execute_idempotent(
     if reservation.outcome == ReserveOutcome.IN_FLIGHT:
         settled = wait_for_terminal(pk, sk, **(wait_kwargs or {}))
         if settled is not None and settled.get("status") == STATUS_COMPLETED:
-            return _recorded_result(settled)
+            return _recorded_result(settled, pk)
         if settled is not None and settled.get("status") == STATUS_FAILED:
             raise RecordedToolFailure(
                 f"tool {tool_name!r} failed terminally on the winning attempt",

--- a/arbiter/stepRunner/__tests__/test_dispatch_generation.py
+++ b/arbiter/stepRunner/__tests__/test_dispatch_generation.py
@@ -1,0 +1,123 @@
+"""Dispatch-generation wiring tests (PR2 fence plumbing).
+
+Covers the path the generation travels: executor.invoke_node increments it in
+the same conditional pending->running write and threads the new value onto the
+SQS dispatch message -> workflow_contract build/parse -> worker_governance env
+-> agent_runner env reader. Each hop is additive/back-compat (absent -> None ->
+unfenced reserve).
+"""
+from __future__ import annotations
+
+import json
+import os
+import sys
+
+from unittest.mock import MagicMock, patch
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+
+from common import workflow_contract  # noqa: E402
+
+
+class TestContractRoundTrip:
+    def test_build_and_parse_dispatch_generation(self):
+        msg = workflow_contract.build_node_dispatch_message(
+            execution_id="e1", node_id="n1", workflow_id="w1", agent_id="a1",
+            dispatch_generation=3,
+        )
+        assert msg["dispatch_generation"] == 3
+        parsed = workflow_contract.parse_node_dispatch_message(msg)
+        assert parsed.dispatch_generation == 3
+
+    def test_generation_omitted_when_absent(self):
+        msg = workflow_contract.build_node_dispatch_message(
+            execution_id="e1", node_id="n1", workflow_id="w1", agent_id="a1",
+        )
+        assert "dispatch_generation" not in msg
+        assert workflow_contract.parse_node_dispatch_message(msg).dispatch_generation is None
+
+    def test_parse_degrades_malformed_generation_to_none(self):
+        msg = workflow_contract.build_node_dispatch_message(
+            execution_id="e1", node_id="n1", workflow_id="w1", agent_id="a1",
+        )
+        msg["dispatch_generation"] = "not-an-int"
+        assert workflow_contract.parse_node_dispatch_message(msg).dispatch_generation is None
+        msg["dispatch_generation"] = True  # bool is not a valid generation
+        assert workflow_contract.parse_node_dispatch_message(msg).dispatch_generation is None
+
+
+class TestSubprocessEnvThreading:
+    def test_generation_sets_env_var(self):
+        from worker_governance import build_subprocess_env
+        env = build_subprocess_env({}, execution_id="e1", node_id="n1", dispatch_generation=2)
+        assert env["CITADEL_DISPATCH_GENERATION"] == "2"
+
+    def test_generation_absent_omits_env_var(self):
+        from worker_governance import build_subprocess_env
+        env = build_subprocess_env({}, execution_id="e1", node_id="n1")
+        assert "CITADEL_DISPATCH_GENERATION" not in env
+
+    def test_generation_bool_is_not_serialized(self):
+        from worker_governance import build_subprocess_env
+        env = build_subprocess_env({}, execution_id="e1", node_id="n1", dispatch_generation=True)
+        assert "CITADEL_DISPATCH_GENERATION" not in env
+
+
+class TestExecutorThreadsGenerationOntoDispatch:
+    def test_invoke_node_increments_and_carries_generation(self, monkeypatch):
+        import executor
+
+        node = {"id": "n0", "agentId": "agent-A", "data": {}}
+        exec_table = MagicMock()
+        # UPDATED_NEW response surfaces the post-increment generation.
+        exec_table.update_item.return_value = {
+            "Attributes": {"nodeResults": {"n0": {"dispatchGeneration": 1}}}
+        }
+        sqs = MagicMock()
+        monkeypatch.setenv("WORKER_QUEUE_URL", "https://sqs/queue")
+        with patch.object(executor, "_executions_table", exec_table), \
+             patch.object(executor, "_get_sqs_client", lambda: sqs), \
+             patch.object(executor, "events", MagicMock()), \
+             patch.object(executor.tracing, "active_trace_context", lambda: None):
+            executor.invoke_node("exec1", "wf1", node, {}, {})
+
+        # The conditional dispatch write increments the per-node generation.
+        upd = exec_table.update_item.call_args.kwargs
+        assert " ADD " in upd["UpdateExpression"]
+        assert upd["ExpressionAttributeNames"]["#gen"] == "dispatchGeneration"
+        assert upd["ExpressionAttributeValues"][":one"] == 1
+        assert upd["ReturnValues"] == "UPDATED_NEW"
+        # The dispatched SQS message carries the new generation.
+        body = json.loads(sqs.send_message.call_args.kwargs["MessageBody"])
+        assert body["dispatch_generation"] == 1
+
+    def test_unparseable_generation_response_omits_it(self, monkeypatch):
+        import executor
+
+        node = {"id": "n0", "agentId": "agent-A", "data": {}}
+        exec_table = MagicMock()  # default MagicMock response — no real Attributes
+        sqs = MagicMock()
+        monkeypatch.setenv("WORKER_QUEUE_URL", "https://sqs/queue")
+        with patch.object(executor, "_executions_table", exec_table), \
+             patch.object(executor, "_get_sqs_client", lambda: sqs), \
+             patch.object(executor, "events", MagicMock()), \
+             patch.object(executor.tracing, "active_trace_context", lambda: None):
+            executor.invoke_node("exec1", "wf1", node, {}, {})
+        body = json.loads(sqs.send_message.call_args.kwargs["MessageBody"])
+        assert "dispatch_generation" not in body  # back-compat: unfenced dispatch
+
+
+class TestAgentRunnerGenerationReader:
+    def test_reads_int(self, monkeypatch):
+        sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "..", "workerWrapper"))
+        import agent_runner
+        monkeypatch.setenv("CITADEL_DISPATCH_GENERATION", "5")
+        assert agent_runner._read_dispatch_generation() == 5
+
+    def test_absent_or_invalid_is_none(self, monkeypatch):
+        sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "..", "workerWrapper"))
+        import agent_runner
+        monkeypatch.delenv("CITADEL_DISPATCH_GENERATION", raising=False)
+        assert agent_runner._read_dispatch_generation() is None
+        monkeypatch.setenv("CITADEL_DISPATCH_GENERATION", "nope")
+        assert agent_runner._read_dispatch_generation() is None

--- a/arbiter/stepRunner/__tests__/test_exactly_once_concurrent_completions.py
+++ b/arbiter/stepRunner/__tests__/test_exactly_once_concurrent_completions.py
@@ -59,6 +59,21 @@ def _apply_set_expression(item, expr, names, values):
     body = expr.strip()
     assert body.upper().startswith('SET '), f"unsupported expression: {expr!r}"
     body = body[4:]
+    # PR2 dispatch-generation fence: strip + apply an optional trailing ADD
+    # clause (per-node counter) before parsing the SET assignments.
+    _ai = body.upper().find(' ADD ')
+    if _ai != -1:
+        _add_body = body[_ai + 5:]
+        body = body[:_ai]
+        for _clause in _add_body.split(','):
+            _parts = _clause.split()
+            _segs = [s.strip() for s in _parts[0].split('.')]
+            _res = [names[s] if s.startswith('#') else s for s in _segs]
+            _delta = values[_parts[1]]
+            _t = item
+            for _s in _res[:-1]:
+                _t = _t.setdefault(_s, {})
+            _t[_res[-1]] = _t.get(_res[-1], 0) + _delta
     for assignment in body.split(','):
         lhs, rhs = assignment.split('=')
         segments = [seg.strip() for seg in lhs.strip().split('.')]
@@ -104,7 +119,7 @@ class ConditionalFakeTable:
 
     def update_item(self, Key, UpdateExpression,  # noqa: N803
                     ConditionExpression=None,
-                    ExpressionAttributeNames=None, ExpressionAttributeValues=None):
+                    ExpressionAttributeNames=None, ExpressionAttributeValues=None, **_kw):
         names = ExpressionAttributeNames or {}
         values = ExpressionAttributeValues or {}
         val = Key[self._key_name]

--- a/arbiter/stepRunner/__tests__/test_execution_concurrency.py
+++ b/arbiter/stepRunner/__tests__/test_execution_concurrency.py
@@ -51,6 +51,21 @@ def _apply_set_expression(item, expr, names, values):
     body = expr.strip()
     assert body.upper().startswith('SET '), f"unsupported expression: {expr!r}"
     body = body[4:]
+    # PR2 dispatch-generation fence: strip + apply an optional trailing ADD
+    # clause (per-node counter) before parsing the SET assignments.
+    _ai = body.upper().find(' ADD ')
+    if _ai != -1:
+        _add_body = body[_ai + 5:]
+        body = body[:_ai]
+        for _clause in _add_body.split(','):
+            _parts = _clause.split()
+            _segs = [s.strip() for s in _parts[0].split('.')]
+            _res = [names[s] if s.startswith('#') else s for s in _segs]
+            _delta = values[_parts[1]]
+            _t = item
+            for _s in _res[:-1]:
+                _t = _t.setdefault(_s, {})
+            _t[_res[-1]] = _t.get(_res[-1], 0) + _delta
     for assignment in body.split(','):
         lhs, rhs = assignment.split('=')
         segments = [seg.strip() for seg in lhs.strip().split('.')]
@@ -105,7 +120,7 @@ class FakeTable:
 
     def update_item(self, Key, UpdateExpression,  # noqa: N803 — boto3 kwarg names
                     ConditionExpression=None,
-                    ExpressionAttributeNames=None, ExpressionAttributeValues=None):
+                    ExpressionAttributeNames=None, ExpressionAttributeValues=None, **_kw):
         names = ExpressionAttributeNames or {}
         values = ExpressionAttributeValues or {}
         val = Key[self._key_name]

--- a/arbiter/stepRunner/__tests__/test_executor_idempotency.py
+++ b/arbiter/stepRunner/__tests__/test_executor_idempotency.py
@@ -45,6 +45,21 @@ from botocore.exceptions import ClientError
 
 def _apply_set_expression(item, expr, names, values):
     body = expr.strip()[4:]  # drop leading 'SET '
+    # PR2 dispatch-generation fence: strip + apply an optional trailing ADD
+    # clause (per-node counter) before parsing the SET assignments.
+    _ai = body.upper().find(' ADD ')
+    if _ai != -1:
+        _add_body = body[_ai + 5:]
+        body = body[:_ai]
+        for _clause in _add_body.split(','):
+            _parts = _clause.split()
+            _segs = [s.strip() for s in _parts[0].split('.')]
+            _res = [names[s] if s.startswith('#') else s for s in _segs]
+            _delta = values[_parts[1]]
+            _t = item
+            for _s in _res[:-1]:
+                _t = _t.setdefault(_s, {})
+            _t[_res[-1]] = _t.get(_res[-1], 0) + _delta
     for assignment in body.split(','):
         lhs, rhs = assignment.split('=')
         segments = [s.strip() for s in lhs.strip().split('.')]
@@ -84,7 +99,7 @@ class StatefulConditionalTable:
         return {'Item': copy.deepcopy(item)} if item is not None else {}
 
     def update_item(self, Key, UpdateExpression, ConditionExpression=None,  # noqa: N803
-                    ExpressionAttributeNames=None, ExpressionAttributeValues=None):
+                    ExpressionAttributeNames=None, ExpressionAttributeValues=None, **_kw):
         names, values = ExpressionAttributeNames or {}, ExpressionAttributeValues or {}
         item = self._items.setdefault(Key[self._key], {self._key: Key[self._key]})
         if ConditionExpression is not None and not _eval_condition_expression(

--- a/arbiter/stepRunner/__tests__/test_resume_simulation.py
+++ b/arbiter/stepRunner/__tests__/test_resume_simulation.py
@@ -36,6 +36,21 @@ import dag
 
 def _apply_set_expression(item, expr, names, values):
     body = expr.strip()[4:]
+    # PR2 dispatch-generation fence: strip + apply an optional trailing ADD
+    # clause (per-node counter) before parsing the SET assignments.
+    _ai = body.upper().find(' ADD ')
+    if _ai != -1:
+        _add_body = body[_ai + 5:]
+        body = body[:_ai]
+        for _clause in _add_body.split(','):
+            _parts = _clause.split()
+            _segs = [s.strip() for s in _parts[0].split('.')]
+            _res = [names[s] if s.startswith('#') else s for s in _segs]
+            _delta = values[_parts[1]]
+            _t = item
+            for _s in _res[:-1]:
+                _t = _t.setdefault(_s, {})
+            _t[_res[-1]] = _t.get(_res[-1], 0) + _delta
     for assignment in body.split(','):
         lhs, rhs = assignment.split('=')
         resolved = [names[s.strip()] if s.strip().startswith('#') else s.strip()
@@ -73,7 +88,7 @@ class FakeTable:
         return {'Item': copy.deepcopy(item)} if item is not None else {}
 
     def update_item(self, Key, UpdateExpression, ConditionExpression=None,  # noqa: N803
-                    ExpressionAttributeNames=None, ExpressionAttributeValues=None):
+                    ExpressionAttributeNames=None, ExpressionAttributeValues=None, **_kw):
         names, values = ExpressionAttributeNames or {}, ExpressionAttributeValues or {}
         item = self._items.setdefault(Key[self._key], {self._key: Key[self._key]})
         if ConditionExpression is not None and not _eval_condition_expression(

--- a/arbiter/stepRunner/__tests__/test_usage_rollup_persistence.py
+++ b/arbiter/stepRunner/__tests__/test_usage_rollup_persistence.py
@@ -35,6 +35,21 @@ from botocore.exceptions import ClientError
 
 def _apply_set_expression(item, expr, names, values):
     body = expr.strip()[4:]
+    # PR2 dispatch-generation fence: strip + apply an optional trailing ADD
+    # clause (per-node counter) before parsing the SET assignments.
+    _ai = body.upper().find(' ADD ')
+    if _ai != -1:
+        _add_body = body[_ai + 5:]
+        body = body[:_ai]
+        for _clause in _add_body.split(','):
+            _parts = _clause.split()
+            _segs = [s.strip() for s in _parts[0].split('.')]
+            _res = [names[s] if s.startswith('#') else s for s in _segs]
+            _delta = values[_parts[1]]
+            _t = item
+            for _s in _res[:-1]:
+                _t = _t.setdefault(_s, {})
+            _t[_res[-1]] = _t.get(_res[-1], 0) + _delta
     for assignment in body.split(','):
         lhs, rhs = assignment.split('=')
         resolved = [names[s.strip()] if s.strip().startswith('#') else s.strip()
@@ -76,7 +91,7 @@ class StatefulConditionalTable:
         return {'Item': copy.deepcopy(item)} if item is not None else {}
 
     def update_item(self, Key, UpdateExpression, ConditionExpression=None,  # noqa: N803
-                    ExpressionAttributeNames=None, ExpressionAttributeValues=None):
+                    ExpressionAttributeNames=None, ExpressionAttributeValues=None, **_kw):
         names, values = ExpressionAttributeNames or {}, ExpressionAttributeValues or {}
         item = self._items.setdefault(Key[self._key], {self._key: Key[self._key]})
         if ConditionExpression is not None and not _eval_condition_expression(
@@ -215,6 +230,14 @@ class TestUsagePersistedInSameUpdateCall:
 
         for call in mock_exec['executions_table'].update_item.call_args_list:
             expr = call.kwargs.get('UpdateExpression', '')
+            # The successor-node dispatch (schedule_frontier -> invoke_node)
+            # DOES use ` ADD nodeResults.#nid.#dispatchGeneration :one` — an
+            # intentional per-node dispatch counter (PR2 fence). Exempt that
+            # specific write; the guard here is about the USAGE/completion
+            # write staying a per-node SET (never an ADD) for idempotent
+            # duplicate delivery.
+            if 'dispatchGeneration' in (call.kwargs.get('ExpressionAttributeNames') or {}).values():
+                continue
             # 'ADD' as a distinct clause keyword, not a substring of e.g. an
             # attribute name — every clause in this codebase starts with SET.
             assert not expr.strip().upper().startswith('ADD ')

--- a/arbiter/stepRunner/__tests__/test_watchdog_reconcile.py
+++ b/arbiter/stepRunner/__tests__/test_watchdog_reconcile.py
@@ -30,6 +30,21 @@ import executor
 
 def _apply_set_expression(item, expr, names, values):
     body = expr.strip()[4:]
+    # PR2 dispatch-generation fence: strip + apply an optional trailing ADD
+    # clause (per-node counter) before parsing the SET assignments.
+    _ai = body.upper().find(' ADD ')
+    if _ai != -1:
+        _add_body = body[_ai + 5:]
+        body = body[:_ai]
+        for _clause in _add_body.split(','):
+            _parts = _clause.split()
+            _segs = [s.strip() for s in _parts[0].split('.')]
+            _res = [names[s] if s.startswith('#') else s for s in _segs]
+            _delta = values[_parts[1]]
+            _t = item
+            for _s in _res[:-1]:
+                _t = _t.setdefault(_s, {})
+            _t[_res[-1]] = _t.get(_res[-1], 0) + _delta
     for assignment in body.split(','):
         lhs, rhs = assignment.split('=')
         resolved = [names[s.strip()] if s.strip().startswith('#') else s.strip()
@@ -67,7 +82,7 @@ class FakeTable:
         return {'Item': copy.deepcopy(item)} if item is not None else {}
 
     def update_item(self, Key, UpdateExpression, ConditionExpression=None,  # noqa: N803
-                    ExpressionAttributeNames=None, ExpressionAttributeValues=None):
+                    ExpressionAttributeNames=None, ExpressionAttributeValues=None, **_kw):
         names, values = ExpressionAttributeNames or {}, ExpressionAttributeValues or {}
         item = self._items.setdefault(Key[self._key], {self._key: Key[self._key]})
         if ConditionExpression is not None and not _eval_condition_expression(

--- a/arbiter/stepRunner/__tests__/test_watchdog_stall.py
+++ b/arbiter/stepRunner/__tests__/test_watchdog_stall.py
@@ -32,6 +32,21 @@ import executor
 
 def _apply_set_expression(item, expr, names, values):
     body = expr.strip()[4:]
+    # PR2 dispatch-generation fence: strip + apply an optional trailing ADD
+    # clause (per-node counter) before parsing the SET assignments.
+    _ai = body.upper().find(' ADD ')
+    if _ai != -1:
+        _add_body = body[_ai + 5:]
+        body = body[:_ai]
+        for _clause in _add_body.split(','):
+            _parts = _clause.split()
+            _segs = [s.strip() for s in _parts[0].split('.')]
+            _res = [names[s] if s.startswith('#') else s for s in _segs]
+            _delta = values[_parts[1]]
+            _t = item
+            for _s in _res[:-1]:
+                _t = _t.setdefault(_s, {})
+            _t[_res[-1]] = _t.get(_res[-1], 0) + _delta
     for assignment in body.split(','):
         lhs, rhs = assignment.split('=')
         resolved = [names[s.strip()] if s.strip().startswith('#') else s.strip()
@@ -69,7 +84,7 @@ class FakeTable:
         return {'Item': copy.deepcopy(item)} if item is not None else {}
 
     def update_item(self, Key, UpdateExpression, ConditionExpression=None,  # noqa: N803
-                    ExpressionAttributeNames=None, ExpressionAttributeValues=None):
+                    ExpressionAttributeNames=None, ExpressionAttributeValues=None, **_kw):
         names, values = ExpressionAttributeNames or {}, ExpressionAttributeValues or {}
         item = self._items.setdefault(Key[self._key], {self._key: Key[self._key]})
         if ConditionExpression is not None and not _eval_condition_expression(

--- a/arbiter/stepRunner/__tests__/test_workflow_e2e.py
+++ b/arbiter/stepRunner/__tests__/test_workflow_e2e.py
@@ -102,6 +102,21 @@ def _apply_set_expression(item, expr, names, values):
     body = expr.strip()
     assert body.upper().startswith('SET '), f"unsupported expression: {expr!r}"
     body = body[4:]
+    # PR2 dispatch-generation fence: strip and apply an optional trailing ADD
+    # clause (a per-node counter increment) before parsing SET assignments.
+    _ai = body.upper().find(' ADD ')
+    if _ai != -1:
+        _add_body = body[_ai + 5:]
+        body = body[:_ai]
+        for _clause in _add_body.split(','):
+            _parts = _clause.split()
+            _segs = [s.strip() for s in _parts[0].split('.')]
+            _res = [names[s] if s.startswith('#') else s for s in _segs]
+            _delta = values[_parts[1]]
+            _t = item
+            for _s in _res[:-1]:
+                _t = _t.setdefault(_s, {})
+            _t[_res[-1]] = _t.get(_res[-1], 0) + _delta
     for assignment in body.split(','):
         lhs, rhs = assignment.split('=')
         segments = [seg.strip() for seg in lhs.strip().split('.')]
@@ -153,7 +168,7 @@ class FakeTable:
 
     def update_item(self, Key, UpdateExpression,  # noqa: N803 — boto3 kwarg names
                     ConditionExpression=None,
-                    ExpressionAttributeNames=None, ExpressionAttributeValues=None):
+                    ExpressionAttributeNames=None, ExpressionAttributeValues=None, **_kw):
         names = ExpressionAttributeNames or {}
         values = ExpressionAttributeValues or {}
         val = Key[self._key_name]

--- a/arbiter/stepRunner/executor.py
+++ b/arbiter/stepRunner/executor.py
@@ -14,6 +14,7 @@ import logging
 import os
 import sys
 from datetime import datetime, timezone
+from numbers import Number
 
 from botocore.exceptions import ClientError
 
@@ -194,6 +195,25 @@ def _get_cloudwatch_client():
 def _now_iso() -> str:
     """Return current UTC time as ISO 8601 string."""
     return datetime.now(timezone.utc).isoformat()
+
+
+def _extract_dispatch_generation(update_response, node_id: str):
+    """Read the post-increment ``dispatchGeneration`` from an UPDATED_NEW
+    update_item response, or None when unavailable/unparseable.
+
+    Defensive by contract: a MagicMock (unit tests that don't model the
+    response), a pre-fence row, or a non-numeric value all degrade to None, in
+    which case the dispatch message carries no generation and the worker's
+    reserve stays unfenced (back-compat). DynamoDB returns numbers as Decimal;
+    both Decimal and int are coerced to int."""
+    try:
+        node = ((update_response.get('Attributes') or {}).get('nodeResults') or {}).get(node_id) or {}
+        gen = node.get('dispatchGeneration')
+    except Exception:  # noqa: BLE001 — a mock/None response must never break dispatch
+        return None
+    if isinstance(gen, bool) or not isinstance(gen, Number):
+        return None
+    return int(gen)
 
 
 def _log_event(action: str, **fields) -> None:
@@ -621,20 +641,36 @@ def invoke_node(
     # the previous unconditional SET, which let both racing dispatchers send
     # (latent double-dispatch of convergence nodes).
     try:
-        _executions_table.update_item(
+        _dispatch_write = _executions_table.update_item(
             Key={'executionId': execution_id},
-            UpdateExpression='SET nodeResults.#nid.#status = :status, nodeResults.#nid.#startedAt = :startedAt',
+            UpdateExpression=(
+                'SET nodeResults.#nid.#status = :status, '
+                'nodeResults.#nid.#startedAt = :startedAt '
+                'ADD nodeResults.#nid.#gen :one'
+            ),
             ConditionExpression='nodeResults.#nid.#status = :pending',
             ExpressionAttributeNames={
                 '#nid': node_id,
                 '#status': 'status',
                 '#startedAt': 'startedAt',
+                # PR2 dispatch-generation fence: a per-node monotonic counter
+                # incremented on EVERY conditional pending->running transition
+                # (first dispatch: 0->1; each watchdog re-dispatch: +1). The
+                # worker carries the resulting value; its tool-call reserve is
+                # fenced against it (same-transaction ConditionCheck), so a
+                # stale re-dispatched-away worker is refused before any side
+                # effect. Incremented INSIDE this exactly-once dispatch guard
+                # so the counter advances once per real dispatch, never on a
+                # lost race.
+                '#gen': 'dispatchGeneration',
             },
             ExpressionAttributeValues={
                 ':status': 'running',
                 ':startedAt': now,
                 ':pending': 'pending',
+                ':one': 1,
             },
+            ReturnValues='UPDATED_NEW',
         )
     except ClientError as exc:
         if exc.response.get('Error', {}).get('Code') == 'ConditionalCheckFailedException':
@@ -692,6 +728,12 @@ def invoke_node(
         # "now" reading — dispatch and node.started are the same instant for
         # this purpose.
         dispatched_at=now,
+        # PR2 dispatch-generation fence: carry the generation this dispatch
+        # just wrote so the worker's tool-call reserve can be fenced against
+        # the execution row's current generation. None (omitted) when the
+        # response did not surface a parseable generation, keeping the message
+        # byte-identical to a pre-fence dispatch.
+        dispatch_generation=_extract_dispatch_generation(_dispatch_write, node_id),
         **_run_id_kwargs,
     )
 

--- a/arbiter/workerWrapper/__tests__/test_tool_client_token.py
+++ b/arbiter/workerWrapper/__tests__/test_tool_client_token.py
@@ -1,0 +1,123 @@
+"""Tests for the PR2 client-token passthrough (server-side, post-canonicalization).
+
+A target that supports an end-to-end idempotency token gets one injected
+SERVER-SIDE by the idempotency hook, AFTER the args hash is computed (so the
+token never perturbs the ledger key) and OVERWRITING any model-supplied value
+(so the model cannot impersonate another org's idempotency namespace). Wiring
+is gated by a per-tool ``clientTokenParam`` config.
+
+Inventory note (grounded, not guessed): no existing adapter — neither the
+agent-source import adapters (``backend/src/adapters/agent-source/*``) nor the
+integration adapters — reads a client/idempotency token today. The single
+server-controlled chokepoint that sees BOTH the derived key and the tool input
+is this hook, so injection lives here; the per-tool ``clientTokenParam`` is the
+forwarding contract for a tool/target that supports it.
+"""
+from __future__ import annotations
+
+import os
+import sys
+
+import pytest
+
+_PROJECT_ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "..", ".."))
+if _PROJECT_ROOT not in sys.path:
+    sys.path.insert(0, _PROJECT_ROOT)
+
+from arbiter.workerWrapper import tool_idempotency_hook as hook_mod  # noqa: E402
+from arbiter.workerWrapper.tool_idempotency_hook import (  # noqa: E402
+    IdempotencyToolHook,
+    _IdempotentToolWrapper,
+)
+from arbiter.workerWrapper.tool_idempotency import (  # noqa: E402
+    build_client_token,
+    build_key,
+)
+
+
+class _FakeEvent:
+    def __init__(self, name, tool_input):
+        self.tool_use = {"name": name, "input": tool_input, "toolUseId": "tu-1"}
+        self.selected_tool = object()  # a stand-in inner tool
+
+
+def _hook(**kw):
+    return IdempotencyToolHook(
+        org_id="orgA", execution_id="exec1", node_id="node1", **kw
+    )
+
+
+class TestClientTokenDerivation:
+    def test_token_is_deterministic_and_org_scoped(self):
+        pk_a, sk = build_key("orgA", "exec1", "node1", 0, "createTicket", {"s": 1})
+        pk_b, _ = build_key("orgB", "exec1", "node1", 0, "createTicket", {"s": 1})
+        # Deterministic: same key -> same token (so a retry dedupes end-to-end).
+        assert build_client_token(pk_a, sk) == build_client_token(pk_a, sk)
+        # Org-scoped: a different org's PK -> a different token (no cross-org
+        # impersonation of another org's idempotency namespace).
+        assert build_client_token(pk_a, sk) != build_client_token(pk_b, sk)
+
+
+class TestClientTokenInjection:
+    def test_token_injected_and_absent_from_args_hash(self):
+        tool_input = {"subject": "hi"}
+        event = _FakeEvent("createTicket", tool_input)
+        hook = _hook(client_token_param_resolver=lambda _n: "Idempotency-Key")
+        hook._on_before_tool_call(event)
+
+        wrapper = event.selected_tool
+        assert isinstance(wrapper, _IdempotentToolWrapper)
+        # The token was injected into the tool input the inner tool will see.
+        assert tool_input["Idempotency-Key"] == build_client_token(wrapper._pk, wrapper._sk)
+        # The ledger key was derived from the ORIGINAL input (no token): the
+        # wrapper's sk equals build_key on the token-free input, and DIFFERS
+        # from a key that hashed the token — proving the token is not in the hash.
+        _, sk_no_token = build_key("orgA", "exec1", "node1", 0, "createTicket", {"subject": "hi"})
+        _, sk_with_token = build_key(
+            "orgA", "exec1", "node1", 0, "createTicket",
+            {"subject": "hi", "Idempotency-Key": tool_input["Idempotency-Key"]},
+        )
+        assert wrapper._sk == sk_no_token
+        assert wrapper._sk != sk_with_token
+
+    def test_model_supplied_token_is_overwritten(self):
+        tool_input = {"subject": "hi", "Idempotency-Key": "MODEL-EVIL-cross-org"}
+        event = _FakeEvent("createTicket", tool_input)
+        hook = _hook(client_token_param_resolver=lambda _n: "Idempotency-Key")
+        hook._on_before_tool_call(event)
+        wrapper = event.selected_tool
+        # The model's value is overwritten by the server-derived token.
+        assert tool_input["Idempotency-Key"] != "MODEL-EVIL-cross-org"
+        assert tool_input["Idempotency-Key"] == build_client_token(wrapper._pk, wrapper._sk)
+
+    def test_no_injection_when_no_param_configured(self):
+        tool_input = {"subject": "hi"}
+        event = _FakeEvent("createTicket", tool_input)
+        hook = _hook()  # no client_token_param_resolver -> passthrough disabled
+        hook._on_before_tool_call(event)
+        assert "Idempotency-Key" not in tool_input
+
+    def test_per_tool_passthrough_only_for_configured_tools(self):
+        # Adapter/tool 'httpCreate' supports a token; 'mcpCall' does not.
+        supported = {"httpCreate": "Idempotency-Key"}
+        hook = _hook(client_token_param_resolver=lambda name: supported.get(name))
+
+        ev_http = _FakeEvent("httpCreate", {"a": 1})
+        hook._on_before_tool_call(ev_http)
+        assert "Idempotency-Key" in ev_http.tool_use["input"]
+
+        ev_mcp = _FakeEvent("mcpCall", {"a": 1})
+        hook._on_before_tool_call(ev_mcp)
+        assert "Idempotency-Key" not in ev_mcp.tool_use["input"]
+
+    def test_resolver_failure_fails_safe_no_injection(self):
+        def boom(_name):
+            raise RuntimeError("config lookup failed")
+
+        tool_input = {"subject": "hi"}
+        event = _FakeEvent("createTicket", tool_input)
+        hook = _hook(client_token_param_resolver=boom)
+        hook._on_before_tool_call(event)
+        # A resolver failure must not inject a token and must not break the call.
+        assert "Idempotency-Key" not in tool_input
+        assert isinstance(event.selected_tool, _IdempotentToolWrapper)

--- a/arbiter/workerWrapper/agent_runner.py
+++ b/arbiter/workerWrapper/agent_runner.py
@@ -390,6 +390,22 @@ def _install_governed_tool_handler():
     return True
 
 
+def _read_dispatch_generation():
+    """Parse ``CITADEL_DISPATCH_GENERATION`` to an int, or None when unset/invalid.
+
+    The step runner sets this only for a fenced workflow-node dispatch. A
+    missing/non-integer value degrades to None -> the tool-call reserve is
+    unfenced (exactly-once-within-attempt only), preserving back-compat for
+    the supervisor task path and pre-fence dispatchers."""
+    raw = os.environ.get('CITADEL_DISPATCH_GENERATION')
+    if raw is None:
+        return None
+    try:
+        return int(raw)
+    except (TypeError, ValueError):
+        return None
+
+
 def _install_idempotency_hook():
     """Patch ``strands.Agent.__init__`` to attach an idempotency HookProvider.
 
@@ -446,6 +462,7 @@ def _install_idempotency_hook():
             org_id=os.environ.get('CITADEL_ORG_ID', ''),
             execution_id=os.environ.get('CITADEL_EXECUTION_ID', ''),
             node_id=os.environ.get('CITADEL_NODE_ID', ''),
+            dispatch_generation=_read_dispatch_generation(),
         )
         existing = kwargs.get('hooks')
         if existing is None:

--- a/arbiter/workerWrapper/index.py
+++ b/arbiter/workerWrapper/index.py
@@ -935,6 +935,12 @@ def _process_workflow_node(event, message_attributes=None):
             execution_id=msg.execution_id,
             node_id=msg.node_id,
             org_id=_resolve_execution_org_id(msg.execution_id),
+            # PR2 dispatch-generation fence: carried on the validated
+            # node-dispatch message (server-minted by the step runner's
+            # dispatch guard). When present, agent_runner fences the tool-call
+            # reserve against it; when None (pre-fence dispatch) the reserve is
+            # unfenced, preserving back-compat.
+            dispatch_generation=msg.dispatch_generation,
         )
 
         usage_sink: list = []

--- a/arbiter/workerWrapper/tool_idempotency.py
+++ b/arbiter/workerWrapper/tool_idempotency.py
@@ -14,12 +14,14 @@ consensus, do NOT collapse it to a bare "exactly-once"):
   produced on *this* attempt. Two byte-identical (post-canonicalization)
   re-issues of the same logical call within one attempt collapse to the same
   key → exactly-once within an attempt, plus reservation-race safety.
-* It does **NOT** provide exactly-once across nondeterministic re-dispatch
-  (a watchdog re-dispatch runs a fresh LLM body whose calls may reorder or
-  reword → different keys). Closing that requires the worker
-  ``dispatchGeneration`` fence, which is **deferred to PR2** and is REQUIRED
-  for the complete guarantee. Nothing here should be read as the complete
-  guarantee.
+* It does **NOT**, on its own, provide exactly-once across nondeterministic
+  re-dispatch (a watchdog re-dispatch runs a fresh LLM body whose calls may
+  reorder or reword → different keys). That is by design: the key stays
+  attempt-scoped. Cross-re-dispatch exactly-once is closed SEPARATELY by the
+  worker ``dispatchGeneration`` fence (landed), which refuses a stale
+  re-dispatched-away worker at the ledger reserve — NOT by putting the
+  generation in the key (that would mint a fresh key per re-dispatch and
+  guarantee duplicates). See ``tool_execution_ledger.reserve``.
 
 Why not just ``json.dumps(sort_keys=True)``? Two flagged determinism traps
 that raw ``dumps`` gets wrong (both are property-tested):
@@ -56,6 +58,7 @@ __all__ = [
     "build_partition_key",
     "build_sort_key",
     "build_key",
+    "build_client_token",
     "classify_idempotency_mode",
     "detect_write_verbs",
     "check_bypass_classification",
@@ -187,6 +190,22 @@ def build_key(
         build_partition_key(org_id, execution_id),
         build_sort_key(node_id, call_index, tool_name, hash_hex),
     )
+
+
+def build_client_token(pk: str, sk: str) -> str:
+    """Derive a stable, org-scoped client-idempotency token from the ledger key.
+
+    Injected SERVER-SIDE into a tool call (for a target that supports an
+    end-to-end idempotency token) AFTER canonicalization, so it never perturbs
+    the ``argsHash``. Because it is a hash of the ledger key — whose partition
+    key is ``orgId#executionId`` — the token is deterministic per logical call
+    (a retry of the SAME call re-derives the SAME token, letting the target
+    dedupe end-to-end) and cannot collide across orgs (a different ``orgId``
+    yields a different ``pk`` -> a different token), so a model can never use it
+    to impersonate another org's idempotency namespace. 64 hex chars, within
+    the length most idempotency-key APIs accept.
+    """
+    return hashlib.sha256(f"{pk}|{sk}".encode("utf-8")).hexdigest()
 
 
 # ---------------------------------------------------------------------------

--- a/arbiter/workerWrapper/tool_idempotency_hook.py
+++ b/arbiter/workerWrapper/tool_idempotency_hook.py
@@ -28,9 +28,13 @@ logic to the real Strands seam; it degrades to a no-op import when
 ``strands`` is unavailable (dev/CI), mirroring ``governed_tool_handler.py``.
 
 Scope note (honesty requirement): this delivers exactly-once WITHIN an
-attempt + reservation-race safety. Exactly-once across nondeterministic
-re-dispatch needs the worker ``dispatchGeneration`` fence, which is DEFERRED
-to PR2 and REQUIRED for the complete guarantee.
+attempt + reservation-race safety, AND — for a workflow-node tool call carrying
+a ``dispatch_generation`` — exactly-once ACROSS a watchdog re-dispatch, because
+the reserve is fenced against the execution row's current generation (a stale
+re-dispatched-away worker is refused before any side effect). A supervisor task
+call or a ``bypass`` tool carries no generation and is unfenced (exactly-once
+within an attempt only). This hook also injects an optional server-side
+client-idempotency token (post-canonicalization) for targets that support one.
 """
 
 from __future__ import annotations
@@ -48,6 +52,7 @@ if _PROJECT_ROOT not in sys.path:
 from arbiter.governance import tool_execution_ledger as ledger  # noqa: E402
 from arbiter.workerWrapper.tool_idempotency import (  # noqa: E402
     MODE_LEDGER,
+    build_client_token,
     build_key,
     classify_idempotency_mode,
 )
@@ -83,7 +88,9 @@ class _IdempotentToolWrapper(AgentTool):  # type: ignore[misc]
     path applies the identical failure matrix over the same primitives).
     """
 
-    def __init__(self, inner: Any, pk: str, sk: str, tool_name: str, mode: str):
+    def __init__(self, inner: Any, pk: str, sk: str, tool_name: str, mode: str,
+                 *, dispatch_generation: int | None = None,
+                 execution_id: str = "", node_id: str = ""):
         try:
             super().__init__()
         except TypeError:  # pragma: no cover — base signature drift
@@ -93,6 +100,9 @@ class _IdempotentToolWrapper(AgentTool):  # type: ignore[misc]
         self._sk = sk
         self._tool_name = tool_name
         self._mode = mode
+        self._dispatch_generation = dispatch_generation
+        self._execution_id = execution_id
+        self._node_id = node_id
 
     # --- AgentTool interface delegation --------------------------------------
     @property
@@ -115,10 +125,27 @@ class _IdempotentToolWrapper(AgentTool):  # type: ignore[misc]
 
         tool_use_id = str(tool_use.get("toolUseId", "")) if hasattr(tool_use, "get") else ""
 
-        reservation = ledger.reserve(self._pk, self._sk, tool_name=self._tool_name)
+        try:
+            reservation = ledger.reserve(
+                self._pk, self._sk, tool_name=self._tool_name,
+                dispatch_generation=self._dispatch_generation,
+                execution_id=self._execution_id or None,
+                node_id=self._node_id or None,
+            )
+        except ledger.StaleWorkerFencedError:
+            # This worker was re-dispatched away (its generation is stale). It
+            # is refused at the reserve fence BEFORE any side effect — a newer
+            # worker owns the node. Surface as an error ToolResult; the tool
+            # never ran.
+            yield ToolResultEvent(_error_result(
+                tool_use_id,
+                "tool execution refused: worker fenced by a newer dispatch "
+                "generation (no side effect performed)",
+            ))
+            return
 
         if reservation.outcome == ledger.ReserveOutcome.HIT_COMPLETED:
-            yield ToolResultEvent(ledger._recorded_result(reservation.row or {}))
+            yield ToolResultEvent(ledger._recorded_result(reservation.row or {}, self._pk))
             return
         if reservation.outcome == ledger.ReserveOutcome.HIT_FAILED:
             yield ToolResultEvent(_error_result(tool_use_id, "prior terminal failure (idempotent replay)"))
@@ -126,7 +153,7 @@ class _IdempotentToolWrapper(AgentTool):  # type: ignore[misc]
         if reservation.outcome == ledger.ReserveOutcome.IN_FLIGHT:
             settled = ledger.wait_for_terminal(self._pk, self._sk)
             if settled is not None and settled.get("status") == ledger.STATUS_COMPLETED:
-                yield ToolResultEvent(ledger._recorded_result(settled))
+                yield ToolResultEvent(ledger._recorded_result(settled, self._pk))
                 return
             # Concurrent loser (or terminal-failed winner): retryable, no
             # execution. Surface as an error ToolResult — we NEVER ran the tool.
@@ -180,11 +207,15 @@ class IdempotencyToolHook:
         execution_id: str,
         node_id: str,
         mode_resolver: Callable[[str], str] | None = None,
+        dispatch_generation: int | None = None,
+        client_token_param_resolver: Callable[[str], str | None] | None = None,
     ):
         self._org_id = org_id or ""
         self._execution_id = execution_id or ""
         self._node_id = node_id or ""
         self._mode_resolver = mode_resolver
+        self._dispatch_generation = dispatch_generation
+        self._client_token_param_resolver = client_token_param_resolver
         self._call_index = 0
 
     @property
@@ -239,7 +270,34 @@ class IdempotencyToolHook:
             event.selected_tool = _KeyDerivationFailedTool(selected)
             return
 
-        event.selected_tool = _IdempotentToolWrapper(selected, pk, sk, tool_name, mode)
+        # Client-token passthrough (PR2): for a target that supports an
+        # end-to-end idempotency token, inject it SERVER-SIDE now — AFTER
+        # build_key has already hashed the ORIGINAL input, so the token never
+        # perturbs the argsHash — and OVERWRITE any model-supplied value so the
+        # model cannot inject its own token (which could impersonate another
+        # org's idempotency namespace). Only when the per-tool config declares
+        # a clientTokenParam AND the tool input is a mutable mapping.
+        token_param = self._resolve_client_token_param(tool_name)
+        if token_param and isinstance(tool_input, dict):
+            tool_input[token_param] = build_client_token(pk, sk)
+
+        event.selected_tool = _IdempotentToolWrapper(
+            selected, pk, sk, tool_name, mode,
+            dispatch_generation=self._dispatch_generation,
+            execution_id=self._execution_id,
+            node_id=self._node_id,
+        )
+
+    def _resolve_client_token_param(self, tool_name: str) -> str | None:
+        """Resolve the per-tool client-token param name, or None. Fail-safe:
+        any resolver error yields None (no token injected)."""
+        if self._client_token_param_resolver is None:
+            return None
+        try:
+            param = self._client_token_param_resolver(tool_name)
+        except Exception:  # noqa: BLE001 — resolver failure must not break the call
+            return None
+        return param if isinstance(param, str) and param else None
 
 
 class _KeyDerivationFailedTool(AgentTool):  # type: ignore[misc]

--- a/arbiter/workerWrapper/worker_governance.py
+++ b/arbiter/workerWrapper/worker_governance.py
@@ -175,6 +175,7 @@ def build_subprocess_env(
     execution_id: str | None = None,
     node_id: str | None = None,
     org_id: str | None = None,
+    dispatch_generation: int | None = None,
 ) -> dict:
     """Build the subprocess environment with governance and config overrides.
 
@@ -283,5 +284,14 @@ def build_subprocess_env(
         env['CITADEL_NODE_ID'] = node_id
     if isinstance(org_id, str) and org_id:
         env['CITADEL_ORG_ID'] = org_id
+
+    # PR2 dispatch-generation fence: the per-node generation this dispatch was
+    # written under. Consumed by agent_runner._install_idempotency_hook and
+    # passed to the ledger reserve so a stale (re-dispatched-away) worker is
+    # refused before any side effect. Additive and optional — absent (or a
+    # bool, which is not a valid generation) leaves the reserve unfenced
+    # (exactly-once-within-attempt only), preserving back-compat.
+    if isinstance(dispatch_generation, int) and not isinstance(dispatch_generation, bool):
+        env['CITADEL_DISPATCH_GENERATION'] = str(dispatch_generation)
 
     return env

--- a/backend/bin/app.ts
+++ b/backend/bin/app.ts
@@ -554,6 +554,7 @@ if (app.node.tryGetContext("nag") !== "false") {
             "/^Resource::arn:aws:secretsmanager:.*:.*:secret:bedrock-agentcore-identity!.+\\*$/g",
         },
         { regex: "/^Resource::<.+\\.Arn>\\/\\*$/g" },
+        { regex: "/^Resource::<.+\\.Arn>\\/tool-results\\/\\*$/g" },
         {
           regex:
             "/^Resource::arn:aws:bedrock-agentcore:.*:.*:workload-identity-directory\\/.+-\\*$/g",

--- a/backend/lib/arbiter-stack.ts
+++ b/backend/lib/arbiter-stack.ts
@@ -440,6 +440,77 @@ export class ArbiterStack extends cdk.Stack {
       },
     );
 
+    // Tool-result offload (PR2). Oversized tool results (> inline cap) are
+    // offloaded here instead of being truncated, so a deduped/replayed caller
+    // receives the FULL recorded body. Security condition C3: a dedicated CMK
+    // (SSE-KMS enforced, non-KMS + wrong-key puts DENIED by the bucket policy
+    // below, mirroring the governance-transcripts precedent), block-public,
+    // TLS-only. Object keys are org/execution-prefixed
+    // (tool-results/{orgId}/{executionId}/…) and the worker's grant is
+    // prefix-scoped with NO cross-org path and NO DeleteObject; the stored
+    // resultRef is additionally re-checked against the caller's org prefix on
+    // read in tool_execution_ledger._fetch_result_ref. A short TTL keeps this
+    // an operational store, not an audit artifact (matches the ledger table).
+    const toolResultsKey = new kms.Key(this, "ToolResultsKey", {
+      description: "Citadel tool-result offload bucket encryption key",
+      enableKeyRotation: true,
+      removalPolicy: cdk.RemovalPolicy.RETAIN,
+      alias: `alias/citadel-tool-results-${props.environment}`,
+    });
+    const toolResultsBucket = new Bucket(this, "ToolResultsBucket", {
+      bucketName: `citadel-tool-results-${props.environment}-${this.account}-${this.region}`,
+      encryption: cdk.aws_s3.BucketEncryption.KMS,
+      encryptionKey: toolResultsKey,
+      bucketKeyEnabled: true,
+      blockPublicAccess: BlockPublicAccess.BLOCK_ALL,
+      enforceSSL: true,
+      removalPolicy: cdk.RemovalPolicy.DESTROY,
+      lifecycleRules: [
+        {
+          id: "tool-results-operational-ttl",
+          enabled: true,
+          expiration: cdk.Duration.days(7),
+        },
+      ],
+    });
+    // Deny any PutObject that is not SSE-KMS encrypted.
+    toolResultsBucket.addToResourcePolicy(
+      new iam.PolicyStatement({
+        effect: iam.Effect.DENY,
+        principals: [new iam.AnyPrincipal()],
+        actions: ["s3:PutObject"],
+        resources: [toolResultsBucket.arnForObjects("*")],
+        conditions: {
+          StringNotEquals: { "s3:x-amz-server-side-encryption": "aws:kms" },
+        },
+      }),
+    );
+    // Deny any PutObject that uses a different KMS key than our CMK.
+    toolResultsBucket.addToResourcePolicy(
+      new iam.PolicyStatement({
+        effect: iam.Effect.DENY,
+        principals: [new iam.AnyPrincipal()],
+        actions: ["s3:PutObject"],
+        resources: [toolResultsBucket.arnForObjects("*")],
+        conditions: {
+          StringNotEqualsIfExists: {
+            "s3:x-amz-server-side-encryption-aws-kms-key-id":
+              toolResultsKey.keyArn,
+          },
+        },
+      }),
+    );
+    NagSuppressions.addResourceSuppressions(toolResultsBucket, [
+      {
+        id: "AwsSolutions-S1",
+        reason:
+          "Operational, short-TTL tool-result offload bucket (not an audit " +
+          "artifact); server-access logging is not wired in the arbiter stack " +
+          "(no shared access-logs bucket prop). Access is loopback of the " +
+          "worker role only, prefix-scoped, and object keys are org-isolated.",
+      },
+    ]);
+
     const workerAgentWrapperLambda = new PythonFunction(
       this,
       "WorkerAgentWrapper",
@@ -470,6 +541,11 @@ export class ArbiterStack extends cdk.Stack {
           // idempotency hook is itself gated on per-node execution/node
           // context, so a missing key context is a back-compat no-op.
           TOOL_EXECUTION_LEDGER_TABLE: toolExecutionLedgerTable.tableName,
+          // Tool-result offload (PR2): oversized results are written here
+          // (SSE-KMS, org-prefixed) instead of being truncated; the worker
+          // no-ops offload when unset and small results always stay inline.
+          TOOL_RESULT_BUCKET: toolResultsBucket.bucketName,
+          TOOL_RESULT_KMS_KEY_ID: toolResultsKey.keyArn,
           ...(props.registryId && { REGISTRY_ID: props.registryId }),
           ...(props.registryId && { REGISTRY_ENABLED: "true" }),
         },
@@ -543,6 +619,27 @@ export class ArbiterStack extends cdk.Stack {
           },
         }),
       );
+      // PR2 dispatch-generation fence: the tool-call reserve is a
+      // TransactWriteItems that Puts the ledger row AND performs a
+      // ConditionCheck on this execution row's
+      // nodeResults.<nodeId>.dispatchGeneration in the SAME atomic write
+      // (security condition C2 — the guard is in the reserve's condition, no
+      // read-then-check TOCTOU window). ConditionCheck is a read-only
+      // condition (no write), scoped to the same nodeResults/executionId
+      // attributes as the UpdateItem grant above — it does not widen the
+      // worker's write surface.
+      workerAgentWrapperLambda.addToRolePolicy(
+        new iam.PolicyStatement({
+          effect: iam.Effect.ALLOW,
+          actions: ["dynamodb:ConditionCheckItem"],
+          resources: [props.executionsTable.tableArn],
+          conditions: {
+            "ForAllValues:StringEquals": {
+              "dynamodb:Attributes": ["nodeResults", "executionId"],
+            },
+          },
+        }),
+      );
     }
 
     // Tool-call idempotency (PR1): least-privilege grant on the tool-execution
@@ -562,6 +659,23 @@ export class ArbiterStack extends cdk.Stack {
         resources: [toolExecutionLedgerTable.tableArn],
       }),
     );
+
+    // Tool-result offload (PR2), least-privilege: PutObject + GetObject on the
+    // tool-results/* prefix ONLY — no DeleteObject, no cross-bucket, no
+    // ListBucket. Per-org isolation is by the org/execution key prefix plus
+    // the read-time resultRef org re-check in the ledger; a per-dispatch scoped
+    // STS session pinning a single org prefix is the follow-up to close the
+    // residual (mirrors the executions-table item-level pinning note above).
+    workerAgentWrapperLambda.addToRolePolicy(
+      new iam.PolicyStatement({
+        effect: iam.Effect.ALLOW,
+        actions: ["s3:PutObject", "s3:GetObject"],
+        resources: [toolResultsBucket.arnForObjects("tool-results/*")],
+      }),
+    );
+    // SSE-KMS on the offload bucket needs GenerateDataKey (put) + Decrypt (get)
+    // on the CMK. grantEncryptDecrypt covers both; scoped to this one key.
+    toolResultsKey.grantEncryptDecrypt(workerAgentWrapperLambda);
 
     // The worker emits best-effort node-level metrics (NodeDurationMs /
     // NodeFailure) into the Citadel/Workflows namespace after running each
@@ -584,6 +698,26 @@ export class ArbiterStack extends cdk.Stack {
             "worker narrows the call to the Citadel/Workflows namespace " +
             "(node duration/failure metrics).",
           appliesTo: ["Resource::*"],
+        },
+        {
+          id: "AwsSolutions-IAM5",
+          reason:
+            "Tool-result offload (PR2): the worker Put/Get is scoped to the " +
+            "tool-results/* key prefix of the dedicated offload bucket only " +
+            "(no DeleteObject, no ListBucket, no cross-bucket). The object-path " +
+            "prefix wildcard (Resource::<bucket.Arn>/tool-results/*) is " +
+            "suppressed at the app level (bin/app.ts appLambdaSuppressions); " +
+            "per-org isolation is enforced by the org key prefix plus the " +
+            "read-time resultRef org re-check.",
+          appliesTo: ["Action::s3:GetObject", "Action::s3:PutObject"],
+        },
+        {
+          id: "AwsSolutions-IAM5",
+          reason:
+            "SSE-KMS on the tool-results offload bucket requires the AWS SDK " +
+            "GenerateDataKey*/ReEncrypt* wildcard actions on the single " +
+            "dedicated CMK (grantEncryptDecrypt), scoped to that key only.",
+          appliesTo: ["Action::kms:GenerateDataKey*", "Action::kms:ReEncrypt*"],
         },
       ],
       true,

--- a/backend/test/arbiter-stack-tool-execution-ledger.test.ts
+++ b/backend/test/arbiter-stack-tool-execution-ledger.test.ts
@@ -164,4 +164,102 @@ describe("ArbiterStack — tool-execution idempotency ledger (PR1)", () => {
       }
     }
   });
+
+  // --- PR2: oversized-result S3 offload (SSE-KMS, org-prefixed, no Delete) ---
+
+  test("offload bucket is CMK-encrypted, block-public, and TLS-only", () => {
+    template.hasResourceProperties("AWS::S3::Bucket", {
+      BucketName: "citadel-tool-results-test-123456789012-us-east-1",
+      BucketEncryption: {
+        ServerSideEncryptionConfiguration: Match.arrayWith([
+          Match.objectLike({
+            ServerSideEncryptionByDefault: Match.objectLike({
+              SSEAlgorithm: "aws:kms",
+            }),
+          }),
+        ]),
+      },
+      PublicAccessBlockConfiguration: {
+        BlockPublicAcls: true,
+        BlockPublicPolicy: true,
+        IgnorePublicAcls: true,
+        RestrictPublicBuckets: true,
+      },
+    });
+  });
+
+  test("offload bucket policy DENIES non-KMS puts", () => {
+    template.hasResourceProperties("AWS::S3::BucketPolicy", {
+      PolicyDocument: {
+        Statement: Match.arrayWith([
+          Match.objectLike({
+            Effect: "Deny",
+            Action: "s3:PutObject",
+            Condition: {
+              StringNotEquals: {
+                "s3:x-amz-server-side-encryption": "aws:kms",
+              },
+            },
+          }),
+        ]),
+      },
+    });
+  });
+
+  test("worker S3 grant is Put/Get on the tool-results/* prefix only — no Delete", () => {
+    const policies = template.findResources("AWS::IAM::Policy");
+    let found = false;
+    for (const policy of Object.values(policies) as any[]) {
+      for (const stmt of policy.Properties.PolicyDocument.Statement) {
+        const actions = Array.isArray(stmt.Action)
+          ? stmt.Action
+          : [stmt.Action];
+        const resStr = JSON.stringify(stmt.Resource ?? "");
+        if (
+          actions.includes("s3:PutObject") &&
+          resStr.includes("tool-results/*")
+        ) {
+          found = true;
+          expect(actions).toEqual(
+            expect.arrayContaining(["s3:PutObject", "s3:GetObject"]),
+          );
+          expect(actions).not.toContain("s3:DeleteObject");
+          expect(actions).not.toContain("s3:*");
+        }
+      }
+    }
+    expect(found).toBe(true);
+  });
+
+  // --- PR2: dispatch-generation fence ConditionCheck on the executions row ---
+
+  test("worker has dynamodb:ConditionCheckItem on the executions table (fence)", () => {
+    template.hasResourceProperties("AWS::IAM::Policy", {
+      PolicyDocument: {
+        Statement: Match.arrayWith([
+          Match.objectLike({
+            Effect: "Allow",
+            Action: "dynamodb:ConditionCheckItem",
+            Condition: Match.objectLike({
+              "ForAllValues:StringEquals": {
+                "dynamodb:Attributes": ["nodeResults", "executionId"],
+              },
+            }),
+          }),
+        ]),
+      },
+    });
+  });
+
+  test("worker env wires the offload bucket + CMK", () => {
+    template.hasResourceProperties("AWS::Lambda::Function", {
+      Handler: "index.lambda_handler",
+      Environment: {
+        Variables: Match.objectLike({
+          TOOL_RESULT_BUCKET: Match.anyValue(),
+          TOOL_RESULT_KMS_KEY_ID: Match.anyValue(),
+        }),
+      },
+    });
+  });
 });

--- a/docs/TOOL_IDEMPOTENCY.md
+++ b/docs/TOOL_IDEMPOTENCY.md
@@ -1,9 +1,15 @@
-# Tool-Call Idempotency (PR1 of 2)
+# Tool-Call Idempotency
 
-Makes a **governed worker tool call** exactly-once *within an attempt* and safe
-under a reservation race, using an org-scoped, TTL'd DynamoDB ledger.
+Makes a **governed worker tool call** exactly-once and safe under a reservation
+race, using an org-scoped, TTL'd DynamoDB ledger, a worker
+`dispatchGeneration` fence, and CMK-encrypted S3 offload of oversized results.
 
-## What PR1 guarantees — stated precisely
+> History: PR1 shipped canonicalization + ledger + reserve/execute/finalize
+> (exactly-once *within an attempt*). PR2 landed the `dispatchGeneration`
+> fence, the S3 result offload, and client-token passthrough — completing the
+> capability. The guarantee below is the current, post-fence statement.
+
+## What is guaranteed — stated precisely
 
 - **Exactly-once execution of a side effect is GUARANTEED for calls that resolve
   to the same idempotency key** — SQS/redelivery, same-attempt SDK/Strands
@@ -11,24 +17,58 @@ under a reservation race, using an org-scoped, TTL'd DynamoDB ledger.
   conditional first-write-wins is the mechanism: one caller wins and executes;
   every other caller is absorbed (recorded result) or bounced with a
   **retryable no-execution error** and never executes.
+- **Exactly-once across a watchdog re-dispatch is GUARANTEED for workflow-node
+  tool calls** (the case PR1 could not close). The step runner increments a
+  per-node `dispatchGeneration` on every conditional `pending→running`
+  transition; the worker carries the generation it was dispatched under; and
+  the reserve is a `TransactWriteItems` whose fence — a `ConditionCheck` on the
+  execution row's `nodeResults.<nodeId>.dispatchGeneration`, evaluated in the
+  **same atomic write** as the reserve `Put` (no read-then-check TOCTOU
+  window) — **refuses a stale (re-dispatched-away) worker before any side
+  effect** (`StaleWorkerFencedError`). So a stalled-but-alive original worker
+  and a nondeterministic re-dispatch body can no longer both reach an adapter:
+  only the current generation's worker executes.
 - **Reservation-race safety**: the concurrent loser bounded-polls for the
   winner's result, then returns a retryable error — it never runs the tool. A
   dead holder is reclaimed via a conditional CAS.
+- **Faithful replay of large results**: an oversized result is offloaded to a
+  CMK-encrypted, org/execution-prefixed S3 object (not truncated), so a
+  deduped caller receives the FULL recorded body. The stored `resultRef` is
+  re-checked against the caller's org prefix on read (`CrossOrgResultRefError`).
 
-## What PR1 does NOT guarantee (and why)
+## What is still NOT guaranteed (and why)
 
-- It is **NOT** exactly-once across nondeterministic re-dispatch. The key is
-  attempt-scoped — `(orgId#executionId, nodeId#callIndex#toolName#argsHash)`.
-  A watchdog re-dispatch runs a fresh LLM body whose tool calls may reorder or
-  reword, yielding *different* keys the ledger cannot recognize.
-- Closing that gap requires a **worker `dispatchGeneration` fence** (a stale
-  re-dispatched worker refused at reserve time). That fence is **DEFERRED to
-  PR2** and is **REQUIRED for the complete guarantee**. Do not read PR1 as the
-  complete exactly-once guarantee.
+- The fence covers tool calls that flow through the ledger **inside the fence
+  envelope**. Two paths deliberately opt out and are therefore NOT
+  generation-fenced (they retain exactly-once-within-attempt + reservation-race
+  safety only):
+  - a **supervisor task** tool call (no execution/node/generation context —
+    the fence has nothing to evaluate against); and
+  - a tool flagged `idempotency.mode='bypass'` (read-only; skips the ledger,
+    and therefore the fence). A side-effecting tool mis-flagged `bypass` loses
+    both dedupe and the fence — which is why the fail-safe default is `ledger`
+    and the write-verb-in-bypass guard blocks in strict enforcement.
+- Fence soundness is a JOINT property of the atomic reserve-before-execute seam
+  ∧ no bypass path ∧ a generation actually threaded. It is not a standalone
+  guarantee for a call that never reserves.
+- Concurrent-loser *result delivery* (not *execution*) remains best-effort.
 
-Also deferred to PR2: S3 offload of oversized results (PR1 records a
-deterministic marker instead), and client-token passthrough to adapters that
-support end-to-end dedupe.
+## Client-token passthrough (optional, per tool)
+
+For a target that supports an end-to-end idempotency token, the idempotency
+hook injects one **server-side, AFTER canonicalization** (so it never perturbs
+the `argsHash`) and **overwrites any model-supplied value** (so the model
+cannot impersonate another org's idempotency namespace). The token is
+`sha256(pk|sk)` — deterministic per logical call (a retry re-derives it) and
+org-scoped via the `orgId#executionId` partition key. Wiring is gated by a
+per-tool `idempotency.clientTokenParam` config.
+
+Inventory note (grounded in the code, not assumed): no existing adapter —
+neither the agent-source import adapters nor the integration adapters — reads a
+client/idempotency token today. The single server-controlled chokepoint that
+sees both the derived key and the tool input is the hook, so injection lives
+there; `clientTokenParam` is the forwarding contract for a tool/target that
+supports it.
 
 ## Key derivation
 


### PR DESCRIPTION
## Summary
The first idempotency PR made tool calls exactly-once *within an attempt*, and said plainly what it did not cover: if the watchdog re-dispatches a stalled node and the agent replays non-deterministically, the keys differ and the ledger cannot absorb the duplicate. This PR closes that gap, completing the capability. It also replaces the interim oversize marker with real result offload and adds client-token passthrough for targets that support it.
## What changed
**Dispatch-generation fence.** The executor already bumps a per-node dispatch counter inside the conditional `pending>running` transition; that generation now reaches the worker and is enforced at reservation time. A stale worker - one whose node has since been re-dispatched - is refused before it can produce a side effect.

The important property is *where* the check happens: the guard is a condition check inside the **same** `TransactWriteItems` as the reservation put, not a preceding read. A read-then-check would reintroduce exactly the race it is meant to close, so a generation bump landing between the two would let the stale worker through. Tests cover both the effect and the mechanism: an unfenced path executes twice where the fenced path executes once (kept as a permanent red proof, and a generation bump interleaved at commit time yields zero executions.

Note the generation is deliberately **not** part of the idempotency key - this would change the key on every re-dispatch and guarantee duplicates rather than prevent them.

**Result offload.** Oversized tool results move to S3 instead of a truncation marker, so replayed results stay faithful. The bucket enforces SSE-KMS with its own customer-managed key and denies non-KMS puts, wrong-key puts, and non-TLS access. Object keys are org-prefixed, the worker's IAM is scoped to that prefix with no `Delete` and no bucket-wide wildcard, and a stored result reference is re-checked against the caller's org on read - a cross-org read is refused.

**Client-token passthrough.** For targets that accept a client/idempotency token, one is injected server-side after* canonicalization, so it never perturbs the args hash, and it overwrites any model-supplied value to prevent impersonation across orgs. Adapter support was inventoried from the code rather than assumed.
## Guarantee (updated, with limits)
With the fence in place, tool calls dispatched for a workflow node are exactly-once for a given key within the fence envelope, including across watchdog re-dispatch. The docs now carry an explicit *not* guaranteed section: the supervisor path, tools deliberately flagged for bypass, and any call that never reaches the reservation. The separate vm-based sandbox execution path remains outside this protocol by construction and is documented as such.
## Testing
- Fence: permanent red proof (unfenced executes twice, fenced once) plus the commit-time generation-bump test.
- Offload: round-trip, cross-orgreference read refused, and a template assertion that non-KMS puts are denied.
- Client tokens: token absent from the args hash; model-supplied token overwritten.
- Prior PR's suite still green: the hypothesis property that a repeated key never re-executes, forced double delivery, and its own red proof.
- Full backend suite 6,811 tests; arbiter pytest 965 passing on touched modules; `tsc` clean; synth clean.
## DepLoyment notes
Adds an S3 bucket with a customer-managed KMS key and prefix-scoped grants, plus fence wiring on the tool-call hot path. Medium risk - a pre-merge deploy to dev is worthwhile. After deploy this capability is ready for its one live acceptance exercise: run a workflow whose node calls a real tool, then confirm a reserve/finalize pair, exactly one ledger row, and that a forced retry produces no second side effect.