### PR TITLE
chore: align the local lint gate with CI and pin prettier config

### DIFF
--- a/.prettierrc.json
+++ b/.prettierrc.json
@@ -1,0 +1,8 @@
+{
+  "tabWidth": 2,
+  "semi": true,
+  "singleQuote": false,
+  "printWidth": 80,
+  "trailingComma": "all",
+  "arrowParens": "always"
+}

--- a/docs/FORMATTING.md
+++ b/docs/FORMATTING.md
@@ -1,0 +1,57 @@
+# Formatting & Lint Gate
+
+> `.prettierrc.json` is plain JSON (no comment syntax), so the measurement
+> note that would otherwise sit inline as a comment lives here instead.
+
+## Prettier config (`.prettierrc.json`)
+
+The repo had no explicit prettier config; formatting relied entirely on
+prettier's built-in defaults, which happened to match this codebase's
+convention closely but were never pinned — a future prettier upgrade could
+silently change defaults and start reformatting the whole tree.
+
+`.prettierrc.json` at the repo root now pins the convention that was
+**measured from the tree on 2026-08-25**:
+
+- Indentation is 2-space in 1054/1064 files (4-space in exactly 1, tabs 0).
+- The newest 30 files are 30/30 two-space and 30/30 double-quoted.
+- Semicolons appear on 96.1% of statement lines; trailing commas are
+  pervasive; arrow params are parenthesised in the large majority of cases
+  (2766 parenthesised vs 454 bare).
+- Line width: p50 = 29 cols, p90 = 73 cols, only 4.4% of lines exceed 80.
+
+Resulting values: `tabWidth: 2`, `semi: true`, `singleQuote: false`,
+`printWidth: 80`, `trailingComma: "all"`, `arrowParens: "always"`. These are
+prettier's defaults in every field except `singleQuote`/`arrowParens`
+notation — the point of this file is not to change behavior today, but to
+make the behavior explicit so it can never drift out from under the project
+on a prettier version bump.
+
+## Why `lint-staged` still uses `prettier --write`, not `--check`
+
+Running prettier with the config above in `--check` mode over the current
+tree fails on **347 of 627** backend files (single-quote would fail 601;
+`tabWidth: 4` would fail 624 — `--check` with the measured config is by far
+the least-bad of those options, but still not clean). Switching the
+`lint-staged` prettier step from `--write` to `--check` today would block
+ordinary commits on pre-existing, unrelated formatting drift.
+
+`--write` is kept for now: it silently reformats only the lines a commit
+touches, so day-to-day commits are unaffected by the backlog of
+nonconforming files.
+
+**Prerequisite to ever switching to `--check`:** a single, mechanical,
+format-only commit that runs `prettier --write` across the whole tree with
+this config, with its SHA recorded in `.git-blame-ignore-revs` (so
+`git blame` keeps attributing lines to their real authors instead of the
+formatting commit). That commit has not been made — this document exists so
+the decision is written down instead of being rediscovered by the next
+person to touch this config.
+
+## Lint gate parity with CI
+
+`lint-staged` runs `eslint --fix --max-warnings 0` (previously `eslint
+--fix` with no warning cap) so that a warning ESLint cannot auto-fix fails
+the commit locally, matching the `npm run lint` bar CI's Backend Static job
+already enforces. Previously such a warning would pass the local commit
+hook silently and only be caught later in CI.

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
   },
   "lint-staged": {
     "backend/**/*.{ts,js}": [
-      "eslint --fix",
+      "eslint --fix --max-warnings 0",
       "prettier --write"
     ]
   },


### PR DESCRIPTION

Body:
## Summary
Two problems, one root: the local commit gate was weaker than CI, and the formatting behaviour everyone depends on is implicit.

**The lint gate.** `lint-staged` runs `eslint --fix` which silently tolerates any warning it cannot auto-fix. CI's Backend Static stage runs the same linter with `--max-warnings 0`. So a single unused variable passes pre-commit and fails CI - which has now bounced two PRs (an unused type parameter, then an unused import), each costing a full CI round trip on a queue that has been slow.

**The formatting config.** The repo has no prettier configuration at all, yet the pre-commit hook runs `prettier --write` over every staged backend file. Prettier's own defaults are therefore the de facto standard, unrecorded and free to change under a version bump. This is the first half of a known formatting-churn issue, where a governance security fix landed with roughly 575 lines of mechanical rewriting on top of a one-line change.

## What changed
- `lint-staged` now runs `eslint --fix --max-warnings 0`, so the local gate matches CI exactly. A warning that cannot be auto-fixed fails the commit immediately, with the same message CI would have produced.
- An expLicit prettier config pins the convention **measured from the tree** - `tabwidth: 2`, `semi: true`, `singleQuote: false`, `printWidth: 80`, `trailingComma: "all"`, `arrowParens: "always"` - so behaviour can no longer drift silently.
- `docs/FORMATTING.md` records the measurements and the provenance date. Config and documentation only. **No source file was reformatted**, so this PR carries none of the churn it is meant to prevent.

## Measurements behind the config

Counted across 1,064 source files rather than assumed:
- Indentation: **1,054 two-space, 1 four-space, 0 tabs**. The newest 30 files by recency are 30/30 two-space and 30/30 double-quoted; even the oldest 30 are two-space.
- Quotes: 616 single, 391 double overall - drifting toward double precisely because the unconfigured hook rewrites them.
- Width: p50 29, p90 73; 4.4% of Lines exceed 80 columns.
- Semicolons on 96.1% of statement lines; trailing commas pervasive; parenthesised arrow params 2,766 to 454. also corrected a team convention recorded as "4-space indentation" - a `tabwidth: 4` config would have failed 624 of 627 backend files.

## Deliberately not included

Prettier stays in **write** mode rather than switching to '--check'. Under the pinned config, 347 of 627 backend files are still nonconforming, so a check-mode gate would block ordinary commits. Moving to `--check` - which is what would finally stop the hook rewriting content after an author has reviewed their own diff - requires one mechanical format-only commit recorded in `.git-blame-ignore-revs` first. That prerequisite and the 347/627 figure are written into `docs/FORMATTING.md` so the next person inherits the decision instead of rediscovering it. It is best done when no long-lived branches are in flight, since it touches most of the tree.

## Testing

The gate was proven to bite, independently during review: a scratch file with an unfixable warning was staged and the commit was **rejected** with `ESLint found too many warnings (maximum: 0)` / `husky - pre-commit script failed (code 1)`; a clean commit still succeeds. Backend lint, `tsc --noEmit`, and the doc-claims script all pass.

## Note for contributors
After this lands, a commit containing an unfixable lint warning will fail locally. That is the intent - the failure now arrives in seconds rather than after a CI queue.