### PR TITLE
fix(worker): give the agent subprocess credentials, fail on refusal

### DIFF
--- a/arbiter/workerWrapper/__tests__/test_governance_refusal_node_failure.py
+++ b/arbiter/workerWrapper/__tests__/test_governance_refusal_node_failure.py
@@ -1,0 +1,272 @@
+"""Regression + invariant tests for finding be80ccd7 (HIGH): a governance /
+infrastructure REFUSAL inside a NORMALLY-COMPLETED agent turn must fail the
+node — the earlier fix (finding 56d763d4) only mapped agent-body EXCEPTIONS.
+
+Ground truth: a tool call's ledger reserve raised a ``LedgerError`` ("ledger
+fenced reserve transport error", produced by the NoCredentialsError of finding
+9ef192d1). strands catches a tool exception, converts it to an error-status
+ToolResult, and lets the agent turn COMPLETE normally (subprocess exit 0, no
+agent-body failure marker). The worker then emitted ``workflow.node.completed``
+and the execution finalized ``completed`` for a run whose governance gate
+hard-failed.
+
+The corrected boundary (DISCRIMINATOR uses the existing typed marker
+``governance.tool_execution_ledger.LedgerError``):
+  * INFRA/GOVERNANCE REFUSAL (a LedgerError raised by reserve/finalize) is
+    recorded in ``tool_idempotency_hook``'s refusal sink; ``agent_runner``
+    drains it after the turn and emits a failure-marked envelope so the node
+    fails with the LedgerError CLASS fed into retry.py.
+  * DOMAIN-level tool error (tool ran + returned status=error, or the agent
+    handled it) records NO refusal and completes normally — never blanket-fails.
+  * ``StaleWorkerFencedError`` is a DESIGNED exactly-once outcome and is NOT
+    recorded as a node-failing refusal (a newer worker owns the node).
+
+All AWS/subprocess is mocked; no real network or credentials.
+"""
+
+import io
+import json
+import os
+import sys
+import tempfile
+from unittest.mock import patch, MagicMock
+
+import pytest
+
+
+_NODE_ENV = {
+    'AGENT_CONFIG_TABLE': 'test-table',
+    'AGENT_BUCKET_NAME': 'test-bucket',
+    'COMPLETION_BUS_NAME': 'citadel-agents-test',
+    'EXECUTIONS_TABLE': 'citadel-executions-test',
+}
+
+NODE_MESSAGE = {
+    'message_type': 'workflow_node',
+    'execution_id': 'exec-1',
+    'node_id': 'smoke-1',
+    'workflow_id': 'wf-1',
+    'agent_id': 'agent-A',
+    'input': {'taskDetails': 'do the thing'},
+    'configuration': {},
+}
+
+MARKER = 'agentExecutionFailed'
+REFUSAL_MARKER = 'governanceRefused'
+
+
+def _fresh_index():
+    sys.modules.pop('index', None)
+    import index
+    return index
+
+
+def _refusal_stdout(error_class='LedgerError',
+                    message='ledger fenced reserve transport error'):
+    """The stdout envelope agent_runner writes when a governance/infrastructure
+    refusal was recorded during an otherwise-completed turn."""
+    return json.dumps({
+        MARKER: True,
+        REFUSAL_MARKER: True,
+        'errorClass': error_class,
+        'error': message,
+        'usage': [],
+    })
+
+
+# ---------------------------------------------------------------------------
+# The recording seam in tool_idempotency_hook.
+# ---------------------------------------------------------------------------
+class TestGovernanceRefusalSink:
+    def test_record_and_drain_roundtrip(self):
+        import tool_idempotency_hook as hook
+        from governance import tool_execution_ledger as ledger
+        hook.drain_governance_refusals()  # start clean
+        hook._record_governance_refusal(ledger.LedgerError('transport boom'))
+        drained = hook.drain_governance_refusals()
+        assert len(drained) == 1
+        assert drained[0]['errorClass'] == 'LedgerError'
+        assert 'transport boom' in drained[0]['error']
+        # Draining clears the sink.
+        assert hook.drain_governance_refusals() == []
+
+    def test_retryable_flag_taken_from_ledger_subclass(self):
+        import tool_idempotency_hook as hook
+        from governance import tool_execution_ledger as ledger
+        hook.drain_governance_refusals()
+        hook._record_governance_refusal(ledger.RetryableNoExecutionError('no side effect'))
+        hook._record_governance_refusal(ledger.LedgerError('transport'))
+        drained = hook.drain_governance_refusals()
+        by_class = {d['errorClass']: d for d in drained}
+        assert by_class['RetryableNoExecutionError']['retryable'] is True
+        assert by_class['LedgerError']['retryable'] is False
+
+    def test_stale_worker_fenced_is_a_ledger_subclass_but_carved_out(self):
+        """StaleWorkerFencedError IS a LedgerError subclass, so the carve-out in
+        _IdempotentToolWrapper.stream() (which handles it in a SEPARATE branch
+        BEFORE the generic LedgerError branch and does NOT record it) is a
+        deliberate exclusion, not a type gap."""
+        from governance import tool_execution_ledger as ledger
+        assert issubclass(ledger.StaleWorkerFencedError, ledger.LedgerError)
+
+
+# ---------------------------------------------------------------------------
+# The envelope builder in agent_runner.
+# ---------------------------------------------------------------------------
+class TestRefusalEnvelope:
+    def test_build_refusal_envelope_carries_marker_and_class(self):
+        import agent_runner
+        env = agent_runner.build_refusal_envelope(
+            [{'errorClass': 'LedgerError', 'error': 'transport boom', 'retryable': False}],
+            [{'inputTokens': 1}],
+        )
+        assert env[agent_runner.AGENT_EXECUTION_FAILURE_MARKER] is True
+        assert env[agent_runner.GOVERNANCE_REFUSAL_MARKER] is True
+        assert env['errorClass'] == 'LedgerError'
+        assert 'transport boom' in env['error']
+        assert env['usage'] == [{'inputTokens': 1}]
+
+    def test_first_refusal_class_is_the_retry_key(self):
+        import agent_runner
+        env = agent_runner.build_refusal_envelope(
+            [
+                {'errorClass': 'OutcomeIndeterminateError', 'error': 'a'},
+                {'errorClass': 'LedgerError', 'error': 'b'},
+            ],
+            [],
+        )
+        assert env['errorClass'] == 'OutcomeIndeterminateError'
+        assert 'a' in env['error'] and 'b' in env['error']
+
+
+# ---------------------------------------------------------------------------
+# agent_runner.main() end-to-end: a handler that records a refusal (mimicking a
+# swallowed ledger error) must emit a failure envelope + non-zero exit even
+# though the handler RETURNED normally.
+# ---------------------------------------------------------------------------
+class TestMainDrainsRefusalOnCompletedTurn:
+    def test_completed_turn_with_recorded_refusal_fails(self):
+        import agent_runner
+        import tool_idempotency_hook as hook
+        hook.drain_governance_refusals()  # clean
+
+        # A handler that returns normally BUT a tool call recorded a ledger
+        # refusal into the shared sink (exactly what the swallowed
+        # error-ToolResult path does at runtime).
+        with tempfile.NamedTemporaryFile(mode='w', suffix='.py', delete=False) as f:
+            f.write(
+                "from governance import tool_execution_ledger as ledger\n"
+                "import tool_idempotency_hook as hook\n"
+                "def handler(**kwargs):\n"
+                "    hook._record_governance_refusal(\n"
+                "        ledger.LedgerError('ledger fenced reserve transport error'))\n"
+                "    return 'the agent finished its turn normally'\n"
+            )
+            module_path = f.name
+        try:
+            payload = json.dumps({'modulePath': module_path, 'request': {}})
+            fake_stdout = io.StringIO()
+            with patch('sys.stdin') as mock_stdin, patch('sys.stdout', fake_stdout):
+                mock_stdin.read.return_value = payload
+                with pytest.raises(SystemExit) as excinfo:
+                    agent_runner.main()
+            assert excinfo.value.code != 0
+            parsed = json.loads(fake_stdout.getvalue())
+            assert parsed[agent_runner.AGENT_EXECUTION_FAILURE_MARKER] is True
+            assert parsed[agent_runner.GOVERNANCE_REFUSAL_MARKER] is True
+            assert parsed['errorClass'] == 'LedgerError'
+            assert 'response' not in parsed  # never laundered into a success
+        finally:
+            os.unlink(module_path)
+            hook.drain_governance_refusals()
+
+    def test_completed_turn_without_refusal_still_succeeds(self):
+        """DOMAIN boundary: a turn that records NO refusal completes normally
+        (a domain-level tool error the agent handled must NOT blanket-fail)."""
+        import agent_runner
+        import tool_idempotency_hook as hook
+        hook.drain_governance_refusals()
+
+        with tempfile.NamedTemporaryFile(mode='w', suffix='.py', delete=False) as f:
+            f.write(
+                "def handler(**kwargs):\n"
+                "    return 'handled a tool error and finished'\n"
+            )
+            module_path = f.name
+        try:
+            payload = json.dumps({'modulePath': module_path, 'request': {}})
+            fake_stdout = io.StringIO()
+            with patch('sys.stdin') as mock_stdin, patch('sys.stdout', fake_stdout):
+                mock_stdin.read.return_value = payload
+                agent_runner.main()  # no SystemExit
+            parsed = json.loads(fake_stdout.getvalue())
+            assert parsed['response'] == 'handled a tool error and finished'
+            assert MARKER not in parsed
+        finally:
+            os.unlink(module_path)
+
+
+# ---------------------------------------------------------------------------
+# STRUCTURAL guard now covers the tool-result/refusal path (exit code 0 is the
+# completed-turn shape).
+# ---------------------------------------------------------------------------
+class TestStructuralGuardCoversRefusal:
+    @pytest.mark.parametrize('returncode', [0, 1])
+    @pytest.mark.parametrize('raise_on_error', [True, False])
+    def test_refusal_envelope_always_raises(self, returncode, raise_on_error):
+        with patch.dict('os.environ', _NODE_ENV):
+            index = _fresh_index()
+            with pytest.raises(index.AgentExecutionError) as excinfo:
+                index._interpret_agent_result(
+                    returncode,
+                    _refusal_stdout(error_class='OutcomeIndeterminateError',
+                                    message='reserve transport error'),
+                    raise_on_error=raise_on_error,
+                )
+        assert excinfo.value.error_class == 'OutcomeIndeterminateError'
+        assert 'reserve transport error' in excinfo.value.message
+
+
+# ---------------------------------------------------------------------------
+# Full worker path: refusal envelope => node.failed (never completed) + the
+# emitted error CLASS drives retry classification (execution then fails).
+# ---------------------------------------------------------------------------
+class TestWorkerEmitsNodeFailedOnRefusal:
+    def test_refusal_emits_node_failed_not_completed_with_retry_class(self):
+        mock_result = MagicMock(
+            returncode=1,
+            stdout=_refusal_stdout(error_class='LedgerError',
+                                   message='ledger fenced reserve transport error'),
+            stderr='',
+        )
+        table = MagicMock()
+        events = MagicMock()
+        events.put_events.return_value = {'FailedEntryCount': 0}
+        resource_mock = MagicMock()
+        resource_mock.Table.return_value = table
+
+        with patch.dict('os.environ', _NODE_ENV):
+            index = _fresh_index()
+            with patch('boto3.resource', return_value=resource_mock), \
+                 patch('boto3.client', return_value=events):
+                with patch.object(index, 'load_config_from_dynamodb',
+                                  return_value={'config': {'filename': 'agent.py'}}), \
+                     patch.object(index, 'get_scoped_credentials', return_value=None), \
+                     patch.object(index, 'load_file_from_s3_into_tmp'), \
+                     patch('subprocess.run', return_value=mock_result):
+                    index.process_event(dict(NODE_MESSAGE), {})
+
+        entry = events.put_events.call_args.kwargs['Entries'][0]
+        assert entry['DetailType'] == 'workflow.node.failed'
+        detail = json.loads(entry['Detail'])
+        assert detail['status'] == 'failed'
+        assert detail['nodeId'] == 'smoke-1'
+        assert detail['error'] == 'LedgerError'
+        # No completed nodeResults persist (would make the run terminal-success).
+        table.update_item.assert_not_called()
+
+        # The emitted class is the retry.py classification key.
+        sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..', '..', 'stepRunner'))
+        from retry import should_retry
+        assert should_retry('LedgerError', ['LedgerError'], 0, 3) is True
+        assert should_retry('LedgerError', ['OtherError'], 0, 3) is False

