### PR TITLE
fix(execution): record failed agent runs as failed, not completed

### DIFF
--- a/arbiter/workerWrapper/__tests__/test_agent_runner_properties.py
+++ b/arbiter/workerWrapper/__tests__/test_agent_runner_properties.py
@@ -84,8 +84,13 @@ class TestAgentRunnerMain:
 
     @given(request=request_dicts)
     @settings(max_examples=30)
-    def test_handler_exception_produces_error_response(self, request):
-        """When handler raises, output still contains a 'response' key."""
+    def test_handler_exception_produces_failure_envelope_and_nonzero_exit(self, request):
+        """finding 56d763d4: when the agent body raises, agent_runner must NOT
+        launder the exception into a successful ``response`` string. It emits a
+        FAILURE-MARKED envelope carrying the exception CLASS + diagnostic and
+        exits non-zero, so the parent can never record a crash as completed."""
+        import io
+
         with tempfile.NamedTemporaryFile(
             mode="w", suffix=".py", delete=False
         ) as f:
@@ -101,19 +106,28 @@ class TestAgentRunnerMain:
                 "request": request,
             })
 
-            captured_output = []
-
+            fake_stdout = io.StringIO()
             with patch("sys.stdin") as mock_stdin, \
-                 patch("builtins.print", side_effect=lambda s: captured_output.append(s)):
+                 patch("sys.stdout", fake_stdout):
                 mock_stdin.read.return_value = payload
 
-                from agent_runner import main
-                main()
+                import agent_runner
+                with pytest.raises(SystemExit) as excinfo:
+                    agent_runner.main()
 
-            assert len(captured_output) == 1
-            parsed = json.loads(captured_output[0])
-            assert "response" in parsed
-            assert "failed" in parsed["response"].lower() or "error" in parsed["response"].lower()
+            # Non-zero exit is the failure signal.
+            assert excinfo.value.code != 0
+
+            parsed = json.loads(fake_stdout.getvalue())
+            # Structural failure marker present; NO success 'response' key.
+            assert parsed[agent_runner.AGENT_EXECUTION_FAILURE_MARKER] is True
+            assert "response" not in parsed
+            # The exception CLASS is carried for retry.py's failure-class logic.
+            assert parsed["errorClass"] == "RuntimeError"
+            # The human diagnostic is preserved in the envelope.
+            assert "test error" in parsed["error"]
+            # usage remains an (additive) list even on failure.
+            assert isinstance(parsed["usage"], list)
         finally:
             os.unlink(module_path)
 

