### PR TITLE
fix(governance): re-port tool governance onto the live hook seam

### DIFF
--- a/arbiter/seedConfig/__tests__/test_smoke_idempotency_agent.py
+++ b/arbiter/seedConfig/__tests__/test_smoke_idempotency_agent.py
@@ -278,13 +278,16 @@ class TestSmokeToolClassification:
         production install call for the idempotency hook never supplies a
         mode_resolver, so IdempotencyToolHook._resolve_mode always returns
         MODE_LEDGER regardless of any tool-level config — the smoke tool
-        included."""
+        included. (Post finding 027c4a89 the install lives in the single
+        composed ``_install_tool_call_hooks`` seam.)"""
         import inspect
 
         from arbiter.workerWrapper import agent_runner
 
-        source = inspect.getsource(agent_runner._install_idempotency_hook)
+        source = inspect.getsource(agent_runner._install_tool_call_hooks)
         assert "mode_resolver" not in source
+        # The idempotency hook is still constructed on the composed seam.
+        assert "IdempotencyToolHook(" in source
 
 
 # ---------------------------------------------------------------------------

--- a/arbiter/workerWrapper/__tests__/test_agent_runner_properties.py
+++ b/arbiter/workerWrapper/__tests__/test_agent_runner_properties.py
@@ -200,11 +200,19 @@ class _FakeStrandsAgent:
 
 
 def _install_fake_strands(monkeypatch):
-    """Install a fake ``strands`` module so agent_runner can patch Agent.__init__."""
+    """Install a fake ``strands`` module so agent_runner can patch Agent.__init__.
+
+    A FRESH ``Agent`` subclass is handed out per call so the ``Agent.__init__``
+    monkeypatch installed by ``_install_tool_call_hooks`` (which mutates the
+    class object, not something monkeypatch auto-restores) never accumulates
+    across tests within this reused worker process."""
     import types
 
+    class _FreshAgent(_FakeStrandsAgent):
+        pass
+
     fake_mod = types.ModuleType("strands")
-    fake_mod.Agent = _FakeStrandsAgent
+    fake_mod.Agent = _FreshAgent
     fake_models = types.ModuleType("strands.models")
 
     class _BedrockModelStub:
@@ -263,21 +271,28 @@ class TestAgentRunnerGovernanceInjection:
         assert parsed["response"] == "tool_handler=None"
 
     def test_injection_when_citadel_agent_id_set(self, monkeypatch):
-        """CITADEL_AGENT_ID set -> every Agent() in loaded module gets a handler."""
+        """CITADEL_AGENT_ID set -> every Agent() in the loaded module gets the
+        composed governance+idempotency hook appended to its hooks list (the
+        re-ported seam; finding 027c4a89). The dead ``tool_handler`` kwarg is
+        no longer used."""
         monkeypatch.setenv("CITADEL_AGENT_ID", "agent-xyz")
         monkeypatch.setenv("CITADEL_WORKFLOW_ID", "wf-42")
         monkeypatch.setenv("DENIED_TOOLS", "tool_a,tool_b")
+        monkeypatch.delenv("CITADEL_EXECUTION_ID", raising=False)
+        monkeypatch.delenv("CITADEL_NODE_ID", raising=False)
         _install_fake_strands(monkeypatch)
 
         module_src = (
             "from strands import Agent\n"
             "def handler(**kwargs):\n"
             "    a = Agent(tools=[])\n"
+            "    hooks = a.kwargs.get('hooks') or []\n"
+            "    h = hooks[0] if hooks else None\n"
             "    return (\n"
-            "        f'injected={a.tool_handler is not None};'\n"
-            "        f'agent_id={getattr(a.tool_handler, \"agent_id\", None)};'\n"
-            "        f'workflow_id={getattr(a.tool_handler, \"workflow_id\", None)};'\n"
-            "        f'denied={sorted(getattr(a.tool_handler, \"denied_tools\", []))}'\n"
+            "        f'count={len(hooks)};'\n"
+            "        f'type={type(h).__name__};'\n"
+            "        f'gov={h.governance is not None};'\n"
+            "        f'idem={h.idempotency is not None}'\n"
             "    )\n"
         )
         captured = []
@@ -286,35 +301,44 @@ class TestAgentRunnerGovernanceInjection:
         assert len(captured) == 1, captured
         parsed = json.loads(captured[0])
         resp = parsed["response"]
-        assert "injected=True" in resp, resp
-        assert "agent_id=agent-xyz" in resp
-        assert "workflow_id=wf-42" in resp
-        assert "denied=['tool_a', 'tool_b']" in resp
+        assert "count=1" in resp, resp
+        assert "type=ComposedToolHook" in resp, resp
+        assert "gov=True" in resp, resp
+        # No idempotency envelope here (supervisor task path) → governance only.
+        assert "idem=False" in resp, resp
 
-    def test_explicit_tool_handler_is_preserved(self, monkeypatch):
-        """When generated code explicitly passes tool_handler=, injector MUST NOT override."""
+    def test_caller_hooks_preserved(self, monkeypatch):
+        """When generated code passes its own hooks=, the composed hook is
+        APPENDED (caller hooks preserved), never clobbered."""
         monkeypatch.setenv("CITADEL_AGENT_ID", "agent-xyz")
-        monkeypatch.setenv("DENIED_TOOLS", "t1")
+        monkeypatch.delenv("CITADEL_EXECUTION_ID", raising=False)
+        monkeypatch.delenv("CITADEL_NODE_ID", raising=False)
         _install_fake_strands(monkeypatch)
 
         module_src = (
             "from strands import Agent\n"
-            "class _MyHandler:\n"
-            "    agent_id = 'custom-caller-handler'\n"
+            "_SENTINEL = object()\n"
             "def handler(**kwargs):\n"
-            "    a = Agent(tools=[], tool_handler=_MyHandler())\n"
-            "    return 'agent_id=' + a.tool_handler.agent_id\n"
+            "    a = Agent(tools=[], hooks=[_SENTINEL])\n"
+            "    hooks = a.kwargs.get('hooks') or []\n"
+            "    return f'count={len(hooks)};first_is_sentinel={hooks[0] is _SENTINEL}'\n"
         )
         captured = []
         _run_runner_with_module(module_src, {}, captured)
 
         assert len(captured) == 1
         parsed = json.loads(captured[0])
-        assert parsed["response"] == "agent_id=custom-caller-handler"
+        resp = parsed["response"]
+        assert "count=2" in resp, resp
+        assert "first_is_sentinel=True" in resp, resp
 
-    def test_injection_skipped_when_strands_unimportable(self, monkeypatch):
-        """Graceful degrade: missing strands -> no crash, runner still works."""
+    def test_install_fails_loud_when_strands_unimportable_in_envelope(self, monkeypatch):
+        """Fail-loud (finding 027c4a89 step 4): with a governance envelope
+        active but strands unimportable, the installer RAISES — the node is
+        never allowed to run unprotected under a silent skip."""
         monkeypatch.setenv("CITADEL_AGENT_ID", "agent-xyz")
+        monkeypatch.delenv("CITADEL_EXECUTION_ID", raising=False)
+        monkeypatch.delenv("CITADEL_NODE_ID", raising=False)
         monkeypatch.delitem(sys.modules, "strands", raising=False)
 
         import builtins
@@ -329,95 +353,32 @@ class TestAgentRunnerGovernanceInjection:
 
         module_src = (
             "def handler(**kwargs):\n"
-            "    return 'ran-without-strands'\n"
+            "    return 'should-not-reach'\n"
         )
         captured = []
-        _run_runner_with_module(module_src, {}, captured)
+        with pytest.raises(RuntimeError, match="governance/idempotency REQUIRED"):
+            _run_runner_with_module(module_src, {}, captured)
 
-        assert len(captured) == 1
-        parsed = json.loads(captured[0])
-        assert parsed["response"] == "ran-without-strands"
-
-    def test_denylisted_tool_never_executes_end_to_end(self, monkeypatch):
-        """US-ARB-012a wiring contract: a denylisted tool call must never
-        reach the underlying tool implementation.
-
-        This exercises the full chain the real subprocess uses: agent_runner
-        installs the patch, the injected GovernedToolHandler's preprocess()
-        DENYs the call, and Strands (simulated here) must short-circuit
-        before invoking the tool function — never call it "just to log",
-        never call it at all.
-        """
-        monkeypatch.setenv("CITADEL_AGENT_ID", "agent-xyz")
-        monkeypatch.setenv("DENIED_TOOLS", "dangerous_tool")
-        fake_mod = _install_fake_strands(monkeypatch)
-
-        # Extend the fake Agent so it actually drives tool_handler.preprocess()
-        # before "calling" a tool, mirroring the real Strands dispatch loop
-        # closely enough to prove the short-circuit contract.
-        class _DrivingAgent(fake_mod.Agent):
-            def dispatch_tool(self, tool_use, executed_log):
-                pre = None
-                if self.tool_handler is not None:
-                    pre = self.tool_handler.preprocess(tool_use)
-                if pre is not None:
-                    return pre  # DENY short-circuit — tool must NOT run.
-                executed_log.append(tool_use["name"])
-                return {"status": "success", "content": [{"text": "ran"}]}
-
-        fake_mod.Agent = _DrivingAgent
+    def test_no_injection_leaves_agent_hooks_absent(self, monkeypatch):
+        """Symmetric control: no envelope → composed hook not installed, so a
+        plain Agent() has no injected hooks."""
+        monkeypatch.delenv("CITADEL_AGENT_ID", raising=False)
+        monkeypatch.delenv("CITADEL_EXECUTION_ID", raising=False)
+        monkeypatch.delenv("CITADEL_NODE_ID", raising=False)
+        _install_fake_strands(monkeypatch)
 
         module_src = (
             "from strands import Agent\n"
             "def handler(**kwargs):\n"
-            "    executed = []\n"
             "    a = Agent(tools=[])\n"
-            "    result = a.dispatch_tool({'name': 'dangerous_tool', 'toolUseId': 'tu-1'}, executed)\n"
-            "    return f'executed={executed};status={result.get(\"status\")}'\n"
+            "    return f'hooks={a.kwargs.get(\"hooks\")}'\n"
         )
         captured = []
         _run_runner_with_module(module_src, {}, captured)
 
         assert len(captured) == 1
         parsed = json.loads(captured[0])
