### PR TITLE
fix(worker): close the tool-call write paths and prove them locally

### DIFF
--- a/arbiter/common/__tests__/test_ddb_marshalling.py
+++ b/arbiter/common/__tests__/test_ddb_marshalling.py
@@ -1,0 +1,82 @@
+"""Unit tests for the single DynamoDB marshalling boundary (finding 96d24639).
+
+The boundary must make it IMPOSSIBLE for a native float to reach DynamoDB
+silently: integral floats collapse to int (DDB TTL requires int), genuine
+fractional floats become Decimal, non-finite floats are REJECTED, and floats
+nested anywhere in the item are caught.
+"""
+import decimal
+
+import pytest
+
+from common.ddb_marshalling import (
+    FloatMarshallingError,
+    marshal_ddb_item,
+    normalize_ddb_value,
+)
+
+
+class TestFloatPolicy:
+    def test_integral_float_becomes_int(self):
+        out = marshal_ddb_item({"ttl": 1000.0})
+        assert out["ttl"] == 1000
+        assert isinstance(out["ttl"], int)
+
+    def test_fractional_float_becomes_decimal_via_repr(self):
+        out = marshal_ddb_item({"writtenAt": 1000.5})
+        assert out["writtenAt"] == decimal.Decimal("1000.5")
+        assert isinstance(out["writtenAt"], decimal.Decimal)
+
+    def test_fractional_float_has_no_binary_precision_tail(self):
+        # Decimal(str(0.1)) == Decimal('0.1'), NOT the 0.1000000000000000055…
+        # tail that Decimal(0.1) would produce.
+        out = marshal_ddb_item({"x": 0.1})
+        assert str(out["x"]) == "0.1"
+
+    def test_negative_zero_float_is_integral(self):
+        out = marshal_ddb_item({"x": -0.0})
+        assert out["x"] == 0
+        assert isinstance(out["x"], int)
+
+    @pytest.mark.parametrize("bad", [float("nan"), float("inf"), float("-inf")])
+    def test_non_finite_float_is_rejected(self, bad):
+        with pytest.raises(FloatMarshallingError):
+            marshal_ddb_item({"x": bad})
+
+
+class TestPassThroughAndNesting:
+    def test_bool_is_preserved_not_coerced_to_int(self):
+        out = marshal_ddb_item({"flag": True, "off": False})
+        assert out["flag"] is True
+        assert out["off"] is False
+
+    def test_int_str_decimal_none_bytes_pass_through(self):
+        item = {"i": 5, "s": "x", "d": decimal.Decimal("1.25"), "n": None, "b": b"raw"}
+        out = marshal_ddb_item(item)
+        assert out == item
+
+    def test_float_nested_in_dict_and_list_is_caught(self):
+        out = marshal_ddb_item({
+            "nested": {"a": 2.0, "deep": {"b": 3.5}},
+            "items": [1.0, 2.5, {"c": 4.0}],
+        })
+        assert out["nested"]["a"] == 2 and isinstance(out["nested"]["a"], int)
+        assert out["nested"]["deep"]["b"] == decimal.Decimal("3.5")
+        assert out["items"][0] == 1 and out["items"][1] == decimal.Decimal("2.5")
+        assert out["items"][2]["c"] == 4
+
+    def test_tuple_becomes_list(self):
+        out = normalize_ddb_value((1.0, 2.5))
+        assert out == [1, decimal.Decimal("2.5")]
+
+
+class TestBoundaryContract:
+    def test_returns_new_dict_never_mutates_caller(self):
+        original = {"ttl": 10.0, "keep": "v"}
+        out = marshal_ddb_item(original)
+        assert original["ttl"] == 10.0  # caller's dict untouched
+        assert out["ttl"] == 10 and out is not original
+
+    def test_non_dict_item_rejected(self):
+        with pytest.raises(TypeError):
+            marshal_ddb_item([("k", 1.0)])

--- a/arbiter/common/ddb_marshalling.py
+++ b/arbiter/common/ddb_marshalling.py
@@ -1,0 +1,107 @@
+"""Single DynamoDB item-marshalling boundary (finding 96d24639).
+
+THE one place every DynamoDB *item* write on the workflow-node tool-call path
+flows through before it reaches boto3. boto3's DynamoDB marshaller rejects a
+native Python ``float`` outright (``Float types are not supported. Use Decimal
+types instead.``) — a run-time ``TypeError`` deep inside ``put_item`` /
+``transact_write_items``. Historically that error surfaced ad hoc, one write
+site at a time, and in at least one path it was swallowed so the row *silently
+never landed* (an unauditable tool execution). Rather than fix each site as it
+breaks, every item write is routed through :func:`marshal_ddb_item`, so a float
+can never silently reach DynamoDB from this path again — a NEW field carrying a
+float is normalized or rejected here automatically, not discovered in
+production.
+
+Float policy (deterministic, total — the two known intents plus a hard reject):
+
+* **Integral float → ``int``** (``1000.0 → 1000``). Lossless. This is also the
+  safety net for a ttl computed as a float: DynamoDB TTL requires an integer
+  epoch-seconds attribute, so callers SHOULD compute ttl as ``int(now) + …``,
+  and this boundary guarantees it even if one forgets.
+* **Fractional float → ``Decimal``** via ``Decimal(str(x))`` — the correct idiom
+  for a *genuine* fractional value (e.g. a sub-second ``writtenAt`` or a
+  fractional epoch ``timestamp`` GSI key). ``str(x)`` uses Python's
+  round-trippable repr, so no spurious binary-float precision tail is stored.
+* **Non-finite float (``NaN`` / ``±Infinity``) → REJECT** with
+  :class:`FloatMarshallingError`. There is no faithful DynamoDB Number for these
+  and ``Decimal('NaN')`` is itself rejected by DynamoDB, so failing loudly at the
+  boundary is the only honest option.
+
+Everything else is passed through untouched — ``Decimal`` (already DDB-safe),
+``int`` / ``str`` / ``bool`` / ``bytes`` / ``None`` — recursing through ``dict``
+and ``list`` / ``tuple`` so a float nested anywhere in the item is caught. A
+``bool`` is deliberately checked before ``float``/``int`` handling because
+``bool`` is an ``int`` subclass and must stay a boolean.
+
+Pure and I/O-free. Deployed in the shared ``ArbiterCatalogLayer`` at
+``/opt/python/common`` so every carrier Lambda — the worker subprocess, the
+governance-layer writers, the seeded smoke tool — imports it as
+``from common.ddb_marshalling import marshal_ddb_item``.
+"""
+
+from __future__ import annotations
+
+import decimal
+import math
+from typing import Any
+
+
+class FloatMarshallingError(TypeError):
+    """A float value cannot be safely marshalled for DynamoDB.
+
+    Raised only for the genuinely unrepresentable case — a non-finite float
+    (``NaN`` / ``±Infinity``). A finite float is always converted (integral →
+    ``int``, fractional → ``Decimal``), never raised on. Subclasses
+    ``TypeError`` so it is a drop-in for the boto3 ``TypeError`` a raw float
+    would otherwise have produced deeper in the stack.
+    """
+
+
+def normalize_ddb_value(value: Any) -> Any:
+    """Recursively normalize a single value to a DynamoDB-safe representation.
+
+    Applies the float policy documented at module scope; recurses through
+    ``dict`` and ``list`` / ``tuple`` (a tuple becomes a list). Total for any
+    finite input; raises :class:`FloatMarshallingError` only on a non-finite
+    float.
+    """
+    # bool BEFORE int/float — bool is an int subclass and must remain boolean.
+    if isinstance(value, bool):
+        return value
+    if isinstance(value, float):
+        if math.isnan(value) or math.isinf(value):
+            raise FloatMarshallingError(
+                f"non-finite float cannot be stored in DynamoDB: {value!r}"
+            )
+        if value.is_integer():
+            # Integral float → int (covers a float ttl / a 1000.0-style value).
+            return int(value)
+        # Genuine fractional value → Decimal via the round-trippable repr.
+        return decimal.Decimal(str(value))
+    if isinstance(value, dict):
+        return {k: normalize_ddb_value(v) for k, v in value.items()}
+    if isinstance(value, (list, tuple)):
+        return [normalize_ddb_value(v) for v in value]
+    # Decimal / int / str / bytes / None / anything else: DDB-safe or the
+    # caller's own concern — passed through untouched.
+    return value
+
+
+def marshal_ddb_item(item: Any) -> dict[Any, Any]:
+    """Return a new item dict with every float normalized (see module doc).
+
+    The single choke point for a DynamoDB item write on the tool-call path:
+    ``put_item(Item=marshal_ddb_item(item))`` and the ``Put``/``Item`` member of
+    a ``TransactWriteItems`` request. Returns a fresh dict (never mutates the
+    caller's) so it is safe to marshal an item the caller still holds a
+    reference to.
+
+    Raises ``TypeError`` if ``item`` is not a mapping (a non-dict item is never
+    a valid DynamoDB write and would fail more obscurely downstream), and
+    :class:`FloatMarshallingError` on a non-finite float anywhere within it.
+    """
+    if not isinstance(item, dict):
+        raise TypeError(
+            f"marshal_ddb_item expects a dict item, got {type(item).__name__}"
+        )
+    return {k: normalize_ddb_value(v) for k, v in item.items()}

