### PR TITLE
fix(worker): make ledger writes valid and test the deployment contract

### DIFF
--- a/arbiter/governance/__tests__/test_ledger_contract_moto.py
+++ b/arbiter/governance/__tests__/test_ledger_contract_moto.py
@@ -1,0 +1,197 @@
+"""Real-client (moto) CONTRACT tests for the tool-execution ledger.
+
+Why this file exists (additive to the FakeTable logic tests, never a
+replacement): the FakeTable in ``test_tool_execution_ledger.py`` /
+``test_tool_execution_fence.py`` faithfully models the *conditional-write
+semantics* this module relies on, but it CANNOT catch DynamoDB **wire-contract**
+defects — attribute typing (S vs M), float-vs-Decimal marshalling, or a
+double-marshal on the ``TransactWriteItems`` fenced reserve — because a Python
+dict store neither marshals nor type-checks. Those are exactly the class of bug
+that reached a live dev execution (double-marshal -> "Type mismatch for key pk
+expected: S actual: M"; and native ``float`` timestamps -> "Float types are not
+supported").
+
+These tests run every conditional/transactional write in the reserve ->
+finalize path against a REAL boto3 client backed by moto, so a marshalling or
+attribute-typing regression fails here even though the FakeTable suite stays
+green.
+
+conftest note: ``arbiter/conftest.py`` replaces ``boto3.client`` /
+``boto3.resource`` with MagicMock factories for the whole arbiter suite. We
+deliberately bypass that stub by constructing a REAL resource via
+``boto3.Session().resource(...)`` (the Session class is NOT stubbed) inside the
+``mock_aws`` context, then point the ledger's lazy ``_get_dynamodb_resource``
+seam at it. ``_get_dynamodb_client()`` then returns that resource's
+transform-laden ``.meta.client`` -- the exact object whose double-marshal was
+Bug A.
+"""
+from __future__ import annotations
+
+import os
+import sys
+
+import boto3
+import pytest
+
+try:
+    from moto import mock_aws
+except ImportError:  # pragma: no cover
+    pytest.skip("moto not installed", allow_module_level=True)
+
+_PROJECT_ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "..", ".."))
+if _PROJECT_ROOT not in sys.path:
+    sys.path.insert(0, _PROJECT_ROOT)
+
+from arbiter.governance import tool_execution_ledger as ledger  # noqa: E402
+from arbiter.governance.tool_execution_ledger import (  # noqa: E402
+    ReserveOutcome,
+    StaleWorkerFencedError,
+    __reset_ledger_client_for_test,
+)
+from arbiter.workerWrapper.tool_idempotency import build_key  # noqa: E402
+
+LEDGER_TABLE = "citadel-tool-execution-ledger-moto"
+EXEC_TABLE = "citadel-executions-moto"
+
+
+def _make_ledger_table(resource):
+    resource.create_table(
+        TableName=LEDGER_TABLE,
+        KeySchema=[
+            {"AttributeName": "pk", "KeyType": "HASH"},
+            {"AttributeName": "sk", "KeyType": "RANGE"},
+        ],
+        AttributeDefinitions=[
+            {"AttributeName": "pk", "AttributeType": "S"},
+            {"AttributeName": "sk", "AttributeType": "S"},
+        ],
+        BillingMode="PAY_PER_REQUEST",
+    )
+
+
+def _make_exec_table(resource):
+    return resource.create_table(
+        TableName=EXEC_TABLE,
+        KeySchema=[{"AttributeName": "executionId", "KeyType": "HASH"}],
+        AttributeDefinitions=[{"AttributeName": "executionId", "AttributeType": "S"}],
+        BillingMode="PAY_PER_REQUEST",
+    )
+
+
+@pytest.fixture
+def moto_ledger(monkeypatch):
+    """Real moto-backed resource wired into the ledger's lazy seam."""
+    with mock_aws():
+        # boto3.Session is NOT stubbed by arbiter/conftest.py (only the
+        # module-level boto3.client/resource are), so this reaches moto.
+        resource = boto3.Session(region_name="us-east-1").resource("dynamodb")
+        _make_ledger_table(resource)
+        exec_table = _make_exec_table(resource)
+
+        monkeypatch.setenv("TOOL_EXECUTION_LEDGER_TABLE", LEDGER_TABLE)
+        monkeypatch.setenv("EXECUTIONS_TABLE", EXEC_TABLE)
+        __reset_ledger_client_for_test()
+        monkeypatch.setattr(ledger, "_get_dynamodb_resource", lambda: resource)
+        try:
+            yield {"resource": resource, "exec_table": exec_table}
+        finally:
+            __reset_ledger_client_for_test()
+
+
+def _raw_item(pk, sk):
+    """Read the row via a fresh low-level client (marshalled view) to assert on
+    the ACTUAL stored attribute types, not the auto-unmarshalled resource view."""
+    client = boto3.Session(region_name="us-east-1").client("dynamodb")
+    resp = client.get_item(TableName=LEDGER_TABLE, Key={"pk": {"S": pk}, "sk": {"S": sk}})
+    return resp.get("Item")
+
+
+# ---------------------------------------------------------------------------
+# Unfenced reserve — conditional first-write-wins + correct attribute types
+# ---------------------------------------------------------------------------
+
+
+class TestUnfencedReserveContract:
+    def test_reserve_persists_string_keys_and_numeric_timestamps(self, moto_ledger):
+        pk, sk = build_key("orgA", "exec1", "node1", 0, "createTicket", {"x": 1})
+        result = ledger.reserve(pk, sk, tool_name="createTicket", now=1_000.5)
+        assert result.outcome == ReserveOutcome.WON
+
+        raw = _raw_item(pk, sk)
+        assert raw is not None
+        # pk/sk MUST be stored as scalar String (S), not Map (M) — the exact
+        # regression the double-marshal produced ("expected S actual M").
+        assert set(raw["pk"].keys()) == {"S"} and raw["pk"]["S"] == pk
+        assert set(raw["sk"].keys()) == {"S"} and raw["sk"]["S"] == sk
+        # timestamps stored as Number (int), not rejected as float.
+        assert raw["createdAt"] == {"N": "1000"}
+        assert raw["status"] == {"S": "in_flight"}
+
+    def test_concurrent_race_second_reserve_does_not_win(self, moto_ledger):
+        pk, sk = build_key("orgA", "exec1", "node1", 0, "createTicket", {"x": 1})
+        first = ledger.reserve(pk, sk, tool_name="createTicket", now=2000.0)
+        assert first.outcome == ReserveOutcome.WON
+        # Second reserve of the SAME key: the real conditional
+        # attribute_not_exists(pk) write is refused; a live holder -> IN_FLIGHT.
+        second = ledger.reserve(pk, sk, tool_name="createTicket", now=2000.0)
+        assert second.outcome == ReserveOutcome.IN_FLIGHT
+
+    def test_finalize_success_transitions_to_completed(self, moto_ledger):
+        pk, sk = build_key("orgA", "exec1", "node1", 0, "createTicket", {"x": 1})
+        ledger.reserve(pk, sk, tool_name="createTicket", now=3000.0)
+        ledger.finalize_success(pk, sk, result={"ticketId": "T-1"}, now=3001.0)
+        row = ledger.get(pk, sk)
+        assert row["status"] == "completed"
+        # updatedAt persisted as an int-derived Number (a float would have raised).
+        raw = _raw_item(pk, sk)
+        assert raw["updatedAt"] == {"N": "3001"}
+
+    def test_release_then_rereserve(self, moto_ledger):
+        pk, sk = build_key("orgA", "exec1", "node1", 0, "createTicket", {"x": 1})
+        ledger.reserve(pk, sk, tool_name="createTicket", now=4000.0)
+        ledger.release(pk, sk)
+        assert ledger.get(pk, sk)["status"] == "released"
+        # A released row is re-reservable via the conditional CAS.
+        again = ledger.reserve(pk, sk, tool_name="createTicket", now=4001.0)
+        assert again.outcome == ReserveOutcome.WON
+        assert again.reclaimed is True
+
+
+# ---------------------------------------------------------------------------
+# Fenced reserve — the TransactWriteItems that carried the double-marshal
+# ---------------------------------------------------------------------------
+
+
+class TestFencedReserveContract:
+    def _seed_exec(self, exec_table, gen):
+        exec_table.put_item(
+            Item={
+                "executionId": "exec1",
+                "nodeResults": {"node1": {"dispatchGeneration": gen}},
+            }
+        )
+
+    def test_fenced_reserve_matching_generation_wins(self, moto_ledger):
+        self._seed_exec(moto_ledger["exec_table"], 2)
+        pk, sk = build_key("orgA", "exec1", "node1", 0, "createTicket", {"x": 1})
+        result = ledger.reserve(
+            pk, sk, tool_name="createTicket", now=5000.0,
+            dispatch_generation=2, execution_id="exec1", node_id="node1",
+        )
+        assert result.outcome == ReserveOutcome.WON
+        raw = _raw_item(pk, sk)
+        # The fenced Put landed with correctly-typed scalar keys (single marshal).
+        assert raw["pk"] == {"S": pk}
+        assert raw["dispatchGeneration"] == {"N": "2"}
+
+    def test_fenced_reserve_stale_generation_rejected(self, moto_ledger):
+        # Execution row is at generation 2; a worker carrying stale gen 1 must be
+        # refused at the reserve fence (ConditionCheck) with NO ledger row written.
+        self._seed_exec(moto_ledger["exec_table"], 2)
+        pk, sk = build_key("orgA", "exec1", "node1", 0, "createTicket", {"x": 1})
+        with pytest.raises(StaleWorkerFencedError):
+            ledger.reserve(
+                pk, sk, tool_name="createTicket", now=5000.0,
+                dispatch_generation=1, execution_id="exec1", node_id="node1",
+            )
+        assert ledger.get(pk, sk) is None  # nothing written on the stale reject