-        resp = parsed["response"]
-        assert "executed=[]" in resp, resp  # tool function never ran
-        assert "status=error" in resp, resp
-
-    def test_permitted_tool_executes_end_to_end(self, monkeypatch):
-        """Symmetric control: a non-denied tool DOES reach execution."""
-        monkeypatch.setenv("CITADEL_AGENT_ID", "agent-xyz")
-        monkeypatch.setenv("DENIED_TOOLS", "dangerous_tool")
-        fake_mod = _install_fake_strands(monkeypatch)
-
-        class _DrivingAgent(fake_mod.Agent):
-            def dispatch_tool(self, tool_use, executed_log):
-                pre = None
-                if self.tool_handler is not None:
-                    pre = self.tool_handler.preprocess(tool_use)
-                if pre is not None:
-                    return pre
-                executed_log.append(tool_use["name"])
-                return {"status": "success", "content": [{"text": "ran"}]}
-
-        fake_mod.Agent = _DrivingAgent
-
-        module_src = (
-            "from strands import Agent\n"
-            "def handler(**kwargs):\n"
-            "    executed = []\n"
-            "    a = Agent(tools=[])\n"
-            "    result = a.dispatch_tool({'name': 'safe_tool', 'toolUseId': 'tu-2'}, executed)\n"
-            "    return f'executed={executed};status={result.get(\"status\")}'\n"
-        )
-        captured = []
-        _run_runner_with_module(module_src, {}, captured)
-
-        assert len(captured) == 1
-        parsed = json.loads(captured[0])
-        resp = parsed["response"]
-        assert "executed=['safe_tool']" in resp, resp
-        assert "status=success" in resp, resp
+        assert parsed["response"] == "hooks=None"
 
 
 # ---------------------------------------------------------------------------
@@ -490,14 +451,14 @@ class TestAgentRunnerModelOverride:
 
 
 # ---------------------------------------------------------------------------
-# Fail-loud idempotency install + best-effort governance guard.
+# Fail-loud composed install (governance + idempotency at one seam).
 #
-# The idempotency hook is a fail-closed security control: inside an active
-# idempotency envelope (CITADEL_EXECUTION_ID + CITADEL_NODE_ID set) a hook
-# that cannot install must ABORT the node — never degrade to a warning — so it
-# can never be mistaken for protected. Governance injection, by contrast, is
-# best-effort AND its tool_handler seam is absent on strands 1.30.0, so it must
-# skip (not crash the agent) when the seam is unavailable.
+# The composed control is fail-closed: inside an ACTIVE envelope (governance =
+# CITADEL_AGENT_ID; idempotency = CITADEL_EXECUTION_ID + CITADEL_NODE_ID) an
+# uninstallable control must ABORT the node — never degrade to a warning — so
+# it can never be mistaken for protected (finding 027c4a89 step 4). Governance
+# now fails loud too, matching the idempotency rule. Outside any envelope the
+# installer is a silent back-compat no-op.
 # ---------------------------------------------------------------------------
 
 import types
@@ -509,61 +470,77 @@ def _fresh_agent_runner():
     return agent_runner
 
 
-class TestIdempotencyHookFailsLoud:
-    def test_backcompat_noop_when_envelope_absent(self, monkeypatch):
-        """No envelope (no execution/node id) → silent no-op, never raises,
-        even with strands unavailable. Preserves agents run outside the
-        idempotency envelope."""
-        monkeypatch.delenv("CITADEL_EXECUTION_ID", raising=False)
-        monkeypatch.delenv("CITADEL_NODE_ID", raising=False)
+class TestComposedInstallFailsLoud:
+    def test_backcompat_noop_when_no_envelope(self, monkeypatch):
+        """No envelope → silent no-op, never raises, even with strands
+        unavailable. Preserves agents run outside any envelope."""
+        for v in ("CITADEL_AGENT_ID", "CITADEL_EXECUTION_ID", "CITADEL_NODE_ID"):
+            monkeypatch.delenv(v, raising=False)
         monkeypatch.setitem(sys.modules, "strands", None)  # import strands -> ImportError
         agent_runner = _fresh_agent_runner()
-        assert agent_runner._install_idempotency_hook() is False
+        assert agent_runner._install_tool_call_hooks() is False
 
-    def test_raises_when_envelope_active_and_strands_unavailable(self, monkeypatch):
-        """Envelope active + strands not importable → RAISE (fail the node),
-        never a silent warn/return-False."""
+    def test_raises_when_idempotency_envelope_active_and_strands_unavailable(self, monkeypatch):
+        """Idempotency envelope active + strands not importable → RAISE."""
+        monkeypatch.setenv("CITADEL_AGENT_ID", "agent-1")
         monkeypatch.setenv("CITADEL_EXECUTION_ID", "exec-1")
         monkeypatch.setenv("CITADEL_NODE_ID", "node-1")
         monkeypatch.setitem(sys.modules, "strands", None)
         agent_runner = _fresh_agent_runner()
-        with pytest.raises(RuntimeError, match="idempotency hook REQUIRED"):
-            agent_runner._install_idempotency_hook()
+        with pytest.raises(RuntimeError, match="governance/idempotency REQUIRED"):
+            agent_runner._install_tool_call_hooks()
 
-    def test_raises_when_envelope_active_and_hook_module_unimportable(self, monkeypatch):
-        """Envelope active, strands present, but the hook module can't be
-        imported (simulating a packaging/bundle regression) → RAISE with a
-        diagnostic naming the likely packaging cause."""
+    def test_raises_when_governance_envelope_active_and_strands_unavailable(self, monkeypatch):
+        """Governance envelope active (no idempotency) + strands not importable
+        → RAISE. Governance is now fail-loud, not a warning (the 027c4a89 fix)."""
+        monkeypatch.setenv("CITADEL_AGENT_ID", "agent-1")
+        monkeypatch.delenv("CITADEL_EXECUTION_ID", raising=False)
+        monkeypatch.delenv("CITADEL_NODE_ID", raising=False)
+        monkeypatch.setitem(sys.modules, "strands", None)
+        agent_runner = _fresh_agent_runner()
+        with pytest.raises(RuntimeError, match="governance/idempotency REQUIRED"):
+            agent_runner._install_tool_call_hooks()
+
+    def test_raises_when_idempotency_hook_module_unimportable(self, monkeypatch):
+        """Idempotency envelope active, strands present, but the hook module
+        can't be imported (packaging/bundle regression) → RAISE naming the
+        likely cause."""
+        monkeypatch.setenv("CITADEL_AGENT_ID", "agent-1")
         monkeypatch.setenv("CITADEL_EXECUTION_ID", "exec-1")
         monkeypatch.setenv("CITADEL_NODE_ID", "node-1")
         monkeypatch.setitem(sys.modules, "strands", types.ModuleType("strands"))
-        # Force `from tool_idempotency_hook import ...` to fail deterministically.
         monkeypatch.setitem(sys.modules, "tool_idempotency_hook", None)
         agent_runner = _fresh_agent_runner()
-        with pytest.raises(RuntimeError, match="tool_idempotency_hook"):
-            agent_runner._install_idempotency_hook()
+        with pytest.raises(RuntimeError, match="idempotency hook REQUIRED"):
+            agent_runner._install_tool_call_hooks()
 
 
-class TestGovernanceInjectionBestEffortGuard:
-    def test_skips_without_crashing_when_agent_lacks_tool_handler_seam(self, monkeypatch):
-        """strands 1.30.0's Agent.__init__ accepts neither ``tool_handler`` nor
-        **kwargs. Injecting a tool_handler kwarg would raise TypeError at every
-        Agent construction. The installer must detect the missing seam and skip
-        (return False, no patch) rather than break agent construction."""
+class TestGovernanceInstallsOnHooksSeam:
+    def test_installs_via_hooks_on_seamless_agent(self, monkeypatch):
+        """strands 1.30.0's Agent.__init__ accepts ``hooks`` but NOT
+        ``tool_handler``. The re-ported installer must INSTALL (patch
+        Agent.__init__ to append the composed hook) — the opposite of the old
+        best-effort skip that left layer-2 inert (finding 027c4a89)."""
         monkeypatch.setenv("CITADEL_AGENT_ID", "agent-1")
+        monkeypatch.delenv("CITADEL_EXECUTION_ID", raising=False)
+        monkeypatch.delenv("CITADEL_NODE_ID", raising=False)
 
         fake_strands = types.ModuleType("strands")
 
         class _FakeAgent:
-            # Mirrors strands 1.30.0: no tool_handler, no **kwargs.
+            # Mirrors strands 1.30.0: hooks accepted, no tool_handler.
             def __init__(self, model=None, tools=None, hooks=None):
-                self.tools = tools
+                self.hooks = hooks
 
         fake_strands.Agent = _FakeAgent
         monkeypatch.setitem(sys.modules, "strands", fake_strands)
 
         agent_runner = _fresh_agent_runner()
         original_init = _FakeAgent.__init__
-        assert agent_runner._install_governed_tool_handler() is False
-        # The installer must NOT have patched Agent.__init__.
-        assert _FakeAgent.__init__ is original_init
+        assert agent_runner._install_tool_call_hooks() is True
+        # The installer MUST have patched Agent.__init__.
+        assert _FakeAgent.__init__ is not original_init
+        # And the composed hook is appended to every constructed Agent.
+        a = _FakeAgent(tools=[])
+        assert isinstance(a.hooks, list) and len(a.hooks) == 1
+        assert type(a.hooks[0]).__name__ == "ComposedToolHook"