--- a/arbiter/governance/__tests__/test_ledger.py
+++ b/arbiter/governance/__tests__/test_ledger.py
@@ -160,7 +160,7 @@ def test_happy_path_writes_expected_item_shape(
     # Key-schema aliases MUST always be present (table HASH + GSI keys).
     assert item["findingId"] == finding.finding_id
     assert item["workflowId"] == finding.workflow_id
-    assert item["timestamp"] == pytest.approx(finding.timestamp)
+    assert float(item["timestamp"]) == pytest.approx(float(finding.timestamp))
     assert "ttl" in item
     # Flattened dataclass fields are carried on the item as well.
     assert item["requesting_agent"] == "agent-a"
@@ -413,7 +413,10 @@ def test_property_write_finding_always_emits_key_schema_attrs(
     # And they must hold the finding's values, not something else.
     assert item["findingId"] == finding.finding_id
     assert item["workflowId"] == finding.workflow_id
-    assert item["timestamp"] == pytest.approx(float(finding.timestamp))
+    # timestamp is now normalized by the marshalling boundary (finding 96d24639):
+    # integral -> int, fractional -> Decimal. Compare via float() so the type
+    # doesn't matter, only the value.
+    assert float(item["timestamp"]) == pytest.approx(float(finding.timestamp))
     # Decision always serialises to its enum .value, never repr.
     assert item["decision"] == finding.decision.value
 

--- a/arbiter/governance/__tests__/test_tool_execution_ledger_marshalling_import.py
+++ b/arbiter/governance/__tests__/test_tool_execution_ledger_marshalling_import.py
@@ -1,0 +1,64 @@
+"""Proves the marshal_ddb_item import boundary in tool_execution_ledger.py
+fails LOUD, not soft.
+
+A prior version silently degraded to an identity no-op on ImportError,
+defeating the "a float can never silently reach DynamoDB" guarantee. This
+test reloads the module with ``common.ddb_marshalling`` import blocked and
+asserts the ImportError propagates out of module import — there must be no
+fallback shim left standing that would let module load (and therefore
+``marshal_ddb_item``) silently succeed with a pass-through implementation.
+"""
+from __future__ import annotations
+
+import builtins
+import importlib
+import os
+import sys
+
+import pytest
+
+_PROJECT_ROOT = os.path.abspath(
+    os.path.join(os.path.dirname(__file__), "..", "..", "..")
+)
+if _PROJECT_ROOT not in sys.path:
+    sys.path.insert(0, _PROJECT_ROOT)
+
+MODULE_NAME = "arbiter.governance.tool_execution_ledger"
+
+
+def test_blocked_marshalling_import_raises_not_silently_noops(monkeypatch):
+    """With common.ddb_marshalling unimportable, importing
+    tool_execution_ledger must raise ImportError — it must NOT load
+    successfully with marshal_ddb_item silently downgraded to an identity
+    pass-through."""
+    real_import = builtins.__import__
+
+    def _blocking_import(name, *args, **kwargs):
+        if name == "common.ddb_marshalling" or name.startswith("common.ddb_marshalling."):
+            raise ImportError("simulated: marshalling boundary unavailable")
+        return real_import(name, *args, **kwargs)
+
+    monkeypatch.setattr(builtins, "__import__", _blocking_import)
+
+    sys.modules.pop(MODULE_NAME, None)
+    try:
+        with pytest.raises(ImportError, match="simulated: marshalling boundary unavailable"):
+            importlib.import_module(MODULE_NAME)
+    finally:
+        # Restore the real __import__ BEFORE reloading — monkeypatch's own
+        # teardown runs after this function returns, so without this the
+        # reload below would still be blocked and clobber module state.
+        monkeypatch.setattr(builtins, "__import__", real_import)
+        sys.modules.pop(MODULE_NAME, None)
+        importlib.import_module(MODULE_NAME)
+
+
+def test_marshal_ddb_item_is_the_real_helper_not_an_identity_stub():
+    """Sanity check on the happy path: the imported symbol is the real
+    common.ddb_marshalling.marshal_ddb_item (which rejects non-dict input),
+    not a permissive identity no-op that would accept anything unchanged."""
+    sys.modules.pop(MODULE_NAME, None)
+    ledger = importlib.import_module(MODULE_NAME)
+
+    with pytest.raises(TypeError):
+        ledger.marshal_ddb_item("not-a-dict")  # identity stub would return this unchanged

--- a/arbiter/governance/ledger.py
+++ b/arbiter/governance/ledger.py
@@ -43,6 +43,15 @@ from botocore.exceptions import BotoCoreError, ClientError
 
 from .models import GovernanceFinding
 
+try:
+    # Shared marshalling boundary (finding 96d24639). Deployed at
+    # /opt/python/common via ArbiterCatalogLayer; resolves from the arbiter
+    # root under pytest. Imported at module top (this package is layer-staged,
+    # not a single-file agent, so a top-level import is safe here).
+    from common.ddb_marshalling import marshal_ddb_item, FloatMarshallingError
+except ImportError:  # pragma: no cover — defensive: relative-package fallback
+    from ..common.ddb_marshalling import marshal_ddb_item, FloatMarshallingError
+
 logger = logging.getLogger(__name__)
 
 
@@ -213,7 +222,23 @@ def write_finding(finding: GovernanceFinding, *, ttl_days: int = 90) -> None:
 
     try:
         item = _serialize_finding(finding)
-        item["ttl"] = time.time() + (ttl_days * 86400)
+        # ttl as INT epoch seconds — DynamoDB TTL requires an integer attribute
+        # (a float ttl is exactly what boto3 rejects). Retention counted from
+        # persist time (QT1-10 = 90 days default).
+        item["ttl"] = int(time.time()) + (ttl_days * 86400)
+        # Single marshalling boundary (finding 96d24639): normalize every float
+        # in the item (integral → int, fractional → Decimal, non-finite →
+        # reject) so a native float — e.g. the fractional epoch ``timestamp``
+        # GSI key, or any future float-valued field — can never silently reach
+        # DynamoDB and either crash the write or (worse) be swallowed into a
+        # row that never lands. This is the SAME boundary the smoke tool and
+        # the tool-execution ledger route through.
+        item = marshal_ddb_item(item)
+    except FloatMarshallingError as exc:
+        raise LedgerWriteError(
+            f"GovernanceFinding {finding.finding_id!r} carries an "
+            f"unrepresentable float: {exc}"
+        ) from exc
     except Exception as exc:  # pragma: no cover — defensive, asdict is total
         raise LedgerWriteError(
             f"Failed to serialise GovernanceFinding {finding.finding_id!r}: {exc}"

--- a/arbiter/governance/tool_execution_ledger.py
+++ b/arbiter/governance/tool_execution_ledger.py
@@ -68,6 +68,16 @@ from typing import Any, Callable
 import boto3
 from botocore.exceptions import BotoCoreError, ClientError
 
+try:
+    # Single marshalling boundary (finding 96d24639) — same helper the smoke
+    # tool and governance finding write route through. The ledger already
+    # stores int epoch timestamps, so this is the consistency backstop that
+    # keeps ALL item writes on this path float-safe through one choke point.
+    from common.ddb_marshalling import marshal_ddb_item
+except ImportError:  # pragma: no cover — defensive
+    def marshal_ddb_item(item):  # type: ignore[misc]
+        return item
+
 logger = logging.getLogger(__name__)
 
 # --- Attribute + status constants -------------------------------------------
@@ -540,7 +550,7 @@ def _reserve_fenced(
         {
             "Put": {
                 "TableName": ledger_table,
-                "Item": item,
+                "Item": marshal_ddb_item(item),
                 "ConditionExpression": f"attribute_not_exists({PK_ATTR})",
             }
         },
@@ -639,7 +649,7 @@ def reserve(
             dispatch_generation=int(dispatch_generation), now=now,
         )
     try:
-        _table().put_item(Item=item, ConditionExpression=f"attribute_not_exists({PK_ATTR})")
+        _table().put_item(Item=marshal_ddb_item(item), ConditionExpression=f"attribute_not_exists({PK_ATTR})")
         return ReserveResult(ReserveOutcome.WON)
     except ClientError as exc:
         if exc.response.get("Error", {}).get("Code") != "ConditionalCheckFailedException":

--- a/arbiter/governance/tool_execution_ledger.py
+++ b/arbiter/governance/tool_execution_ledger.py
@@ -68,15 +68,21 @@ from typing import Any, Callable
 import boto3
 from botocore.exceptions import BotoCoreError, ClientError
 
-try:
-    # Single marshalling boundary (finding 96d24639) — same helper the smoke
-    # tool and governance finding write route through. The ledger already
-    # stores int epoch timestamps, so this is the consistency backstop that
-    # keeps ALL item writes on this path float-safe through one choke point.
-    from common.ddb_marshalling import marshal_ddb_item
-except ImportError:  # pragma: no cover — defensive
-    def marshal_ddb_item(item):  # type: ignore[misc]
-        return item
+# Single marshalling boundary (finding 96d24639) — same helper the smoke
+# tool and governance finding write route through. The ledger already
+# stores int epoch timestamps, so this is the consistency backstop that
+# keeps ALL item writes on this path float-safe through one choke point.
+#
+# FAIL LOUD, not soft: an ImportError here means the marshalling module is
+# missing from the deployment (mis-packaged Lambda layer/bundle). There is
+# deliberately NO fallback shim — a prior version of this import silently
+# degraded to an identity no-op on ImportError, which would let a bare float
+# reach DynamoDB and defeats the exact guarantee this boundary exists to
+# provide (a fail-closed control quietly disabling itself, the same failure
+# pattern this module's write paths were hardened against elsewhere). An
+# unimportable marshalling boundary means the module is mis-deployed and
+# must not run, so the ImportError is left to propagate uncaught.
+from common.ddb_marshalling import marshal_ddb_item
 
 logger = logging.getLogger(__name__)
 

--- a/arbiter/seedConfig/smoke_idempotency_agent.py
+++ b/arbiter/seedConfig/smoke_idempotency_agent.py
@@ -100,19 +100,29 @@ def handler(**kwargs):
         """
         import boto3
 
+        # Single marshalling boundary (finding 96d24639): every DynamoDB item
+        # write on this path goes through common.ddb_marshalling so a native
+        # float can never silently reach DynamoDB. ``writtenAt`` is a genuine
+        # fractional epoch (→ Decimal); ``ttl`` is int epoch seconds (DynamoDB
+        # TTL requires an integer). Imported here (not at module top) to honor
+        # the single-file agent contract — the helper resolves from the shared
+        # ArbiterCatalogLayer (/opt/python/common) in the deployed worker and
+        # from the arbiter root under pytest.
+        from common.ddb_marshalling import marshal_ddb_item
+
         marker_id = str(uuid.uuid4())
         org_id = os.environ.get("CITADEL_ORG_ID") or "unscoped"
         now = time.time()
 
         table = boto3.resource("dynamodb").Table(_table_name())
         table.put_item(
-            Item={
+            Item=marshal_ddb_item({
                 "orgId": org_id,
                 "markerId": marker_id,
                 "note": (note or "")[:200],
                 "writtenAt": now,
                 "ttl": int(now) + SMOKE_TTL_SECONDS,
-            }
+            })
         )
 
         return {

--- a/arbiter/workerWrapper/__tests__/test_composed_tool_governance.py
+++ b/arbiter/workerWrapper/__tests__/test_composed_tool_governance.py
@@ -51,6 +51,21 @@ from tool_idempotency_hook import ComposedToolHook, IdempotencyToolHook, _Idempo
 ledger = tool_idempotency_hook.ledger  # noqa: E402
 
 
+@pytest.fixture(autouse=True)
+def _governance_writes_succeed(monkeypatch):
+    """These tests exercise the deny/permit ORDERING and stream side-effect
+    boundary, NOT the governance-write policy (that is covered in
+    test_governed_tool_handler.py). Make the audit write succeed so a PERMIT
+    falls through to idempotency rather than being fail-closed-BLOCKED
+    (decision gov-write-fail-closed, finding 4595b730). Drain the shared
+    refusal sink around each test for isolation."""
+    import governed_tool_handler
+    monkeypatch.setattr(governed_tool_handler, "write_finding", lambda *a, **k: None)
+    tool_idempotency_hook.drain_governance_refusals()
+    yield
+    tool_idempotency_hook.drain_governance_refusals()
+
+
 # ---------------------------------------------------------------------------
 # Fakes for the strands seam
 # ---------------------------------------------------------------------------
@@ -132,7 +147,8 @@ class TestDenyBeforeReserve:
         idempotency reserve is NEVER reached (no reservation, no ledger row)."""
         reserve_calls = []
         monkeypatch.setattr(ledger, "reserve", lambda *a, **k: reserve_calls.append((a, k)))
-        # write_finding will raise LedgerWriteError (no table) → caught + WARN.
+        # Audit write succeeds (autouse _governance_writes_succeed) so the DENY
+        # here is a policy denial, not a fail-closed audit block.
 
         inner = _FakeInnerTool("dangerous", [])
         event = _FakeEvent("dangerous", "tu-1", {"x": 1}, inner)

--- a/arbiter/workerWrapper/__tests__/test_governed_tool_handler.py
+++ b/arbiter/workerWrapper/__tests__/test_governed_tool_handler.py
@@ -101,13 +101,19 @@ def test_preprocess_permit_returns_none_and_writes_permit_finding():
 
 
 # ---------------------------------------------------------------------------
-# AC 9.4 — LedgerWriteError is caught and WARN-logged; preprocess does NOT
-# raise. Covers both DENY and PERMIT paths.
+# GOVERNANCE-WRITE POLICY — FAIL-CLOSED (decision gov-write-fail-closed,
+# finding 4595b730). A LedgerWriteError is NO LONGER best-effort: it BLOCKS the
+# tool (returns an audit-unavailable error ToolResult) and records a refusal in
+# the shared node-failure sink so the node FAILS. An unauditable tool execution
+# is not permitted. Replaces the former AC 9.4 WARN+continue behavior.
 # ---------------------------------------------------------------------------
 
 
-def test_preprocess_ledger_unset_permit_best_effort(monkeypatch, caplog):
-    """PERMIT path: ledger failure is best-effort — warn, return None."""
+def test_preprocess_ledger_unset_permit_fails_closed(monkeypatch, caplog):
+    """PERMIT path: a governance-write failure BLOCKS the tool (fail-closed)
+    and records a node-failure refusal — no longer a best-effort no-op."""
+    import tool_idempotency_hook as hook
+    hook.drain_governance_refusals()  # start clean
     monkeypatch.delenv('GOVERNANCE_LEDGER_TABLE', raising=False)
     handler = GovernedToolHandler(denied_tools=set())
 
@@ -115,19 +121,27 @@ def test_preprocess_ledger_unset_permit_best_effort(monkeypatch, caplog):
         'governed_tool_handler.write_finding',
         side_effect=LedgerWriteError('GOVERNANCE_LEDGER_TABLE not configured'),
     ):
-        with caplog.at_level(logging.WARNING, logger='governed_tool_handler'):
-            result = handler.preprocess({'name': 'safe_tool'})
+        with caplog.at_level(logging.ERROR, logger='governed_tool_handler'):
+            result = handler.preprocess({'name': 'safe_tool', 'toolUseId': 'tu-p'})
 
-    assert result is None  # PERMIT path survives ledger failure
-    warnings = [r for r in caplog.records if r.levelno == logging.WARNING]
-    assert len(warnings) == 1
-    assert 'governance ledger write failed' in warnings[0].getMessage()
+    # Fail-closed: the tool is blocked with an audit-unavailable error result.
+    assert isinstance(result, dict)
+    assert result['status'] == 'error'
+    assert 'audit record could not be written' in result['content'][0]['text']
+    errors = [r for r in caplog.records if r.levelno == logging.ERROR]
+    assert len(errors) == 1
+    assert 'fail-closed' in errors[0].getMessage()
+    # The node-failure refusal was recorded (so the node FAILS post-turn).
+    drained = hook.drain_governance_refusals()
+    assert len(drained) == 1
+    assert drained[0]['errorClass'] == 'LedgerWriteError'
 
 
-def test_preprocess_ledger_unset_deny_best_effort(monkeypatch, caplog):
-    """DENY path: ledger failure is best-effort — warn, still return
-    the denial ToolResult (the deny decision itself does NOT depend on
-    the ledger at worker-tool-handler scope per AC 9.4)."""
+def test_preprocess_ledger_unset_deny_fails_closed(monkeypatch, caplog):
+    """DENY path: a governance-write failure still blocks the tool (a denial is
+    preserved a fortiori) AND records a node-failure refusal (fail-closed)."""
+    import tool_idempotency_hook as hook
+    hook.drain_governance_refusals()
     monkeypatch.delenv('GOVERNANCE_LEDGER_TABLE', raising=False)
     handler = GovernedToolHandler(denied_tools={'blocked'})
 
@@ -135,14 +149,17 @@ def test_preprocess_ledger_unset_deny_best_effort(monkeypatch, caplog):
         'governed_tool_handler.write_finding',
         side_effect=LedgerWriteError('GOVERNANCE_LEDGER_TABLE not configured'),
     ):
-        with caplog.at_level(logging.WARNING, logger='governed_tool_handler'):
+        with caplog.at_level(logging.ERROR, logger='governed_tool_handler'):
             result = handler.preprocess({'name': 'blocked', 'toolUseId': 'tu-x'})
 
     assert isinstance(result, dict)
     assert result['status'] == 'error'
-    warnings = [r for r in caplog.records if r.levelno == logging.WARNING]
-    assert len(warnings) == 1
-    assert 'governance ledger write failed' in warnings[0].getMessage()
+    errors = [r for r in caplog.records if r.levelno == logging.ERROR]
+    assert len(errors) == 1
+    assert 'fail-closed' in errors[0].getMessage()
+    drained = hook.drain_governance_refusals()
+    assert len(drained) == 1
+    assert drained[0]['errorClass'] == 'LedgerWriteError'
 
 
 # ---------------------------------------------------------------------------

--- a/arbiter/workerWrapper/__tests__/test_tool_call_write_paths_e2e_moto.py
+++ b/arbiter/workerWrapper/__tests__/test_tool_call_write_paths_e2e_moto.py
@@ -354,3 +354,102 @@ class TestStepRunnerWrites:
         )
         row = e2e["resource"].Table(EXEC_TABLE).get_item(Key={"executionId": "exec1"})["Item"]
         assert row["status"] == "failed"
+
+
+# ===========================================================================
+# 8. Single marshalling boundary (finding 96d24639) — floats never reach DDB
+#    silently. These are the two sites that FAILED before the boundary landed.
+# ===========================================================================
+class TestMarshallingBoundary:
+    def test_smoke_marker_stores_int_ttl_and_decimal_writtenat(self, e2e):
+        """The smoke tool wrote a float ``writtenAt`` (time.time()) — before the
+        boundary this raised 'Float types are not supported'. Now: ttl is an
+        INT epoch (DDB TTL requires int), writtenAt a Decimal (fractional)."""
+        import decimal
+        from arbiter.seedConfig import smoke_idempotency_agent as smoke
+
+        smoke.handler(note="marshalling")
+        row = e2e["resource"].Table(SMOKE_TABLE).scan()["Items"][0]
+        assert isinstance(row["ttl"], decimal.Decimal) and row["ttl"] == int(row["ttl"])
+        # boto3's resource layer returns Numbers as Decimal; the stored value
+        # must be a genuine fractional (writtenAt = time.time()).
+        assert isinstance(row["writtenAt"], decimal.Decimal)
+
+    def test_governance_finding_persists_with_numeric_timestamp_and_ttl(self, e2e):
+        """The governance finding wrote a float timestamp + ttl — before the
+        boundary this raised and record_governance_decision SWALLOWED it, so the
+        row silently never landed. Now it persists with numeric key/ttl."""
+        import decimal
+        from arbiter.workerWrapper.governed_tool_handler import build_governance_finding
+        from arbiter.governance.ledger import write_finding
+
+        finding = build_governance_finding(
+            "smoke_write_marker", denied=False,
+            agent_id="smoke-idempotency-agent", workflow_id="wf-smoke",
+        )
+        write_finding(finding)
+        row = _raw(GOV_TABLE, {"findingId": {"S": finding.finding_id}})
+        assert row is not None
+        # timestamp GSI key stored as Number (N); ttl stored as an int epoch.
+        assert set(row["timestamp"].keys()) == {"N"}
+        assert set(row["ttl"].keys()) == {"N"}
+        assert decimal.Decimal(row["ttl"]["N"]) == int(decimal.Decimal(row["ttl"]["N"]))
+
+    def test_boundary_rejects_non_finite_float(self, e2e):
+        from arbiter.governance import tool_execution_ledger as tel
+
+        # A non-finite float can never be a valid DDB Number — the boundary
+        # REJECTS rather than silently corrupts. FloatMarshallingError subclasses
+        # TypeError, so assert on TypeError to stay robust to the common/
+        # arbiter.common dual-import identity trap documented in conftest.
+        with pytest.raises(TypeError):
+            tel.marshal_ddb_item({"pk": "x", "bad": float("inf")})
+
+
+# ===========================================================================
+# 9. FINALIZE ON RAISE (finding 4595b730) — no ledger row remains in_flight
+#    after a terminal outcome, driven against the REAL moto ledger.
+# ===========================================================================
+class TestNoInFlightAfterTerminal:
+    def _key(self, tel, suffix):
+        from arbiter.workerWrapper.tool_idempotency import build_key
+        return build_key("orgA", "exec1", "node1", 0, "smoke_write_marker", {"n": suffix})
+
+    def test_raising_tool_leaves_no_in_flight_row(self, e2e):
+        from arbiter.governance import tool_execution_ledger as tel
+
+        pk, sk = self._key(tel, "raise")
+
+        def boom():
+            raise RuntimeError("tool crashed mid-execution")
+
+        with pytest.raises(tel.OutcomeIndeterminateError):
+            tel.execute_idempotent(
+                pk=pk, sk=sk, tool_name="smoke_write_marker",
+                mode="ledger", run_tool=boom,
+            )
+        row = tel.get(pk, sk)
+        assert row is not None and row["status"] != tel.STATUS_IN_FLIGHT
+        assert row["status"] == tel.STATUS_FAILED
+
+    def test_domain_error_result_leaves_no_in_flight_row(self, e2e):
+        from arbiter.governance import tool_execution_ledger as tel
+
+        pk, sk = self._key(tel, "domain")
+        result = tel.execute_idempotent(
+            pk=pk, sk=sk, tool_name="smoke_write_marker", mode="ledger",
+            run_tool=lambda: {"status": "error", "content": [{"text": "handled"}]},
+        )
+        assert result["status"] == "error"
+        row = tel.get(pk, sk)
+        assert row["status"] == tel.STATUS_FAILED  # terminal, not in_flight
+
+    def test_success_leaves_no_in_flight_row(self, e2e):
+        from arbiter.governance import tool_execution_ledger as tel
+
+        pk, sk = self._key(tel, "ok")
+        tel.execute_idempotent(
+            pk=pk, sk=sk, tool_name="smoke_write_marker", mode="ledger",
+            run_tool=lambda: {"status": "success", "markerId": "m"},
+        )
+        assert tel.get(pk, sk)["status"] == tel.STATUS_COMPLETED

--- a/arbiter/workerWrapper/__tests__/test_tool_call_write_paths_e2e_moto.py
+++ b/arbiter/workerWrapper/__tests__/test_tool_call_write_paths_e2e_moto.py
@@ -1,0 +1,356 @@
+"""END-TO-END (moto) harness for the workflow-node TOOL-CALL write paths.
+
+DISCOVERY HARNESS (not a fix). Purpose: surface EVERY DynamoDB wire-contract
+defect on the node tool-call flow in ONE local pass, instead of one-per-deploy.
+It follows the ``test_ledger_contract_moto.py`` precedent (real boto3 clients
+against moto, real table definitions matching the CDK schemas, raw low-level
+reads to assert stored attribute types) but widens coverage from the ledger
+alone to the FULL tool-call write sequence a workflow node drives:
+
+    1. governance finding write        governance/ledger.py::write_finding
+                                        (worker-tool-handler PERMIT/DENY audit)
+    2. tool-execution ledger reserve    governance/tool_execution_ledger.py::reserve
+       (fenced TransactWriteItems)      -> _reserve_fenced
+    3. the tool body's marker write     seedConfig/smoke_idempotency_agent.py
+                                        smoke_write_marker put_item
+    4. ledger finalize (success/fail)   tool_execution_ledger.py::finalize_success
+                                        / finalize_failure
+    5. worker node-result write         workerWrapper/index.py::_persist_node_completion
+    6. stepRunner node-failure update   stepRunner/executor.py handle_node_failure
+    7. execution finalize               stepRunner/executor.py (start/cancel)
+
+REAL vs STUBBED (explicit)
+--------------------------
+* REAL, against moto: every DynamoDB write above and every table
+  (schemas copied verbatim from backend/lib/arbiter-stack.ts and
+  backend-stack.ts). NO in-memory FakeTable is used for any write.
+* STUBBED — the strands agent runtime ONLY. ``strands`` is not installed in
+  this env, and even where it is, the agent executes in a SUBPROCESS
+  (workerWrapper/index.py launches ``sys.executable``), which cannot run
+  in-process. We inject a minimal fake ``strands`` module (``Agent`` + ``tool``)
+  so the REAL ``smoke_write_marker`` tool BODY executes its REAL boto3 put_item
+  against moto. The strands ``BeforeToolCallEvent`` hook seam
+  (ComposedToolHook = governance + idempotency) is therefore also stubbed; the
+  harness instead drives the governance-finding write and the ledger
+  reserve->finalize EXPLICITLY, in the same order the ComposedToolHook fires
+  them, so no real write is faked — only the event dispatch is.
+
+conftest note: ``arbiter/conftest.py`` swaps ``boto3.client``/``boto3.resource``
+for MagicMock factories for the whole suite. Modules that call
+``boto3.resource(...)`` directly (the smoke tool) would therefore hit a mock
+and HIDE the float bug. Inside ``mock_aws`` we restore ``boto3.resource`` /
+``boto3.client`` to real Session-backed callables (``boto3.Session`` is NOT
+stubbed), so those direct calls reach moto.
+"""
+from __future__ import annotations
+
+import os
+import sys
+import types
+from types import SimpleNamespace
+
+import boto3
+import pytest
+
+try:
+    from moto import mock_aws
+except ImportError:  # pragma: no cover
+    pytest.skip("moto not installed", allow_module_level=True)
+
+_PROJECT_ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "..", ".."))
+if _PROJECT_ROOT not in sys.path:
+    sys.path.insert(0, _PROJECT_ROOT)
+
+REGION = "us-east-1"
+SMOKE_TABLE = "citadel-smoke-idempotency-moto"
+EXEC_TABLE = "citadel-executions-moto"
+LEDGER_TABLE = "citadel-tool-execution-ledger-moto"
+GOV_TABLE = "citadel-governance-ledger-moto"
+
+
+# ---------------------------------------------------------------------------
+# Table definitions — verbatim from the CDK stacks
+# ---------------------------------------------------------------------------
+def _make_tables(resource):
+    # backend/lib/arbiter-stack.ts SmokeIdempotencyTable: PK orgId(S) SK markerId(S)
+    resource.create_table(
+        TableName=SMOKE_TABLE,
+        KeySchema=[
+            {"AttributeName": "orgId", "KeyType": "HASH"},
+            {"AttributeName": "markerId", "KeyType": "RANGE"},
+        ],
+        AttributeDefinitions=[
+            {"AttributeName": "orgId", "AttributeType": "S"},
+            {"AttributeName": "markerId", "AttributeType": "S"},
+        ],
+        BillingMode="PAY_PER_REQUEST",
+    )
+    # backend/lib/backend-stack.ts ExecutionsTable: PK executionId(S)
+    resource.create_table(
+        TableName=EXEC_TABLE,
+        KeySchema=[{"AttributeName": "executionId", "KeyType": "HASH"}],
+        AttributeDefinitions=[{"AttributeName": "executionId", "AttributeType": "S"}],
+        BillingMode="PAY_PER_REQUEST",
+    )
+    # backend/lib/arbiter-stack.ts ToolExecutionLedgerTable: PK pk(S) SK sk(S)
+    resource.create_table(
+        TableName=LEDGER_TABLE,
+        KeySchema=[
+            {"AttributeName": "pk", "KeyType": "HASH"},
+            {"AttributeName": "sk", "KeyType": "RANGE"},
+        ],
+        AttributeDefinitions=[
+            {"AttributeName": "pk", "AttributeType": "S"},
+            {"AttributeName": "sk", "AttributeType": "S"},
+        ],
+        BillingMode="PAY_PER_REQUEST",
+    )
+    # backend/lib/arbiter-stack.ts GovernanceLedgerTable: PK findingId(S),
+    # + workflow-index GSI (HASH workflowId(S), RANGE timestamp(N)).
+    resource.create_table(
+        TableName=GOV_TABLE,
+        KeySchema=[{"AttributeName": "findingId", "KeyType": "HASH"}],
+        AttributeDefinitions=[
+            {"AttributeName": "findingId", "AttributeType": "S"},
+            {"AttributeName": "workflowId", "AttributeType": "S"},
+            {"AttributeName": "timestamp", "AttributeType": "N"},
+        ],
+        GlobalSecondaryIndexes=[
+            {
+                "IndexName": "workflow-index",
+                "KeySchema": [
+                    {"AttributeName": "workflowId", "KeyType": "HASH"},
+                    {"AttributeName": "timestamp", "KeyType": "RANGE"},
+                ],
+                "Projection": {"ProjectionType": "ALL"},
+            }
+        ],
+        BillingMode="PAY_PER_REQUEST",
+    )
+
+
+def _install_fake_strands():
+    """Stub ONLY the agent runtime so the REAL tool body executes in-process.
+
+    ``@tool`` returns the function unchanged; ``Agent(tools=[fn])`` exposes
+    ``agent.tool.<fn.__name__>`` -> the real fn, matching how
+    smoke_idempotency_agent.handler drives the direct (synchronous) tool call.
+    """
+    strands = types.ModuleType("strands")
+
+    def tool(fn=None, **_kw):
+        if fn is None:
+            return lambda f: f
+        return fn
+
+    class Agent:  # noqa: D401
+        def __init__(self, tools=None, **_kw):
+            self.tool = SimpleNamespace(
+                **{getattr(t, "__name__", "tool"): t for t in (tools or [])}
+            )
+
+    strands.Agent = Agent
+    strands.tool = tool
+    sys.modules["strands"] = strands
+    return strands
+
+
+@pytest.fixture
+def e2e(monkeypatch):
+    with mock_aws():
+        # Restore REAL boto3 factories (conftest stubbed them) so every
+        # write below — including the smoke tool's direct boto3.resource
+        # call — reaches moto. boto3.Session is not stubbed by conftest.
+        monkeypatch.setattr(
+            boto3, "resource", lambda *a, **k: boto3.Session(region_name=REGION).resource(*a, **k)
+        )
+        monkeypatch.setattr(
+            boto3, "client", lambda *a, **k: boto3.Session(region_name=REGION).client(*a, **k)
+        )
+        resource = boto3.Session(region_name=REGION).resource("dynamodb")
+        _make_tables(resource)
+
+        monkeypatch.setenv("SMOKE_IDEMPOTENCY_TABLE", SMOKE_TABLE)
+        monkeypatch.setenv("EXECUTIONS_TABLE", EXEC_TABLE)
+        monkeypatch.setenv("TOOL_EXECUTION_LEDGER_TABLE", LEDGER_TABLE)
+        monkeypatch.setenv("GOVERNANCE_LEDGER_TABLE", GOV_TABLE)
+        monkeypatch.setenv("CITADEL_ORG_ID", "orgA")
+
+        _install_fake_strands()
+
+        # Wire the two ledgers' lazy DDB seams at the moto resource.
+        from arbiter.governance import ledger as gov_ledger
+        from arbiter.governance import tool_execution_ledger as tel
+
+        tel.__reset_ledger_client_for_test()
+        gov_ledger.__reset_ledger_client_for_test()
+        monkeypatch.setattr(tel, "_get_dynamodb_resource", lambda: resource)
+        monkeypatch.setattr(gov_ledger, "_get_dynamodb_resource", lambda: resource)
+
+        try:
+            yield {"resource": resource}
+        finally:
+            tel.__reset_ledger_client_for_test()
+            gov_ledger.__reset_ledger_client_for_test()
+
+
+def _raw(table, key):
+    client = boto3.Session(region_name=REGION).client("dynamodb")
+    return client.get_item(TableName=table, Key=key).get("Item")
+
+
+# ===========================================================================
+# 1. Governance finding write (worker-tool-handler PERMIT audit)
+# ===========================================================================
+class TestGovernanceFindingWrite:
+    def test_permit_finding_row_persists(self, e2e):
+        from arbiter.workerWrapper.governed_tool_handler import build_governance_finding
+        from arbiter.governance.ledger import write_finding
+
+        finding = build_governance_finding(
+            "smoke_write_marker", denied=False,
+            agent_id="smoke-idempotency-agent", workflow_id="wf-smoke",
+        )
+        # REAL write against moto — surfaces any wire-contract defect verbatim.
+        write_finding(finding)
+        row = _raw(GOV_TABLE, {"findingId": {"S": finding.finding_id}})
+        assert row is not None
+
+
+# ===========================================================================
+# 2. Tool-execution ledger fenced reserve (TransactWriteItems)
+# ===========================================================================
+class TestFencedReserve:
+    def _seed_exec(self, resource, gen):
+        resource.Table(EXEC_TABLE).put_item(
+            Item={
+                "executionId": "exec1",
+                "nodeResults": {"node1": {"dispatchGeneration": gen, "status": "running"}},
+            }
+        )
+
+    def test_fenced_reserve_wins(self, e2e):
+        from arbiter.governance import tool_execution_ledger as tel
+        from arbiter.workerWrapper.tool_idempotency import build_key
+
+        self._seed_exec(e2e["resource"], 3)
+        pk, sk = build_key("orgA", "exec1", "node1", 0, "smoke_write_marker", {"note": "x"})
+        res = tel.reserve(
+            pk, sk, tool_name="smoke_write_marker",
+            dispatch_generation=3, execution_id="exec1", node_id="node1",
+        )
+        assert res.outcome == tel.ReserveOutcome.WON
+        raw = _raw(LEDGER_TABLE, {"pk": {"S": pk}, "sk": {"S": sk}})
+        assert raw["pk"] == {"S": pk}
+        assert set(raw["createdAt"].keys()) == {"N"}
+
+
+# ===========================================================================
+# 3. Smoke tool body marker write (the real tool @tool body)
+# ===========================================================================
+class TestSmokeMarkerWrite:
+    def test_marker_row_persists(self, e2e):
+        from arbiter.seedConfig import smoke_idempotency_agent as smoke
+
+        # REAL tool body via the fake-strands Agent -> real put_item to moto.
+        result = smoke.handler(note="e2e-harness")
+        assert result["orgId"] == "orgA"
+        # Assert exactly one marker row landed.
+        rows = e2e["resource"].Table(SMOKE_TABLE).scan()["Items"]
+        assert len(rows) == 1
+
+
+# ===========================================================================
+# 4. Ledger finalize (success) with the real tool result
+# ===========================================================================
+class TestLedgerFinalize:
+    def test_reserve_then_finalize_success(self, e2e):
+        from arbiter.governance import tool_execution_ledger as tel
+        from arbiter.workerWrapper.tool_idempotency import build_key
+
+        pk, sk = build_key("orgA", "exec1", "node1", 0, "smoke_write_marker", {"note": "y"})
+        tel.reserve(pk, sk, tool_name="smoke_write_marker")
+        tel.finalize_success(
+            pk, sk,
+            result={"markerId": "m-1", "orgId": "orgA", "writtenAt": "1000.5"},
+        )
+        row = tel.get(pk, sk)
+        assert row["status"] == "completed"
+
+
+# ===========================================================================
+# 5. Worker node-result write (index.py::_persist_node_completion)
+# ===========================================================================
+class TestWorkerNodeResultWrite:
+    def test_persist_node_completion(self, e2e):
+        import arbiter.workerWrapper.index as widx
+
+        # getattr avoids dunder name-mangling inside this class body.
+        getattr(widx, "__reset_boto3_clients_for_test")()
+
+        # Seed the execution row with a pending node (nested map must exist for
+        # the SET nodeResults.#nid.#status path).
+        e2e["resource"].Table(EXEC_TABLE).put_item(
+            Item={
+                "executionId": "exec1",
+                "nodeResults": {"node1": {"status": "running"}},
+            }
+        )
+        msg = SimpleNamespace(execution_id="exec1", node_id="node1")
+        widx._persist_node_completion(
+            msg,
+            output={"markerId": "m-1", "orgId": "orgA", "writtenAt": "1000.5"},
+            usage=[{"inputTokens": 5, "outputTokens": 7}],
+        )
+        row = e2e["resource"].Table(EXEC_TABLE).get_item(Key={"executionId": "exec1"})["Item"]
+        assert row["nodeResults"]["node1"]["status"] == "completed"
+
+
+# ===========================================================================
+# 6/7. stepRunner node-failure update + execution finalize
+# ===========================================================================
+class TestStepRunnerWrites:
+    def _wire(self, monkeypatch, resource):
+        import arbiter.stepRunner.executor as ex
+        monkeypatch.setattr(ex, "_executions_table", resource.Table(EXEC_TABLE))
+        return ex
+
+    def test_execution_start_finalize(self, e2e, monkeypatch):
+        ex = self._wire(monkeypatch, e2e["resource"])
+        e2e["resource"].Table(EXEC_TABLE).put_item(
+            Item={"executionId": "exec1", "status": "pending", "nodeResults": {}}
+        )
+        ex._executions_table.update_item(
+            Key={"executionId": "exec1"},
+            UpdateExpression="SET #status = :s, #startedAt = :t",
+            ExpressionAttributeNames={"#status": "status", "#startedAt": "startedAt"},
+            ExpressionAttributeValues={":s": "running", ":t": ex._now_iso()},
+        )
+        row = e2e["resource"].Table(EXEC_TABLE).get_item(Key={"executionId": "exec1"})["Item"]
+        assert row["status"] == "running"
+
+    def test_node_failure_terminal_update(self, e2e, monkeypatch):
+        ex = self._wire(monkeypatch, e2e["resource"])
+        e2e["resource"].Table(EXEC_TABLE).put_item(
+            Item={"executionId": "exec1", "status": "running",
+                  "nodeResults": {"node1": {"status": "running"}}}
+        )
+        # Mirror the no-retry terminal branch (executor.py handle_node_failure).
+        ex._executions_table.update_item(
+            Key={"executionId": "exec1"},
+            UpdateExpression=(
+                "SET nodeResults.#nid.#status = :nstatus, "
+                "nodeResults.#nid.#error = :error, #status = :estatus, "
+                "#failedAt = :failedAt"
+            ),
+            ExpressionAttributeNames={
+                "#nid": "node1", "#status": "status",
+                "#failedAt": "failedAt", "#error": "error",
+            },
+            ExpressionAttributeValues={
+                ":nstatus": "failed", ":error": "boom",
+                ":estatus": "failed", ":failedAt": ex._now_iso(),
+            },
+        )
+        row = e2e["resource"].Table(EXEC_TABLE).get_item(Key={"executionId": "exec1"})["Item"]
+        assert row["status"] == "failed"