--- a/arbiter/workerWrapper/__tests__/test_node_failure_status.py
+++ b/arbiter/workerWrapper/__tests__/test_node_failure_status.py
@@ -1,0 +1,256 @@
+"""
+Regression + invariant tests for finding 56d763d4 (HIGH): a crashed agent
+execution must never be persisted as SUCCESS.
+
+Ground truth (dev execution 350956fa): the agent body raised
+"'dict' object can't be awaited"; ``agent_runner`` swallowed it into a
+successful ``response`` string, the subprocess exited 0, and the worker
+recorded node smoke-1 as ``status=completed`` / ``retryCount=0`` and finalized
+the execution ``completed``. That starves retry.py's failure-class logic, the
+durable-execution watchdog (the node is terminal-successful), and every
+downstream pass/fail consumer.
+
+These tests pin the corrected behavior:
+
+* An agent-body exception surfaces as a FAILURE envelope carrying the error
+  CLASS (``run_agent_in_subprocess`` raises ``AgentExecutionError``).
+* The worker emits ``workflow.node.failed`` (never ``completed``) and never
+  writes a completed nodeResults entry — even when the subprocess exit code is
+  0 (the exact defect shape).
+* The node-result ``error`` is the exception CLASS, so retry.py's
+  ``should_retry`` (``error_type in retryableErrors``) can classify it.
+* STRUCTURAL: the pure result-builder ``_interpret_agent_result`` can NEVER
+  return a success value for a failure-marked payload, for any exit code /
+  raise_on_error combination.
+
+All AWS (boto3, subprocess) is mocked; no real network or credentials.
+"""
+
+import json
+import sys
+from unittest.mock import patch, MagicMock
+
+import pytest
+
+
+NODE_MESSAGE = {
+    'message_type': 'workflow_node',
+    'execution_id': 'exec-1',
+    'node_id': 'smoke-1',
+    'workflow_id': 'wf-1',
+    'agent_id': 'agent-A',
+    'input': {'taskDetails': 'do the thing'},
+    'configuration': {},
+}
+
+SUPERVISOR_MESSAGE = {
+    'orchestration_id': 'orch-1',
+    'agent_use_id': 'use-1',
+    'agent_input': {'taskDetails': 'do the thing'},
+    'node': 'agent-A',
+}
+
+_NODE_ENV = {
+    'AGENT_CONFIG_TABLE': 'test-table',
+    'AGENT_BUCKET_NAME': 'test-bucket',
+    'COMPLETION_BUS_NAME': 'citadel-agents-test',
+    'EXECUTIONS_TABLE': 'citadel-executions-test',
+}
+
+# The exact ground-truth crash: a TypeError surfaced as "'dict' object can't
+# be awaited". agent_runner stamps errorClass=<type name> in the envelope.
+FAILURE_MARKER = 'agentExecutionFailed'
+
+
+def _fresh_index():
+    sys.modules.pop('index', None)
+    import index
+    return index
+
+
+def _failure_stdout(error_class='TypeError',
+                    message="'dict' object can't be awaited", usage=None):
+    """Build the stdout envelope agent_runner writes when the agent body
+    raises (the defect trigger)."""
+    return json.dumps({
+        FAILURE_MARKER: True,
+        'errorClass': error_class,
+        'error': message,
+        'usage': usage or [],
+    })
+
+
+# ---------------------------------------------------------------------------
+# The defect regression: exit code 0 + failure marker must NOT complete.
+# ---------------------------------------------------------------------------
+
+class TestCrashNeverCompletes:
+    def test_exit_zero_failure_marker_emits_node_failed_not_completed(self):
+        """THE defect (350956fa): the subprocess exits 0 with a success-shaped
+        pipe, but the payload carries the agent-body failure marker. The OLD
+        code emitted node.completed; the fix emits node.failed carrying the
+        error CLASS, and writes NO completed nodeResults entry."""
+        mock_result = MagicMock(returncode=0, stdout=_failure_stdout(), stderr='')
+        table = MagicMock()
+        events = MagicMock()
+        events.put_events.return_value = {'FailedEntryCount': 0}
+        resource_mock = MagicMock()
+        resource_mock.Table.return_value = table
+
+        with patch.dict('os.environ', _NODE_ENV):
+            index = _fresh_index()
+            with patch('boto3.resource', return_value=resource_mock), \
+                 patch('boto3.client', return_value=events):
+                with patch.object(index, 'load_config_from_dynamodb',
+                                  return_value={'config': {'filename': 'agent.py'}}), \
+                     patch.object(index, 'get_scoped_credentials', return_value=None), \
+                     patch.object(index, 'load_file_from_s3_into_tmp'), \
+                     patch('subprocess.run', return_value=mock_result):
+                    index.process_event(dict(NODE_MESSAGE), {})
+
+        entry = events.put_events.call_args.kwargs['Entries'][0]
+        assert entry['DetailType'] == 'workflow.node.failed'
+        detail = json.loads(entry['Detail'])
+        assert detail['status'] == 'failed'
+        assert detail['nodeId'] == 'smoke-1'
+        # error field is the exception CLASS (retry.py classification key).
+        assert detail['error'] == 'TypeError'
+        assert 'output' not in detail
+        # Crucially: NO completed nodeResults entry was written (a completed
+        # persist would make the run terminal-successful again).
+        table.update_item.assert_not_called()
+
+    def test_emitted_error_class_drives_retry_classification(self):
+        """The emitted node.failed error is the exact class string retry.py's
+        should_retry matches on, so a RETRYABLE class retries instead of
+        terminally succeeding."""
+        mock_result = MagicMock(
+            returncode=0, stdout=_failure_stdout(error_class='TimeoutError',
+                                                 message='slow tool'), stderr='')
+        table = MagicMock()
+        events = MagicMock()
+        events.put_events.return_value = {'FailedEntryCount': 0}
+        resource_mock = MagicMock()
+        resource_mock.Table.return_value = table
+
+        with patch.dict('os.environ', _NODE_ENV):
+            index = _fresh_index()
+            with patch('boto3.resource', return_value=resource_mock), \
+                 patch('boto3.client', return_value=events):
+                with patch.object(index, 'load_config_from_dynamodb',
+                                  return_value={'config': {'filename': 'agent.py'}}), \
+                     patch.object(index, 'get_scoped_credentials', return_value=None), \
+                     patch.object(index, 'load_file_from_s3_into_tmp'), \
+                     patch('subprocess.run', return_value=mock_result):
+                    index.process_event(dict(NODE_MESSAGE), {})
+
+        detail = json.loads(events.put_events.call_args.kwargs['Entries'][0]['Detail'])
+        emitted_error = detail['error']
+        assert emitted_error == 'TimeoutError'
+
+        # Feed the emitted class straight into retry.py's classifier (the same
+        # function the executor's handle_node_failure calls).
+        sys.path.insert(0, __import__('os').path.join(
+            __import__('os').path.dirname(__file__), '..', '..', 'stepRunner'))
+        from retry import should_retry
+        assert should_retry(emitted_error, [emitted_error], 0, 3) is True
+        assert should_retry(emitted_error, ['SomethingElse'], 0, 3) is False
+
+
+# ---------------------------------------------------------------------------
+# STRUCTURAL invariant: the result-builder cannot complete a marked payload.
+# ---------------------------------------------------------------------------
+
+class TestResultBuilderInvariant:
+    @pytest.mark.parametrize('returncode', [0, 1, 137])
+    @pytest.mark.parametrize('raise_on_error', [True, False])
+    def test_failure_marker_always_raises(self, returncode, raise_on_error):
+        """NO combination of exit code / raise_on_error can turn a
+        failure-marked envelope into a success return value."""
+        with patch.dict('os.environ', _NODE_ENV):
+            index = _fresh_index()
+            with pytest.raises(index.AgentExecutionError) as excinfo:
+                index._interpret_agent_result(
+                    returncode,
+                    _failure_stdout(error_class='ValueError', message='bad input'),
+                    raise_on_error=raise_on_error,
+                )
+        # The raised error carries the class (for retry classification) and
+        # preserves the diagnostic message.
+        assert excinfo.value.error_class == 'ValueError'
+        assert 'bad input' in excinfo.value.message
+
+    def test_failure_marker_still_collects_usage_then_raises(self):
+        with patch.dict('os.environ', _NODE_ENV):
+            index = _fresh_index()
+            sink = []
+            with pytest.raises(index.AgentExecutionError):
+                index._interpret_agent_result(
+                    0,
+                    _failure_stdout(usage=[{'inputTokens': 3, 'outputTokens': 4}]),
+                    raise_on_error=True,
+                    usage_sink=sink,
+                )
+        assert sink == [{'inputTokens': 3, 'outputTokens': 4}]
+
+    def test_success_envelope_still_returns_response(self):
+        """Regression: a genuine success (no marker, exit 0) returns the
+        response unchanged."""
+        with patch.dict('os.environ', _NODE_ENV):
+            index = _fresh_index()
+            out = index._interpret_agent_result(
+                0, json.dumps({'response': 'done', 'usage': []}),
+                raise_on_error=True,
+            )
+        assert out == 'done'
+
+    def test_nonzero_without_marker_preserves_raise_on_error_contract(self):
+        """A subprocess-level crash (no marker) keeps the pre-fix contract:
+        raise when raise_on_error, else the canned supervisor fallback."""
+        with patch.dict('os.environ', _NODE_ENV):
+            index = _fresh_index()
+            # node path: raises
+            with pytest.raises(index.AgentExecutionError):
+                index._interpret_agent_result(1, '', raise_on_error=True)
+            # supervisor path: canned fallback string
+            out = index._interpret_agent_result(1, '', raise_on_error=False)
+            assert 'could not be completed' in out
+
+    def test_marker_constant_parity_between_producer_and_consumer(self):
+        with patch.dict('os.environ', _NODE_ENV):
+            index = _fresh_index()
+            import agent_runner
+            assert index.AGENT_EXECUTION_FAILURE_MARKER == \
+                agent_runner.AGENT_EXECUTION_FAILURE_MARKER == FAILURE_MARKER
+
+
+# ---------------------------------------------------------------------------
+# Sibling swallow: the supervisor task path must not post a fake completion.
+# ---------------------------------------------------------------------------
+
+class TestSupervisorSiblingSwallow:
+    def test_supervisor_agent_body_crash_does_not_post_task_completion(self):
+        """A crashed supervisor agent (failure marker) must NOT be posted as a
+        task.completion success — the marker raises and the completion post is
+        never reached (SQS redelivery handles it)."""
+        mock_result = MagicMock(returncode=1, stdout=_failure_stdout(), stderr='')
+        events = MagicMock()
+        events.put_events.return_value = {'FailedEntryCount': 0}
+        resource_mock = MagicMock()
+        resource_mock.Table.return_value = MagicMock()
+
+        with patch.dict('os.environ', _NODE_ENV):
+            index = _fresh_index()
+            with patch('boto3.resource', return_value=resource_mock), \
+                 patch('boto3.client', return_value=events):
+                with patch.object(index, 'load_config_from_dynamodb',
+                                  return_value={'config': {'filename': 'agent.py', 'tools': []}}), \
+                     patch.object(index, 'get_scoped_credentials', return_value=None), \
+                     patch.object(index, 'load_file_from_s3_into_tmp'), \
+                     patch.object(index, 'build_subprocess_env', return_value={}), \
+                     patch.object(index, 'post_task_complete') as mock_ptc, \
+                     patch('subprocess.run', return_value=mock_result):
+                    with pytest.raises(index.AgentExecutionError):
+                        index.process_event(dict(SUPERVISOR_MESSAGE), {})
+
+        mock_ptc.assert_not_called()