--- a/arbiter/workerWrapper/__tests__/test_index_properties.py
+++ b/arbiter/workerWrapper/__tests__/test_index_properties.py
@@ -162,13 +162,21 @@ class TestRunAgentCredentialIsolation:
             assert child_env["AWS_SECRET_ACCESS_KEY"] == secret_key
             assert child_env["AWS_SESSION_TOKEN"] == session_token
 
-    def test_no_credentials_removes_stale_env_vars(self):
-        """Without scoped creds, AWS credential env vars are removed."""
-        # Set stale creds in parent env
+    def test_no_scoped_credentials_propagates_ambient_env(self):
+        """Without scoped creds, the wrapper's ambient credential env is
+        PROPAGATED into the child (finding 9ef192d1).
+
+        Previously this test asserted the vars were REMOVED "so the child uses
+        the Lambda's default IAM role via the metadata service" — but AWS
+        Lambda has no IMDS/metadata service; the execution role is delivered
+        ONLY through these env vars, so stripping them left the child with no
+        credentials at all (NoCredentialsError). The documented backward-compat
+        behavior (docs/AGENT_PERMISSIONS.md §5) — run under the Lambda's
+        ambient role — is only achievable by INHERITING them."""
         with patch.dict(os.environ, {
-            "AWS_ACCESS_KEY_ID": "STALE",
-            "AWS_SECRET_ACCESS_KEY": "STALE",
-            "AWS_SESSION_TOKEN": "STALE",
+            "AWS_ACCESS_KEY_ID": "AMBIENTPARENT",
+            "AWS_SECRET_ACCESS_KEY": "ambient-secret",
+            "AWS_SESSION_TOKEN": "ambient-token",
         }):
             with patch("index.subprocess") as mock_subprocess:
                 mock_result = MagicMock()