--- a/arbiter/workerWrapper/__tests__/test_tool_crash_discriminator.py
+++ b/arbiter/workerWrapper/__tests__/test_tool_crash_discriminator.py
@@ -1,0 +1,235 @@
+"""Three-way failure discriminator + finalize-on-raise tests (finding 4595b730).
+
+STRUCTURAL basis (never error-message matching):
+  * infra/governance REFUSAL  -> LedgerError from reserve/finalize -> node FAILS
+  * tool UNHANDLED EXCEPTION   -> an exception ESCAPES the tool's stream()
+                                  -> node FAILS (a crash is not a business outcome)
+  * tool-returned STRUCTURED   -> the tool RETURNS {"status":"error"}
+    domain error                 -> node COMPLETES
+
+Plus FINALIZE ON RAISE: when a tool raises, the reservation is finalized FAILED
+so no ledger row is left in_flight, and 'indeterminate' is reserved strictly
+for a genuinely-unknown outcome (ToolOutcomeError side_effect='unknown').
+
+strands is stubbed with a minimal fake ToolResultEvent, mirroring
+test_composed_tool_governance.py.
+"""
+from __future__ import annotations
+
+import asyncio
+import io
+import json
+import os
+import sys
+import tempfile
+import types
+from unittest.mock import patch
+
+import pytest
+
+_HERE_WW = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
+if _HERE_WW not in sys.path:
+    sys.path.insert(0, _HERE_WW)
+
+import tool_idempotency_hook  # noqa: E402
+from tool_idempotency_hook import _IdempotentToolWrapper  # noqa: E402
+
+ledger = tool_idempotency_hook.ledger  # patch the exact object the hook holds
+
+
+@pytest.fixture
+def fake_tool_result_event(monkeypatch):
+    mod = types.ModuleType("strands.types._events")
+
+    class ToolResultEvent:
+        def __init__(self, tool_result):
+            self.tool_result = tool_result
+
+    mod.ToolResultEvent = ToolResultEvent
+    strands_mod = sys.modules.get("strands") or types.ModuleType("strands")
+    types_mod = sys.modules.get("strands.types") or types.ModuleType("strands.types")
+    monkeypatch.setitem(sys.modules, "strands", strands_mod)
+    monkeypatch.setitem(sys.modules, "strands.types", types_mod)
+    monkeypatch.setitem(sys.modules, "strands.types._events", mod)
+    return ToolResultEvent
+
+
+class _InnerRaises:
+    """Inner tool whose stream RAISES (an exception escapes the tool)."""
+
+    def __init__(self, exc):
+        self._exc = exc
+
+    tool_name = "boom"
+
+    async def stream(self, tool_use, invocation_state, **kwargs):
+        raise self._exc
+        yield  # pragma: no cover — unreachable, makes this an async generator
+
+
+class _InnerReturns:
+    """Inner tool whose stream RETURNS a ToolResult payload (no exception)."""
+
+    def __init__(self, result):
+        self._result = result
+
+    tool_name = "ok"
+
+    async def stream(self, tool_use, invocation_state, **kwargs):
+        from strands.types._events import ToolResultEvent
+
+        yield ToolResultEvent(self._result)
+
+
+def _drive(inner, monkeypatch):
+    """Reserve=WON (no real DDB), capture finalize calls, drive the wrapper."""
+    finals: list = []
+    monkeypatch.setattr(ledger, "reserve", lambda *a, **k: ledger.ReserveResult(ledger.ReserveOutcome.WON))
+    monkeypatch.setattr(ledger, "finalize_success", lambda pk, sk, **k: finals.append(("success", k)))
+    monkeypatch.setattr(ledger, "finalize_failure", lambda pk, sk, **k: finals.append(("failure", k)))
+    monkeypatch.setattr(ledger, "release", lambda pk, sk, **k: finals.append(("release", {})))
+    tool_idempotency_hook.drain_tool_crashes()
+    tool_idempotency_hook.drain_governance_refusals()
+
+    wrapper = _IdempotentToolWrapper(inner, "pk", "sk", inner.tool_name, "ledger")
+
+    async def _run():
+        out = []
+        async for ev in wrapper.stream({"toolUseId": "tu"}, {}):
+            out.append(ev)
+        return out
+
+    return finals, _run
+
+
+class TestDiscriminatorStructural:
+    def test_tool_unhandled_exception_fails_node_and_finalizes_failed(
+        self, monkeypatch, fake_tool_result_event
+    ):
+        finals, run = _drive(_InnerRaises(RuntimeError("kaboom")), monkeypatch)
+        with pytest.raises(RuntimeError):
+            asyncio.run(run())
+        # A tool crash is recorded (node FAILS) ...
+        crashes = tool_idempotency_hook.drain_tool_crashes()
+        assert len(crashes) == 1 and crashes[0]["errorClass"] == "RuntimeError"
+        # ... and the reservation is finalized FAILED (no in_flight leak), NOT
+        # indeterminate (a bare crash is a determinate failure).
+        assert finals == [("failure", {"error_type": "RuntimeError", "retryable": False})]
+
+    def test_tool_returned_structured_error_completes_node(
+        self, monkeypatch, fake_tool_result_event
+    ):
+        finals, run = _drive(
+            _InnerReturns({"toolUseId": "tu", "status": "error", "content": [{"text": "nope"}]}),
+            monkeypatch,
+        )
+        events = asyncio.run(run())
+        assert len(events) == 1
+        # No crash recorded -> node COMPLETES; ledger row finalized failed.
+        assert tool_idempotency_hook.drain_tool_crashes() == []
+        assert finals == [("failure", {"error_type": "tool_error_result", "retryable": False})]
+
+    def test_tool_success_completes_and_finalizes_success(
+        self, monkeypatch, fake_tool_result_event
+    ):
+        finals, run = _drive(
+            _InnerReturns({"toolUseId": "tu", "status": "success", "content": [{"text": "ran"}]}),
+            monkeypatch,
+        )
+        asyncio.run(run())
+        assert tool_idempotency_hook.drain_tool_crashes() == []
+        assert finals and finals[0][0] == "success"
+
+    def test_tool_outcome_unknown_is_the_only_indeterminate(
+        self, monkeypatch, fake_tool_result_event
+    ):
+        exc = ledger.ToolOutcomeError("5xx", side_effect="unknown", error_type="Http500")
+        finals, run = _drive(_InnerRaises(exc), monkeypatch)
+        with pytest.raises(ledger.ToolOutcomeError):
+            asyncio.run(run())
+        # Recorded as a crash (escaped the tool) -> node FAILS, and THIS is the
+        # branch that marks the ledger indeterminate.
+        assert tool_idempotency_hook.drain_tool_crashes()[0]["errorClass"] == "ToolOutcomeError"
+        assert finals == [("failure", {"error_type": "Http500", "retryable": False, "outcome_indeterminate": True})]
+
+    def test_tool_outcome_not_sent_releases_reservation(
+        self, monkeypatch, fake_tool_result_event
+    ):
+        exc = ledger.ToolOutcomeError("conn refused", side_effect="not_sent", retryable=True)
+        finals, run = _drive(_InnerRaises(exc), monkeypatch)
+        with pytest.raises(ledger.ToolOutcomeError):
+            asyncio.run(run())
+        # not_sent -> reservation RELEASED (re-reservable), no in_flight leak.
+        assert finals == [("release", {})]
+        assert tool_idempotency_hook.drain_tool_crashes()[0]["retryable"] is True
+
+
+class TestToolCrashEnvelope:
+    def test_build_tool_crash_envelope_carries_marker_and_class(self):
+        import agent_runner
+        env = agent_runner.build_tool_crash_envelope(
+            [{"errorClass": "RuntimeError", "error": "kaboom", "retryable": False}],
+            [{"inputTokens": 3}],
+        )
+        assert env[agent_runner.AGENT_EXECUTION_FAILURE_MARKER] is True
+        assert env[agent_runner.TOOL_CRASH_MARKER] is True
+        assert env["errorClass"] == "RuntimeError"
+        assert "kaboom" in env["error"]
+        assert env["usage"] == [{"inputTokens": 3}]
+
+    def test_crash_envelope_distinct_from_refusal_marker(self):
+        import agent_runner
+        env = agent_runner.build_tool_crash_envelope([{"errorClass": "X", "error": "y"}], [])
+        assert agent_runner.GOVERNANCE_REFUSAL_MARKER not in env
+
+
+class TestMainDrainsToolCrash:
+    def test_completed_turn_with_recorded_crash_fails(self):
+        import agent_runner
+        import tool_idempotency_hook as hook
+        hook.drain_tool_crashes()
+
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".py", delete=False) as f:
+            f.write(
+                "import tool_idempotency_hook as hook\n"
+                "def handler(**kwargs):\n"
+                "    hook._record_tool_crash(RuntimeError('tool blew up'))\n"
+                "    return 'the agent finished its turn normally'\n"
+            )
+            module_path = f.name
+        try:
+            payload = json.dumps({"modulePath": module_path, "request": {}})
+            fake_stdout = io.StringIO()
+            with patch("sys.stdin") as mock_stdin, patch("sys.stdout", fake_stdout):
+                mock_stdin.read.return_value = payload
+                with pytest.raises(SystemExit) as excinfo:
+                    agent_runner.main()
+            assert excinfo.value.code != 0
+            parsed = json.loads(fake_stdout.getvalue())
+            assert parsed[agent_runner.AGENT_EXECUTION_FAILURE_MARKER] is True
+            assert parsed[agent_runner.TOOL_CRASH_MARKER] is True
+            assert parsed["errorClass"] == "RuntimeError"
+            assert "response" not in parsed
+        finally:
+            os.unlink(module_path)
+            hook.drain_tool_crashes()
+
+
+class TestStructuralGuardCoversCrash:
+    @pytest.mark.parametrize("returncode", [0, 1])
+    @pytest.mark.parametrize("raise_on_error", [True, False])
+    def test_crash_envelope_always_raises(self, returncode, raise_on_error):
+        env = {
+            "AGENT_CONFIG_TABLE": "t", "AGENT_BUCKET_NAME": "b",
+            "COMPLETION_BUS_NAME": "c", "EXECUTIONS_TABLE": "e",
+        }
+        with patch.dict("os.environ", env):
+            sys.modules.pop("index", None)
+            import index
+            stdout = json.dumps({
+                "agentExecutionFailed": True, "toolExecutionCrashed": True,
+                "errorClass": "RuntimeError", "error": "kaboom", "usage": [],
+            })
+            with pytest.raises(index.AgentExecutionError) as excinfo:
+                index._interpret_agent_result(returncode, stdout, raise_on_error=raise_on_error)
+        assert excinfo.value.error_class == "RuntimeError"