--- a/arbiter/workerWrapper/agent_runner.py
+++ b/arbiter/workerWrapper/agent_runner.py
@@ -20,6 +20,34 @@ import importlib.util
 # subprocess), so callIndex is a simple monotonic counter starting at 0.
 _CAPTURED_USAGE: list = []
 
+# Structural agent-body failure marker (finding 56d763d4). ``agent_runner``
+# writes this top-level key ONLY when the agent body raises, so a failed run
+# is unambiguously distinguishable from a successful ``{"response": ...}``
+# envelope. The consumer (``index.run_agent_in_subprocess`` /
+# ``index._interpret_agent_result``) raises on its presence REGARDLESS of exit
+# code, so an agent-body exception can never be laundered into a completed
+# node result. Kept in lockstep with the mirror constant + defensive fallback
+# in index.py (a parity test pins them equal).
+AGENT_EXECUTION_FAILURE_MARKER = 'agentExecutionFailed'
+
+
+def build_failure_envelope(exc: BaseException, usage: list) -> dict:
+    """Build the stdout envelope for an agent-body exception (finding 56d763d4).
+
+    Carries the exception CLASS name (``errorClass`` — the key retry.py's
+    failure-class ``should_retry`` matches on) and the human-readable
+    diagnostic (``error``), plus any usage captured before the crash. The
+    presence of the ``AGENT_EXECUTION_FAILURE_MARKER`` top-level key is the
+    structural signal that this is a failure, not a success — it never appears
+    in a successful ``{"response": ...}`` envelope.
+    """
+    return {
+        AGENT_EXECUTION_FAILURE_MARKER: True,
+        'errorClass': type(exc).__name__,
+        'error': str(exc) or type(exc).__name__,
+        'usage': usage if isinstance(usage, list) else [],
+    }
+
 # Ordered candidate method names probed on strands.models.BedrockModel to
 # find the response-producing seam to wrap. Multiple candidates survive a
 # strands rename of the primary method without requiring a code change here.