@@ -181,9 +189,10 @@ class TestRunAgentCredentialIsolation:
 
                 call_kwargs = mock_subprocess.run.call_args[1]
                 child_env = call_kwargs["env"]
-                assert "AWS_ACCESS_KEY_ID" not in child_env
-                assert "AWS_SECRET_ACCESS_KEY" not in child_env
-                assert "AWS_SESSION_TOKEN" not in child_env
+                # Ambient credentials MUST survive into the child env.
+                assert child_env["AWS_ACCESS_KEY_ID"] == "AMBIENTPARENT"
+                assert child_env["AWS_SECRET_ACCESS_KEY"] == "ambient-secret"
+                assert child_env["AWS_SESSION_TOKEN"] == "ambient-token"
 
     def test_subprocess_timeout_is_840_seconds(self):
         """Subprocess timeout is set to 840s (14 min, under Lambda 15 min)."""

--- a/arbiter/workerWrapper/__tests__/test_subprocess_credentials.py
+++ b/arbiter/workerWrapper/__tests__/test_subprocess_credentials.py
@@ -1,0 +1,161 @@
+"""Regression tests for finding 9ef192d1 (HIGH): the agent subprocess had no
+AWS credentials.
+
+Ground truth (dev run 732013d3): the smoke agent declared no
+``requiredPermissions`` so ``get_scoped_credentials`` returned ``None``.
+``run_agent_in_subprocess`` then POPPED AWS_ACCESS_KEY_ID /
+AWS_SECRET_ACCESS_KEY / AWS_SESSION_TOKEN from the child env "so the child
+uses the Lambda's default IAM role via the metadata service". But AWS Lambda
+delivers the execution role ONLY through those three env vars — there is no
+IMDS/metadata service to fall back to. The child therefore had NO credential
+source and boto3 raised ``NoCredentialsError``, which the governance ledger
+surfaced as "ledger fenced reserve transport error" and refused the tool
+fail-closed (0 ledger rows, 0 smoke rows). The wrapper Lambda itself HAD
+working credentials in the same invocation.
+
+These tests pin the corrected behavior:
+
+* No scoped credentials -> the child env PROPAGATES the wrapper's ambient
+  credential env (does NOT strip it), and a client constructed from that env
+  resolves credentials through botocore's own provider chain and can SIGN a
+  request. (Constructing a *live-signing* boto3 client that hits STS is
+  impractical in a unit test — no live credentials or endpoint — so we assert
+  the child env carries USABLE credential material by resolving it through the
+  same ``EnvProvider`` path a real boto3 client uses, then SigV4-signing with
+  the resolved credentials. That is the exact path that raised
+  NoCredentialsError when the vars were stripped.)
+* Scoped credentials -> the three credential env vars are OVERWRITTEN with the
+  scoped ones (isolation: the child never sees the parent's ambient role).
+* The parent process's ``os.environ`` is never modified either way.
+
+All AWS (boto3 client construction, subprocess) is mocked; no real network.
+"""
+
+import json
+import os
+import sys
+from unittest.mock import patch, MagicMock
+
+import pytest
+
+from botocore.session import get_session
+from botocore.credentials import Credentials
+from botocore.auth import SigV4Auth
+from botocore.awsrequest import AWSRequest
+
+
+_ENV = {
+    'AGENT_CONFIG_TABLE': 'test-table',
+    'AGENT_BUCKET_NAME': 'test-bucket',
+    'COMPLETION_BUS_NAME': 'citadel-agents-test',
+    'EXECUTIONS_TABLE': 'citadel-executions-test',
+}
+
+# Ambient credentials the AWS Lambda runtime sets from the execution role.
+_AMBIENT_CREDS = {
+    'AWS_ACCESS_KEY_ID': 'AKIAAMBIENTPARENT',
+    'AWS_SECRET_ACCESS_KEY': 'ambient/secret/key/value',
+    'AWS_SESSION_TOKEN': 'ambient-session-token',
+}
+
+_SCOPED = {
+    'accessKeyId': 'AKIASCOPEDCHILD',
+    'secretAccessKey': 'scoped/secret/key/value',
+    'sessionToken': 'scoped-session-token',
+}
+
+
+def _fresh_index():
+    sys.modules.pop('index', None)
+    import index
+    return index
+
+
+def _success_stdout():
+    return json.dumps({'response': 'ok', 'usage': []})
+
+
+def _run_capture_env(index, scoped_credentials):
+    """Invoke run_agent_in_subprocess with subprocess.run mocked; return the
+    ``env`` dict that would have been handed to the child subprocess."""
+    mock_result = MagicMock(returncode=0, stdout=_success_stdout(), stderr='')
+    with patch('subprocess.run', return_value=mock_result) as mock_run:
+        index.run_agent_in_subprocess(
+            {'taskDetails': 'x'}, scoped_credentials, None, raise_on_error=True,
+        )
+    return mock_run.call_args.kwargs['env']
+
+
+def _resolve_via_provider_chain(child_env):
+    """Resolve credentials from *child_env* through botocore's real provider
+    chain (the same EnvProvider path a boto3 client uses at construction), by
+    pointing os.environ at the child env. Returns the resolved Credentials or
+    None — None is exactly the NoCredentialsError condition."""
+    only_aws = {k: v for k, v in child_env.items() if k.startswith('AWS_')}
+    with patch.dict(os.environ, only_aws, clear=True):
+        session = get_session()
+        return session.get_credentials()
+
+
+class TestNoScopedCredentialsPropagatesAmbient:
+    def test_child_env_carries_ambient_credentials(self):
+        """The three credential env vars must SURVIVE into the child env when
+        there are no scoped credentials (the fix: propagate, don't strip)."""
+        with patch.dict('os.environ', {**_ENV, **_AMBIENT_CREDS}):
+            index = _fresh_index()
+            child_env = _run_capture_env(index, scoped_credentials=None)
+
+        assert child_env['AWS_ACCESS_KEY_ID'] == _AMBIENT_CREDS['AWS_ACCESS_KEY_ID']
+        assert child_env['AWS_SECRET_ACCESS_KEY'] == _AMBIENT_CREDS['AWS_SECRET_ACCESS_KEY']
+        assert child_env['AWS_SESSION_TOKEN'] == _AMBIENT_CREDS['AWS_SESSION_TOKEN']
+
+    def test_client_from_child_env_resolves_and_can_sign(self):
+        """A client constructed from the child env resolves usable credentials
+        through botocore's provider chain and can SIGN a request — the exact
+        path that raised NoCredentialsError when the vars were stripped."""
+        with patch.dict('os.environ', {**_ENV, **_AMBIENT_CREDS}):
+            index = _fresh_index()
+            child_env = _run_capture_env(index, scoped_credentials=None)
+
+        creds = _resolve_via_provider_chain(child_env)
+        assert creds is not None, "child env yielded no credentials (NoCredentialsError)"
+        frozen = creds.get_frozen_credentials()
+        assert frozen.access_key == _AMBIENT_CREDS['AWS_ACCESS_KEY_ID']
+
+        # Prove the resolved credentials actually sign a SigV4 request.
+        req = AWSRequest(method='GET', url='https://sts.us-east-1.amazonaws.com/')
+        SigV4Auth(creds, 'sts', 'us-east-1').add_auth(req)
+        assert req.headers.get('Authorization', '').startswith('AWS4-HMAC-SHA256')
+
+
+class TestScopedCredentialsOverwriteAmbient:
+    def test_scoped_credentials_replace_ambient_in_child_env(self):
+        """When scoped credentials are vended they OVERWRITE the ambient ones,
+        so the child sees only the narrowed role (isolation)."""
+        with patch.dict('os.environ', {**_ENV, **_AMBIENT_CREDS}):
+            index = _fresh_index()
+            child_env = _run_capture_env(index, scoped_credentials=_SCOPED)
+
+        assert child_env['AWS_ACCESS_KEY_ID'] == _SCOPED['accessKeyId']
+        assert child_env['AWS_SECRET_ACCESS_KEY'] == _SCOPED['secretAccessKey']
+        assert child_env['AWS_SESSION_TOKEN'] == _SCOPED['sessionToken']
+
+        creds = _resolve_via_provider_chain(child_env)
+        assert creds is not None
+        assert creds.get_frozen_credentials().access_key == _SCOPED['accessKeyId']
+
+
+class TestParentEnvNeverModified:
+    def test_parent_os_environ_unchanged_no_scoped(self):
+        with patch.dict('os.environ', {**_ENV, **_AMBIENT_CREDS}):
+            index = _fresh_index()
+            _run_capture_env(index, scoped_credentials=None)
+            assert os.environ['AWS_ACCESS_KEY_ID'] == _AMBIENT_CREDS['AWS_ACCESS_KEY_ID']
+
+    def test_parent_os_environ_unchanged_scoped(self):
+        with patch.dict('os.environ', {**_ENV, **_AMBIENT_CREDS}):
+            index = _fresh_index()
+            _run_capture_env(index, scoped_credentials=_SCOPED)
+            # The parent keeps its OWN ambient creds — scoped creds only ever
+            # reach the child env.
+            assert os.environ['AWS_ACCESS_KEY_ID'] == _AMBIENT_CREDS['AWS_ACCESS_KEY_ID']