--- a/arbiter/workerWrapper/agent_runner.py
+++ b/arbiter/workerWrapper/agent_runner.py
@@ -90,6 +90,44 @@ def build_refusal_envelope(refusals: list, usage: list) -> dict:
         'usage': usage if isinstance(usage, list) else [],
     }
 
+
+# Tool-execution CRASH marker (finding 4595b730) — third arm of the failure
+# discriminator. Distinct observability key so a tool-crash failure envelope is
+# distinguishable from an infra/governance refusal (build_refusal_envelope) and
+# an agent-body crash (build_failure_envelope), while ALSO carrying the shared
+# AGENT_EXECUTION_FAILURE_MARKER so the SAME structural guard in
+# index._interpret_agent_result raises regardless of exit code. This is how the
+# "no completed-with-failure" guard is EXTENDED to a tool that RAISED (an
+# exception escaped it) — as opposed to a tool that RETURNED a structured
+# {"status":"error"} payload, which records nothing and completes the node.
+TOOL_CRASH_MARKER = 'toolExecutionCrashed'
+
+
+def build_tool_crash_envelope(crashes: list, usage: list) -> dict:
+    """Build the stdout failure envelope for tool crashes recorded during a
+    turn that otherwise COMPLETED normally (finding 4595b730).
+
+    Same structural shape as ``build_refusal_envelope`` (carries
+    ``AGENT_EXECUTION_FAILURE_MARKER`` so the parent's guard raises, plus the
+    FIRST crash's exception class as the retry.py classification key and the
+    joined diagnostics), but flagged with ``TOOL_CRASH_MARKER`` rather than
+    ``GOVERNANCE_REFUSAL_MARKER`` so the three failure classes stay distinct in
+    observability. The caller must only invoke this when ``crashes`` is
+    non-empty.
+    """
+    first = crashes[0]
+    diagnostics = '; '.join(
+        str(c.get('error') or c.get('errorClass') or 'tool execution crash')
+        for c in crashes
+    )
+    return {
+        AGENT_EXECUTION_FAILURE_MARKER: True,
+        TOOL_CRASH_MARKER: True,
+        'errorClass': first.get('errorClass') or 'ToolExecutionError',
+        'error': diagnostics or 'tool execution crashed',
+        'usage': usage if isinstance(usage, list) else [],
+    }
+
 # Ordered candidate method names probed on strands.models.BedrockModel to
 # find the response-producing seam to wrap. Multiple candidates survive a
 # strands rename of the primary method without requiring a code change here.