--- a/arbiter/governance/__tests__/test_tool_execution_fence.py
+++ b/arbiter/governance/__tests__/test_tool_execution_fence.py
@@ -7,13 +7,16 @@ generation guard to be evaluated inside the SAME conditional write as the
 reserve — so it is implemented as a ``ConditionCheck`` on the execution row
 inside the reserve's ``TransactWriteItems``.
 
-The fake ``transact_write_items`` here is FAITHFUL: it unmarshals the real
-marshalled TransactItems (exercising ``_marshal``/``TypeSerializer``),
-evaluates BOTH the ledger ``attribute_not_exists`` Put condition and the
-execution-row generation ``ConditionCheck`` against shared state, and raises a
-real ``TransactionCanceledException`` with per-item ``CancellationReasons`` —
-so the differential RED (unfenced double-execute) and the TOCTOU proof
-(a generation bump interleaved at commit time) both bite for the right reason.
+The fake ``transact_write_items`` here mirrors the CORRECTED contract: production
+passes **native** Python values in the ``TransactItems`` (the resource-backed
+client auto-marshals them exactly once), so the fake reads them natively — no
+manual unmarshalling. It evaluates BOTH the ledger ``attribute_not_exists`` Put
+condition and the execution-row generation ``ConditionCheck`` against shared
+state, and raises a real ``TransactionCanceledException`` with per-item
+``CancellationReasons`` — so the differential RED (unfenced double-execute) and
+the TOCTOU proof (a generation bump interleaved at commit time) both bite for
+the right reason. Real-DynamoDB attribute typing / double-marshal regressions
+are covered by the moto contract suite (``test_ledger_contract_moto.py``).
 """
 from __future__ import annotations
 
@@ -22,7 +25,6 @@ import sys
 
 import pytest
 from botocore.exceptions import ClientError
-from boto3.dynamodb.types import TypeDeserializer
 
 _PROJECT_ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "..", ".."))
 if _PROJECT_ROOT not in sys.path:
@@ -39,12 +41,6 @@ from arbiter.workerWrapper.tool_idempotency import MODE_LEDGER, build_key  # noq
 
 LEDGER_TABLE = "citadel-tool-execution-ledger-test"
 EXEC_TABLE = "citadel-executions-test"
-
-_deser = TypeDeserializer()
-
-
-def _unmarshal(marshalled: dict) -> dict:
-    return {k: _deser.deserialize(v) for k, v in marshalled.items()}
 
 
 class _FakeLedgerTable:
@@ -117,15 +113,19 @@ class _FakeClient:
     def transact_write_items(self, TransactItems):  # noqa: N803
         put = TransactItems[0]["Put"]
         check = TransactItems[1]["ConditionCheck"]
-        put_item = _unmarshal(put["Item"])
+        # Production passes NATIVE values (the resource-backed client
+        # auto-marshals once); the fake mirrors that. A regression back to
+        # pre-marshalled {"S": ...} maps would make pk/sk dicts here and blow
+        # up — the in-process analogue of DynamoDB's "expected S actual M".
+        put_item = put["Item"]
         put_ok = self._ledger.store.get((put_item[ledger.PK_ATTR], put_item[ledger.SK_ATTR])) is None
 
         if self.pre_eval_hook is not None:
             self.pre_eval_hook()
 
-        check_key = _unmarshal(check["Key"])
+        check_key = check["Key"]
         names = check["ExpressionAttributeNames"]
-        gen_value = _deser.deserialize(check["ExpressionAttributeValues"][":gen"])
+        gen_value = check["ExpressionAttributeValues"][":gen"]
         row = self._exec.get(check_key["executionId"], {})
         node = (row.get("nodeResults") or {}).get(names["#nid"], {})
         current = node.get(names["#gen"])

--- a/arbiter/governance/tool_execution_ledger.py
+++ b/arbiter/governance/tool_execution_ledger.py
@@ -66,7 +66,6 @@ from numbers import Number
 from typing import Any, Callable
 
 import boto3
-from boto3.dynamodb.types import TypeSerializer
 from botocore.exceptions import BotoCoreError, ClientError
 
 logger = logging.getLogger(__name__)
@@ -275,40 +274,28 @@ def __reset_ledger_client_for_test() -> None:
 
 # --- Lazy DynamoDB client (fenced reserve uses TransactWriteItems) -----------
 
-_serializer = TypeSerializer()
-
 
 def _get_dynamodb_client() -> Any:
-    """The low-level DynamoDB client backing the resource.
+    """The DynamoDB client backing the resource, used for ``TransactWriteItems``.
 
-    ``TransactWriteItems`` (the fenced reserve) is a client-level operation
-    with no resource-Table equivalent. Reusing ``resource.meta.client`` keeps
-    a single credential/config source and lets a test that patches
-    :func:`_get_dynamodb_resource` reach a fake client through ``.meta.client``
-    with no second seam.
+    ``TransactWriteItems`` (the fenced reserve) has no resource-``Table``
+    equivalent, so it must go through a client. We deliberately reuse
+    ``resource.meta.client`` — the SAME client the resource ``Table`` calls sit
+    on — so this module speaks ONE DynamoDB dialect end to end: **native Python
+    values everywhere**. boto3 registers its DynamoDB (un)marshalling transform
+    on that client, so ``transact_write_items`` auto-marshals the native
+    ``TransactItems`` exactly once — identical to what ``Table.put_item`` /
+    ``Table.update_item`` do on the single-item paths.
+
+    Do NOT hand this client pre-marshalled ``{"S": ...}`` AttributeValue maps:
+    the transform would marshal them a SECOND time (``{"M": {"S": {...}}}``),
+    which real DynamoDB rejects with ``Type mismatch for key pk expected: S
+    actual: M``. Keep every value native and let the single transform do the
+    work. (This module previously marshalled by hand AND passed the result to
+    this transform-laden client — the double-marshal that broke the fenced
+    reserve.)
     """
     return _get_dynamodb_resource().meta.client