--- a/arbiter/workerWrapper/agent_runner.py
+++ b/arbiter/workerWrapper/agent_runner.py
@@ -48,6 +48,48 @@ def build_failure_envelope(exc: BaseException, usage: list) -> dict:
         'usage': usage if isinstance(usage, list) else [],
     }
 
+
+# Governance/infrastructure refusal marker (finding be80ccd7). Distinct
+# observability key so a governance-refusal failure envelope is
+# distinguishable from an agent-body crash envelope — but it ALSO carries the
+# shared AGENT_EXECUTION_FAILURE_MARKER, so the SAME structural guard in
+# index._interpret_agent_result raises on it. That is how the "no
+# completed-with-failure" guard is EXTENDED from the exception path to the
+# tool-result path: a completed turn that hid a governance/infrastructure
+# refusal is turned into a failure-marked envelope here and can never be
+# laundered into a node.completed.
+GOVERNANCE_REFUSAL_MARKER = 'governanceRefused'
+
+
+def build_refusal_envelope(refusals: list, usage: list) -> dict:
+    """Build the stdout failure envelope for governance/infrastructure refusals
+    recorded during a turn that otherwise COMPLETED normally (finding
+    be80ccd7).
+
+    The envelope carries the SAME ``AGENT_EXECUTION_FAILURE_MARKER`` as an
+    agent-body crash (so index._interpret_agent_result's structural guard
+    raises regardless of exit code), plus:
+      * ``errorClass`` — the FIRST refusal's LedgerError subclass name, the key
+        retry.py's ``should_retry`` matches on. (First is deterministic and
+        sufficient; a run is failed by the first gate refusal it hit.)
+      * ``error`` — the refusal diagnostic(s).
+      * ``GOVERNANCE_REFUSAL_MARKER`` — True, for observability.
+
+    The caller must only invoke this when ``refusals`` is non-empty.
+    """
+    first = refusals[0]
+    diagnostics = '; '.join(
+        str(r.get('error') or r.get('errorClass') or 'governance refusal')
+        for r in refusals
+    )
+    return {
+        AGENT_EXECUTION_FAILURE_MARKER: True,
+        GOVERNANCE_REFUSAL_MARKER: True,
+        'errorClass': first.get('errorClass') or 'LedgerError',
+        'error': diagnostics or 'governance/infrastructure refusal',
+        'usage': usage if isinstance(usage, list) else [],
+    }
+
 # Ordered candidate method names probed on strands.models.BedrockModel to
 # find the response-producing seam to wrap. Multiple candidates survive a
 # strands rename of the primary method without requiring a code change here.