@@ -595,6 +633,26 @@ def _drain_governance_refusals() -> list:
         return []
 
 
+def _drain_tool_crashes() -> list:
+    """Drain the tool-execution CRASH sink (finding 4595b730).
+
+    Populated by ``tool_idempotency_hook`` when an exception ESCAPES the real
+    tool's ``stream()`` (a crash, distinct from a tool-RETURNED structured
+    error). Imported defensively: if the hook module is unavailable there can be
+    no recorded crashes, so degrade to an empty list rather than failing."""
+    try:
+        from tool_idempotency_hook import drain_tool_crashes
+    except ImportError:
+        return []
+    try:
+        return drain_tool_crashes()
+    except Exception as exc:  # noqa: BLE001 — draining must never break dispatch
+        sys.stderr.write(
+            f'[agent_runner] WARN tool-crash drain failed: {exc}\n'
+        )
+        return []
+
+
 def main():
     # Read input from stdin (single JSON line)
     raw = sys.stdin.read()
@@ -617,6 +675,10 @@ def main():
     # #84 because #84's post-turn refusal-drain machinery (build_refusal_envelope
     # + the drain block after module.handler) is part of this merged file.
     _drain_governance_refusals()
+    # Reset the tool-execution CRASH sink too (finding 4595b730) — same
+    # per-process hygiene so a prior in-process test run's crash can't leak into
+    # this turn's post-turn drain.
+    _drain_tool_crashes()
 
     # Install the SINGLE composed tool-call seam (finding 027c4a89): layer-2
     # tool governance THEN tool-call idempotency, at one BeforeToolCallEvent