-
-
-def _to_ddb_number_safe(obj: Any) -> Any:
-    """Recursively convert ``float`` to ``Decimal`` so ``TypeSerializer`` (which
-    rejects floats) can marshal a ledger item for the client-level transaction.
-    Ints/strings/None/bools/containers pass through unchanged."""
-    if isinstance(obj, bool):
-        return obj
-    if isinstance(obj, float):
-        return Decimal(str(obj))
-    if isinstance(obj, dict):
-        return {k: _to_ddb_number_safe(v) for k, v in obj.items()}
-    if isinstance(obj, (list, tuple)):
-        return [_to_ddb_number_safe(v) for v in obj]
-    return obj
-
-
-def _marshal(mapping: dict[str, Any]) -> dict[str, Any]:
-    """Marshal a plain dict to DynamoDB AttributeValue JSON for the client API."""
-    safe = _to_ddb_number_safe(mapping)
-    return {k: _serializer.serialize(v) for k, v in safe.items()}
 
 
 # --- Lazy S3 client (oversized-result offload) -------------------------------
@@ -427,14 +414,14 @@ def _reclaim_stale(pk: str, sk: str, *, seen_created_at: Any, now: float) -> boo
     try:
         _table().update_item(
             Key={PK_ATTR: pk, SK_ATTR: sk},
-            UpdateExpression="SET #s = :inflight, createdAt = :now, updatedAt = :now, ttl = :ttl",
+            UpdateExpression="SET #s = :inflight, createdAt = :now, updatedAt = :now, #ttl = :ttl",
             ConditionExpression="#s = :inflight_guard AND createdAt = :seen",
-            ExpressionAttributeNames={"#s": "status"},
+            ExpressionAttributeNames={"#s": "status", "#ttl": "ttl"},
             ExpressionAttributeValues={
                 ":inflight": STATUS_IN_FLIGHT,
                 ":inflight_guard": STATUS_IN_FLIGHT,
                 ":seen": seen_created_at,
-                ":now": now,
+                ":now": int(now),
                 ":ttl": int(now) + ttl_seconds(),
             },
         )
@@ -456,13 +443,13 @@ def _reclaim_released(pk: str, sk: str, *, now: float) -> bool:
     try:
         _table().update_item(
             Key={PK_ATTR: pk, SK_ATTR: sk},
-            UpdateExpression="SET #s = :inflight, createdAt = :now, updatedAt = :now, ttl = :ttl",
+            UpdateExpression="SET #s = :inflight, createdAt = :now, updatedAt = :now, #ttl = :ttl",
             ConditionExpression="#s = :released",
-            ExpressionAttributeNames={"#s": "status"},
+            ExpressionAttributeNames={"#s": "status", "#ttl": "ttl"},
             ExpressionAttributeValues={
                 ":inflight": STATUS_IN_FLIGHT,
                 ":released": STATUS_RELEASED,
-                ":now": now,
+                ":now": int(now),
                 ":ttl": int(now) + ttl_seconds(),
             },
         )
@@ -545,21 +532,25 @@ def _reserve_fenced(
             "dispatch fence requested but EXECUTIONS_TABLE not configured — "
             "cannot evaluate the generation guard (fail-closed)"
         )