@@ -585,6 +627,29 @@ def _install_model_override():
     return True
 
 
+def _drain_governance_refusals() -> list:
+    """Drain the tool-call governance/infrastructure refusal sink (finding
+    be80ccd7).
+
+    The refusals are recorded by ``tool_idempotency_hook`` when the ledger gate
+    raises a ``LedgerError`` during a tool call (strands swallows it into an
+    error ToolResult, so the turn completes normally). Imported defensively:
+    if the hook module is unavailable in this environment there can be no
+    recorded refusals, so degrade to an empty list rather than failing the run.
+    """
+    try:
+        from tool_idempotency_hook import drain_governance_refusals
+    except ImportError:
+        return []
+    try:
+        return drain_governance_refusals()
+    except Exception as exc:  # noqa: BLE001 — draining must never break dispatch
+        sys.stderr.write(
+            f'[agent_runner] WARN governance-refusal drain failed: {exc}\n'
+        )
+        return []
+
+
 def main():
     # Read input from stdin (single JSON line)
     raw = sys.stdin.read()
@@ -599,6 +664,11 @@ def main():
     # repeatedly within one interpreter (or re-run this module) get a fresh
     # 0-based callIndex sequence each time rather than accumulating state.
     _CAPTURED_USAGE.clear()
+
+    # Reset the per-process governance-refusal sink for the same reason
+    # (repeated in-process main() calls in tests must start clean). In the real
+    # Lambda subprocess this is a no-op (one exec per process).
+    _drain_governance_refusals()
 
     # Install governance patch BEFORE exec_module so every Agent(...)
     # construction in the loaded module picks it up. Safe no-op when the