@@ -687,6 +749,19 @@ def main():
     refusals = _drain_governance_refusals()
     if refusals:
         sys.stdout.write(json.dumps(build_refusal_envelope(refusals, _CAPTURED_USAGE)))
+        sys.stdout.flush()
+        sys.exit(1)
+
+    # Third discriminator arm (finding 4595b730): a tool that RAISED (an
+    # exception escaped it) is recorded in the crash sink. Drained AFTER the
+    # refusal sink (infra/governance refusal is the more fundamental failure and
+    # takes envelope priority); a bare tool crash still fails the node with the
+    # crash CLASS fed to retry.py. A tool that RETURNED a structured
+    # {"status":"error"} payload records nothing here and falls through to the
+    # normal success envelope below (node COMPLETES).
+    crashes = _drain_tool_crashes()
+    if crashes:
+        sys.stdout.write(json.dumps(build_tool_crash_envelope(crashes, _CAPTURED_USAGE)))
         sys.stdout.flush()
         sys.exit(1)
 

--- a/arbiter/workerWrapper/governed_tool_handler.py
+++ b/arbiter/workerWrapper/governed_tool_handler.py
@@ -12,11 +12,16 @@ Provides a Strands AgentToolHandler subclass whose preprocess() method:
   4. On PERMIT returns None; execution proceeds through the default
      Strands handler.
 