--- a/arbiter/workerWrapper/__tests__/test_composed_tool_governance.py
+++ b/arbiter/workerWrapper/__tests__/test_composed_tool_governance.py
@@ -1,0 +1,366 @@
+"""Tests for the composed layer-2 governance + tool-idempotency seam
+(finding 027c4a89).
+
+Covers:
+  * governance DENY swaps selected_tool BEFORE any idempotency reserve
+    (deny-before-reserve ordering invariant): no reservation, no execution;
+  * governance PERMIT falls through to the idempotency reserve/wrap;
+  * async stream drive: a denied tool yields the deny error and NEVER calls the
+    inner tool nor the ledger reserve; a permitted tool reserves (WON) then
+    executes then finalizes success;
+  * the differential RED proof: with the governance step REMOVED
+    (governance=None) the very same denied tool proceeds to execution — this is
+    exactly what made layer-2 inert, and is what the composed seam prevents;
+  * the single installer `_install_tool_call_hooks`: back-compat no-op,
+    fail-loud on an uninstallable control inside an active envelope, and one
+    ComposedToolHook appended to Agent(hooks=...).
+
+strands is not installed in this env, so the strands seam is simulated with a
+minimal fake ``strands.types._events.ToolResultEvent`` and fake event/tool
+objects — the same technique the existing agent_runner tests use.
+"""
+from __future__ import annotations
+
+import asyncio
+import os
+import sys
+import types
+
+import pytest
+
+_PROJECT_ROOT = os.path.abspath(
+    os.path.join(os.path.dirname(__file__), "..", "..", "..")
+)
+if _PROJECT_ROOT not in sys.path:
+    sys.path.insert(0, _PROJECT_ROOT)
+
+_HERE_WW = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
+if _HERE_WW not in sys.path:
+    sys.path.insert(0, _HERE_WW)
+
+import governance_tool_hook  # noqa: E402
+import tool_idempotency_hook  # noqa: E402
+from governance_tool_hook import GovernanceEvaluator, _GovernanceDeniedTool  # noqa: E402
+from tool_idempotency_hook import ComposedToolHook, IdempotencyToolHook, _IdempotentToolWrapper  # noqa: E402
+
+# CRITICAL (module-identity trap): the hook imports its ledger as
+# ``from governance import tool_execution_ledger as ledger``. A separate
+# ``arbiter.governance.tool_execution_ledger`` import is a DISTINCT module
+# object, so monkeypatching it would NOT affect the hook. Patch the exact
+# object the hook holds.
+ledger = tool_idempotency_hook.ledger  # noqa: E402
+
+
+# ---------------------------------------------------------------------------
+# Fakes for the strands seam
+# ---------------------------------------------------------------------------
+
+
+class _FakeEvent:
+    def __init__(self, name, tool_use_id, tool_input, selected_tool):
+        self.tool_use = {"name": name, "toolUseId": tool_use_id, "input": tool_input}
+        self.selected_tool = selected_tool
+
+
+class _FakeInnerTool:
+    """A stand-in real tool. ``stream`` appends to an executed log and yields a
+    single ToolResultEvent, so a test can prove whether it ran."""
+
+    def __init__(self, name, executed_log, result=None):
+        self._name = name
+        self._log = executed_log
+        self._result = result or {"toolUseId": "tu", "status": "success", "content": [{"text": "ran"}]}
+
+    @property
+    def tool_name(self):
+        return self._name
+
+    async def stream(self, tool_use, invocation_state, **kwargs):
+        from strands.types._events import ToolResultEvent
+
+        self._log.append(self._name)
+        yield ToolResultEvent(self._result)
+
+
+@pytest.fixture
+def fake_tool_result_event(monkeypatch):
+    """Install a minimal fake ``strands.types._events.ToolResultEvent`` so the
+    async wrapper streams can be driven without real strands."""
+    mod = types.ModuleType("strands.types._events")
+
+    class ToolResultEvent:
+        def __init__(self, tool_result):
+            self.tool_result = tool_result
+
+    mod.ToolResultEvent = ToolResultEvent
+    strands_mod = sys.modules.get("strands") or types.ModuleType("strands")
+    types_mod = sys.modules.get("strands.types") or types.ModuleType("strands.types")
+    monkeypatch.setitem(sys.modules, "strands", strands_mod)
+    monkeypatch.setitem(sys.modules, "strands.types", types_mod)
+    monkeypatch.setitem(sys.modules, "strands.types._events", mod)
+    return ToolResultEvent
+
+
+def _drain(agen):
+    async def _run():
+        out = []
+        async for ev in agen:
+            out.append(ev)
+        return out
+
+    return asyncio.run(_run())
+
+
+def _evaluator(denied=("dangerous",)):
+    return GovernanceEvaluator(
+        agent_id="agent-1", workflow_id="wf-1", denied_tools=set(denied), eval_run_id=None,
+    )
+
+
+def _idempotency():
+    return IdempotencyToolHook(org_id="org-1", execution_id="exec-1", node_id="node-1")
+
+
+# ---------------------------------------------------------------------------
+# Ordering invariant: deny BEFORE reserve
+# ---------------------------------------------------------------------------
+
+
+class TestDenyBeforeReserve:
+    def test_deny_swaps_selected_tool_and_never_reserves(self, monkeypatch):
+        """A denied tool: selected_tool becomes the deny tool, and the
+        idempotency reserve is NEVER reached (no reservation, no ledger row)."""
+        reserve_calls = []
+        monkeypatch.setattr(ledger, "reserve", lambda *a, **k: reserve_calls.append((a, k)))
+        # write_finding will raise LedgerWriteError (no table) → caught + WARN.
+
+        inner = _FakeInnerTool("dangerous", [])
+        event = _FakeEvent("dangerous", "tu-1", {"x": 1}, inner)
+        hook = ComposedToolHook(governance=_evaluator(), idempotency=_idempotency())
+
+        hook._on_before_tool_call(event)
+
+        assert isinstance(event.selected_tool, _GovernanceDeniedTool)
+        assert not isinstance(event.selected_tool, _IdempotentToolWrapper)
+        assert reserve_calls == []  # deny-before-reserve: no reservation created
+
+    def test_permit_falls_through_to_idempotency_wrap(self, monkeypatch):
+        """A permitted tool is wrapped by the idempotency wrapper (reserve is
+        deferred into the wrapper's stream, not called during selection)."""
+        reserve_calls = []
+        monkeypatch.setattr(ledger, "reserve", lambda *a, **k: reserve_calls.append((a, k)))
+
+        inner = _FakeInnerTool("safe", [])
+        event = _FakeEvent("safe", "tu-2", {"x": 1}, inner)
+        hook = ComposedToolHook(governance=_evaluator(), idempotency=_idempotency())
+
+        hook._on_before_tool_call(event)
+
+        assert isinstance(event.selected_tool, _IdempotentToolWrapper)
+        assert reserve_calls == []  # reserve happens inside stream(), not here
+
+    def test_permit_governance_only_leaves_tool_unchanged(self):
+        """Governance-only (supervisor path): a permitted tool is left as-is."""
+        inner = _FakeInnerTool("safe", [])
+        event = _FakeEvent("safe", "tu-3", {"x": 1}, inner)
+        hook = ComposedToolHook(governance=_evaluator(), idempotency=None)
+
+        hook._on_before_tool_call(event)
+
+        assert event.selected_tool is inner
+
+
+# ---------------------------------------------------------------------------
+# Async stream drive — the real side-effect boundary
+# ---------------------------------------------------------------------------
+
+
+class TestStreamExecution:
+    def test_denied_stream_yields_error_and_never_runs_inner_or_reserves(
+        self, monkeypatch, fake_tool_result_event
+    ):
+        reserve_calls = []
+        monkeypatch.setattr(ledger, "reserve", lambda *a, **k: reserve_calls.append((a, k)))
+
+        executed: list = []
+        inner = _FakeInnerTool("dangerous", executed)
+        event = _FakeEvent("dangerous", "tu-1", {"x": 1}, inner)
+        ComposedToolHook(governance=_evaluator(), idempotency=_idempotency())._on_before_tool_call(event)
+
+        events = _drain(event.selected_tool.stream(event.tool_use, {}))
+
+        assert executed == []           # inner tool NEVER ran (no side effect)
+        assert reserve_calls == []      # no reservation
+        assert len(events) == 1
+        assert events[0].tool_result["status"] == "error"
+        assert "not authorised" in events[0].tool_result["content"][0]["text"]
+
+    def test_permitted_stream_reserves_won_then_executes_then_finalizes(
+        self, monkeypatch, fake_tool_result_event
+    ):
+        reserve_calls = []
+        finalize_calls = []
+
+        def _fake_reserve(pk, sk, **k):
+            reserve_calls.append((pk, sk, k))
+            return ledger.ReserveResult(ledger.ReserveOutcome.WON)
+
+        monkeypatch.setattr(ledger, "reserve", _fake_reserve)
+        monkeypatch.setattr(
+            ledger, "finalize_success",
+            lambda pk, sk, **k: finalize_calls.append(("success", pk, sk, k)),
+        )
+
+        executed: list = []
+        inner = _FakeInnerTool("safe", executed)
+        event = _FakeEvent("safe", "tu-2", {"x": 1}, inner)
+        ComposedToolHook(governance=_evaluator(), idempotency=_idempotency())._on_before_tool_call(event)
+
+        events = _drain(event.selected_tool.stream(event.tool_use, {}))
+
+        assert executed == ["safe"]              # permitted tool ran once
+        assert len(reserve_calls) == 1           # reserved exactly once
+        assert finalize_calls and finalize_calls[0][0] == "success"
+        assert len(events) == 1
+
+
+# ---------------------------------------------------------------------------
+# Differential RED proof: removing the governance step lets a denied tool run
+# ---------------------------------------------------------------------------
+
+
+class TestGovernanceRemovalRedProof:
+    """RED proof (finding 027c4a89): with the governance step present a denied
+    tool is blocked; with governance REMOVED (governance=None — the inert
+    pre-fix state where only idempotency was installed) the SAME denied tool
+    proceeds to idempotency wrapping and would execute. Differential in one
+    test so the guard can never silently regress to the inert state again."""
+
+    def test_denied_tool_blocked_with_governance_but_executes_without(
+        self, monkeypatch, fake_tool_result_event
+    ):
+        monkeypatch.setattr(
+            ledger, "reserve", lambda *a, **k: ledger.ReserveResult(ledger.ReserveOutcome.WON)
+        )
+        monkeypatch.setattr(ledger, "finalize_success", lambda *a, **k: None)
+
+        # WITH governance: denied → deny tool, inner never runs.
+        with_exec: list = []
+        inner1 = _FakeInnerTool("dangerous", with_exec)
+        ev1 = _FakeEvent("dangerous", "tu-1", {"x": 1}, inner1)
+        ComposedToolHook(governance=_evaluator(), idempotency=_idempotency())._on_before_tool_call(ev1)
+        _drain(ev1.selected_tool.stream(ev1.tool_use, {}))
+        assert with_exec == []
+        assert isinstance(ev1.selected_tool, _GovernanceDeniedTool)
+
+        # WITHOUT governance (the inert pre-fix state): the SAME denied tool is
+        # wrapped only for idempotency and DOES execute — the vulnerability.
+        without_exec: list = []
+        inner2 = _FakeInnerTool("dangerous", without_exec)
+        ev2 = _FakeEvent("dangerous", "tu-1", {"x": 1}, inner2)
+        ComposedToolHook(governance=None, idempotency=_idempotency())._on_before_tool_call(ev2)
+        _drain(ev2.selected_tool.stream(ev2.tool_use, {}))
+        assert without_exec == ["dangerous"]  # RED: denied tool executed
+        assert isinstance(ev2.selected_tool, _IdempotentToolWrapper)
+
+
+# ---------------------------------------------------------------------------
+# Single installer — envelopes + fail-loud
+# ---------------------------------------------------------------------------
+
+
+def _fresh_agent_runner():
+    sys.modules.pop("agent_runner", None)
+    import agent_runner
+    return agent_runner
+
+
+def _install_fake_hooks_strands(monkeypatch):
+    """Install a fake ``strands`` whose Agent accepts hooks (not tool_handler).
+
+    A FRESH Agent class per call so the ``Agent.__init__`` wrapping done by
+    ``_install_tool_call_hooks`` never accumulates across tests."""
+    class _FreshHooksAgent:
+        def __init__(self, model=None, tools=None, hooks=None):
+            self.tools = tools
+            self.hooks = hooks
+
+    fake = types.ModuleType("strands")
+    fake.Agent = _FreshHooksAgent
+    monkeypatch.setitem(sys.modules, "strands", fake)
+    return fake
+
+
+class TestInstallToolCallHooks:
+    def test_backcompat_noop_when_no_envelope(self, monkeypatch):
+        for v in ("CITADEL_AGENT_ID", "CITADEL_EXECUTION_ID", "CITADEL_NODE_ID"):
+            monkeypatch.delenv(v, raising=False)
+        monkeypatch.setitem(sys.modules, "strands", None)
+        agent_runner = _fresh_agent_runner()
+        assert agent_runner._install_tool_call_hooks() is False
+
+    def test_governance_envelope_installs_composed_hook(self, monkeypatch):
+        monkeypatch.setenv("CITADEL_AGENT_ID", "agent-1")
+        monkeypatch.delenv("CITADEL_EXECUTION_ID", raising=False)
+        monkeypatch.delenv("CITADEL_NODE_ID", raising=False)
+        fake = _install_fake_hooks_strands(monkeypatch)
+        agent_runner = _fresh_agent_runner()
+
+        assert agent_runner._install_tool_call_hooks() is True
+        a = fake.Agent(tools=[])
+        assert isinstance(a.hooks, list) and len(a.hooks) == 1
+        composed = a.hooks[0]
+        assert composed.governance is not None
+        assert composed.idempotency is None
+
+    def test_both_envelopes_install_governance_and_idempotency(self, monkeypatch):
+        monkeypatch.setenv("CITADEL_AGENT_ID", "agent-1")
+        monkeypatch.setenv("CITADEL_EXECUTION_ID", "exec-1")
+        monkeypatch.setenv("CITADEL_NODE_ID", "node-1")
+        fake = _install_fake_hooks_strands(monkeypatch)
+        agent_runner = _fresh_agent_runner()
+
+        assert agent_runner._install_tool_call_hooks() is True
+        a = fake.Agent(tools=[])
+        composed = a.hooks[0]
+        assert composed.governance is not None
+        assert composed.idempotency is not None
+
+    def test_composed_hook_appended_to_caller_hooks(self, monkeypatch):
+        monkeypatch.setenv("CITADEL_AGENT_ID", "agent-1")
+        fake = _install_fake_hooks_strands(monkeypatch)
+        agent_runner = _fresh_agent_runner()
+        agent_runner._install_tool_call_hooks()
+
+        sentinel = object()
+        a = fake.Agent(hooks=[sentinel])
+        assert a.hooks[0] is sentinel and len(a.hooks) == 2
+
+    def test_fail_loud_governance_envelope_strands_unavailable(self, monkeypatch):
+        monkeypatch.setenv("CITADEL_AGENT_ID", "agent-1")
+        monkeypatch.delenv("CITADEL_EXECUTION_ID", raising=False)
+        monkeypatch.delenv("CITADEL_NODE_ID", raising=False)
+        monkeypatch.setitem(sys.modules, "strands", None)  # import strands -> ImportError
+        agent_runner = _fresh_agent_runner()
+        with pytest.raises(RuntimeError, match="governance/idempotency REQUIRED"):
+            agent_runner._install_tool_call_hooks()
+
+    def test_fail_loud_governance_module_unimportable(self, monkeypatch):
+        monkeypatch.setenv("CITADEL_AGENT_ID", "agent-1")
+        monkeypatch.delenv("CITADEL_EXECUTION_ID", raising=False)
+        monkeypatch.delenv("CITADEL_NODE_ID", raising=False)
+        _install_fake_hooks_strands(monkeypatch)
+        monkeypatch.setitem(sys.modules, "governance_tool_hook", None)
+        agent_runner = _fresh_agent_runner()
+        with pytest.raises(RuntimeError, match="layer-2 tool governance REQUIRED"):
+            agent_runner._install_tool_call_hooks()
+
+    def test_fail_loud_idempotency_module_unimportable(self, monkeypatch):
+        monkeypatch.setenv("CITADEL_AGENT_ID", "agent-1")
+        monkeypatch.setenv("CITADEL_EXECUTION_ID", "exec-1")
+        monkeypatch.setenv("CITADEL_NODE_ID", "node-1")
+        _install_fake_hooks_strands(monkeypatch)
+        monkeypatch.setitem(sys.modules, "tool_idempotency_hook", None)
+        agent_runner = _fresh_agent_runner()
+        with pytest.raises(RuntimeError, match="idempotency hook REQUIRED"):
+            agent_runner._install_tool_call_hooks()