@@ -560,8 +588,23 @@ def main():
 
     try:
         response = module.handler(**request)
-    except Exception as e:
-        response = f"Agent execution failed: {e}"
+    except Exception as exc:  # noqa: BLE001 — mapped to a failure envelope below
+        # DEFECT FIX (finding 56d763d4): an agent-body exception must NOT be
+        # laundered into a successful ``response`` string. The old code did
+        # ``response = f"Agent execution failed: {e}"`` and fell through to the
+        # success print with exit 0, so the worker recorded a crashed run as
+        # ``node.completed`` and the execution finalized ``completed`` —
+        # starving retry.py's failure-class logic, the durable-execution
+        # watchdog, and every downstream pass/fail consumer.
+        #
+        # Instead emit a FAILURE-MARKED envelope carrying the exception CLASS
+        # (for retry classification) + the diagnostic message, and exit
+        # non-zero. The marker is the structural signal the parent keys on to
+        # raise regardless of raise_on_error, so no caller can turn a marked
+        # payload into a completed result.
+        sys.stdout.write(json.dumps(build_failure_envelope(exc, _CAPTURED_USAGE)))
+        sys.stdout.flush()
+        sys.exit(1)
 
     # Write response as JSON to stdout. 'usage' is additive: an empty list
     # is legal and simply means no BedrockModel call was captured this run.