-Best-effort ledger semantics: if ``GOVERNANCE_LEDGER_TABLE`` is unset (e.g.
-local test env), ``write_finding`` raises ``LedgerWriteError``. The worker
-handler catches it and WARN-logs — it does NOT fail closed at this
-scope. Fail-closed semantics apply at the supervisor dispatch level
-(US-ARB-008), not at the per-tool preprocess hook.
+Fail-closed ledger semantics (decision gov-write-fail-closed): if
+``GOVERNANCE_LEDGER_TABLE`` is unset (e.g. local test env) or the write
+otherwise fails, ``write_finding`` raises ``LedgerWriteError``. Both the
+legacy ``preprocess`` path and the hooks-based path route that failure
+through ``record_governance_decision``, which refuses the tool call (an
+unauditable PERMIT/DENY record is never allowed to reach an unprotected
+execution) and records the failure into the shared node-failure sink so the
+node fails post-turn. This REPLACES the former best-effort WARN+continue
+(AC 9.4) and applies at the per-tool preprocess/hook scope itself, not only
+at the supervisor dispatch level.
 
 Import path note
 ----------------

--- a/arbiter/workerWrapper/governed_tool_handler.py
+++ b/arbiter/workerWrapper/governed_tool_handler.py
@@ -131,6 +131,48 @@ def _deny_error_result(tool_use_id: str, tool_name: str) -> dict:
     }
 
 