+    # Native values ONLY. The resource-backed client (see _get_dynamodb_client)
+    # auto-marshals these exactly once, matching the single-item paths. Passing
+    # pre-marshalled AttributeValue maps here would double-marshal and DynamoDB
+    # would reject the ledger pk as type M (expected S).
     transact_items = [
         {
             "Put": {
                 "TableName": ledger_table,
-                "Item": _marshal(item),
+                "Item": item,
                 "ConditionExpression": f"attribute_not_exists({PK_ATTR})",
             }
         },
         {
             "ConditionCheck": {
                 "TableName": exec_table,
-                "Key": _marshal({"executionId": execution_id}),
+                "Key": {"executionId": execution_id},
                 "ConditionExpression": "nodeResults.#nid.#gen = :gen",
                 "ExpressionAttributeNames": {"#nid": node_id, "#gen": "dispatchGeneration"},
-                "ExpressionAttributeValues": {":gen": _serializer.serialize(int(dispatch_generation))},
+                "ExpressionAttributeValues": {":gen": int(dispatch_generation)},
             }
         },
     ]
@@ -619,16 +610,22 @@ def reserve(
     conditional ``PutItem`` — exactly-once-within-attempt only.
     """
     now = time.time() if now is None else now
+    now_i = int(now)
     item = {
         PK_ATTR: pk,
         SK_ATTR: sk,
         "status": STATUS_IN_FLIGHT,
         "toolName": tool_name,
-        "createdAt": now,
-        "updatedAt": now,
+        # Timestamps stored as INTEGER epoch seconds: boto3's DynamoDB marshaller
+        # (resource Table AND the resource-backed client behind the fenced
+        # transact) rejects native ``float`` ("Float types are not supported");
+        # ints marshal cleanly and second precision is ample for a 48h TTL /
+        # lease window.
+        "createdAt": now_i,
+        "updatedAt": now_i,
         # TTL derived from SERVER write-time (not a producer clock), so a
         # skewed/malicious producer cannot force early expiry.
-        "ttl": int(now) + ttl_seconds(),
+        "ttl": now_i + ttl_seconds(),
     }
     if dispatch_generation is not None:
         if not (execution_id and node_id):
@@ -685,17 +682,23 @@ def wait_for_terminal(
 def _finalize(pk: str, sk: str, *, attributes: dict[str, Any], now: float) -> None:
     """Transition an in-flight row to a terminal state (guarded)."""
     names = {"#s": "status"}
-    values: dict[str, Any] = {":inflight": STATUS_IN_FLIGHT, ":now": now}
+    values: dict[str, Any] = {":inflight": STATUS_IN_FLIGHT, ":now": int(now)}
     set_parts = ["#s = :status", "updatedAt = :now"]
     for i, (key, value) in enumerate(attributes.items()):
+        # 'status' is written via the fixed ``#s = :status`` clause above; it
+        # must NOT also get an ``#a{i}`` name alias, or that alias is declared
+        # in ExpressionAttributeNames but never referenced — which real
+        # DynamoDB rejects ("Value provided in ExpressionAttributeNames unused
+        # in expressions"). Only non-status attributes contribute an aliased
+        # ``#a{i} = :v{i}`` assignment.
+        if key == "status":
+            values[":status"] = value
+            continue
         placeholder = f":v{i}"
         name_placeholder = f"#a{i}"
         names[name_placeholder] = key
         values[placeholder] = value
-        if key == "status":
-            values[":status"] = value
-        else:
-            set_parts.append(f"{name_placeholder} = {placeholder}")
+        set_parts.append(f"{name_placeholder} = {placeholder}")
     if ":status" not in values:
         raise LedgerError("_finalize requires a 'status' attribute")
     try:
@@ -772,7 +775,7 @@ def release(pk: str, sk: str) -> None:
     matrix). Guarded by ``status = in_flight`` so a completed/failed record is
     never clobbered.
     """
-    now = time.time()
+    now = int(time.time())
     try:
         _table().update_item(
             Key={PK_ATTR: pk, SK_ATTR: sk},

--- a/arbiter/requirements-dev.txt
+++ b/arbiter/requirements-dev.txt
@@ -1,2 +1,10 @@
 pytest==9.1.1
 hypothesis==6.161.5
+# Real-client DynamoDB contract tests (deployment-contract hardening): moto
+# provides an in-process AWS mock that ENFORCES DynamoDB wire semantics
+# (attribute typing S/M, float-vs-Decimal marshalling, expression/attribute-name
+# validity, reserved keywords) — the class of defect a dict-backed FakeTable
+# cannot catch. Chosen over DynamoDB Local (no Docker/JVM dependency; pure
+# Python, integrates directly with the existing pytest suite). Version resolved
+# from PyPI (latest, no advisories), not hand-written.
+moto[dynamodb]==5.2.3

--- a/arbiter/stepRunner/__tests__/test_node_failure_contract_moto.py
+++ b/arbiter/stepRunner/__tests__/test_node_failure_contract_moto.py
@@ -1,0 +1,90 @@
+"""Real-client (moto) CONTRACT test for the step runner's node-failure UpdateItem.
+
+The terminal node-failure branch of ``handle_node_failure`` issues an
+``update_item`` that sets BOTH the node status (``nodeResults.<nid>.status``)
+and the execution status to 'failed'. A malformed ExpressionAttributeNames on
+that call (a declared alias that the expression never references) is rejected by
+real DynamoDB with "Value provided in ExpressionAttributeNames unused in
+expressions" — which crashed the handler on every retry and stranded the
+execution in status=running (Bug B).
+
+The FakeTable-style stand-ins in the other stepRunner tests do not validate
+expression/attribute-name consistency, so this defect was invisible to them.
+This test runs the REAL update against moto, so an unused-alias (or reserved-
+keyword, or attribute-typing) regression on this write fails here.
+"""
+import json
+import os
+import sys
+
+import boto3
+import pytest
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+
+try:
+    from moto import mock_aws
+except ImportError:  # pragma: no cover
+    pytest.skip("moto not installed", allow_module_level=True)
+
+import executor  # noqa: E402
+
+EXEC_TABLE = "citadel-executions-sr-moto"
+WF_TABLE = "citadel-workflows-sr-moto"
+
+
+@pytest.fixture
+def moto_executor(monkeypatch):
+    with mock_aws():
+        resource = boto3.Session(region_name="us-east-1").resource("dynamodb")
+        exec_table = resource.create_table(
+            TableName=EXEC_TABLE,
+            KeySchema=[{"AttributeName": "executionId", "KeyType": "HASH"}],
+            AttributeDefinitions=[{"AttributeName": "executionId", "AttributeType": "S"}],
+            BillingMode="PAY_PER_REQUEST",
+        )
+        wf_table = resource.create_table(
+            TableName=WF_TABLE,
+            KeySchema=[{"AttributeName": "workflowId", "KeyType": "HASH"}],
+            AttributeDefinitions=[{"AttributeName": "workflowId", "AttributeType": "S"}],
+            BillingMode="PAY_PER_REQUEST",
+        )
+        # Point the executor's module-global tables at the real moto tables.
+        monkeypatch.setattr(executor, "_executions_table", exec_table)
+        monkeypatch.setattr(executor, "_workflows_table", wf_table)
+        yield {"exec_table": exec_table, "wf_table": wf_table}
+
+
+def _seed(exec_table, wf_table):
+    # A single-node workflow whose node has no retry policy (maxRetries=0), so a
+    # failure lands directly in the terminal no-retry branch under test.
+    wf_table.put_item(
+        Item={
+            "workflowId": "wf1",
+            "definition": json.dumps({"nodes": [{"id": "node1", "data": {}}], "edges": []}),
+        }
+    )
+    exec_table.put_item(
+        Item={
+            "executionId": "exec1",
+            "workflowId": "wf1",
+            "status": "running",
+            "nodeResults": {"node1": {"status": "running", "agentId": "agentA"}},
+        }
+    )
+
+
+class TestNodeFailureUpdatePersists:
+    def test_terminal_failure_persists_node_and_execution_status(self, moto_executor):
+        exec_table = moto_executor["exec_table"]
+        _seed(exec_table, moto_executor["wf_table"])
+
+        # Pre-fix, this raised ValidationException (unused #nstatus alias) and
+        # never persisted — the execution stayed 'running'.
+        executor.handle_node_failure("exec1", "node1", "BoomError")
+
+        row = exec_table.get_item(Key={"executionId": "exec1"})["Item"]
+        assert row["status"] == "failed"  # execution status persisted
+        assert row["nodeResults"]["node1"]["status"] == "failed"  # node status persisted
+        assert row["nodeResults"]["node1"]["error"] == "BoomError"
+        assert "failedAt" in row

--- a/arbiter/stepRunner/executor.py
+++ b/arbiter/stepRunner/executor.py
@@ -1217,7 +1217,15 @@ def handle_node_failure(execution_id: str, node_id: str, error: str) -> None:
             retryCount=new_retry_count,
         )
     else:
-        # No retry — mark node and execution as failed
+        # No retry — mark node and execution as failed.
+        # The single ``#status`` alias ('status') is reused for BOTH the node
+        # (nodeResults.#nid.#status) and the execution (#status) attributes.
+        # (A leftover ``#nstatus`` alias here was declared but never referenced
+        # in the expression, so DynamoDB rejected the whole UpdateItem with
+        # "Value provided in ExpressionAttributeNames unused in expressions" —
+        # crashing the handler on every retry and stranding the execution in
+        # status=running. Both statuses ARE meant to persist; the alias was the
+        # only defect.)
         _executions_table.update_item(
             Key={'executionId': execution_id},
             UpdateExpression='SET nodeResults.#nid.#status = :nstatus, nodeResults.#nid.#error = :error, #status = :estatus, #failedAt = :failedAt',
@@ -1225,7 +1233,6 @@ def handle_node_failure(execution_id: str, node_id: str, error: str) -> None:
                 '#nid': node_id,
                 '#status': 'status',
                 '#failedAt': 'failedAt',
-                '#nstatus': 'status',
                 '#error': 'error',
             },
             ExpressionAttributeValues={

--- a/backend/lib/arbiter-stack.ts
+++ b/backend/lib/arbiter-stack.ts
@@ -1918,6 +1918,37 @@ export class ArbiterStack extends cdk.Stack {
     );
     const governanceLedgerTable = this.governanceLedgerTable;
 
+    // ============================================================
+    // Governance legibility wiring for WorkerAgentWrapper (Bug C)
+    // ============================================================
+    // WorkerAgentWrapper is declared far earlier in this constructor (before
+    // the governance ledger table construct exists), so — like
+    // SeedAgentConfigFunction above — its governance-ledger env var and grant
+    // are patched in here now that `governanceLedgerTable` is defined.
+    //
+    // Without GOVERNANCE_LEDGER_TABLE on the worker's env, the governed tool
+    // path's write-once legibility record (arbiter/governance/ledger.py) fails
+    // CLOSED on EVERY tool call ("GOVERNANCE_LEDGER_TABLE not configured —
+    // cannot produce legibility record") — a missing legibility record means
+    // the decision cannot be honoured (Article 3), so no governed tool runs.
+    //
+    // The grant is deliberately dynamodb:PutItem ONLY on the single ledger
+    // table ARN — the ledger is write-once (a conditional
+    // attribute_not_exists(findingId) PutItem), so no UpdateItem/DeleteItem/
+    // Query/Scan and no wildcard, matching the least-privilege shape of the
+    // sibling governance writers and this worker's own tool-ledger grant.
+    workerAgentWrapperLambda.addEnvironment(
+      "GOVERNANCE_LEDGER_TABLE",
+      governanceLedgerTable.tableName,
+    );
+    workerAgentWrapperLambda.addToRolePolicy(
+      new iam.PolicyStatement({
+        effect: iam.Effect.ALLOW,
+        actions: ["dynamodb:PutItem"],
+        resources: [governanceLedgerTable.tableArn],
+      }),
+    );
+
     governanceLedgerTable.addGlobalSecondaryIndex({
       indexName: "workflow-index",
       partitionKey: { name: "workflowId", type: dynamodb.AttributeType.STRING },

--- a/backend/test/arbiter-stack-env-parity.test.ts
+++ b/backend/test/arbiter-stack-env-parity.test.ts
@@ -1,0 +1,277 @@
+import * as cdk from "aws-cdk-lib";
+import { Template } from "aws-cdk-lib/assertions";
+import * as dynamodb from "aws-cdk-lib/aws-dynamodb";
+import * as events from "aws-cdk-lib/aws-events";
+import * as lambda from "aws-cdk-lib/aws-lambda";
+import * as appsync from "aws-cdk-lib/aws-appsync";
+import { Bucket } from "aws-cdk-lib/aws-s3";
+import * as fs from "fs";
+import * as path from "path";
+import {
+  scaffoldBackendAssetDirs,
+  scaffoldArbiterStubs,
+} from "./helpers/scaffold-stub-assets";
+
+scaffoldBackendAssetDirs(["dist/lambda", "src/schema"]);
+scaffoldArbiterStubs();
+
+import { ArbiterStack } from "../lib/arbiter-stack";
+
+const ARBITER_ROOT = path.resolve(__dirname, "../../arbiter");
+
+/**
+ * GENERIC env-var parity guard.
+ *
+ * Contract: every environment variable a Lambda handler READS from its own
+ * runtime (os.environ[...] / os.environ.get(...) / os.getenv(...)) — across its
+ * entry package AND the specific shared-layer seam modules it executes — must
+ * be PROVIDED on the corresponding synthesized CDK function, unless it is on a
+ * documented allowlist of genuinely-optional / ambient / subprocess-injected
+ * vars.
+ *
+ * This is the class of defect behind Bug C: the worker's governed-tool path
+ * reads GOVERNANCE_LEDGER_TABLE (in the layer module arbiter/governance/
+ * ledger.py) to write its write-once legibility record, but the WorkerAgentWrapper
+ * function env never set it — so every governed tool call failed closed
+ * ("cannot produce legibility record"). A FakeTable / unit test cannot see a
+ * missing *deployment* env var; only a synth-vs-source parity check does.
+ *
+ * Scoping (deliberate, documented): we scan each function's entry directory
+ * plus ONLY the layer seam modules that function actually runs — not the whole
+ * shared layer — so unrelated layer modules (e.g. governance/engine.py,
+ * d4_retrospective.py) don't over-attribute their env reads to a function that
+ * never executes them.
+ */
+
+const ENV_READ_PATTERNS = [
+  /os\.environ\.get\(\s*['"]([A-Z0-9_]+)['"]/g,
+  /os\.getenv\(\s*['"]([A-Z0-9_]+)['"]/g,
+  /os\.environ\[\s*['"]([A-Z0-9_]+)['"]\s*\]/g,
+];
+
+function pyFilesUnder(target: string): string[] {
+  const abs = path.join(ARBITER_ROOT, target);
+  const stat = fs.statSync(abs);
+  if (stat.isFile()) return [abs];
+  const out: string[] = [];
+  const walk = (dir: string) => {
+    for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+      const p = path.join(dir, entry.name);
+      if (entry.isDirectory()) {
+        // Skip test + cache dirs — we want production runtime reads only.
+        if (entry.name === "__tests__" || entry.name === "__pycache__")
+          continue;
+        walk(p);
+      } else if (entry.name.endsWith(".py")) {
+        out.push(p);
+      }
+    }
+  };
+  walk(abs);
+  return out;
+}
+
+function envVarsRead(targets: string[]): Set<string> {
+  const names = new Set<string>();
+  for (const t of targets) {
+    for (const file of pyFilesUnder(t)) {
+      const src = fs.readFileSync(file, "utf8");
+      for (const re of ENV_READ_PATTERNS) {
+        for (const m of src.matchAll(re)) names.add(m[1]);
+      }
+    }
+  }
+  return names;
+}
+
+function functionEnvKeys(
+  template: Template,
+  logicalIdPrefix: string,
+): Set<string> {
+  const fns = template.findResources("AWS::Lambda::Function");
+  const match = Object.entries(fns).find(([id]) =>
+    id.startsWith(logicalIdPrefix),
+  );
+  if (!match) {
+    throw new Error(
+      `no synthesized function with logical id prefix ${logicalIdPrefix}`,
+    );
+  }
+  const vars = (match[1] as any).Properties?.Environment?.Variables ?? {};
+  return new Set(Object.keys(vars));
+}
+
+/**
+ * Allowlist of env vars a handler may read WITHOUT the CDK function setting
+ * them, each with a documented reason. Split into a shared set (ambient /
+ * Lambda-runtime / subprocess-injected) and per-function optional/feature-gated
+ * sets. Anything read but not here AND not set on the function fails the test.
+ */
+const AMBIENT_OR_SUBPROCESS = new Set<string>([
+  // Lambda runtime / ambient credentials + tracing — injected by the platform.
+  "AWS_ACCESS_KEY_ID",
+  "AWS_SECRET_ACCESS_KEY",
+  "AWS_REGION",
+  "PATH",
+  "_X_AMZN_TRACE_ID",
+  // Per-invocation dispatch context the worker sets on the agent SUBPROCESS's
+  // env at launch (never a CDK function env var): see workerWrapper subprocess
+  // launch. All CITADEL_* + MODEL_OVERRIDE are in this class.
+  "CITADEL_AGENT_ID",
+  "CITADEL_DISPATCH_GENERATION",
+  "CITADEL_EVAL_RUN_ID",
+  "CITADEL_EXECUTION_ID",
+  "CITADEL_NODE_ID",
+  "CITADEL_ORG_ID",
+  "CITADEL_WORKFLOW_ID",
+  "MODEL_OVERRIDE",
+]);
+
+interface Target {
+  name: string;
+  logicalIdPrefix: string;
+  // Entry package + the specific layer seam modules this function executes.
+  sources: string[];
+  // Function-specific optional / feature-gated / tunable vars (read defensively
+  // via .get() with a fallback/skip), documented per entry.
+  optional: Set<string>;
+}
+
+const TARGETS: Target[] = [
+  {
+    name: "WorkerAgentWrapper",
+    logicalIdPrefix: "WorkerAgentWrapper",
+    sources: [
+      "workerWrapper",
+      // Governed-tool legibility seam (write-once ledger) — GOVERNANCE_LEDGER_TABLE
+      // lives here, NOT in workerWrapper/. This is the Bug C seam.
+      "governance/ledger.py",
+      // Tool-idempotency ledger the worker reserves/finalizes against.
+      "governance/tool_execution_ledger.py",
+    ],
+    optional: new Set<string>([
+      // Feature-gated / defensive reads (os.environ.get(...) with None/default,
+      // never fail-closed for the core path):
+      "TOOLS_CONFIG_TABLE", // dynamic-tools config; None-guarded, feature-gated
+      "DENIED_TOOLS", // optional deny list; '' default
+      "EVENT_BUS_NAME", // legacy alias; the worker emits on COMPLETION_BUS_NAME (which IS set)
+      "RELEASE_DEFAULT_ORG_ID", // release-attribution seam; only set in release-enabled envs
+      "WORKER_MAX_PROMPT_ADDITION_CHARS", // size cap tunable; has a default
+      // tool-execution-ledger tunables — all have defaults (_int_env/_float_env):
+      "TOOL_LEDGER_TTL_SECONDS",
+      "TOOL_RESULT_MAX_INLINE_BYTES",
+      "TOOL_LEDGER_LEASE_SECONDS",
+      "TOOL_LEDGER_POLL_TIMEOUT_SECONDS",
+      "TOOL_LEDGER_POLL_INTERVAL_SECONDS",
+      // governance ledger correlation id — best-effort, absent-tolerant:
+      "ENVIRONMENT",
+    ]),
+  },
+  {
+    name: "StepRunnerFunction",
+    logicalIdPrefix: "StepRunnerFunction",
+    sources: ["stepRunner"],
+    optional: new Set<string>([
+      "REGISTRY_ENABLED", // registry feature gate; default off
+      "REGISTRY_ID", // only read when REGISTRY_ENABLED
+      "WORKFLOW_TIMEOUT_SECONDS", // watchdog tunable; has a default
+      "RELEASE_DEFAULT_ORG_ID", // release-attribution seam; feature-gated env
+      "RELEASE_DISPATCH_ENVIRONMENT", // release-dispatch feature switch; feature-gated env
+    ]),
+  },
+];
+
+describe("ArbiterStack — handler env-var parity (deployment contract)", () => {
+  let template: Template;
+
+  beforeAll(() => {
+    const app = new cdk.App({ context: { "aws:cdk:bundling-stacks": [] } });
+    const backendStack = new cdk.Stack(app, "MockBackendStack", {
+      env: { account: "123456789012", region: "us-east-1" },
+    });
+    const agentEventBus = new events.EventBus(backendStack, "AgentEventBus", {
+      eventBusName: "citadel-agents-test",
+    });
+    const mkTable = (id: string, name: string, pk: string) =>
+      new dynamodb.Table(backendStack, id, {
+        tableName: name,
+        partitionKey: { name: pk, type: dynamodb.AttributeType.STRING },
+        billingMode: dynamodb.BillingMode.PAY_PER_REQUEST,
+        removalPolicy: cdk.RemovalPolicy.DESTROY,
+      });
+    const agentConfigTable = mkTable(
+      "AgentConfigTable",
+      "citadel-agents-test",
+      "agentId",
+    );
+    const workflowsTable = mkTable(
+      "WorkflowsTable",
+      "citadel-workflows-test",
+      "workflowId",
+    );
+    const executionsTable = mkTable(
+      "ExecutionsTable",
+      "citadel-executions-test",
+      "executionId",
+    );
+    const executionSpecificationsTable = mkTable(
+      "ExecutionSpecificationsTable",
+      "citadel-execution-specifications-test",
+      "specId",
+    );
+    const codeBucket = new Bucket(backendStack, "CodeBucket", {
+      bucketName: "citadel-code-test",
+    });
+    const fanoutFunction = new lambda.Function(backendStack, "FanoutFunction", {
+      runtime: lambda.Runtime.NODEJS_24_X,
+      handler: "workflow-progress-fanout.handler",
+      code: lambda.Code.fromAsset("dist/lambda"),
+      timeout: cdk.Duration.seconds(30),
+    });
+    const appSyncApi = new appsync.GraphqlApi(backendStack, "MockApi", {
+      name: "mock-api",
+      schema: appsync.SchemaFile.fromAsset(
+        path.resolve(__dirname, "../src/schema/schema.graphql"),
+      ),
+    });
+
+    const stack = new ArbiterStack(app, "TestArbiterStack", {
+      environment: "test",
+      env: { account: "123456789012", region: "us-east-1" },
+      agentEventBus,
+      agentConfigTable,
+      codeBucket,
+      workflowsTable,
+      executionsTable,
+      fanoutFunction,
+      appSyncEndpoint: appSyncApi.graphqlUrl,
+      executionSpecificationsTable,
+    });
+    template = Template.fromStack(stack);
+  });
+
+  for (const target of TARGETS) {
+    test(`${target.name}: every required env var it reads is set on the function`, () => {
+      const read = envVarsRead(target.sources);
+      const provided = functionEnvKeys(template, target.logicalIdPrefix);
+
+      const missing: string[] = [];
+      for (const name of read) {
+        if (AMBIENT_OR_SUBPROCESS.has(name)) continue;
+        if (target.optional.has(name)) continue;
+        if (!provided.has(name)) missing.push(name);
+      }
+      expect({ fn: target.name, missing: missing.sort() }).toEqual({
+        fn: target.name,
+        missing: [],
+      });
+    });
+  }
+
+  test("GOVERNANCE_LEDGER_TABLE is wired on the worker (Bug C regression guard)", () => {
+    // The specific var behind Bug C — pinned so a future edit that drops it
+    // fails loudly even if the generic scan is later rescoped.
+    const provided = functionEnvKeys(template, "WorkerAgentWrapper");
+    expect(provided.has("GOVERNANCE_LEDGER_TABLE")).toBe(true);
+  });
+});

--- a/backend/test/arbiter-stack-step-runner.test.ts
+++ b/backend/test/arbiter-stack-step-runner.test.ts
@@ -454,11 +454,15 @@ describe("ArbiterStack — Step Runner Lambda and EventBridge rules (Task 1.6)",
       // it must NOT be used, on the executions table or anywhere else.
       expect(actions.has("dynamodb:DeleteItem")).toBe(false);
       expect(actions.has("dynamodb:BatchWriteItem")).toBe(false);
-      // PutItem is now present in TWO statements: the tool-execution-ledger
-      // grant (PR1, Put/Get/Update trio) and the idempotency-seam smoke
-      // fixture's grant (this task, non-prod only, PutItem-ONLY on its own
-      // dedicated table). Neither may leak Delete/Scan/Query, and the smoke
-      // statement must never widen beyond a single PutItem action.
+      // PutItem is now present in THREE statements: the tool-execution-ledger
+      // grant (PR1, Put/Get/Update trio), the idempotency-seam smoke
+      // fixture's grant (non-prod only, PutItem-ONLY on its own dedicated
+      // table), and the governance-ledger legibility-record grant (this
+      // branch, PutItem-ONLY on the governance ledger table — write-once via
+      // attribute_not_exists(findingId), so no UpdateItem/DeleteItem/Query/
+      // Scan). None may leak Delete/Scan/Query/BatchWrite, and both
+      // single-action statements must never widen beyond PutItem, nor may
+      // either resolve to a wildcard or GSI (/index/*) resource.
       const policies = template.findResources("AWS::IAM::Policy");
       const putStatements: any[] = [];
       for (const p of Object.values(policies) as any[]) {
@@ -469,18 +473,49 @@ describe("ArbiterStack — Step Runner Lambda and EventBridge rules (Task 1.6)",
           continue;
         for (const s of p.Properties?.PolicyDocument?.Statement || []) {
           const acts = Array.isArray(s.Action) ? s.Action : [s.Action];
-          if (acts.includes("dynamodb:PutItem")) putStatements.push(acts);
+          if (acts.includes("dynamodb:PutItem"))
+            putStatements.push({ actions: acts, resources: s.Resource });
         }
       }
-      expect(putStatements.length).toBe(2);
-      const ledgerStatement = putStatements.find((acts) => acts.length === 3);
-      const smokeStatement = putStatements.find((acts) => acts.length === 1);
-      expect(ledgerStatement).toEqual([
+      expect(putStatements.length).toBe(3);
+      const ledgerStatement = putStatements.find((s) => s.actions.length === 3);
+      const singleActionStatements = putStatements.filter(
+        (s) => s.actions.length === 1,
+      );
+      expect(singleActionStatements.length).toBe(2);
+      expect(ledgerStatement.actions).toEqual([
         "dynamodb:PutItem",
         "dynamodb:GetItem",
         "dynamodb:UpdateItem",
       ]);
-      expect(smokeStatement).toEqual(["dynamodb:PutItem"]);
+      for (const s of singleActionStatements) {
+        expect(s.actions).toEqual(["dynamodb:PutItem"]);
+      }
+      // Pin the governance-ledger statement precisely by its resource ARN
+      // (Fn::GetAtt on GovernanceLedgerTable's logical id) so it cannot be
+      // confused with the smoke fixture's own dedicated table — exact
+      // Action AND exact Resource, no wildcard, no /index/* suffix.
+      const governanceLedgerStatement = singleActionStatements.find((s) => {
+        const arn = s.resources?.["Fn::GetAtt"]?.[0];
+        return (
+          typeof arn === "string" && arn.startsWith("GovernanceLedgerTable")
+        );
+      });
+      expect(governanceLedgerStatement).toBeDefined();
+      expect(governanceLedgerStatement.actions).toEqual(["dynamodb:PutItem"]);
+      // Resource must be EXACTLY { "Fn::GetAtt": [<GovernanceLedgerTable logical id>, "Arn"] }
+      // — a bare CFN GetAtt reference to the table's own ARN attribute, not a
+      // string, not an array of resources, and no /index/* GSI suffix.
+      expect(typeof governanceLedgerStatement.resources).toBe("object");
+      expect(Array.isArray(governanceLedgerStatement.resources)).toBe(false);
+      const getAtt = governanceLedgerStatement.resources["Fn::GetAtt"];
+      expect(Array.isArray(getAtt)).toBe(true);
+      expect(getAtt.length).toBe(2);
+      expect(getAtt[0]).toMatch(/^GovernanceLedgerTable/);
+      expect(getAtt[1]).toBe("Arn");
+      expect(Object.keys(governanceLedgerStatement.resources)).toEqual([
+        "Fn::GetAtt",
+      ]);
     });
 
     test("the UpdateItem grant is FGAC-restricted to the nodeResults/executionId attributes", () => {


### PR DESCRIPTION
## Summary 
The tool-idempotency capability shipped with green tests, clean synth, and correct wiring - and failed on every real tool call. Three smoke runs found three different defects, each of which a passing test suite had approved:
- The ledger's fenced reserve double-marshalled its keys, so DynamoDB rejected every `TransactwriteItem` with `Type mismatch for key pk expected: S actual: M`. The fenced reserve had never worked against real DynamoDB.
- The node-failure `UpdateItem` declared an `ExpressionAttributeNames` entry it never referenced, so DynamoDB rejected it. The handler crashed on every retry and executions hung in 'running' - the previous fix for masked failures could not persist a failure.
- `GOVERNANCE_LEDGER_TABLE` was never wired onto the worker, so the governed tool handler failed closed on every call and no governance decision could be recorded.
The common thread matters more than the individual bugs: fake tables accept invalid attribute types, mocked clients accept malformed expressions, and unit tests never check that a handler's env vars exist on the deployed function. The suite was validating logic, not deployability - so the smoke run was serving as the first real test. This PR fixes the three defects and closes that gap.
## What changed
**Fixes**
- Standardised on one DynamoDB API in the ledger client, and audited reserve, finalize, and the fence condition check for the same double-marshalling mistake.
- Corrected the node-failure update so the failed node and execution statuses actually persist; swept the repo for other unused-`ExpressionAttributeNames` sites.
- Wired `GOVERNANCE_LEDGER_TABLE` with a `PutItem`-only grant scoped to the single governance-ledger table.
**The test layer (the substance)**
- **Real-client contract tests** (moto): reserve, the concurrent-reservation conditional, finalize, the fenced transaction - both success and stale-generation rejection - and the node-failure update. These fail on exactly what the in-memory fakes accept. Both bugs' red proofs were independently re-derived during review by temporarily reverting each fix and observing the tests fail.
- **Generic env-parity test**: extracts every env var name each handler reads from source and asserts it exists on the synthesized function, with a documented allowlist. Bite-proven by removing a var from the stack. This catches the missing-wiring class rather than this instance of it.
- The existing in-memory tests are retained; this layer is additive.

**A guard that worked**
The new governance grant tripped an existing least-privilege assertion (the worker must hold exactly two `Put`-bearing statements). Rather than relax it, the guard was extended: the exact count is preserved, and the new statement is pinned to `dynamodb:PutItem` on the precise table ARN, with wildcard and index-suffix forms structurally rejected. This is the behaviour the contract layer is meant to generalise.
## Testing
Backend jest 6,830 passing across 445 suites; arbiter pytest 507; moto contract tests 7; `tsc` clean; both affected stacks synth clean. No existing assertion was weakened - test files were diffed against main to confirm.
## Deployment notes
Adds one env var and one narrowly scoped grant; no new resources. Deploy from **main** after merge, not from a branch. The smoke workflow should then produce one ledger row, one side-effect row, and - for the first time - one governance ALLOW record for the same tool call, followed by a forced re-dispatch to exercise the dispatch fence live.