@@ -641,6 +711,20 @@ def main():
         # raise regardless of raise_on_error, so no caller can turn a marked
         # payload into a completed result.
         sys.stdout.write(json.dumps(build_failure_envelope(exc, _CAPTURED_USAGE)))
+        sys.stdout.flush()
+        sys.exit(1)
+
+    # The turn COMPLETED normally, but a tool call may have hit a governance /
+    # infrastructure REFUSAL (a LedgerError from the idempotency/ledger gate)
+    # that strands swallowed into an error-status ToolResult (finding
+    # be80ccd7). Drain the refusal sink and, if any were recorded, emit a
+    # failure-marked envelope INSTEAD of the success response so the node fails
+    # with the refusal class (fed to retry.py) rather than being laundered into
+    # node.completed. Domain-level tool errors record NO refusal and fall
+    # through to the normal success envelope below.
+    refusals = _drain_governance_refusals()
+    if refusals:
+        sys.stdout.write(json.dumps(build_refusal_envelope(refusals, _CAPTURED_USAGE)))
         sys.stdout.flush()
         sys.exit(1)
 

--- a/arbiter/workerWrapper/index.py
+++ b/arbiter/workerWrapper/index.py
@@ -518,15 +518,43 @@ def run_agent_in_subprocess(request: dict, scoped_credentials: dict | None, extr
     child_env = os.environ.copy()
 
     if scoped_credentials:
+        # Scoped STS credentials declared via requiredPermissions: OVERWRITE
+        # the three credential env vars so the child sees ONLY the narrowed
+        # role. boto3's provider chain reads AWS_ACCESS_KEY_ID first, so these
+        # take precedence over any ambient container/role source that remains
+        # in the inherited env — the child never sees the parent's broader
+        # permissions (docs/AGENT_PERMISSIONS.md §"Why Subprocess Isolation").
         child_env['AWS_ACCESS_KEY_ID'] = scoped_credentials['accessKeyId']
         child_env['AWS_SECRET_ACCESS_KEY'] = scoped_credentials['secretAccessKey']
         child_env['AWS_SESSION_TOKEN'] = scoped_credentials['sessionToken']
         print("Subprocess will use scoped credentials")
     else:
-        # Remove any stale credential env vars so the child uses the
-        # Lambda's default IAM role via the metadata service
-        for key in ['AWS_ACCESS_KEY_ID', 'AWS_SECRET_ACCESS_KEY', 'AWS_SESSION_TOKEN']:
-            child_env.pop(key, None)
+        # No scoped vending for this agent (no requiredPermissions) — the
+        # DOCUMENTED backward-compat path (docs/AGENT_PERMISSIONS.md §5) is for
+        # the agent to run under the wrapper Lambda's ambient IAM role.
+        #
+        # FIX (finding 9ef192d1): the ambient role must be PROPAGATED into the
+        # child, not stripped. In AWS Lambda the execution role is delivered
+        # ONLY through the AWS_ACCESS_KEY_ID / AWS_SECRET_ACCESS_KEY /
+        # AWS_SESSION_TOKEN environment variables the runtime sets — there is
+        # NO IMDS/metadata service to "fall back" to (that only exists on EC2/
+        # ECS). The previous code popped exactly those three keys, so the child
+        # had no credential source at all and boto3 raised
+        # NoCredentialsError ("Unable to locate credentials"), which the
+        # governance ledger surfaced as a fenced-reserve transport error and
+        # refused the tool fail-closed (dev run 732013d3: 0 ledger rows, 0
+        # smoke rows). ``child_env = os.environ.copy()`` already carries the
+        # parent's credential env, so we simply leave it in place — no pop.
+        #
+        # LEAST-PRIVILEGE TRADEOFF: on this path the child inherits the
+        # wrapper's full role (broader than a scoped vend). This is exactly the
+        # behaviour the design intends for agents without requiredPermissions
+        # ("runs using the Lambda's ambient IAM role"); narrowing still applies
+        # whenever an agent declares requiredPermissions (the branch above).
+        # We are fixing the broken mechanism, not widening privilege beyond the
+        # documented design. AWS_CONTAINER_CREDENTIALS_* (if the deployment
+        # substrate ever sets them) are likewise inherited untouched.
+        pass
 
     # Apply governance and config overrides (stepConstraints, appConfig, modelOverride)
     if extra_env:

--- a/arbiter/workerWrapper/index.py
+++ b/arbiter/workerWrapper/index.py
@@ -635,6 +635,19 @@ def _interpret_agent_result(returncode, stdout, *, raise_on_error=False, usage_s
     through, so the "crash recorded as success" defect cannot recur on any
     path.
 
+    This guard now covers TWO producers of the marker in ``agent_runner``, both
+    of which must fail the node and can never complete it (finding be80ccd7
+    extends finding 56d763d4 from the exception path to the tool-result path):
+      1. An agent-body EXCEPTION (``build_failure_envelope``) — errorClass is
+         the raised exception type.
+      2. A governance / infrastructure REFUSAL during a turn that otherwise
+         COMPLETED normally (``build_refusal_envelope``) — a ``LedgerError``
+         from the idempotency/ledger gate that strands swallowed into an
+         error-status ToolResult; errorClass is the LedgerError subclass. A
+         DOMAIN-level tool error (the tool ran and returned status=error, or
+         the agent handled it) records NO refusal and produces a normal success
+         envelope, so it is NOT blanket-failed here.
+
     Non-marker outcomes preserve the pre-fix contract exactly:
       * non-zero exit + raise_on_error=True  -> raise (node path -> node.failed)
       * non-zero exit + raise_on_error=False -> canned fallback (supervisor path)

--- a/arbiter/workerWrapper/tool_idempotency_hook.py
+++ b/arbiter/workerWrapper/tool_idempotency_hook.py
@@ -72,6 +72,61 @@ from tool_idempotency import (  # noqa: E402
 
 logger = logging.getLogger(__name__)
 
+
+# ---------------------------------------------------------------------------
+# Governance / infrastructure REFUSAL sink (finding be80ccd7).
+# ---------------------------------------------------------------------------
+# A ``LedgerError`` raised by the idempotency/ledger gate during a tool call is
+# an INFRASTRUCTURE / GOVERNANCE REFUSAL — the gate itself failed (transport /
+# credential error) or refused; the tool did NOT run under a completed
+# reservation. strands catches a tool exception, converts it to an
+# error-status ToolResult, and lets the agent turn COMPLETE "normally"
+# (returncode 0, no agent-body failure marker). Without capturing it here the
+# worker would emit ``workflow.node.completed`` for a run whose governance gate
+# hard-failed — the exact defect in finding be80ccd7 (the earlier fix, finding
+# 56d763d4, only mapped agent-body EXCEPTIONS, not error-status tool RESULTS).
+#
+# We therefore record such refusals into this per-process sink. ``agent_runner``
+# drains it AFTER the turn and, if non-empty, emits a failure-marked envelope so
+# the node fails with the refusal CLASS fed into retry.py's failure-class logic.
+#
+# DISCRIMINATOR (concrete, uses the EXISTING typed marker the governance layer
+# emits — ``governance.tool_execution_ledger.LedgerError`` and subclasses):
+#   * INFRA/GOVERNANCE REFUSAL -> a LedgerError was raised by reserve/finalize
+#     => recorded here => node FAILS with that class.
+#   * DOMAIN-LEVEL tool error -> the tool ran and returned {"status":"error"},
+#     or the agent handled a tool error and completed its turn. No LedgerError
+#     is raised => nothing recorded => the node COMPLETES. The agent is
+#     expected to handle these; they must NOT blanket-fail the node.
+# CARVE-OUT: ``StaleWorkerFencedError`` is a DESIGNED exactly-once outcome (this
+# worker was re-dispatched away; a NEWER worker owns the node). It is surfaced
+# as an error ToolResult but is NOT recorded as a node-failing refusal —
+# failing here would double-signal a node another worker is completing.
+_GOVERNANCE_REFUSALS: list[dict[str, Any]] = []
+
+
+def drain_governance_refusals() -> list[dict[str, Any]]:
+    """Return and CLEAR the governance/infrastructure refusals recorded during
+    this process's tool calls. Called once by ``agent_runner`` after the turn.
+    Clearing keeps repeated in-process test invocations independent."""
+    drained = list(_GOVERNANCE_REFUSALS)
+    _GOVERNANCE_REFUSALS.clear()
+    return drained
+
+
+def _record_governance_refusal(exc: "ledger.LedgerError") -> None:
+    """Record a LedgerError refusal (class + diagnostic + retryable flag).
+
+    ``retryable`` is read from the LedgerError subclass (the ledger hierarchy
+    already encodes it) and preserved for observability; the node-failure
+    CLASS is what retry.py's ``should_retry`` matches on downstream."""
+    _GOVERNANCE_REFUSALS.append({
+        "errorClass": type(exc).__name__,
+        "error": str(exc) or type(exc).__name__,
+        "retryable": bool(getattr(exc, "retryable", False)),
+    })
+
+
 try:
     from strands.hooks import BeforeToolCallEvent  # type: ignore
     from strands.types.tools import AgentTool  # type: ignore
@@ -149,11 +204,27 @@ class _IdempotentToolWrapper(AgentTool):  # type: ignore[misc]
             # This worker was re-dispatched away (its generation is stale). It
             # is refused at the reserve fence BEFORE any side effect — a newer
             # worker owns the node. Surface as an error ToolResult; the tool
-            # never ran.
+            # never ran. DESIGNED exactly-once outcome, NOT a node-failing
+            # refusal (see the carve-out on _GOVERNANCE_REFUSALS): a newer
+            # worker is completing this node, so we must not double-signal it.
             yield ToolResultEvent(_error_result(
                 tool_use_id,
                 "tool execution refused: worker fenced by a newer dispatch "
                 "generation (no side effect performed)",
+            ))
+            return
+        except ledger.LedgerError as exc:
+            # Infrastructure / governance REFUSAL (finding be80ccd7): the ledger
+            # gate itself FAILED — e.g. the ground-truth "ledger fenced reserve
+            # transport error" that a NoCredentialsError produced. The tool
+            # never ran. Record it so agent_runner fails the node with this
+            # class (fed into retry.py); surface an error ToolResult so the turn
+            # does not crash mid-stream (the node-failure decision is made
+            # uniformly post-turn from the drained refusal sink).
+            _record_governance_refusal(exc)
+            yield ToolResultEvent(_error_result(
+                tool_use_id,
+                f"tool execution refused (governance/infrastructure): {exc}",
             ))
             return
 
@@ -190,10 +261,17 @@ class _IdempotentToolWrapper(AgentTool):  # type: ignore[misc]
             )
             raise
 
-        if isinstance(last_result, dict) and last_result.get("status") == "error":
-            ledger.finalize_failure(self._pk, self._sk, error_type="tool_error_result", retryable=False)
-        elif last_result is not None:
-            ledger.finalize_success(self._pk, self._sk, result=last_result)
+        try:
+            if isinstance(last_result, dict) and last_result.get("status") == "error":
+                ledger.finalize_failure(self._pk, self._sk, error_type="tool_error_result", retryable=False)
+            elif last_result is not None:
+                ledger.finalize_success(self._pk, self._sk, result=last_result)
+        except ledger.LedgerError as exc:
+            # The tool already ran, but the ledger could not durably record its
+            # outcome (infrastructure refusal). Record it so the node fails
+            # (the run's governance state is indeterminate); no ToolResult to
+            # yield here — the tool's own result already streamed.
+            _record_governance_refusal(exc)
 
 
 class IdempotencyToolHook:


### PR DESCRIPTION
## Summary
The first successful run of the instrumented tool path revealed that the agent subprocess has no AWS credentials. Every idempotency-ledger reservation failed
`NoCredentialsError`, and because that path is fail-closed, every side-effecting tool call was refused: zero ledger rows, zero side effects. The wrapper Lambda itself had working credentials in the same invocation - only the child process was starved.
The same run exposed a second failure-masking path. The node and execution were recorded as `completed` even though the tool never ran, because the agent turn itself finished normally with an error-status tool result. The earlier fix mapped agent *exceptions* to failure; it did not cover a refusal handled inside a completed turn - which is precisely the shape a governance or ledger refusal takes.
## What changed
**Credentials into the child.** The subprocess now inherits the wrapper's ambient credential environment, and scoped STS credentials overwrite it when a node declares required permissions. The narrower option was checked first rather than assumed: the platform's documented guarantee is that agents run under the ambient execution role unless scoped vending applies, so inheriting is the intended behaviour here and the least-privilege tradeoff is recorded inline.
Proof is a test that builds a real credential provider and signs a request from inside the child environment - nothing previously exercised the child's AWS access at all.
**Refusals fail the node.** An infrastructure or governance refusal - a `LedgerError` raised by reserve or finalize - now fails the node and feeds its class into the existing failure-class retry logic, so transient refusals retry rather than passing. A domain-level tool error that the agent is expected to handle still completes. The discriminator reuses the typed error the ledger already raises rather than inventing a new convention, and the boundary is documented alongside the guarantee it qualifies.
**The guard is structural.** The no-`completed`-with-a-failure-marker check sits at one choke point, evaluated before any return-code branching, and now covers both the exception path and the tool-result path, with a parametrised test across both exit conditions.
## Testing
- A client constructed inside the child environment resolves credentials and signs (real provider, real SigV4).
- A ledger/governance refusal yields node failed and execution failed, with the emitted class asserted against the real retry classifier rather than a hardcoded expectation.
- A completed turn with no refusal still succeeds; the earlier failed-node mapping tests remain green.
- Arbiter pytest: 1,015 passing. Python-only change - no schema, IAM, or infrastructure deltas.
## Deployment notes
Merge alongside the tool-governance re-port and deploy from **main**, not from either branch: the branches are independent, so deploying one on its own reverts the other's stack footprint. After the combined deploy, the smoke workflow should produce exactly one ledger row and one side-effect row.
Follow-up noted, not fixed here: the agent-permissions doc still describes the superseded credential mechanism in one parenthetical.