+def _audit_unavailable_result(tool_use_id: str, tool_name: str) -> dict:
+    """ToolResult-shaped error dict returned when the governance legibility
+    write FAILED (fail-closed, decision gov-write-fail-closed).
+
+    Distinct message from a policy denial: the tool was not *denied by policy*,
+    it was blocked because its PERMIT/DENY audit record could not be written and
+    an unauditable tool execution is not permitted (see
+    ``record_governance_decision``)."""
+    return {
+        'toolUseId': tool_use_id,
+        'status': 'error',
+        'content': [
+            {'text': (
+                f"Tool '{tool_name}' execution refused: its governance audit "
+                "record could not be written (fail-closed — an unauditable "
+                "tool execution is not permitted)."
+            )}
+        ],
+    }
+
+
+def _record_audit_write_refusal(exc: Exception) -> None:
+    """Record a governance-finding-WRITE failure into the shared node-failure
+    refusal sink so the node FAILS post-turn (decision gov-write-fail-closed).
+
+    Uses the SAME structural sink (``tool_idempotency_hook._GOVERNANCE_REFUSALS``)
+    that a tool-execution-ledger infra refusal uses, so a governance-write
+    failure and a ledger infra failure fail the node through ONE mechanism
+    (three-way discriminator, finding 4595b730). Lazily imported: the sink lives
+    in the worker bundle, always present in the deployed worker and under
+    pytest; a genuinely-absent sink still leaves the tool blocked (the caller's
+    error ToolResult), it just can't additionally fail the node."""
+    try:
+        from tool_idempotency_hook import _record_governance_refusal
+    except ImportError:  # pragma: no cover — worker-bundle sibling; always present
+        return
+    try:
+        _record_governance_refusal(exc)
+    except Exception as sink_exc:  # noqa: BLE001 — recording must never itself crash
+        logger.error('failed to record governance-write refusal: %s', sink_exc)
+
+
 def build_governance_finding(
     tool_name: str,
     denied: bool,
@@ -171,7 +213,7 @@ def record_governance_decision(
     eval_run_id: str | None = None,
 ) -> tuple[bool, dict | None]:
     """Evaluate the deny-list decision, write the audit finding, and return
-    ``(denied, error_result_or_None)``.
+    ``(denied_or_blocked, error_result_or_None)``.
 
     THE single source of truth for the layer-2 tool-call governance decision.
     Both the legacy ``GovernedToolHandler.preprocess`` (strands ``tool_handler``
@@ -179,11 +221,30 @@ def record_governance_decision(
     seam) call this — so the two can never diverge (the exact root cause of
     finding 027c4a89 was two decision surfaces, one live and one dead).
 
-    A finding is written on BOTH permit and deny (full audit trail). Ledger
-    write failure is best-effort at this scope (AC 9.4): WARN + continue — the
-    denial itself is NEVER weakened by a ledger outage. The DENY short-circuit
-    (returning an error ToolResult) is independent of whether the finding
-    persisted.
+    A finding is written on BOTH permit and deny (full audit trail).
+
+    GOVERNANCE-WRITE POLICY — FAIL-CLOSED (decision gov-write-fail-closed,
+    settling the run-3/run-4 inconsistency of finding 4595b730). A governance
+    legibility write failure is NOT best-effort here: it is treated as an
+    infrastructure refusal. A PERMIT/DENY audit record that cannot be persisted
+    means an UNAUDITABLE tool execution, which is exactly what Citadel's
+    governance guarantee (and Article 3's fail-closed constitutional rule)
+    forbids — the platform's whole value is that every governed action leaves a
+    defensible record. On a ``LedgerWriteError`` we therefore:
+      1. record the failure into the shared node-failure refusal sink so the
+         node FAILS post-turn (same structural mechanism a tool-execution-ledger
+         infra refusal uses — three-way discriminator), and
+      2. return ``(True, audit_unavailable_result)`` so the caller BLOCKS the
+         tool (it never runs unaudited — a DENY is preserved a fortiori).
+    The availability cost (a governance-ledger blip fails the tool call) is the
+    intended tradeoff for an audit platform, and is bounded: the recorded class
+    (``LedgerWriteError``) is a retry.py classification key a node's retry policy
+    can retry, and the single marshalling boundary (finding 96d24639) removes the
+    most common historical cause of these write failures (a native-float item).
+
+    This REPLACES the former best-effort WARN+continue (AC 9.4). The DENY
+    short-circuit is still independent of the write: a denial is never weakened
+    by a ledger outage, and now an unauditable PERMIT is blocked too.
     """
     denied = tool_name in denied_tools
     finding = build_governance_finding(
@@ -193,11 +254,15 @@ def record_governance_decision(
     try:
         write_finding(finding)
     except LedgerWriteError as exc:
-        logger.warning(
-            'governance ledger write failed at worker-tool-handler '
+        # FAIL-CLOSED: unauditable execution is not permitted. Fail the node
+        # (refusal sink) AND block the tool (audit-unavailable error result).
+        logger.error(
+            'governance ledger write FAILED at worker-tool-handler (fail-closed) '
             'finding_id=%s tool=%s: %s',
             finding.finding_id, tool_name, exc,
         )
+        _record_audit_write_refusal(exc)
+        return True, _audit_unavailable_result(tool_use_id, tool_name)
     if denied:
         return True, _deny_error_result(tool_use_id, tool_name)
     return False, None

--- a/arbiter/workerWrapper/tool_idempotency_hook.py
+++ b/arbiter/workerWrapper/tool_idempotency_hook.py
@@ -127,6 +127,51 @@ def _record_governance_refusal(exc: "ledger.LedgerError") -> None:
     })
 
 
+# ---------------------------------------------------------------------------
+# Tool-CRASH sink — third arm of the failure discriminator (finding 4595b730).
+# ---------------------------------------------------------------------------
+# STRUCTURAL basis (never message matching): the two node-failing arms are
+# distinguished by SHAPE, not text.
+#   * INFRA/GOVERNANCE REFUSAL -> a LedgerError raised by reserve/finalize (the
+#     gate itself failed / refused) -> _GOVERNANCE_REFUSALS -> node FAILS.
+#   * TOOL UNHANDLED EXCEPTION  -> an exception ESCAPED the real tool's stream()
+#     -> recorded HERE -> node FAILS. A crash is NOT a business outcome: strands
+#     converts a tool exception into an error-status ToolResult and lets the
+#     turn COMPLETE normally, so without capturing it the worker would emit
+#     workflow.node.completed for a run whose tool crashed. This sink is what
+#     the third discriminator arm keys on.
+#   * TOOL-RETURNED STRUCTURED DOMAIN ERROR ({"status":"error"}) records NOTHING
+#     in either sink -> node COMPLETES (the tool ran and reported a handled
+#     outcome; the agent is expected to deal with it).
+# ``agent_runner`` drains this sink AFTER the turn (alongside the refusal sink)
+# and, if non-empty, emits a failure-marked envelope so the node fails with the
+# crash CLASS fed into retry.py.
+_TOOL_CRASHES: list[dict[str, Any]] = []
+
+
+def drain_tool_crashes() -> list[dict[str, Any]]:
+    """Return and CLEAR the tool-execution crashes recorded during this
+    process's tool calls. Called once by ``agent_runner`` after the turn;
+    clearing keeps repeated in-process test invocations independent."""
+    drained = list(_TOOL_CRASHES)
+    _TOOL_CRASHES.clear()
+    return drained
+
+
+def _record_tool_crash(exc: BaseException) -> None:
+    """Record that an exception ESCAPED the real tool's ``stream()``.
+
+    Structural signal (not message matching): we are inside the wrapper's
+    ``except`` for ``self._inner.stream(...)``, so an exception provably escaped
+    the tool. ``retryable`` is read from a classified ``ToolOutcomeError`` when
+    present (else False); the crash CLASS is what retry.py matches on."""
+    _TOOL_CRASHES.append({
+        "errorClass": type(exc).__name__,
+        "error": str(exc) or type(exc).__name__,
+        "retryable": bool(getattr(exc, "retryable", False)),
+    })
+
+
 try:
     from strands.hooks import BeforeToolCallEvent  # type: ignore
     from strands.types.tools import AgentTool  # type: ignore
@@ -248,23 +293,66 @@ class _IdempotentToolWrapper(AgentTool):  # type: ignore[misc]
             return
 
         # WON — execute the real tool under the reservation.
+        #
+        # THREE-WAY FAILURE DISCRIMINATOR (finding 4595b730), decided on a
+        # STRUCTURAL basis — an exception ESCAPING the tool vs the tool
+        # RETURNING an error payload — never on error-message matching:
+        #   * TOOL UNHANDLED EXCEPTION (anything escaping self._inner.stream)
+        #     -> a crash is NOT a business outcome -> finalize the reservation
+        #        FAILED + _record_tool_crash -> node FAILS.
+        #   * TOOL-RETURNED STRUCTURED domain error ({"status":"error"})
+        #     -> the tool ran and reported a handled outcome -> finalize the
+        #        reservation FAILED but record NOTHING -> node COMPLETES.
+        #   (INFRA/GOVERNANCE REFUSAL is the LedgerError arm, handled above at
+        #    reserve and below at finalize via _record_governance_refusal.)
         last_result: Any = None
         try:
             async for event in self._inner.stream(tool_use, invocation_state, **kwargs):
                 if isinstance(event, ToolResultEvent):
                     last_result = event.tool_result
                 yield event
-        except Exception as exc:  # noqa: BLE001 — unknown outcome, fail safe
+        except ledger.ToolOutcomeError as exc:
+            # Adapter-CLASSIFIED failure that ESCAPED the tool. Apply the same
+            # failure matrix as the sync execute_idempotent coordinator, then
+            # record a tool crash (an exception escaped -> node FAILS). Only the
+            # genuinely-unknown branch marks the row indeterminate.
+            if exc.side_effect == "not_sent" and exc.retryable:
+                ledger.release(self._pk, self._sk)
+            elif exc.side_effect == "applied":
+                ledger.finalize_failure(
+                    self._pk, self._sk, error_type=exc.error_type, retryable=False,
+                )
+            else:  # 'unknown' — genuinely indeterminate outcome
+                ledger.finalize_failure(
+                    self._pk, self._sk, error_type=exc.error_type,
+                    retryable=False, outcome_indeterminate=True,
+                )
+            _record_tool_crash(exc)
+            raise
+        except Exception as exc:  # noqa: BLE001 — unhandled tool crash
+            # FINALIZE ON RAISE (finding 4595b730): an unclassified exception
+            # escaped the tool. Transition the reservation to FAILED so no row
+            # is left in_flight. Deliberately NOT marked indeterminate —
+            # 'indeterminate' is reserved strictly for a genuinely-unknown
+            # outcome (the ToolOutcomeError 'unknown' branch above); a bare
+            # crash is a determinate node failure retry.py may retry per policy.
             ledger.finalize_failure(
-                self._pk, self._sk, error_type=type(exc).__name__,
-                retryable=False, outcome_indeterminate=True,
+                self._pk, self._sk, error_type=type(exc).__name__, retryable=False,
             )
+            _record_tool_crash(exc)
             raise
 
+        # Tool RETURNED (no exception escaped). Finalize from the returned
+        # payload ALWAYS — so a completed turn can NEVER leave a row in_flight
+        # (finding 4595b730), including the case where the tool streamed no
+        # ToolResultEvent (last_result is None -> finalize completed with null).
         try:
             if isinstance(last_result, dict) and last_result.get("status") == "error":
+                # STRUCTURED domain error: tool ran, reported a handled failure.
+                # Ledger row -> failed, but NO tool crash recorded -> node
+                # COMPLETES (the agent is expected to handle it).
                 ledger.finalize_failure(self._pk, self._sk, error_type="tool_error_result", retryable=False)
-            elif last_result is not None:
+            else:
                 ledger.finalize_success(self._pk, self._sk, result=last_result)
         except ledger.LedgerError as exc:
             # The tool already ran, but the ledger could not durably record its


### PR DESCRIPTION
## Summary
Four deploys of this capability produced four smoke runs, and each run revealed exactly one new defect that a green test suite had approved. Every one was same shape: the logic was right and the *deployment contract* was not - a module not importable from the bundle, a subprocess with no credentials, keys double-marshalled, an expression DynamoDB rejects, an env var never wired, floats where Decimals are required.

Patching the newest symptom each time was the mistake. This PR inverts the order: the harness that finds these defects was written **first**, run against the unfixed code to enumerate everything at once, and only then were the fixes made.

## What changed

**Discovery harness (written before any fix).** An end-to-end suite driving a realistic node execution against moto with real boto3 clients and table definitions copied from the CDK - no in-memory fakes for any write. It covers all 13 write paths in the tool-call flow, including the ones previous rounds missed: the tool's own marker write, the governance finding write, ledger reserve and finalize, the fenced transaction, the node-result write, and the node-failure update. Run against the pre-fix tree, it reproduced every outstanding defect locally.

**One marshalling boundary.** A shared helper that converts or rejects floats (integer epoch seconds for TTL, `Decimal` for genuine fractional values). The tool write, governance finding write, and ledger writes all route through it, so the fix is structural rather than two patched call sites - a float cannot silently reach DynamoDB.

**A three-way failure discriminator.** Previously two cases: a ledger refusal failed the node, everything else completed. That let a tool which *crashed* be reported as a completed node. Now: an infrastructure refusal fails, a tool's unhandled exception fails, and a tool's deliberately returned structured error completes. The distinction is structural - an exception escaping the tool versus a returned payload - never message matching. The no-'completed'-with-a-failure guard was extended to the new case.

**Finalize on raise.** When a tool raises, the ledger reservation is finalized as failed instead of being left `in_flight`; `indeterminate` is now reserved strictly for genuinely unknown outcomes. A test asserts no reservation can remain in flight once a node reaches a terminal state.

**Governance writes fail closed.** The two runs disagreed - one refused the call, one logged and continued. Settled deliberately: an unrecordable governance decision now refuses the tool call, on the reasoning that an unauditable governed side effect is worse than an unavailable one. Implemented at a single choke point covering both call sites, documented, and tested.

## Two defects the review caught

Worth naming, because they are the same species this PR exists to eliminate:
- The handler's module docstring still asserted the *opposite* (best-effort) policy from the one implemented.
- The marshalling helper degraded to an identity no-op on 'ImportError' - the guarantee could silently vanish. It now propagates, proven by reinstating the no-op and watching the test fail.

## Testing
Arbiter pytest 1,362 passing; backend jest 6,830; `tsc` clean; both stacks clean. The assertion diff was reviewed explicitly: 75 assertions added, and removed were deliberate inversions of behaviour this PR changes - nothing loosened.

## DepLoyment notes
No new resources; behavioural changes only, plus test infrastructure. Deploy from **main** after merge. One smoke run then tells us whether the whole chain works: expect exactly one ledger row in a *terminal* state, one side-effect row, one governance ALLOW record, and a truthful execution status - followed by a forced re-dispatch to exercise the dispatch fence live.