--- a/arbiter/workerWrapper/__tests__/test_deployed_bundle_importability.py
+++ b/arbiter/workerWrapper/__tests__/test_deployed_bundle_importability.py
@@ -47,6 +47,7 @@ _BUNDLE_MODULES = [
     "agent_runner.py",
     "tool_idempotency_hook.py",
     "tool_idempotency.py",
+    "governance_tool_hook.py",
     "governed_tool_handler.py",
     "worker_governance.py",
 ]

--- a/arbiter/workerWrapper/agent_runner.py
+++ b/arbiter/workerWrapper/agent_runner.py
@@ -337,109 +337,6 @@ def _install_usage_capture():
     return True
 
 
-def _install_governed_tool_handler():
-    """Patch ``strands.Agent.__init__`` to inject a GovernedToolHandler.
-
-    Runs inside the subprocess before the agent module is exec'd, so every
-    ``Agent(...)`` construction inside the loaded module automatically
-    picks up governance enforcement at tool-call time (QD-5 layer 2,
-    ``scope_evaluated='worker-tool-handler'``).
-
-    No-op when ``CITADEL_AGENT_ID`` is not set in the environment — that
-    preserves backward compatibility with agents running outside the
-    governance envelope (local dev, legacy callers).
-
-    Graceful degrade when ``strands`` or ``governed_tool_handler`` cannot
-    be imported: WARN to stderr and return False. Best-effort semantics
-    (AC 9.4) mean a missing layer-2 handler must not halt execution of
-    an otherwise-valid agent.
-
-    Caller-supplied ``tool_handler=...`` on ``Agent(...)`` always wins —
-    the injector only fills in the default. This preserves the escape
-    hatch for agents that ship their own policy surface.
-
-    Returns True when the patch was installed, False otherwise.
-    """
-    if not os.environ.get('CITADEL_AGENT_ID'):
-        return False
-
-    try:
-        import strands  # type: ignore[import-not-found]
-    except ImportError as exc:
-        sys.stderr.write(
-            f'[agent_runner] WARN governance injection skipped — '
-            f'strands unavailable: {exc}\n'
-        )
-        return False
-
-    # strands 1.30.0 removed the tool_handler seam this injector targets:
-    # Agent.__init__ accepts NEITHER a ``tool_handler`` kwarg NOR **kwargs
-    # (verified against the pinned release). Injecting ``tool_handler=`` into
-    # such an Agent raises TypeError at construction, which would break EVERY
-    # agent in a governed dispatch — a fail-open→fail-the-node regression far
-    # worse than the best-effort skip AC 9.4 mandates. Probe the signature and
-    # skip injection (WARN, no patch) when the seam is absent. Layer-2 tool
-    # governance needs a hooks-based re-port on this strands line (tracked as
-    # the "dead governance tool_handler injection under strands 1.30.0"
-    # finding); this guard makes the module importable without regressing
-    # agent construction.
-    import inspect
-    try:
-        _params = inspect.signature(strands.Agent.__init__).parameters
-        _accepts_tool_handler = ('tool_handler' in _params) or any(
-            p.kind is inspect.Parameter.VAR_KEYWORD for p in _params.values()
-        )
-    except (TypeError, ValueError):
-        _accepts_tool_handler = False
-    if not _accepts_tool_handler:
-        sys.stderr.write(
-            '[agent_runner] WARN governance injection skipped — installed '
-            'strands.Agent does not accept a tool_handler kwarg; layer-2 tool '
-            'governance requires a hooks-based re-port on this version\n'
-        )
-        return False
-    _here = os.path.dirname(os.path.abspath(__file__))
-    if _here not in sys.path:
-        sys.path.insert(0, _here)
-
-    try:
-        from governed_tool_handler import GovernedToolHandler
-    except ImportError as exc:
-        sys.stderr.write(
-            f'[agent_runner] WARN governance injection skipped — '
-            f'governed_tool_handler unavailable: {exc}\n'
-        )
-        return False
-
-    original_init = strands.Agent.__init__
-
-    def _governed_init(self, *args, **kwargs):
-        # Caller-supplied handler always wins — never override an explicit
-        # tool_handler= in generated code.
-        if 'tool_handler' not in kwargs or kwargs['tool_handler'] is None:
-            kwargs['tool_handler'] = GovernedToolHandler(
-                agent_id=os.environ.get('CITADEL_AGENT_ID', 'unknown-agent'),
-                workflow_id=os.environ.get('CITADEL_WORKFLOW_ID', 'unknown-workflow'),
-                # ``denied_tools=None`` lets GovernedToolHandler read
-                # DENIED_TOOLS from env itself, keeping a single source of
-                # truth for env parsing semantics. DENIED_TOOLS itself
-                # already carries the union of static deny-list entries
-                # and any per-run forbiddenTools (CIT-102 Pass B) — see
-                # worker_governance.build_subprocess_env, which merges
-                # them before setting the env var.
-                denied_tools=None,
-                # CIT-102 Pass B: per-run eval-context correlation id.
-                # None (the trigger is absent) for every non-eval
-                # invocation — GovernedToolHandler treats None
-                # byte-identically to its pre-CIT-102 behavior.
-                eval_run_id=os.environ.get('CITADEL_EVAL_RUN_ID') or None,
-            )
-        return original_init(self, *args, **kwargs)
-
-    strands.Agent.__init__ = _governed_init
-    return True
-
-
 def _read_dispatch_generation():
     """Parse ``CITADEL_DISPATCH_GENERATION`` to an int, or None when unset/invalid.
 
@@ -456,90 +353,138 @@ def _read_dispatch_generation():
         return None
 
 
-def _install_idempotency_hook():
-    """Patch ``strands.Agent.__init__`` to attach an idempotency HookProvider.
+def _install_tool_call_hooks():
+    """Install the SINGLE composed ``BeforeToolCallEvent`` seam that applies
+    layer-2 tool governance THEN tool-call idempotency (finding 027c4a89).
 
-    Tool-call idempotency (PR1). Uses the ONLY tool-call extension surface the
-    pinned ``strands-agents==1.30.0`` actually exposes: the hooks system
-    (``Agent(hooks=[...])`` + ``BeforeToolCallEvent``). Verified against the
-    1.30.0 source — that release has NO ``strands.handlers.tool_handler``
-    /``AgentToolHandler`` and ``Agent.__init__`` accepts neither
-    ``tool_handler`` nor ``**kwargs``; it does accept ``hooks``. We therefore
-    APPEND an ``IdempotencyToolHook`` to whatever ``hooks`` list the caller
-    passed (never clobbering caller-supplied hooks).
+    Replaces the two former independent ``strands.Agent.__init__`` patches
+    (``_install_governed_tool_handler`` targeting the removed ``tool_handler``
+    kwarg, and ``_install_idempotency_hook``). Those two installers were the
+    root cause: idempotency was re-ported to the hooks API while governance
+    still targeted the dead kwarg and silently went inert. One installer +
+    one ``ComposedToolHook`` (one callback) makes divergence impossible.
 
-    No-op unless BOTH ``CITADEL_EXECUTION_ID`` and ``CITADEL_NODE_ID`` are set
-    (back-compat: an agent run outside the idempotency envelope is unchanged).
-    ``CITADEL_ORG_ID`` is optional (empty -> shared org prefix; executionId is
-    still globally unique) and is read ONLY from the trusted subprocess env
-    that the worker set server-side, never from tool/agent input.
+    Two independent envelopes:
+      * governance active  ⇔ ``CITADEL_AGENT_ID`` set (both dispatch paths).
+      * idempotency active ⇔ ``CITADEL_EXECUTION_ID`` AND ``CITADEL_NODE_ID``
+        set (workflow-node path). Idempotency-active ⟹ governance-active.
 
-    Graceful degrade (WARN, return False) when strands or the hook module
-    cannot be imported — a missing idempotency layer must never halt an
-    otherwise-valid agent.
+    Back-compat: when NEITHER envelope is present, this is a silent no-op
+    (agents run outside any envelope are unchanged) and returns False.
 
-    Returns True when the patch was installed, False otherwise.
+    FAIL-LOUD (finding 027c4a89 step 4): inside an ACTIVE envelope, a control
+    that cannot install must ABORT the node — never degrade to a warning. A
+    silently-skipped control lets a node run UNPROTECTED while looking
+    protected. This now applies to governance too, matching the rule already
+    enforced for idempotency. Raising exits the subprocess non-zero, which the
+    workflow-node dispatch (``run_agent_in_subprocess`` ``raise_on_error=True``)
+    turns into ``workflow.node.failed``.
+
+    Returns True when the composed hook was installed, False on back-compat
+    no-op.
     """