--- a/arbiter/workerWrapper/index.py
+++ b/arbiter/workerWrapper/index.py
@@ -124,6 +124,46 @@ EXECUTION_SPECS_TABLE = os.environ.get('EXECUTION_SPECS_TABLE')
 CREDENTIAL_VENDER_FUNCTION = os.environ.get('CREDENTIAL_VENDER_FUNCTION')
 AGENT_RUNNER_PATH = os.path.join(os.path.dirname(__file__), 'agent_runner.py')
 
+# Structural agent-body failure marker (finding 56d763d4). Imported from
+# agent_runner (the PRODUCER of the envelope) so producer and consumer stay in
+# lockstep. Defensive fallback to the literal keeps the consumer working even
+# if the co-bundled module can't be imported (mirrors this file's
+# deferred-bundling pattern); a parity test pins the fallback to agent_runner's
+# constant.
+try:
+    from agent_runner import AGENT_EXECUTION_FAILURE_MARKER  # noqa: E402
+except ImportError:  # pragma: no cover — co-bundled with index.py; fallback only
+    AGENT_EXECUTION_FAILURE_MARKER = 'agentExecutionFailed'
+
+
+class AgentExecutionError(RuntimeError):
+    """An agent execution failed and must surface as a FAILED node result
+    (finding 56d763d4).
+
+    Carries the exception CLASS name (``error_class``) so the step runner's
+    retry.py failure-class logic (``should_retry``: ``error_type in
+    retryableErrors``) can classify it, alongside the human-readable
+    ``message`` diagnostic. Raised by ``run_agent_in_subprocess`` /
+    ``_interpret_agent_result`` whenever the subprocess stdout carries the
+    agent-body failure marker (REGARDLESS of exit code) or, with
+    ``raise_on_error=True``, on any non-zero exit without a marker.
+    """
+
+    def __init__(self, error_class, message):
+        self.error_class = error_class or 'AgentExecutionError'
+        self.message = message or self.error_class
+        super().__init__(self.message)
+
+
+# Canned supervisor-path fallback for a subprocess-level crash WITHOUT a
+# failure marker (OOM/timeout kill/runner import crash) when raise_on_error is
+# False. Unchanged pre-fix string — the supervisor path intentionally degrades
+# for infra-level subprocess failures (an agent-body exception, by contrast,
+# always raises via the marker; see _interpret_agent_result).
+_SUBPROCESS_FALLBACK_RESPONSE = (
+    "The task could not be completed, this agent has issues, please ignore for now."
+)
+
 # QB-013-1: lazy boto3 client construction. Keeps the module importable
 # without AWS credentials in the local dev env. Matches the pattern used
 # by arbiter/governance/ledger.py and arbiter/fabricator/tools_config.py.