-    if not (os.environ.get('CITADEL_EXECUTION_ID') and os.environ.get('CITADEL_NODE_ID')):
+    agent_id = os.environ.get('CITADEL_AGENT_ID')
+    execution_id = os.environ.get('CITADEL_EXECUTION_ID')
+    node_id = os.environ.get('CITADEL_NODE_ID')
+    governance_active = bool(agent_id)
+    idempotency_active = bool(execution_id and node_id)
+
+    if not governance_active and not idempotency_active:
         return False
 
-    # FAIL-CLOSED (fail-loud). Inside an ACTIVE idempotency envelope (both
-    # CITADEL_EXECUTION_ID and CITADEL_NODE_ID present ⇒ a workflow-dispatched
-    # node), a hook that cannot install must ABORT the node — it must NEVER
-    # degrade to a warning. The idempotency hook is a fail-closed security
-    # control: silently disabling it would let a node run UNPROTECTED while
-    # looking protected (duplicate side effects across a watchdog
-    # re-dispatch), which is exactly the "idempotency hook skipped … No module
-    # named arbiter ⇒ 0 ledger rows" defect the first real smoke run exposed.
-    # Raising here exits the agent_runner subprocess non-zero, which the
-    # workflow-node dispatch (run_agent_in_subprocess raise_on_error=True)
-    # turns into workflow.node.failed. Diagnostic messages name the likely
-    # packaging cause so a bundle regression is triaged fast.
+    # FAIL-LOUD: strands must be importable to install ANY active control.
     try:
         import strands  # type: ignore[import-not-found]
     except ImportError as exc:
         raise RuntimeError(
-            'idempotency hook REQUIRED but strands is unavailable in the '
-            'agent_runner subprocess while an idempotency envelope is active '
-            f'(CITADEL_EXECUTION_ID/CITADEL_NODE_ID set): {exc}'
+            'tool-call governance/idempotency REQUIRED but strands is '
+            'unavailable in the agent_runner subprocess while an active '
+            'envelope is present (CITADEL_AGENT_ID and/or CITADEL_EXECUTION_ID'
+            f'/CITADEL_NODE_ID set): {exc}'
         ) from exc
 
     _here = os.path.dirname(os.path.abspath(__file__))
     if _here not in sys.path:
         sys.path.insert(0, _here)
 
+    governance = None
+    if governance_active:
+        # FAIL-LOUD: an uninstallable governance control inside its envelope
+        # aborts the node (never a warning) — this is the finding-027c4a89 fix.
+        try:
+            from governance_tool_hook import GovernanceEvaluator
+        except ImportError as exc:
+            raise RuntimeError(
+                'layer-2 tool governance REQUIRED but governance_tool_hook '
+                'could not be imported in the agent_runner subprocess while a '
+                'governance envelope is active (CITADEL_AGENT_ID set). This '
+                'control must not silently disable itself — check that the '
+                "ArbiterCatalogLayer 'governance'/'common' packages are on the "
+                'subprocess PYTHONPATH (index.py propagates the parent '
+                f'sys.path): {exc}'
+            ) from exc
+        governance = GovernanceEvaluator(
+            agent_id=agent_id or 'unknown-agent',
+            workflow_id=os.environ.get('CITADEL_WORKFLOW_ID', 'unknown-workflow'),
+            # ``denied_tools=None`` → read DENIED_TOOLS from env (single
+            # env-parsing source of truth; the worker already merges static
+            # deny-list + per-run forbiddenTools into DENIED_TOOLS).
+            denied_tools=None,
+            eval_run_id=os.environ.get('CITADEL_EVAL_RUN_ID') or None,
+        )
+
+    idempotency = None
+    if idempotency_active:
+        # FAIL-LOUD idempotency (unchanged intent from the former
+        # _install_idempotency_hook): a fail-closed security control that
+        # silently degrades would let a node duplicate side effects across a
+        # watchdog re-dispatch while looking protected.
+        try:
+            from tool_idempotency_hook import IdempotencyToolHook
+        except ImportError as exc:
+            raise RuntimeError(
+                'idempotency hook REQUIRED but tool_idempotency_hook could not '
+                'be imported in the agent_runner subprocess while an '
+                'idempotency envelope is active. This fail-closed security '
+                'control must not silently disable itself — check that the '
+                "ArbiterCatalogLayer 'governance'/'common' packages are on the "
+                'subprocess PYTHONPATH (index.py propagates the parent '
+                'sys.path) and that the worker bundle ships '
+                f'tool_idempotency/tool_idempotency_hook: {exc}'
+            ) from exc
+        idempotency = IdempotencyToolHook(
+            org_id=os.environ.get('CITADEL_ORG_ID', ''),
+            execution_id=execution_id or '',
+            node_id=node_id or '',
+            dispatch_generation=_read_dispatch_generation(),
+        )
+
+    # The composed hook lives with the idempotency seam so both concerns share
+    # one module and one BeforeToolCallEvent callback.
     try:
-        from tool_idempotency_hook import IdempotencyToolHook
+        from tool_idempotency_hook import ComposedToolHook
     except ImportError as exc:
         raise RuntimeError(
-            'idempotency hook REQUIRED but tool_idempotency_hook could not be '
-            'imported in the agent_runner subprocess while an idempotency '
-            'envelope is active. This fail-closed security control must not '
-            'silently disable itself — check that the ArbiterCatalogLayer '
-            "'governance'/'common' packages are on the subprocess PYTHONPATH "
-            '(index.py propagates the parent sys.path) and that the worker '
-            f'bundle ships tool_idempotency/tool_idempotency_hook: {exc}'
+            'composed tool hook REQUIRED but tool_idempotency_hook could not '
+            'be imported in the agent_runner subprocess while an active '
+            f'envelope is present: {exc}'
         ) from exc
+
+    composed = ComposedToolHook(governance=governance, idempotency=idempotency)
 
     original_init = strands.Agent.__init__
 
-    def _idempotent_init(self, *args, **kwargs):
-        hook = IdempotencyToolHook(
-            org_id=os.environ.get('CITADEL_ORG_ID', ''),
-            execution_id=os.environ.get('CITADEL_EXECUTION_ID', ''),
-            node_id=os.environ.get('CITADEL_NODE_ID', ''),
-            dispatch_generation=_read_dispatch_generation(),
-        )
+    def _hooked_init(self, *args, **kwargs):
         existing = kwargs.get('hooks')
         if existing is None:
-            kwargs['hooks'] = [hook]
+            kwargs['hooks'] = [composed]
         elif isinstance(existing, list):
-            kwargs['hooks'] = [*existing, hook]
-        # If a caller passed a non-list hooks value we leave it untouched —
-        # strands will validate it; we never overwrite caller intent.
+            kwargs['hooks'] = [*existing, composed]
+        # A non-list caller hooks value is left untouched — strands validates
+        # it; we never overwrite caller intent.
         return original_init(self, *args, **kwargs)
 
-    strands.Agent.__init__ = _idempotent_init
+    strands.Agent.__init__ = _hooked_init
     return True
 
 
@@ -600,14 +545,14 @@ def main():
     # 0-based callIndex sequence each time rather than accumulating state.
     _CAPTURED_USAGE.clear()
 
-    # Install governance patch BEFORE exec_module so every Agent(...)
-    # construction in the loaded module picks it up. Safe no-op when the
-    # subprocess env lacks CITADEL_AGENT_ID (backward compatible).
-    _install_governed_tool_handler()
-
-    # Install the tool-call idempotency hook (PR1) via the strands hooks
-    # system — no-op unless CITADEL_EXECUTION_ID + CITADEL_NODE_ID are set.
-    _install_idempotency_hook()
+    # Install the SINGLE composed tool-call seam (finding 027c4a89): layer-2
+    # tool governance THEN tool-call idempotency, at one BeforeToolCallEvent
+    # callback, patched onto strands.Agent.__init__ BEFORE exec_module so every
+    # Agent(...) in the loaded module picks it up. No-op when neither the
+    # governance envelope (CITADEL_AGENT_ID) nor the idempotency envelope
+    # (CITADEL_EXECUTION_ID + CITADEL_NODE_ID) is present. FAIL-LOUD (raises)
+    # when an active envelope's control cannot install.
+    _install_tool_call_hooks()
 
     # Overrides the model id for operator-selected per-agent overrides;
     # no-op unless MODEL_OVERRIDE is set in the subprocess environment.

--- a/arbiter/workerWrapper/governance_tool_hook.py
+++ b/arbiter/workerWrapper/governance_tool_hook.py
@@ -1,0 +1,187 @@
+"""Layer-2 tool-call governance on the live Strands hooks seam (finding 027c4a89).
+
+Background
+----------
+The original layer-2 governance surface (``governed_tool_handler.GovernedToolHandler``)
+was injected as ``Agent(tool_handler=...)``. ``strands-agents==1.30.0`` REMOVED
+that seam: ``Agent.__init__`` accepts neither ``tool_handler`` nor ``**kwargs``,
+and ``strands.handlers.tool_handler`` is gone. So the injector
+(``agent_runner._install_governed_tool_handler``) detected the missing kwarg and
+merely WARNED — layer-2 allow/deny was INERT at runtime on every workflow-node
+agent execution, while the sibling idempotency concern HAD been re-ported to the
+hooks API. This module re-ports governance onto the SAME seam the idempotency
+hook uses (``BeforeToolCallEvent`` + writable ``selected_tool``), so the two are
+composed at one seam and can never diverge again (see ``tool_idempotency_hook.ComposedToolHook``).
+
+Decision (single source of truth)
+----------------------------------
+The allow/deny + audit-finding decision itself lives in
+``governed_tool_handler.record_governance_decision`` — this module only binds
+that decision to the real tool-call event. On DENY it REPLACES ``selected_tool``
+with a :class:`_GovernanceDeniedTool` whose ``stream()`` yields the deny error
+ToolResult and NEVER touches the real tool (mirroring the idempotency hook's
+``_KeyDerivationFailedTool``). On PERMIT it leaves ``selected_tool`` unchanged
+(the composing hook then applies idempotency).
+
+Degrades to a no-op import when ``strands`` is unavailable (dev/CI), mirroring
+``tool_idempotency_hook.py`` / ``governed_tool_handler.py``.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+import sys
+from typing import Any
+
+_HERE = os.path.dirname(os.path.abspath(__file__))
+if _HERE not in sys.path:
+    sys.path.insert(0, _HERE)
+
+from governed_tool_handler import (  # noqa: E402
+    SCOPE_WORKER_TOOL_HANDLER,  # re-exported for symmetric reference
+    _parse_denied_tools_env,
+    record_governance_decision,
+)
+
+logger = logging.getLogger(__name__)
+
+try:
+    from strands.hooks import BeforeToolCallEvent  # type: ignore
+    from strands.types.tools import AgentTool  # type: ignore
+
+    _STRANDS_AVAILABLE = True
+except ImportError:  # pragma: no cover — dev/CI without strands-agents
+    _STRANDS_AVAILABLE = False
+    BeforeToolCallEvent = object  # type: ignore[assignment,misc]
+    AgentTool = object  # type: ignore[assignment,misc]
+
+
+class _GovernanceDeniedTool(AgentTool):  # type: ignore[misc]
+    """Replacement tool installed when governance DENYs a call. Its ``stream()``
+    yields the deny error ToolResult and never delegates to the real tool — so a
+    denied tool performs no side effect and never reaches the idempotency
+    reserve. Mirrors ``tool_idempotency_hook._KeyDerivationFailedTool``."""
+
+    def __init__(self, inner: Any, error_result: dict[str, Any]):
+        try:
+            super().__init__()
+        except TypeError:  # pragma: no cover — base signature drift
+            pass
+        self._inner = inner
+        self._error_result = error_result
+
+    @property
+    def tool_name(self) -> str:  # pragma: no cover — thin delegation
+        return self._inner.tool_name
+
+    @property
+    def tool_spec(self) -> Any:  # pragma: no cover — thin delegation
+        return self._inner.tool_spec
+
+    @property
+    def tool_type(self) -> str:  # pragma: no cover — thin delegation
+        return self._inner.tool_type
+
+    def get_display_properties(self) -> dict[str, str]:  # pragma: no cover
+        return self._inner.get_display_properties()
+
+    async def stream(self, tool_use: Any, invocation_state: dict[str, Any], **kwargs: Any):  # pragma: no cover — requires strands runtime
+        from strands.types._events import ToolResultEvent  # local import; strands-only
+
+        yield ToolResultEvent(self._error_result)
+
+
+class GovernanceEvaluator:
+    """Applies the layer-2 allow/deny decision to a ``BeforeToolCallEvent``.
+
+    ``evaluate(event)`` writes the audit finding (PERMIT or DENY) via the shared
+    ``record_governance_decision`` and, on DENY, swaps ``event.selected_tool``
+    for a :class:`_GovernanceDeniedTool` and returns ``True``. On PERMIT it
+    returns ``False`` and leaves the event untouched. This is deliberately a
+    plain object (not a HookProvider) so it can be COMPOSED into the single
+    idempotency callback (``ComposedToolHook``) rather than registering a second,
+    independently-ordered callback.
+    """
+
+    def __init__(
+        self,
+        *,
+        agent_id: str,
+        workflow_id: str,
+        denied_tools: set[str] | None = None,
+        eval_run_id: str | None = None,
+    ):
+        self._agent_id = agent_id or 'unknown-agent'
+        self._workflow_id = workflow_id or 'unknown-workflow'
+        # ``None`` → read DENIED_TOOLS from env (single env-parsing source of
+        # truth). An explicit (possibly empty) set overrides the env fallback.
+        self._denied_tools = (
+            denied_tools if denied_tools is not None else _parse_denied_tools_env()
+        )
+        self._eval_run_id = eval_run_id
+
+    @property
+    def denied_tools(self) -> set[str]:  # pragma: no cover — trivial accessor
+        return self._denied_tools
+
+    def evaluate(self, event: Any) -> bool:
+        """Return True if the call was DENIED (and ``selected_tool`` swapped)."""
+        tool_use = getattr(event, "tool_use", None)
+        selected = getattr(event, "selected_tool", None)
+        if tool_use is None or selected is None:
+            return False
+        if hasattr(tool_use, "get"):
+            tool_name = tool_use.get("name", "") or ""
+            tool_use_id = tool_use.get("toolUseId", "") or ""
+        else:
+            tool_name = getattr(tool_use, "name", "") or ""
+            tool_use_id = getattr(tool_use, "toolUseId", "") or ""
+
+        denied, error_result = record_governance_decision(
+            tool_name, tool_use_id,
+            agent_id=self._agent_id,
+            workflow_id=self._workflow_id,
+            denied_tools=self._denied_tools,
+            eval_run_id=self._eval_run_id,
+        )
+        if denied and error_result is not None:
+            event.selected_tool = _GovernanceDeniedTool(selected, error_result)
+            return True
+        return False
+
+
+class GovernanceToolHook:
+    """A standalone Strands ``HookProvider`` for layer-2 governance.
+
+    Used on the supervisor-task path (governance active, no idempotency
+    envelope). On the workflow-node path governance is instead COMPOSED with
+    idempotency into a single callback (``ComposedToolHook``) so ordering is
+    guaranteed and the two seams cannot diverge.
+    """
+
+    def __init__(
+        self,
+        *,
+        agent_id: str,
+        workflow_id: str,
+        denied_tools: set[str] | None = None,
+        eval_run_id: str | None = None,
+    ):
+        self._evaluator = GovernanceEvaluator(
+            agent_id=agent_id, workflow_id=workflow_id,
+            denied_tools=denied_tools, eval_run_id=eval_run_id,
+        )
+
+    @property
+    def evaluator(self) -> GovernanceEvaluator:  # pragma: no cover — accessor
+        return self._evaluator
+
+    def register_hooks(self, registry: Any, **_kwargs: Any) -> None:
+        if not _STRANDS_AVAILABLE:  # pragma: no cover — dev/CI guard
+            logger.warning("governance hook skipped — strands unavailable")
+            return
+        registry.add_callback(BeforeToolCallEvent, self._on_before_tool_call)
+
+    def _on_before_tool_call(self, event: Any) -> None:  # pragma: no cover — requires strands runtime
+        self._evaluator.evaluate(event)

--- a/arbiter/workerWrapper/governed_tool_handler.py
+++ b/arbiter/workerWrapper/governed_tool_handler.py
@@ -35,16 +35,21 @@ real smoke run). The same names resolve under pytest via
 
 Wiring status
 -------------
-Wired. ``arbiter/workerWrapper/agent_runner.py`` installs a
-``strands.Agent.__init__`` patch (``_install_governed_tool_handler``) before
-the agent module is exec'd inside the subprocess, so every ``Agent(...)``
-constructed by the loaded module automatically receives a
-``GovernedToolHandler`` instance as its ``tool_handler`` — unless the caller
-explicitly passes its own, which always wins. The patch is a no-op when
-``CITADEL_AGENT_ID`` is unset in the subprocess environment (back-compat with
-agents run outside the governance envelope). See
-``arbiter/workerWrapper/__tests__/test_agent_runner_properties.py`` for the
-injection-contract tests.
+The ``strands.Agent(tool_handler=...)`` seam this class was written for was
+REMOVED in ``strands-agents==1.30.0`` (``Agent.__init__`` accepts neither
+``tool_handler`` nor ``**kwargs``), which left layer-2 governance INERT at
+runtime (finding 027c4a89). Governance was re-ported onto the live hooks seam:
+``arbiter/workerWrapper/governance_tool_hook.py`` (``GovernanceEvaluator`` /
+``GovernanceToolHook``), composed with tool-call idempotency behind ONE
+``BeforeToolCallEvent`` callback (``tool_idempotency_hook.ComposedToolHook``),
+installed by ``agent_runner._install_tool_call_hooks``.
+
+The DECISION itself (deny-list lookup + audit finding) lives in the shared
+``record_governance_decision`` / ``build_governance_finding`` helpers in this
+module — the SINGLE source of truth both the (now legacy) ``preprocess`` path
+and the live hooks path call, so the two can never diverge again. This
+``GovernedToolHandler`` class is retained for the legacy ``AgentToolHandler``
+interface but is no longer installed on strands 1.30.0.
 
 Spec: arbiter-governance-engine/requirements.md Requirement 9.1–9.5.
 """