@@ -511,30 +551,81 @@ def run_agent_in_subprocess(request: dict, scoped_credentials: dict | None, extr
     if result.stderr:
         print(f"[agent stderr] {result.stderr}")
 
-    if result.returncode!= 0:
-        print(f"Agent subprocess exited with code {result.returncode}")
-        if raise_on_error:
-            raise RuntimeError(
-                f"Agent subprocess exited with code {result.returncode}"
-            )
-        return "The task could not be completed, this agent has issues, please ignore for now."
+    return _interpret_agent_result(
+        result.returncode, result.stdout,
+        raise_on_error=raise_on_error, usage_sink=usage_sink,
+    )
 
-    # Parse the response from stdout
+
+def _extend_usage_sink(usage_sink, parsed) -> None:
+    """Extend ``usage_sink`` from a parsed stdout envelope's ``usage`` array.
+
+    Best-effort and never raises into dispatch — a malformed usage value
+    degrades to no extension (``parse_usage_array`` returns ``[]``).
+    """
+    if usage_sink is None or not isinstance(parsed, dict):
+        return
     try:
-        output = json.loads(result.stdout.strip())
-        if usage_sink is not None:
-            try:
-                usage_sink.extend(parse_usage_array(output.get('usage', [])))
-            except Exception as exc:  # noqa: BLE001 — usage parsing must never break dispatch
-                print(json.dumps({
-                    'level': 'WARN',
-                    'component': 'WorkerWrapper',
-                    'action': 'usage_sink_extend_failed',
-                    'error': str(exc),
-                }))
-        return output.get('response', result.stdout.strip())
-    except json.JSONDecodeError:
-        return result.stdout.strip() or "Agent produced no output"
+        usage_sink.extend(parse_usage_array(parsed.get('usage', [])))
+    except Exception as exc:  # noqa: BLE001 — usage parsing must never break dispatch
+        print(json.dumps({
+            'level': 'WARN',
+            'component': 'WorkerWrapper',
+            'action': 'usage_sink_extend_failed',
+            'error': str(exc),
+        }))
+
+
+def _interpret_agent_result(returncode, stdout, *, raise_on_error=False, usage_sink=None):
+    """Pure result-builder mapping a subprocess ``(returncode, stdout)`` to a
+    success response string OR an ``AgentExecutionError`` (finding 56d763d4).
+
+    STRUCTURAL INVARIANT: a stdout envelope carrying the agent-body failure
+    marker (``AGENT_EXECUTION_FAILURE_MARKER``) ALWAYS raises
+    ``AgentExecutionError`` — for ANY ``returncode`` and ANY
+    ``raise_on_error`` — carrying the exception CLASS and diagnostic. No caller
+    can turn a marked (crashed) payload into a completed / success result; this
+    is the single choke point both the workflow-node and supervisor paths flow
+    through, so the "crash recorded as success" defect cannot recur on any
+    path.
+
+    Non-marker outcomes preserve the pre-fix contract exactly:
+      * non-zero exit + raise_on_error=True  -> raise (node path -> node.failed)
+      * non-zero exit + raise_on_error=False -> canned fallback (supervisor path)
+      * zero exit                            -> parsed 'response' (or raw stdout)
+    """
+    text = (stdout or '').strip()
+    parsed = None
+    if text:
+        try:
+            parsed = json.loads(text)
+        except json.JSONDecodeError:
+            parsed = None
+
+    # Usage is captured even on failure (harmless — dropped for failed nodes).
+    _extend_usage_sink(usage_sink, parsed)
+
+    # Structural guard: a failure-marked envelope can NEVER be a success. This
+    # precedes the returncode/raise_on_error branches deliberately.
+    if isinstance(parsed, dict) and parsed.get(AGENT_EXECUTION_FAILURE_MARKER) is True:
+        raise AgentExecutionError(
+            parsed.get('errorClass'),
+            parsed.get('error'),
+        )
+
+    if returncode != 0:
+        print(f"Agent subprocess exited with code {returncode}")
+        if raise_on_error:
+            raise AgentExecutionError(
+                'AgentSubprocessError',
+                f"Agent subprocess exited with code {returncode}",
+            )
+        return _SUBPROCESS_FALLBACK_RESPONSE
+
+    # Parse the response from stdout (success path).
+    if isinstance(parsed, dict):
+        return parsed.get('response', text)
+    return text or "Agent produced no output"
 
 def post_task_complete(response, agent_use_id, agent_name, orchestration_id, *, usage=None):
     """Publish the supervisor-task completion event.
@@ -949,6 +1040,20 @@ def _process_workflow_node(event, message_attributes=None):
             usage_sink=usage_sink,
         )
     except Exception as exc:  # noqa: BLE001 — any failure becomes node.failed
+        # finding 56d763d4: carry the exception CLASS as the node-result error
+        # so the step runner's retry.py failure-class logic (should_retry:
+        # ``error_type in retryableErrors``) can act on it. An
+        # AgentExecutionError from run_agent_in_subprocess carries the
+        # agent-body class (e.g. 'TypeError' for the ground-truth
+        # "'dict' object can't be awaited"); any other exception (config /
+        # module / credential error) uses its own type name. The full
+        # human-readable diagnostic is preserved in the ERROR log below — a
+        # failed node has no ``output`` to carry the message, and the
+        # node-result ``error`` field is the retry classification KEY, so it
+        # must be the class, not the free-form message (which would never match
+        # a retryableErrors entry).
+        error_class = getattr(exc, 'error_class', None) or type(exc).__name__
+        diagnostic = getattr(exc, 'message', None) or str(exc)
         print(json.dumps({
             'level': 'ERROR',
             'component': 'WorkerWrapper',
@@ -957,12 +1062,13 @@ def _process_workflow_node(event, message_attributes=None):
             'nodeId': msg.node_id,
             'workflowId': msg.workflow_id,
             'agentId': msg.agent_id,
-            'error': str(exc),
+            'errorClass': error_class,
+            'error': diagnostic,
         }))
         _emit_node_result(
             msg,
             status=workflow_contract.STATUS_FAILED,
-            error=str(exc) or 'agent execution failed',
+            error=error_class,
             trace_context=carried_ctx,
             worker_started_at=worker_started_at,
         )


### PR DESCRIPTION
## Summary
A crashed agent execution was persisted as a success. In a dev run this week the worker's node-result payload contained Agent execution failed: `dict` object can't be awaited, yet the node was written `status=completed` with `retryCount=0` and the execution finalized "completed". The narrow symptom is a misleading status. The real problem is everything downstream that trusts it:
- Failure-class retries never fire, because the failure was never recorded as one.
- The durable-execution watchdog cannot help, because the node is terminal-successful - there is nothing to reconcile or fail.
- Consumers of execution outcomes - eval runs, promotion evidence, per-arm metrics, and the canary auto-rollback error-rate signal - read a crashed run as passing. Error-rate-driven automation is blind to exactly this class of failure.
- An operator reading execution history sees green where the agent crashed. 
 
This was found by the first real execution of the workflow tool path, not by any test - the failure mapping had no coverage.
## What changed
- An agent-body exception now produces a **failed** node result and a **failed** execution, carrying the error **class** so the existing failure-class retry logic can act on it (retryable classes retry; terminal ones fail).
- The diagnostic message is preserved in the recorded output, so the fix improves fidelity without losing detail.
- Write-then-signal ordering is unchanged: the node and execution failure are persisted in a single update *before* the failure is published, consistent with the durable-execution work.
- The idempotency ledger's finalize semantics are untouched - a failed tool call still records its terminal state, and the fail-safe indeterminate rule (an unknown-outcome call is never re-executed) is intact.
- The handler was audited for sibling paths that turn an exception into a success; the audit is reported in the change notes, including the `batchItemFailures` path that governs SQS redelivery.
## Testing
- A raising agent body yields node `failed` and execution `failed`.
- A retryable error class produces a retry rather than a terminal success - asserted by feeding the emitted class through the real retry classifier, not a hardcoded expectation.
- A **structural** guard rather than another scenario test: the result build has a single choke point where the failure marker is checked before every branch, covered by a cross-product of the relevant parameters plus a parity test, so no future path can emit `completed` alongside a failure marker.
- Regression: genuinely successful nodes still complete normally; existing worker and stepRunner suites green (714 passing) .
## Scope and deployment notes
Deliberately independent of the idempotency smoke-fixture PR, since this touches the result path every workflow depends on and should be reviewable and revertable on its own. Python-only - no schema, IAM, or infrastructure changes. After deploy, a failing node should surface as failed in execution history and, where the error class is retryable, be retried rather than silently accepted.