@@ -107,6 +112,95 @@ def _parse_denied_tools_env() -> set[str]:
     """
     raw = os.environ.get('DENIED_TOOLS', '')
     return {t.strip() for t in raw.split(',') if t.strip()}
+
+
+def _deny_error_result(tool_use_id: str, tool_name: str) -> dict:
+    """The ToolResult-shaped error dict returned when a tool is denied.
+
+    Strands accepts duck-typed dicts; the same shape is used whether the
+    decision fires from the legacy ``preprocess`` path or the hooks-based
+    ``GovernanceToolHook`` path — a single source of truth for the message
+    the model sees on a denial.
+    """
+    return {
+        'toolUseId': tool_use_id,
+        'status': 'error',
+        'content': [
+            {'text': f"Tool '{tool_name}' is not authorised for this agent."}
+        ],
+    }
+
+
+def build_governance_finding(
+    tool_name: str,
+    denied: bool,
+    *,
+    agent_id: str,
+    workflow_id: str,
+    eval_run_id: str | None = None,
+) -> GovernanceFinding:
+    """Build the worker-tool-handler-scope ``GovernanceFinding`` for one tool
+    call. Shared by the legacy ``GovernedToolHandler.preprocess`` and the
+    hooks-based ``GovernanceToolHook`` so both layers emit byte-identical
+    findings (QD-5: scope ``worker-tool-handler``, distinct from
+    ``worker-pre-filter``). PERMIT and DENY both produce a finding."""
+    decision = ArbitrationDecision.DENY if denied else ArbitrationDecision.PERMIT
+    return GovernanceFinding.create(
+        workflow_id=workflow_id,
+        decision=decision,
+        requesting_agent=agent_id,
+        target_agent=f'tool:{tool_name}',
+        reason=(
+            f'tool_denied:explicit_deny_list:{tool_name}'
+            if denied
+            else f'tool_permitted:not_on_deny_list:{tool_name}'
+        ),
+        scope_evaluated=SCOPE_WORKER_TOOL_HANDLER,
+        contract_evaluated=None,
+        eval_run_id=eval_run_id,
+    )
+
+
+def record_governance_decision(
+    tool_name: str,
+    tool_use_id: str,
+    *,
+    agent_id: str,
+    workflow_id: str,
+    denied_tools: set[str],
+    eval_run_id: str | None = None,
+) -> tuple[bool, dict | None]:
+    """Evaluate the deny-list decision, write the audit finding, and return
+    ``(denied, error_result_or_None)``.
+
+    THE single source of truth for the layer-2 tool-call governance decision.
+    Both the legacy ``GovernedToolHandler.preprocess`` (strands ``tool_handler``
+    seam, dead on 1.30.0) and the live ``GovernanceToolHook`` (BeforeToolCallEvent
+    seam) call this — so the two can never diverge (the exact root cause of
+    finding 027c4a89 was two decision surfaces, one live and one dead).
+
+    A finding is written on BOTH permit and deny (full audit trail). Ledger
+    write failure is best-effort at this scope (AC 9.4): WARN + continue — the
+    denial itself is NEVER weakened by a ledger outage. The DENY short-circuit
+    (returning an error ToolResult) is independent of whether the finding
+    persisted.
+    """
+    denied = tool_name in denied_tools
+    finding = build_governance_finding(
+        tool_name, denied,
+        agent_id=agent_id, workflow_id=workflow_id, eval_run_id=eval_run_id,
+    )
+    try:
+        write_finding(finding)
+    except LedgerWriteError as exc:
+        logger.warning(
+            'governance ledger write failed at worker-tool-handler '
+            'finding_id=%s tool=%s: %s',
+            finding.finding_id, tool_name, exc,
+        )
+    if denied:
+        return True, _deny_error_result(tool_use_id, tool_name)
+    return False, None
 
 
 class GovernedToolHandler(AgentToolHandler):  # type: ignore[misc]
@@ -178,45 +272,15 @@ class GovernedToolHandler(AgentToolHandler):  # type: ignore[misc]
             tool_name = getattr(tool, 'name', '') or ''
             tool_use_id = getattr(tool, 'toolUseId', '') or ''
 
-        denied = tool_name in self.denied_tools
-        decision = ArbitrationDecision.DENY if denied else ArbitrationDecision.PERMIT
-
-        finding = GovernanceFinding.create(
+        # Delegate to the shared decision (single source of truth, also used by
+        # the live BeforeToolCallEvent seam in governance_tool_hook.py).
+        _denied, error_result = record_governance_decision(
+            tool_name, tool_use_id,
+            agent_id=self.agent_id,
             workflow_id=self.workflow_id,
-            decision=decision,
-            requesting_agent=self.agent_id,
-            target_agent=f'tool:{tool_name}',
-            reason=(
-                f'tool_denied:explicit_deny_list:{tool_name}'
-                if denied
-                else f'tool_permitted:not_on_deny_list:{tool_name}'
-            ),
-            scope_evaluated=SCOPE_WORKER_TOOL_HANDLER,
-            contract_evaluated=None,
+            denied_tools=self.denied_tools,
             eval_run_id=self.eval_run_id,
         )
-
-        try:
-            write_finding(finding)
-        except LedgerWriteError as exc:
-            # Best-effort at worker-tool-handler scope per AC 9.4.
-            # Fail-closed semantics belong at supervisor dispatch
-            # (US-ARB-008), not here — logging + continue is correct.
-            logger.warning(
-                'governance ledger write failed at worker-tool-handler '
-                'finding_id=%s tool=%s: %s',
-                finding.finding_id, tool_name, exc,
-            )
-
-        if denied:
-            # ToolResult-shaped dict; Strands accepts duck-typed dicts.
-            return {
-                'toolUseId': tool_use_id,
-                'status': 'error',
-                'content': [
-                    {'text': f"Tool '{tool_name}' is not authorised for this agent."}
-                ],
-            }
-
-        # PERMIT → fall through to default handler.
-        return None
+        # error_result is the ToolResult-shaped deny dict on DENY, else None
+        # (PERMIT → fall through to the default handler).
+        return error_result

--- a/arbiter/workerWrapper/index.py
+++ b/arbiter/workerWrapper/index.py
@@ -1020,11 +1020,14 @@ def _process_workflow_node(event, message_attributes=None):
         load_file_from_s3_into_tmp(os.environ["AGENT_BUCKET_NAME"], fileName)
 
         # Layer-2 governance parity with the supervisor task path: build the
-        # same governance-carrying subprocess env so the subprocess
-        # GovernedToolHandler is installed for workflow-dispatched agents
-        # instead of being silently bypassed. CITADEL_AGENT_ID is the trigger
-        # (agent_runner patches strands.Agent only when it is set); without it
-        # the handler is never installed and layer-2 tool governance is skipped.
+        # same governance-carrying subprocess env so the subprocess layer-2
+        # governance hook is installed for workflow-dispatched agents instead
+        # of being silently bypassed. CITADEL_AGENT_ID is the trigger
+        # (agent_runner._install_tool_call_hooks builds the GovernanceEvaluator
+        # only when it is set, composed with idempotency on one
+        # BeforeToolCallEvent seam — finding 027c4a89); without it the
+        # governance hook is never installed and layer-2 tool governance is
+        # skipped.
         # The workflow-node per-run correlation id is execution_id — mirroring
         # the supervisor path, which feeds its per-run orchestration_id into the
         # same slot — so ledger findings stay correlatable to a single

--- a/arbiter/workerWrapper/tool_idempotency_hook.py
+++ b/arbiter/workerWrapper/tool_idempotency_hook.py
@@ -345,3 +345,66 @@ class _KeyDerivationFailedTool(AgentTool):  # type: ignore[misc]
             "idempotency key could not be derived from tool input; refused "
             "(fail-closed, no side effect performed)",
         ))
+
+
+class ComposedToolHook:
+    """The SINGLE ``BeforeToolCallEvent`` seam that composes layer-2 tool
+    governance with tool-call idempotency (finding 027c4a89).
+
+    Root cause of 027c4a89: governance and idempotency were two INDEPENDENT
+    ``strands.Agent.__init__`` monkeypatches. Idempotency was re-ported to the
+    hooks API; governance still targeted the removed ``tool_handler`` kwarg and
+    silently went inert. Composing both concerns behind ONE callback (this
+    class) removes the ability for them to diverge again.
+
+    Ordering (invariant): a governance DENIAL is applied FIRST, and on denial we
+    RETURN before the idempotency step runs. Therefore a denied tool:
+      * performs no side effect (``selected_tool`` is swapped for a tool that
+        only yields the deny error), AND
+      * creates NO idempotency reservation / execution-ledger row (``reserve``
+        is never reached) — so no ledger row can imply a completed run that
+        never happened.
+    A DENY audit ``GovernanceFinding`` IS still written (that is the governance
+    findings ledger, distinct from the idempotency execution ledger).
+
+    Either collaborator may be ``None``:
+      * governance-only (supervisor task path): idempotency=None.
+      * governance+idempotency (workflow-node path): both present.
+    At least one MUST be non-None (the installer guarantees this); a fully-empty
+    composed hook would be a no-op.
+    """
+
+    def __init__(
+        self,
+        *,
+        governance: Any | None = None,
+        idempotency: "IdempotencyToolHook | None" = None,
+    ):
+        self._governance = governance
+        self._idempotency = idempotency
+
+    @property
+    def governance(self) -> Any | None:  # pragma: no cover — accessor
+        return self._governance
+
+    @property
+    def idempotency(self) -> "IdempotencyToolHook | None":  # pragma: no cover
+        return self._idempotency
+
+    def register_hooks(self, registry: Any, **_kwargs: Any) -> None:
+        if not _STRANDS_AVAILABLE:  # pragma: no cover — dev/CI guard
+            logger.warning("composed tool hook skipped — strands unavailable")
+            return
+        registry.add_callback(BeforeToolCallEvent, self._on_before_tool_call)
+
+    def _on_before_tool_call(self, event: Any) -> None:
+        # 1) Governance decision FIRST. On DENY the evaluator swaps
+        #    ``event.selected_tool`` for a deny-only tool and returns True; we
+        #    then RETURN so idempotency's reserve/wrap never runs (deny before
+        #    reserve — no reservation, no side effect).
+        if self._governance is not None:
+            if self._governance.evaluate(event):
+                return
+        # 2) PERMIT → idempotency reserve/execute/finalize wrapping.
+        if self._idempotency is not None:
+            self._idempotency._on_before_tool_call(event)

--- a/arbiter/workerWrapper/worker_governance.py
+++ b/arbiter/workerWrapper/worker_governance.py
@@ -185,21 +185,23 @@ def build_subprocess_env(
     ``None``/empty the corresponding env var is not set — keeps the
     existing callers backward compatible.
 
-    The governance triplet drives ``agent_runner._install_governed_tool_handler``:
+    The governance triplet drives ``agent_runner._install_tool_call_hooks``
+    (which builds the ``GovernanceEvaluator`` on the live BeforeToolCallEvent
+    seam, finding 027c4a89):
       - ``CITADEL_AGENT_ID`` is the trigger. When absent the runner does
-        NOT patch ``strands.Agent``, so legacy callers see no change.
+        NOT install the governance hook, so legacy callers see no change.
       - ``CITADEL_WORKFLOW_ID`` flows into every finding written at scope
         ``'worker-tool-handler'`` for trace correlation.
       - ``DENIED_TOOLS`` is the comma-separated allow-list of tools the
-        handler will deny at preprocess time. Callers are responsible for
+        evaluator will deny at tool-call time. Callers are responsible for
         unioning any per-run forbiddenTools (CIT-102 Pass B) into
         ``denied_tools`` BEFORE calling this function — this function only
         serializes whatever set it is given, it never merges.
 
     ``eval_run_id`` (CIT-102 Pass B) is additive and optional: when a
     non-empty string, sets ``CITADEL_EVAL_RUN_ID`` so
-    ``agent_runner._install_governed_tool_handler`` stamps it on the
-    ``GovernedToolHandler`` it constructs. Omitted entirely when absent —
+    ``agent_runner._install_tool_call_hooks`` stamps it on the
+    ``GovernanceEvaluator`` it constructs. Omitted entirely when absent —
     every non-eval caller (the overwhelming majority) produces a
     byte-identical env dict to the pre-CIT-102 shape.
 


### PR DESCRIPTION
## Summary
Layer-2 tool governance has not been running. Every agent execution logged `governance injection skipped - installed strands. Agent does not accept a tool handler kwarg`, and the system continued with a warning. The interposition point the platform documents as intercepting every worker tool call - allow/deny decisions and record-and-block behaviour - was simply not installed on the current Strands version.
The cause is instructive: the idempotency hook was re-ported to the current hooks API while governance injection kept targeting a kwarg that no longer exists. Two independent installers for two concerns at the same seam, and one of them silently stopped working. That divergence, not the kwarg, is the real defect.
## Audit (the most important part)
Before changing anything, every consumer of the removed injection was enumerated and checked at runtime, and the findings were independently spot-checked during review:
- **Layer-2 tool allow/deny governance** - was INERT; fixed by this PR.
- **Approval-required tool gating** - has **zero** non-test references. This was never implemented, rather than implemented and broken. Flagged separately; it is not in scope here, and any documentation claiming it is enforced overstates the current state.
- The inertness premise holds on both the version cited in code and the version actually installed.
## What changed
- Governance and idempotency are now installed as **one composed hook** at a single seam. This is deliberate: two installers are how the drift happened, so the fix removes the possibility rather than repairing this instance of it.
- **Deny before reserve.** A governance denial blocks execution and Leaves no ledger row, so the ledger can never imply a completed call that was actually refused. Both invariants hold: no unauthorised side effect, and no misleading audit row.
- **Fail loud.** Inside an active execution envelope, an uninstallable governance control now fails the node instead of warning - the same rule already applied to the idempotency hook. A security control that quietly disables itself is the defect being fixed, so this PR refuses to reintroduce it.
## Testing
- A denial swaps the selected tool and never reserves - asserted, not assumed.
- A **red differential proof**: with the governance step removed, a denied tool executes; with it in place, it does not.
- Fail-loud tests for both an unavailable agent library and an unimportable governance module.
- Regression under the composed seam: 66 tests covering the idempotency property, the dispatch fence red/green pair, and refusal mapping all pass.
- Arbiter pytest 825 plus 236 stepRunner. Python-only.
## DepLoyment notes
Merge together with the credentials fix and deploy from **main** - deploying either branch alone reverts the other. After deploy, the smoke run exercises governance and idempotency through the same seam for the first time.