### PR TITLE
feat(deploy): gate deploys on expected ref and resource deletion

### DIFF
--- a/backend/lib/arbiter-stack.ts
+++ b/backend/lib/arbiter-stack.ts
@@ -24,7 +24,7 @@ import { SqsEventSource } from "aws-cdk-lib/aws-lambda-event-sources";
 import { BlockPublicAccess, Bucket } from "aws-cdk-lib/aws-s3";
 import { Construct } from "constructs";
 import { NagSuppressions } from "cdk-nag";
-import path = require("path");
+import * as path from "path";
 import * as fs from "fs";
 
 // Resolve the repo-root `arbiter/` directory regardless of whether this
@@ -436,7 +436,19 @@ export class ArbiterStack extends cdk.Stack {
         timeToLiveAttribute: "ttl",
         encryption: dynamodb.TableEncryption.AWS_MANAGED,
         pointInTimeRecoverySpecification: { pointInTimeRecoveryEnabled: true },
-        removalPolicy: cdk.RemovalPolicy.DESTROY,
+        // Deploy-safety (findings 7f42ae86 / 9c92a738): this is an operational
+        // idempotency store (short TTL, not an audit artifact) — but its rows
+        // are LIVE in-flight state, and a divergent-branch deploy that silently
+        // DELETES the whole table would break idempotency guarantees for every
+        // reservation currently inside its TTL window (the finding-9c92a738
+        // DELETE_COMPLETE path). RETAIN + deletionProtection guard the TABLE;
+        // the `ttl` attribute above still expires individual rows, so the
+        // operational self-cleaning this store was designed around is
+        // unchanged. This deliberately reverses the prior DESTROY intent per
+        // the approved finding. Orphaned-table-on-re-add recovery (AlreadyExists
+        // -> import or rename) is documented in docs/DEPLOYMENT.md.
+        removalPolicy: cdk.RemovalPolicy.RETAIN,
+        deletionProtection: true,
       },
     );
 
@@ -464,7 +476,18 @@ export class ArbiterStack extends cdk.Stack {
       bucketKeyEnabled: true,
       blockPublicAccess: BlockPublicAccess.BLOCK_ALL,
       enforceSSL: true,
-      removalPolicy: cdk.RemovalPolicy.DESTROY,
+      // Deploy-safety (findings 7f42ae86 / 9c92a738): oversized tool results
+      // offloaded here are LIVE state referenced by not-yet-expired ledger
+      // rows; a divergent-branch deploy that silently DELETES the bucket would
+      // make those resultRefs unresolvable (the finding-9c92a738 path applied
+      // to a bucket). RETAIN so the bucket survives stack teardown/reconcile.
+      // S3 has no per-bucket deletionProtection flag; the KMS CMK above is
+      // already RETAIN, so the objects stay decryptable. The 7-day lifecycle
+      // rule below still expires individual objects, so this stays an
+      // operational store — RETAIN only blocks silent whole-bucket teardown.
+      // This deliberately reverses the prior DESTROY intent per the approved
+      // finding; orphaned-bucket-on-re-add recovery is in docs/DEPLOYMENT.md.
+      removalPolicy: cdk.RemovalPolicy.RETAIN,
       lifecycleRules: [
         {
           id: "tool-results-operational-ttl",
@@ -1788,10 +1811,13 @@ export class ArbiterStack extends cdk.Stack {
     //
     // Four governance-critical configuration tables (authority units,
     // composition contracts, case law, constitutional layers) plus one
-    // append-only ledger. The four config tables carry DeletionProtection
-    // and RemovalPolicy.RETAIN so the corpus survives stack deletion; the
-    // ledger uses RemovalPolicy.DESTROY with a 90-day TTL (`ttl` attr)
-    // since its lifecycle is governed by TTL rather than table retention.
+    // append-only ledger. All five carry DeletionProtection and
+    // RemovalPolicy.RETAIN so the corpus AND the accountability ledger
+    // survive stack deletion / divergent-branch reconciliation (findings
+    // 7f42ae86, 9c92a738). The ledger additionally keeps a 90-day TTL
+    // (`ttl` attr): deletionProtection guards the TABLE while the TTL still
+    // expires individual rows, so operational self-cleaning is unchanged —
+    // only silent whole-table teardown is now blocked.
     // All five enable PITR to satisfy AwsSolutions-DDB3 (cdk-nag).
     //
     // Tables are exposed as public readonly fields on ArbiterStack so
@@ -1901,7 +1927,16 @@ export class ArbiterStack extends cdk.Stack {
           type: dynamodb.AttributeType.STRING,
         },
         billingMode: dynamodb.BillingMode.PAY_PER_REQUEST,
-        removalPolicy: cdk.RemovalPolicy.DESTROY,
+        // Deploy-safety (findings 7f42ae86 / 9c92a738): the governance ledger
+        // is an accountability/audit store. RETAIN + deletionProtection so a
+        // divergent-branch deploy cannot silently DELETE the table (finding
+        // 9c92a738's DELETE_COMPLETE path). The `ttl` attribute still expires
+        // individual rows on its 90-day schedule — deletionProtection guards
+        // the TABLE, not the rows — so operational self-cleaning is unchanged;
+        // only whole-table teardown-by-reconcile is now blocked. Tradeoff:
+        // orphaned-table-on-re-add (AlreadyExists) recovery in docs/DEPLOYMENT.md.
+        removalPolicy: cdk.RemovalPolicy.RETAIN,
+        deletionProtection: true,
         timeToLiveAttribute: "ttl",
         pointInTimeRecoverySpecification: { pointInTimeRecoveryEnabled: true },
         // Wave 3.C: enable DynamoDB streams so the governance-finding-fanout

--- a/backend/lib/backend-stack.ts
+++ b/backend/lib/backend-stack.ts
@@ -15,8 +15,6 @@ import { Asset } from "aws-cdk-lib/aws-s3-assets";
 import { CfnGraphQLSchema } from "aws-cdk-lib/aws-appsync";
 import * as path from "path";
 import { Construct } from "constructs";
-import { Provider } from "aws-cdk-lib/custom-resources";
-import { CustomResource, Duration } from "aws-cdk-lib";
 import { NagSuppressions } from "cdk-nag";
 
 interface BackendStackProps extends cdk.StackProps {
@@ -404,7 +402,16 @@ export class BackendStack extends cdk.Stack {
         type: dynamodb.AttributeType.STRING,
       },
       billingMode: dynamodb.BillingMode.PAY_PER_REQUEST,
-      removalPolicy: cdk.RemovalPolicy.DESTROY,
+      // Deploy-safety (findings 7f42ae86 / 9c92a738): workflow execution
+      // records are data-bearing state, not a disposable fixture. RETAIN +
+      // deletionProtection so a divergent-branch deploy (which reconciles the
+      // environment to the deployed tree) cannot silently DELETE this table
+      // and take live execution history with it. Tradeoff: RETAIN converts a
+      // silent data loss into an ORPHANED table, which then makes a later
+      // deploy that re-adds ExecutionsTable fail LOUDLY with AlreadyExists —
+      // recovery (import or rename) is documented in docs/DEPLOYMENT.md.
+      removalPolicy: cdk.RemovalPolicy.RETAIN,
+      deletionProtection: true,
       pointInTimeRecoverySpecification: { pointInTimeRecoveryEnabled: true },
     });
 
@@ -768,7 +775,7 @@ export class BackendStack extends cdk.Stack {
       description: "Full system access",
     });
 
-    const projectManagerGroup = new cognito.CfnUserPoolGroup(
+    const _projectManagerGroup = new cognito.CfnUserPoolGroup(
       this,
       "ProjectManagerGroup",
       {
@@ -778,7 +785,7 @@ export class BackendStack extends cdk.Stack {
       },
     );
 
-    const architectGroup = new cognito.CfnUserPoolGroup(
+    const _architectGroup = new cognito.CfnUserPoolGroup(
       this,
       "ArchitectGroup",
       {
@@ -788,7 +795,7 @@ export class BackendStack extends cdk.Stack {
       },
     );
 
-    const developerGroup = new cognito.CfnUserPoolGroup(
+    const _developerGroup = new cognito.CfnUserPoolGroup(
       this,
       "DeveloperGroup",
       {

--- a/backend/split-baseline/citadel-backend-dev.json
+++ b/backend/split-baseline/citadel-backend-dev.json
@@ -928,8 +928,8 @@
     },
     "ExecutionsTableA2EE59C2": {
       "type": "AWS::DynamoDB::Table",
-      "deletionPolicy": "Delete",
-      "updateReplacePolicy": "Delete",
+      "deletionPolicy": "Retain",
+      "updateReplacePolicy": "Retain",
       "properties": {
         "AttributeDefinitions": [
           {

--- a/backend/test/arbiter-stack-governance-tables.test.ts
+++ b/backend/test/arbiter-stack-governance-tables.test.ts
@@ -117,7 +117,9 @@ describe("ArbiterStack — US-ARB-002 governance tables (Δ8)", () => {
   });
 
   // ----------------------------------------------------------------
-  // DeletionPolicy: Retain on config tables, Delete on the ledger
+  // DeletionPolicy: Retain on all five governance tables (the four config
+  // tables and the ledger — the ledger was flipped from Delete to Retain by
+  // deploy-safety findings 7f42ae86/9c92a738).
   // ----------------------------------------------------------------
   describe("DeletionPolicy", () => {
     const retainedNames = [
@@ -141,15 +143,25 @@ describe("ArbiterStack — US-ARB-002 governance tables (Δ8)", () => {
       },
     );
 
-    test("ledger table has DeletionPolicy=Delete", () => {
+    test("ledger table has DeletionPolicy=Retain (deploy-safety findings 7f42ae86/9c92a738)", () => {
+      // The governance ledger is an accountability store: RETAIN +
+      // deletionProtection so a divergent-branch deploy cannot silently DELETE
+      // it. The `ttl` attribute still expires individual rows; deletionProtection
+      // guards only the table.
       const tables = template.findResources("AWS::DynamoDB::Table", {
         Properties: { TableName: "citadel-governance-ledger-test" },
       });
       const logicalIds = Object.keys(tables);
       expect(logicalIds).toHaveLength(1);
       const resource = tables[logicalIds[0]];
-      expect(resource.DeletionPolicy).toBe("Delete");
-      expect(resource.UpdateReplacePolicy).toBe("Delete");
+      expect(resource.DeletionPolicy).toBe("Retain");
+      expect(resource.UpdateReplacePolicy).toBe("Retain");
+      expect(resource.Properties.DeletionProtectionEnabled).toBe(true);
+      // TTL is retained for row-level expiry even though the table is now retained.
+      expect(resource.Properties.TimeToLiveSpecification).toEqual({
+        AttributeName: "ttl",
+        Enabled: true,
+      });
     });
   });
 

--- a/backend/test/deploy-safety-retention.test.ts
+++ b/backend/test/deploy-safety-retention.test.ts
@@ -1,0 +1,223 @@
+/**
+ * Deploy-safety retention pins (findings 7f42ae86 provenance / 9c92a738
+ * divergent-branch deletion).
+ *
+ * Finding 9c92a738: a divergent-branch deploy reconciles the environment to
+ * the deployed tree and can silently DELETE stateful resources. The defence in
+ * CDK is RemovalPolicy.RETAIN (+ DynamoDB deletionProtection where supported)
+ * on every DATA-BEARING store, so CloudFormation refuses to tear the store
+ * down and the loss becomes a LOUD orphaned-resource / AlreadyExists failure
+ * instead of a silent DELETE_COMPLETE.
+ *
+ * These assertions pin that posture for the resources this change flipped from
+ * DESTROY to RETAIN — executions (backend), governance ledger + tool-execution
+ * ledger + tool-results bucket (arbiter) — and pin the DELIBERATE EXCLUSION of
+ * the disposable smoke fixture (which must stay DESTROY so it self-cleans and
+ * never becomes an orphan that blocks a later deploy).
+ */
+
+import * as cdk from "aws-cdk-lib";
+import { Template, Match } from "aws-cdk-lib/assertions";
+import * as dynamodb from "aws-cdk-lib/aws-dynamodb";
+import * as events from "aws-cdk-lib/aws-events";
+import * as lambda from "aws-cdk-lib/aws-lambda";
+import * as appsync from "aws-cdk-lib/aws-appsync";
+import { Bucket } from "aws-cdk-lib/aws-s3";
+import * as path from "path";
+import * as fs from "fs";
+import {
+  scaffoldBackendAssetDirs,
+  scaffoldArbiterStubs,
+} from "./helpers/scaffold-stub-assets";
+
+scaffoldBackendAssetDirs(["dist/lambda", "src/schema"]);
+scaffoldArbiterStubs();
+
+// BackendStack also needs these seed-lambda asset dirs to synth.
+for (const dir of [
+  path.resolve(__dirname, "../../src/lambda/seed-organizations"),
+  path.resolve(__dirname, "../src/lambda/seed-admin-user"),
+  path.resolve(__dirname, "../src/lambda/seed-organizations"),
+]) {
+  if (!fs.existsSync(dir)) fs.mkdirSync(dir, { recursive: true });
+}
+
+import { BackendStack } from "../lib/backend-stack";
+import { ArbiterStack } from "../lib/arbiter-stack";
+
+function buildArbiterTemplate(environment: string): Template {
+  const app = new cdk.App({ context: { "aws:cdk:bundling-stacks": [] } });
+  const backendStack = new cdk.Stack(app, "MockBackendStack", {
+    env: { account: "123456789012", region: "us-east-1" },
+  });
+  const agentEventBus = new events.EventBus(backendStack, "AgentEventBus", {
+    eventBusName: `citadel-agents-${environment}`,
+  });
+  const mkTable = (id: string, name: string, pk: string) =>
+    new dynamodb.Table(backendStack, id, {
+      tableName: name,
+      partitionKey: { name: pk, type: dynamodb.AttributeType.STRING },
+      billingMode: dynamodb.BillingMode.PAY_PER_REQUEST,
+      removalPolicy: cdk.RemovalPolicy.DESTROY,
+    });
+  const agentConfigTable = mkTable(
+    "AgentConfigTable",
+    `citadel-agents-${environment}`,
+    "agentId",
+  );
+  const workflowsTable = mkTable(
+    "WorkflowsTable",
+    `citadel-workflows-${environment}`,
+    "workflowId",
+  );
+  const executionsTable = mkTable(
+    "ExecutionsTable",
+    `citadel-executions-${environment}`,
+    "executionId",
+  );
+  const executionSpecificationsTable = mkTable(
+    "ExecutionSpecificationsTable",
+    `citadel-execution-specifications-${environment}`,
+    "specId",
+  );
+  const codeBucket = new Bucket(backendStack, "CodeBucket", {
+    bucketName: `citadel-code-${environment}`,
+  });
+  const fanoutFunction = new lambda.Function(backendStack, "FanoutFunction", {
+    runtime: lambda.Runtime.NODEJS_24_X,
+    handler: "workflow-progress-fanout.handler",
+    code: lambda.Code.fromAsset("dist/lambda"),
+    timeout: cdk.Duration.seconds(30),
+  });
+  const appSyncApi = new appsync.GraphqlApi(backendStack, "MockApi", {
+    name: "mock-api",
+    schema: appsync.SchemaFile.fromAsset(
+      path.resolve(__dirname, "../src/schema/schema.graphql"),
+    ),
+  });
+
+  const stack = new ArbiterStack(app, "TestArbiterStack", {
+    environment,
+    env: { account: "123456789012", region: "us-east-1" },
+    agentEventBus,
+    agentConfigTable,
+    codeBucket,
+    workflowsTable,
+    executionsTable,
+    fanoutFunction,
+    appSyncEndpoint: appSyncApi.graphqlUrl,
+    executionSpecificationsTable,
+  });
+  return Template.fromStack(stack);
+}
+
+// Helper: assert a DynamoDB table by name carries RETAIN + deletionProtection.
+function expectRetainedProtectedTable(template: Template, tableName: string) {
+  const tables = template.findResources("AWS::DynamoDB::Table", {
+    Properties: { TableName: tableName },
+  });
+  const ids = Object.keys(tables);
+  expect(ids).toHaveLength(1);
+  const resource = tables[ids[0]];
+  expect(resource.DeletionPolicy).toBe("Retain");
+  expect(resource.UpdateReplacePolicy).toBe("Retain");
+  expect(resource.Properties.DeletionProtectionEnabled).toBe(true);
+}
+
+describe("Deploy-safety retention — BackendStack executions table", () => {
+  let template: Template;
+  beforeAll(() => {
+    const app = new cdk.App();
+    const stack = new BackendStack(app, "TestBackendStackRetention", {
+      environment: "test",
+      env: { account: "123456789012", region: "us-east-1" },
+    });
+    template = Template.fromStack(stack);
+  });
+
+  test("executions table is RETAIN + deletionProtection (data-bearing execution history)", () => {
+    expectRetainedProtectedTable(template, "citadel-executions-test");
+  });
+
+  test("executions table keeps PITR", () => {
+    template.hasResourceProperties("AWS::DynamoDB::Table", {
+      TableName: "citadel-executions-test",
+      PointInTimeRecoverySpecification: { PointInTimeRecoveryEnabled: true },
+    });
+  });
+});
+
+describe("Deploy-safety retention — ArbiterStack data-bearing stores", () => {
+  let template: Template;
+  beforeAll(() => {
+    template = buildArbiterTemplate("test");
+  });
+
+  test("governance ledger table is RETAIN + deletionProtection (audit store)", () => {
+    expectRetainedProtectedTable(template, "citadel-governance-ledger-test");
+  });
+
+  test("governance ledger keeps its row-level TTL (deletionProtection guards the table, not rows)", () => {
+    template.hasResourceProperties("AWS::DynamoDB::Table", {
+      TableName: "citadel-governance-ledger-test",
+      TimeToLiveSpecification: { AttributeName: "ttl", Enabled: true },
+    });
+  });
+
+  test("tool-execution ledger table is RETAIN + deletionProtection (live idempotency state)", () => {
+    expectRetainedProtectedTable(
+      template,
+      "citadel-tool-execution-ledger-test",
+    );
+  });
+
+  test("tool-execution ledger keeps its row-level TTL", () => {
+    template.hasResourceProperties("AWS::DynamoDB::Table", {
+      TableName: "citadel-tool-execution-ledger-test",
+      TimeToLiveSpecification: { AttributeName: "ttl", Enabled: true },
+    });
+  });
+
+  test("tool-results offload bucket is RETAIN (offloaded results referenced by unexpired ledger rows)", () => {
+    const buckets = template.findResources("AWS::S3::Bucket", {
+      Properties: {
+        BucketName: "citadel-tool-results-test-123456789012-us-east-1",
+      },
+    });
+    const ids = Object.keys(buckets);
+    expect(ids).toHaveLength(1);
+    const resource = buckets[ids[0]];
+    expect(resource.DeletionPolicy).toBe("Retain");
+    expect(resource.UpdateReplacePolicy).toBe("Retain");
+  });
+
+  test("tool-results bucket keeps its 7-day operational lifecycle rule (RETAIN blocks teardown, TTL still expires objects)", () => {
+    template.hasResourceProperties("AWS::S3::Bucket", {
+      BucketName: "citadel-tool-results-test-123456789012-us-east-1",
+      LifecycleConfiguration: {
+        Rules: Match.arrayWith([
+          Match.objectLike({
+            Id: "tool-results-operational-ttl",
+            Status: "Enabled",
+            ExpirationInDays: 7,
+          }),
+        ]),
+      },
+    });
+  });
+
+  // --- Deliberate EXCLUSION: the disposable smoke fixture must stay DESTROY ---
+  test("smoke idempotency fixture is DESTROY and NOT deletion-protected (disposable, self-cleaning)", () => {
+    const tables = template.findResources("AWS::DynamoDB::Table", {
+      Properties: { TableName: "citadel-smoke-idempotency-test" },
+    });
+    const ids = Object.keys(tables);
+    expect(ids).toHaveLength(1);
+    const resource = tables[ids[0]];
+    expect(resource.DeletionPolicy).toBe("Delete");
+    expect(resource.UpdateReplacePolicy).toBe("Delete");
+    // Must NOT be deletion-protected: RETAIN on a self-cleaning fixture would
+    // orphan it and block a later re-add (AlreadyExists) for zero data value.
+    expect(resource.Properties.DeletionProtectionEnabled).not.toBe(true);
+  });
+});

--- a/deploy.sh
+++ b/deploy.sh
@@ -215,6 +215,13 @@ cdk_diff() {
     last_error=$(echo "$diff_output" | grep -v '^[[:space:]]*$' | tail -1)
     warn "cdk diff unavailable: $last_error"
   fi
+  # Expose the captured diff to the deletion gate (finding 9c92a738). These
+  # globals let the main flow parse the SAME diff text for resource deletions
+  # without re-invoking cdk. CDK_DIFF_RC=0 means the diff succeeded and its
+  # output can be trusted; non-zero means the gate must fail closed.
+  CDK_DIFF_OUTPUT="$diff_output"
+  CDK_DIFF_RC="$diff_rc"
+  export CDK_DIFF_OUTPUT CDK_DIFF_RC
   popd > /dev/null
 }
 
@@ -653,25 +660,246 @@ health_check() {
 }
 
 # --- Write deployment manifest ---
+# Provenance record (finding 7f42ae86): after a successful run, capture what
+# is actually running so it can be READ rather than recalled from scrollback.
+# Written to deployment-manifest.json at the repo root; that path is gitignored
+# via the `deployment-*.json` rule in .gitignore, so it never gets committed.
 write_manifest() {
   local manifest_file="deployment-manifest.json"
   local deployer
   deployer=$(aws sts get-caller-identity --query 'Arn' --output text ${AWS_PROFILE:+--profile $AWS_PROFILE} 2>/dev/null || echo "unknown")
 
+  # Build a JSON array of the concrete stack names this run targeted.
+  local stacks_json="[]"
+  local names
+  names=$(resolve_deployed_stack_names)
+  if [ -n "$names" ]; then
+    stacks_json=$(printf '%s\n' "$names" | awk 'NF{printf "%s\"%s\"", (c++?",":""), $0} END{print ""}')
+    stacks_json="[${stacks_json}]"
+  fi
+
+  local expected_ref_json="null"
+  [ -n "${EXPECT_REF:-}" ] && expected_ref_json="\"${EXPECT_REF}\""
+
   cat > "$manifest_file" <<EOF
 {
-  "timestamp": "$(date -u +%Y-%m-%dT%H:%M:%SZ)",
+  "started_at": "${DEPLOY_STARTED_AT:-unknown}",
+  "completed_at": "$(date -u +%Y-%m-%dT%H:%M:%SZ)",
   "environment": "$ENVIRONMENT",
   "region": "$CDK_DEFAULT_REGION",
   "account": "$CDK_DEFAULT_ACCOUNT",
   "git_sha": "$GIT_SHA",
   "git_branch": "$GIT_BRANCH",
   "git_dirty": "$GIT_DIRTY",
+  "expected_ref": ${expected_ref_json},
   "deployer": "$deployer",
-  "stacks_deployed": "$DEPLOY_MODE"
+  "deploy_mode": "$DEPLOY_MODE",
+  "stacks": ${stacks_json}
 }
 EOF
-  ok "Deployment manifest written to $manifest_file"
+  ok "Deployment manifest written to $manifest_file (gitignored)"
+}
+
+# --- Expected-ref gate (finding 7f42ae86 — provenance) ---
+# Cross-checks the ref the operator INTENDED against the ref actually resolved
+# from HEAD, so a deploy from the wrong clone/branch cannot proceed silently.
+#   - EXPECT_REF set: accept a branch name, a full sha, or a short/prefix sha;
+#     normalise, compare, and ABORT (naming both) on mismatch.
+#   - EXPECT_REF empty: print the resolved branch+short sha BEFORE any CDK work
+#     and require an interactive y/N confirmation. If stdin is NOT a TTY (an
+#     unattended run), REFUSE rather than hang — an unattended deploy must never
+#     silently proceed without the operator having named the intended ref.
+verify_expected_ref() {
+  local expected="${1:-}"
+  local branch full_sha short_sha
+  branch=$(git rev-parse --abbrev-ref HEAD 2>/dev/null || echo "unknown")
+  full_sha=$(git rev-parse HEAD 2>/dev/null || echo "unknown")
+  short_sha=$(git rev-parse --short HEAD 2>/dev/null || echo "unknown")
+
+  if [ -n "$expected" ]; then
+    # Normalise a fully-qualified ref down to its short name for comparison.
+    local norm="${expected#refs/heads/}"
+    norm="${norm#refs/tags/}"
+    if [ "$norm" = "$branch" ] || [ "$norm" = "$full_sha" ] || [ "$norm" = "$short_sha" ]; then
+      ok "Expected-ref check passed: HEAD is ${branch}@${short_sha} (matches --expect-ref '${expected}')"
+      return 0
+    fi
+    # Allow an abbreviated/extended sha: expected is a case-insensitive prefix
+    # of the full sha (and looks like a hex sha of at least 4 chars).
+    if [[ "$norm" =~ ^[0-9a-fA-F]{4,40}$ ]]; then
+      local norm_lc full_lc
+      norm_lc=$(printf '%s' "$norm" | tr 'A-F' 'a-f')
+      full_lc=$(printf '%s' "$full_sha" | tr 'A-F' 'a-f')
+      if [ "${full_lc#"$norm_lc"}" != "$full_lc" ]; then
+        ok "Expected-ref check passed (sha prefix): HEAD ${short_sha} matches --expect-ref '${expected}'"
+        return 0
+      fi
+    fi
+    err "Expected-ref MISMATCH — refusing to deploy."
+    err "  --expect-ref requested: ${expected}"
+    err "  resolved HEAD:          ${branch}@${short_sha} (${full_sha})"
+    err "This clone's HEAD is not the ref you intended to deploy (finding 7f42ae86). Check out the intended ref, or correct --expect-ref."
+    return 1
+  fi
+
+  # No --expect-ref supplied.
+  warn "No --expect-ref supplied. Resolved deploy target: ${branch}@${short_sha}"
+  if [ -t 0 ]; then
+    printf 'Proceed deploying %s@%s to environment "%s"? [y/N] ' "$branch" "$short_sha" "${ENVIRONMENT:-?}"
+    local reply=""
+    read -r reply || true
+    case "$reply" in
+      y|Y|yes|YES|Yes)
+        ok "Operator confirmed deploy of ${branch}@${short_sha}"
+        return 0
+        ;;
+      *)
+        err "Operator declined confirmation — aborting."
+        return 1
+        ;;
+    esac
+  fi
+  err "No --expect-ref and stdin is not a TTY — refusing to deploy unattended (finding 7f42ae86)."
+  err "Re-run with --expect-ref ${branch} (or --expect-ref ${short_sha}) to name the intended ref explicitly."
+  return 1
+}
+
+# --- Tree-state gate (dirty / divergence) ---
+# Two distinct checks, each with an explicit refuse-vs-warn rationale:
+#   1. DIRTY working tree -> REFUSE (override: --allow-dirty -> loud WARN).
+#      Why refuse: a dirty tree corresponds to NO commit, so the git_sha the
+#      success banner and provenance manifest record would misrepresent what is
+#      actually running (finding 7f42ae86). --allow-dirty proceeds but the
+#      manifest records git_dirty=dirty so the lie is at least on the record.
+#   2. HEAD is NOT an ancestor of origin/main AND no --expect-ref -> REFUSE.
+#      Why refuse: this is the exact finding-9c92a738 shape — deploying a
+#      divergent branch can silently reconcile away stateful resources added on
+#      OTHER unmerged branches. Supplying --expect-ref is the operator
+#      explicitly asserting "yes, deploy this divergent ref on purpose", which
+#      downgrades it to a loud WARN (the deletion gate remains the backstop).
+check_tree_state() {
+  local expected="${1:-}"
+  local allow_dirty="${2:-false}"
+
+  local dirty="clean"
+  if ! git diff --quiet 2>/dev/null || ! git diff --cached --quiet 2>/dev/null; then
+    dirty="dirty"
+  fi
+
+  if [ "$dirty" = "dirty" ]; then
+    if [ "$allow_dirty" = "true" ]; then
+      warn "Working tree is DIRTY and --allow-dirty was supplied — proceeding; provenance manifest will record git_dirty=dirty."
+    else
+      err "Working tree is DIRTY — refusing to deploy."
+      err "A dirty tree corresponds to no commit, so the recorded provenance sha would misrepresent what is running (finding 7f42ae86)."
+      err "Commit or stash your changes, or pass --allow-dirty to deploy anyway (recorded as dirty)."
+      return 1
+    fi
+  fi
+
+  # Divergence check: only meaningful if origin/main is resolvable.
+  local divergent="false"
+  if git rev-parse --verify -q origin/main >/dev/null 2>&1; then
+    if ! git merge-base --is-ancestor HEAD origin/main 2>/dev/null; then
+      divergent="true"
+    fi
+  else
+    warn "origin/main not resolvable — skipping divergence (ancestry) check."
+  fi
+
+  if [ "$divergent" = "true" ]; then
+    if [ -n "$expected" ]; then
+      warn "HEAD is NOT an ancestor of origin/main (divergent branch), but --expect-ref '${expected}' was supplied — proceeding on an explicit ref."
+      warn "Divergent-branch deploys can reconcile away stateful resources added on OTHER unmerged branches (finding 9c92a738); the deletion gate is your backstop."
+    else
+      err "HEAD is NOT an ancestor of origin/main (divergent branch) and no --expect-ref was supplied — refusing."
+      err "This is the finding-9c92a738 shape: deploying a divergent branch can silently DELETE stateful resources added on other unmerged branches."
+      err "If this divergent deploy is intentional, re-run with --expect-ref <branch|sha> to assert it explicitly."
+      return 1
+    fi
+  fi
+  return 0
+}
+
+# --- Parse cdk diff output for resource DELETIONS ---
+# CDK renders a removed resource as a line whose first non-whitespace token is
+# the removal marker "[-]", e.g.:
+#   [-] AWS::DynamoDB::Table SmokeTable citadelsmoke0AB12CD3 destroy
+# Echoes one "<Type> <Name...>" per deleted resource (marker stripped). Emits
+# nothing when there are no deletions.
+extract_cdk_deletions() {
+  local diff_text="$1"
+  # Strip ANSI colour escapes first (cdk diff colourizes the [-] marker red),
+  # then match lines whose first non-whitespace token is the removal marker.
+  printf '%s\n' "$diff_text" \
+    | sed -E 's/\x1b\[[0-9;]*[mK]//g' \
+    | grep -E '^[[:space:]]*\[-\][[:space:]]' \
+    | sed -E 's/^[[:space:]]*\[-\][[:space:]]+//'
+}
+
+# --- Deletion gate (finding 9c92a738) — FAIL CLOSED ---
+# Args: <diff_text> <allow_deletions:true|false> <diff_ok:true|false>
+# REFUSES (return 1) when the diff shows resource deletions and --allow-deletions
+# was not passed. If the diff is empty or cdk diff failed (diff_ok!=true), also
+# REFUSES: we cannot PROVE the deploy performs no deletions, so we fail closed
+# rather than assume none.
+deletion_gate() {
+  local diff_text="$1"
+  local allow_deletions="${2:-false}"
+  local diff_ok="${3:-true}"
+
+  local stripped="${diff_text//[[:space:]]/}"
+  if [ "$diff_ok" != "true" ] || [ -z "$stripped" ]; then
+    err "Deletion gate: cdk diff output is empty or could not be parsed — refusing (fail-closed)."
+    err "Cannot prove this deploy performs no resource deletions; re-run once 'cdk diff' succeeds with parseable output."
+    return 1
+  fi
+
+  local deletions
+  deletions=$(extract_cdk_deletions "$diff_text")
+  if [ -z "$deletions" ]; then
+    ok "Deletion gate: cdk diff shows no resource deletions."
+    return 0
+  fi
+
+  err "Deletion gate: this deploy will DELETE the following resource(s):"
+  local line
+  while IFS= read -r line; do
+    [ -n "$line" ] && err "  DELETE → ${line}"
+  done <<< "$deletions"
+
+  if [ "$allow_deletions" = "true" ]; then
+    warn "--allow-deletions supplied — proceeding despite the deletions listed above."
+    return 0
+  fi
+  err "Refusing. If these deletions are intended, re-run with --allow-deletions."
+  err "Finding 9c92a738: a divergent-branch deploy can silently reconcile away stateful resources — confirm every name above is truly disposable first."
+  return 1
+}
+
+# --- Resolve the concrete stack names this run will deploy ---
+# Mirrors the DEPLOY_MODE switch in main so the provenance manifest records
+# WHICH stacks were targeted, not just the mode string.
+resolve_deployed_stack_names() {
+  local env="$ENVIRONMENT"
+  case "$DEPLOY_MODE" in
+    all)
+      printf '%s\n' "${KNOWN_STACKS[@]/%/-$env}"
+      ;;
+    backend)
+      local s
+      for s in "${KNOWN_STACKS[@]}"; do
+        [ "$s" = "citadel-frontend" ] && continue
+        printf '%s\n' "${s}-${env}"
+      done
+      ;;
+    frontend)
+      printf '%s\n' "citadel-frontend-${env}"
+      ;;
+    single)
+      printf '%s\n' "$STACK_NAME"
+      ;;
+  esac
 }
 
 # --- Help ---
@@ -689,6 +917,9 @@ show_help() {
   echo "  --profile <name>     Use specific AWS profile"
   echo "  --dry-run            Preview changes only (cdk diff)"
   echo "  --no-verify          Skip post-deploy health checks"
+  echo "  --expect-ref <ref>   Abort unless HEAD resolves to <ref> (branch name, full or short sha)"
+  echo "  --allow-deletions    Proceed even if cdk diff shows resource DELETIONS (default: refuse)"
+  echo "  --allow-dirty        Proceed even if the working tree is dirty (default: refuse)"
   echo "  --admin-email <addr> Admin email for initial user (overrides ADMIN_EMAIL env var)"
   echo "  --help               Show this help message"
   exit 0
@@ -714,6 +945,10 @@ SKIP_BACKEND_BUILD=false
 DRY_RUN=false
 NO_VERIFY=false
 ADMIN_EMAIL_ARG=""
+EXPECT_REF=""
+ALLOW_DELETIONS=false
+ALLOW_DIRTY=false
+DEPLOY_STARTED_AT="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
 
 while [[ $# -gt 0 ]]; do
   case $1 in
@@ -726,6 +961,9 @@ while [[ $# -gt 0 ]]; do
     --profile)        AWS_PROFILE="$2"; shift 2 ;;
     --dry-run)        DRY_RUN=true; shift ;;
     --no-verify)      NO_VERIFY=true; shift ;;
+    --expect-ref)     EXPECT_REF="$2"; shift 2 ;;
+    --allow-deletions) ALLOW_DELETIONS=true; shift ;;
+    --allow-dirty)    ALLOW_DIRTY=true; shift ;;
     --admin-email)    ADMIN_EMAIL_ARG="$2"; shift 2 ;;
     *)
       if [ -z "$STACK_NAME" ]; then
@@ -742,6 +980,17 @@ header "Citadel Deployment"
 load_env "backend/.env"
 validate_env
 capture_git_info
+
+# --- Provenance & divergence gates (findings 7f42ae86, 9c92a738) ---
+# Run BEFORE any expensive build/synth so a wrong-clone / wrong-branch /
+# divergent / dirty deploy fails fast, and so an unattended run without an
+# explicit intended ref can never silently proceed.
+if ! verify_expected_ref "$EXPECT_REF"; then
+  exit 1
+fi
+if ! check_tree_state "$EXPECT_REF" "$ALLOW_DIRTY"; then
+  exit 1
+fi
 
 [ -n "${AWS_PROFILE:-}" ] && { export AWS_PROFILE; ok "AWS Profile: $AWS_PROFILE"; } || unset AWS_PROFILE
 
@@ -833,6 +1082,16 @@ ok "Deploy target: account=$CDK_DEFAULT_ACCOUNT region=$AWS_DEFAULT_REGION"
 if [ "$DRY_RUN" = true ]; then
   ok "Dry run complete — no changes deployed"
   exit 0
+fi
+
+# --- Deletion gate (finding 9c92a738) — FAIL CLOSED ---
+# Parse the cdk diff captured just above for resource DELETIONS and REFUSE
+# (naming each resource) unless --allow-deletions was passed. If the diff is
+# empty or failed, refuse rather than assume no deletions.
+diff_ok="true"
+[ "${CDK_DIFF_RC:-1}" -eq 0 ] || diff_ok="false"
+if ! deletion_gate "${CDK_DIFF_OUTPUT:-}" "$ALLOW_DELETIONS" "$diff_ok"; then
+  exit 1
 fi
 
 # Deploy phase

--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -170,8 +170,100 @@ The Gateway ID is automatically imported from the Services Stack and passed to t
 | `--profile <name>` | Use specific AWS profile |
 | `--dry-run` | Preview changes only (`cdk diff`) — nothing is deployed |
 | `--no-verify` | Skip post-deploy health checks |
+| `--expect-ref <ref>` | Abort unless HEAD resolves to `<ref>` (branch name, full or short sha). See Deploy Safety Gates. |
+| `--allow-deletions` | Proceed even if `cdk diff` shows resource DELETIONS (default: refuse). |
+| `--allow-dirty` | Proceed even if the working tree is dirty (default: refuse). |
 | `--admin-email <addr>` | Admin email for initial user (overrides `ADMIN_EMAIL` env var) |
 | `--help` | Show help message |
+
+## Deploy Safety Gates
+
+Deploys are **manual** (`./deploy.sh`, never CI) into a **shared** environment,
+so `deploy.sh` runs four safety gates BEFORE any CDK work. They exist because
+of two real incidents:
+
+- **Wrong-ref deploy (provenance).** A run deployed a branch from the wrong
+  clone while the intended work sat elsewhere, and later an operator mistook
+  stale scrollback for a completed deploy.
+- **Divergent-branch deletion.** Deploying a branch that predates another
+  *unmerged* branch made CDK reconcile the environment to the deployed tree and
+  silently **DELETE** stateful resources the other branch had added (a table, a
+  seeded record, an IAM grant, an env var) — all while reporting success.
+
+### 1. Expected-ref gate (`--expect-ref`)
+
+`--expect-ref <ref>` cross-checks the ref you INTENDED against the ref actually
+resolved from `HEAD`. It accepts a branch name, a full sha, or a short/prefix
+sha, normalises, and **ABORTS on mismatch, printing both**. When `--expect-ref`
+is omitted the script prints the resolved branch + short sha and requires an
+interactive confirmation; **if stdin is not a TTY (an unattended run) it refuses
+rather than hang** — an unattended deploy must never silently proceed without a
+named ref.
+
+### 2. Dirty / divergence gates — refuse-vs-warn matrix
+
+| Condition | Behaviour | Why |
+|-----------|-----------|-----|
+| Working tree **dirty** | **REFUSE** (override: `--allow-dirty` → loud warn, manifest records `git_dirty=dirty`) | A dirty tree corresponds to no commit, so the recorded provenance sha would misrepresent what is running. |
+| HEAD **not an ancestor of `origin/main`** AND no `--expect-ref` | **REFUSE** | The divergent-branch shape: an unconfirmed divergent deploy is exactly how stateful resources get silently reconciled away. |
+| HEAD not an ancestor of `origin/main` WITH `--expect-ref` | **WARN** (proceed) | Supplying `--expect-ref` is the operator explicitly asserting the divergent ref is intentional; the deletion gate remains the backstop. |
+| `--expect-ref` mismatch | **REFUSE** (names both refs) | Wrong clone/branch. |
+| No `--expect-ref`, no TTY | **REFUSE** | Unattended run without a named intended ref. |
+
+### 3. Deletion gate — FAIL CLOSED
+
+`deploy.sh` parses its own `cdk diff` for resource **deletions** (lines whose
+first token is the CDK removal marker `[-]`) and **REFUSES**, naming each
+resource (e.g. `this deploy will DELETE citadel-smoke-idempotency-dev`), unless
+you pass `--allow-deletions`. It **fails closed**: if the diff is empty or
+`cdk diff` failed, it refuses rather than assume there are no deletions.
+
+### 4. Provenance record (`deployment-manifest.json`)
+
+After a successful run, `deploy.sh` writes `deployment-manifest.json` at the
+repo root capturing `environment`, `git_branch`, resolved `git_sha`,
+`git_dirty`, `expected_ref`, `deployer`, the concrete `stacks` deployed, and
+`started_at`/`completed_at` timestamps — so what is running can be **read**
+rather than recalled from scrollback. The file is **gitignored** (matched by the
+`deployment-*.json` rule in `.gitignore`), so it is never committed. It is
+written ONLY on a successful run — a refused/failed deploy writes no manifest.
+
+### RETAIN on data-bearing resources — the tradeoff, and recovery
+
+To make the divergent-branch deletion path **loud instead of silent**, the
+data-bearing stores carry `RemovalPolicy.RETAIN` and (for DynamoDB)
+`deletionProtection`:
+
+| Resource | Stack | Protected | Rationale |
+|----------|-------|-----------|-----------|
+| `citadel-executions-*` | backend | RETAIN + deletionProtection | Workflow execution history. |
+| `citadel-governance-ledger-*` | arbiter | RETAIN + deletionProtection (keeps 90-day row TTL) | Accountability/audit ledger. |
+| `citadel-tool-execution-ledger-*` | arbiter | RETAIN + deletionProtection (keeps row TTL) | Live in-flight idempotency state. |
+| `citadel-tool-results-*` (S3) | arbiter | RETAIN (KMS key already RETAIN; 7-day object TTL kept) | Offloaded results referenced by unexpired ledger rows. |
+| `citadel-agent-releases-*`, `citadel-environment-release-pointers-*`, `citadel-environment-release-pointer-history-*`, authority/contracts/case-law/constitutional tables | backend/arbiter/governance | RETAIN + deletionProtection (already) | Release + governance state/history. |
+| **`citadel-smoke-idempotency-*`** | arbiter | **EXCLUDED — stays DESTROY** | Disposable, self-cleaning 24h-TTL smoke fixture holding no data worth recovering. Protecting it would only create an orphan that blocks a later re-add. |
+
+For the two operational stores (tool-execution ledger, tool-results bucket) the
+prior design deliberately chose DESTROY as "operational, not audit". RETAIN
+deliberately reverses that per the approved findings: the row/object TTLs still
+self-expire contents, so only the **silent whole-store teardown** is blocked.
+
+**The tradeoff (must understand before operating):** RETAIN converts a *silent
+data loss* into an **orphaned resource**. The next deploy that re-adds the same
+logical resource then fails **loudly** with `… already exists`
+(`AlreadyExists`). That loud failure replacing a silent one is the entire point.
+
+**Recovery when a re-add hits `AlreadyExists`:**
+
+1. Confirm the orphaned resource genuinely holds data you need
+   (`aws dynamodb scan --max-items 1 …` / `aws s3 ls …`). If it is empty and
+   disposable, delete it manually and redeploy.
+2. Otherwise **import** the orphan back under CloudFormation management:
+   `cdk import <stack>` (map the logical id to the existing physical name), then
+   redeploy — the stack resumes ownership with data intact.
+3. If import is not viable, **rename** the logical resource (new physical name),
+   deploy to create the fresh resource, then migrate/backfill data from the
+   orphan and decommission it.
 
 ## What Gets Deployed
 

--- a/scripts/test-deploy-sh.sh
+++ b/scripts/test-deploy-sh.sh
@@ -371,6 +371,326 @@ else
 fi
 
 ########################################
+# Deploy-safety gates (findings 7f42ae86 provenance / 9c92a738 deletion)
+########################################
+# A configurable fake `git` driven by env vars, so the ref/tree gates can be
+# exercised without a real repo:
+#   FAKE_BRANCH, FAKE_FULL_SHA, FAKE_SHORT_SHA  — what rev-parse returns
+#   FAKE_DIRTY=clean|dirty                       — git diff --quiet exit code
+#   FAKE_HAS_ORIGIN_MAIN=1|0                     — origin/main resolvable
+#   FAKE_IS_ANCESTOR=1|0                         — HEAD ancestor of origin/main
+write_fake_git() {
+  cat > "$FAKE_BIN/git" <<'FAKE_GIT_EOF'
+#!/bin/bash
+case "$1 $2 $3" in
+  "rev-parse --abbrev-ref HEAD") echo "${FAKE_BRANCH:-main}"; exit 0 ;;
+esac
+case "$1 $2" in
+  "rev-parse --short") echo "${FAKE_SHORT_SHA:-abc1234}"; exit 0 ;;
+  "rev-parse --verify")
+    # `git rev-parse --verify -q origin/main`
+    [ "${FAKE_HAS_ORIGIN_MAIN:-1}" = "1" ] && { echo "deadbeef"; exit 0; }
+    exit 1 ;;
+  "rev-parse HEAD") echo "${FAKE_FULL_SHA:-abc1234567890abc1234567890abc1234567890a}"; exit 0 ;;
+  "merge-base --is-ancestor") [ "${FAKE_IS_ANCESTOR:-1}" = "1" ] && exit 0 || exit 1 ;;
+  "diff --quiet") [ "${FAKE_DIRTY:-clean}" = "clean" ] && exit 0 || exit 1 ;;
+  "diff --cached") [ "${FAKE_DIRTY:-clean}" = "clean" ] && exit 0 || exit 1 ;;
+esac
+# `git rev-parse HEAD` (two-token form) handled above; default:
+if [ "$1" = "rev-parse" ] && [ "$2" = "HEAD" ]; then
+  echo "${FAKE_FULL_SHA:-abc1234567890abc1234567890abc1234567890a}"; exit 0
+fi
+exit 0
+FAKE_GIT_EOF
+  chmod +x "$FAKE_BIN/git"
+}
+
+# --- expect-ref: match proceeds (branch name, full sha, short sha, prefix) ---
+section "verify_expected_ref: match proceeds (branch / full sha / short sha / prefix)"
+reset_fakes
+write_fake_git
+export FAKE_BRANCH="chore/deploy-safety-gates"
+export FAKE_FULL_SHA="abc1234567890abc1234567890abc1234567890a"
+export FAKE_SHORT_SHA="abc1234"
+set +e
+PATH="$FAKE_BIN:$PATH" DEPLOY_LOG="$TMP_DIR/deploy.log" verify_expected_ref "chore/deploy-safety-gates" >/dev/null 2>&1
+rc_branch=$?
+PATH="$FAKE_BIN:$PATH" DEPLOY_LOG="$TMP_DIR/deploy.log" verify_expected_ref "$FAKE_FULL_SHA" >/dev/null 2>&1
+rc_full=$?
+PATH="$FAKE_BIN:$PATH" DEPLOY_LOG="$TMP_DIR/deploy.log" verify_expected_ref "abc1234" >/dev/null 2>&1
+rc_short=$?
+PATH="$FAKE_BIN:$PATH" DEPLOY_LOG="$TMP_DIR/deploy.log" verify_expected_ref "abc123" >/dev/null 2>&1
+rc_prefix=$?
+set -e 2>/dev/null || true
+if [ $rc_branch -eq 0 ] && [ $rc_full -eq 0 ] && [ $rc_short -eq 0 ] && [ $rc_prefix -eq 0 ]; then
+  pass "expected-ref match proceeds for branch, full sha, short sha, and sha prefix"
+else
+  fail "expected all match forms to proceed; branch=$rc_branch full=$rc_full short=$rc_short prefix=$rc_prefix"
+fi
+
+# --- expect-ref: mismatch ABORTS naming both refs ---
+section "verify_expected_ref: mismatch aborts naming both refs"
+reset_fakes
+write_fake_git
+export FAKE_BRANCH="main"
+export FAKE_SHORT_SHA="abc1234"
+export FAKE_FULL_SHA="abc1234567890abc1234567890abc1234567890a"
+set +e
+mismatch_out=$(PATH="$FAKE_BIN:$PATH" DEPLOY_LOG="$TMP_DIR/deploy.log" verify_expected_ref "feat/other-branch" 2>&1)
+mismatch_rc=$?
+set -e 2>/dev/null || true
+mismatch_plain=$(echo "$mismatch_out" | sed 's/\x1b\[[0-9;]*m//g')
+if [ $mismatch_rc -ne 0 ]; then
+  pass "expected-ref mismatch aborts (rc=$mismatch_rc)"
+else
+  fail "expected non-zero on mismatch, got rc=$mismatch_rc"
+fi
+if echo "$mismatch_plain" | grep -q "feat/other-branch" && echo "$mismatch_plain" | grep -q "main" && echo "$mismatch_plain" | grep -q "abc1234"; then
+  pass "mismatch message names BOTH the requested ref and the resolved HEAD"
+else
+  fail "mismatch message did not name both refs: $mismatch_plain"
+fi
+
+# --- expect-ref: absent + no TTY REFUSES (never hangs) ---
+section "verify_expected_ref: absent --expect-ref with no TTY refuses"
+reset_fakes
+write_fake_git
+export FAKE_BRANCH="main"
+export FAKE_SHORT_SHA="abc1234"
+set +e
+notty_out=$(PATH="$FAKE_BIN:$PATH" DEPLOY_LOG="$TMP_DIR/deploy.log" verify_expected_ref "" </dev/null 2>&1)
+notty_rc=$?
+set -e 2>/dev/null || true
+notty_plain=$(echo "$notty_out" | sed 's/\x1b\[[0-9;]*m//g')
+if [ $notty_rc -ne 0 ] && echo "$notty_plain" | grep -qi "not a TTY"; then
+  pass "absent --expect-ref with non-TTY stdin refuses (rc=$notty_rc), citing TTY"
+else
+  fail "expected refusal citing TTY; rc=$notty_rc output=$notty_plain"
+fi
+
+# --- tree-state: dirty tree refuses by default; --allow-dirty warns+proceeds ---
+section "check_tree_state: dirty tree refuses; --allow-dirty proceeds"
+reset_fakes
+write_fake_git
+export FAKE_DIRTY="dirty"; export FAKE_IS_ANCESTOR=1; export FAKE_HAS_ORIGIN_MAIN=1
+set +e
+dirty_out=$(PATH="$FAKE_BIN:$PATH" DEPLOY_LOG="$TMP_DIR/deploy.log" check_tree_state "" "false" 2>&1)
+dirty_rc=$?
+allowdirty_out=$(PATH="$FAKE_BIN:$PATH" DEPLOY_LOG="$TMP_DIR/deploy.log" check_tree_state "" "true" 2>&1)
+allowdirty_rc=$?
+set -e 2>/dev/null || true
+dirty_plain=$(echo "$dirty_out" | sed 's/\x1b\[[0-9;]*m//g')
+if [ $dirty_rc -ne 0 ] && echo "$dirty_plain" | grep -qi "DIRTY"; then
+  pass "dirty tree refuses by default (rc=$dirty_rc), citing DIRTY"
+else
+  fail "expected dirty refusal; rc=$dirty_rc output=$dirty_plain"
+fi
+if [ $allowdirty_rc -eq 0 ] && echo "$allowdirty_out" | sed 's/\x1b\[[0-9;]*m//g' | grep -qi "allow-dirty"; then
+  pass "--allow-dirty proceeds with a loud warning (rc=$allowdirty_rc)"
+else
+  fail "expected --allow-dirty to proceed with warning; rc=$allowdirty_rc output=$allowdirty_out"
+fi
+
+# --- tree-state: divergent HEAD + no expect-ref refuses; +expect-ref warns ---
+section "check_tree_state: divergent branch refuses w/o ref, warns w/ ref"
+reset_fakes
+write_fake_git
+export FAKE_DIRTY="clean"; export FAKE_HAS_ORIGIN_MAIN=1; export FAKE_IS_ANCESTOR=0
+set +e
+div_out=$(PATH="$FAKE_BIN:$PATH" DEPLOY_LOG="$TMP_DIR/deploy.log" check_tree_state "" "false" 2>&1)
+div_rc=$?
+divref_out=$(PATH="$FAKE_BIN:$PATH" DEPLOY_LOG="$TMP_DIR/deploy.log" check_tree_state "feat/mybranch" "false" 2>&1)
+divref_rc=$?
+set -e 2>/dev/null || true
+div_plain=$(echo "$div_out" | sed 's/\x1b\[[0-9;]*m//g')
+if [ $div_rc -ne 0 ] && echo "$div_plain" | grep -q "9c92a738"; then
+  pass "divergent HEAD with no --expect-ref refuses (rc=$div_rc), citing finding 9c92a738"
+else
+  fail "expected divergence refusal; rc=$div_rc output=$div_plain"
+fi
+if [ $divref_rc -eq 0 ] && echo "$divref_out" | sed 's/\x1b\[[0-9;]*m//g' | grep -qi "divergent"; then
+  pass "divergent HEAD WITH --expect-ref downgrades to a loud warn and proceeds (rc=$divref_rc)"
+else
+  fail "expected divergence+ref to warn and proceed; rc=$divref_rc output=$divref_out"
+fi
+
+# --- deletion gate: diff with a deletion REFUSES and names the resource ---
+section "deletion_gate: diff with a deletion refuses and names the resource"
+DELETION_DIFF="Stack citadel-arbiter-dev
+Resources
+[-] AWS::DynamoDB::Table SmokeIdempotencyTable citadel-smoke-idempotency-dev destroy
+[~] AWS::Lambda::Function WorkerFn WorkerFn12AB modified"
+set +e
+del_out=$(deletion_gate "$DELETION_DIFF" "false" "true" 2>&1)
+del_rc=$?
+set -e 2>/dev/null || true
+del_plain=$(echo "$del_out" | sed 's/\x1b\[[0-9;]*m//g')
+if [ $del_rc -ne 0 ] && echo "$del_plain" | grep -q "citadel-smoke-idempotency-dev"; then
+  pass "deletion diff refuses (rc=$del_rc) and NAMES citadel-smoke-idempotency-dev"
+else
+  fail "expected deletion refusal naming the resource; rc=$del_rc output=$del_plain"
+fi
+
+# --allow-deletions proceeds on the same diff
+set +e
+delallow_out=$(deletion_gate "$DELETION_DIFF" "true" "true" 2>&1)
+delallow_rc=$?
+set -e 2>/dev/null || true
+if [ $delallow_rc -eq 0 ] && echo "$delallow_out" | sed 's/\x1b\[[0-9;]*m//g' | grep -qi "allow-deletions"; then
+  pass "--allow-deletions proceeds on a deletion diff with a loud warning (rc=$delallow_rc)"
+else
+  fail "expected --allow-deletions to proceed; rc=$delallow_rc output=$delallow_out"
+fi
+
+# --- deletion gate: unparseable / empty / failed diff REFUSES (fail-closed) ---
+section "deletion_gate: empty and failed diff refuse (fail-closed)"
+set +e
+empty_out=$(deletion_gate "" "false" "true" 2>&1); empty_rc=$?
+failed_out=$(deletion_gate "some diff text" "false" "false" 2>&1); failed_rc=$?
+set -e 2>/dev/null || true
+if [ $empty_rc -ne 0 ] && echo "$empty_out" | sed 's/\x1b\[[0-9;]*m//g' | grep -qi "fail-closed"; then
+  pass "empty diff refuses (fail-closed, rc=$empty_rc)"
+else
+  fail "expected empty diff to fail-closed; rc=$empty_rc output=$empty_out"
+fi
+if [ $failed_rc -ne 0 ]; then
+  pass "cdk-diff-failed (diff_ok=false) refuses (fail-closed, rc=$failed_rc)"
+else
+  fail "expected failed diff to fail-closed; rc=$failed_rc"
+fi
+
+# --- deletion gate: clean no-deletion diff PROCEEDS ---
+section "deletion_gate: clean no-deletion diff proceeds"
+CLEAN_DIFF="Stack citadel-backend-dev
+Resources
+[~] AWS::Lambda::Function WorkerFn WorkerFn12AB modified
+[+] AWS::DynamoDB::Table NewTable citadel-new-dev"
+set +e
+clean_out=$(deletion_gate "$CLEAN_DIFF" "false" "true" 2>&1); clean_rc=$?
+set -e 2>/dev/null || true
+if [ $clean_rc -eq 0 ] && echo "$clean_out" | sed 's/\x1b\[[0-9;]*m//g' | grep -qi "no resource deletions"; then
+  pass "clean (no [-]) diff proceeds (rc=$clean_rc)"
+else
+  fail "expected clean diff to proceed; rc=$clean_rc output=$clean_out"
+fi
+
+# --- deletion gate: ANSI-coloured [-] marker is still detected ---
+section "deletion_gate: ANSI-coloured deletion marker is still parsed"
+ANSI_DIFF=$'Resources\n\x1b[31m[-] AWS::S3::Bucket ToolResultsBucket citadel-tool-results-dev destroy\x1b[0m'
+set +e
+ansi_out=$(deletion_gate "$ANSI_DIFF" "false" "true" 2>&1); ansi_rc=$?
+set -e 2>/dev/null || true
+if [ $ansi_rc -ne 0 ] && echo "$ansi_out" | sed 's/\x1b\[[0-9;]*m//g' | grep -q "citadel-tool-results-dev"; then
+  pass "ANSI-coloured [-] line is detected and named (rc=$ansi_rc)"
+else
+  fail "expected ANSI deletion to be caught; rc=$ansi_rc output=$ansi_out"
+fi
+
+# --- provenance manifest: written with the right fields on success ---
+section "write_manifest: writes deployment-manifest.json with required fields"
+reset_fakes
+cat > "$FAKE_BIN/aws" <<'FAKE_AWS_EOF'
+#!/bin/bash
+if [ "$1" = "sts" ] && [ "$2" = "get-caller-identity" ]; then
+  echo "arn:aws:iam::123456789012:user/deployer"; exit 0
+fi
+exit 0
+FAKE_AWS_EOF
+chmod +x "$FAKE_BIN/aws"
+MANIFEST_DIR="$TMP_DIR/manifest-success"
+mkdir -p "$MANIFEST_DIR"
+(
+  cd "$MANIFEST_DIR" || exit 1
+  export ENVIRONMENT="dev" CDK_DEFAULT_REGION="us-east-1" CDK_DEFAULT_ACCOUNT="123456789012"
+  export GIT_SHA="abc1234" GIT_BRANCH="chore/deploy-safety-gates" GIT_DIRTY="clean"
+  export DEPLOY_MODE="all" STACK_NAME="" EXPECT_REF="chore/deploy-safety-gates"
+  export DEPLOY_STARTED_AT="2026-08-25T10:00:00Z"
+  PATH="$FAKE_BIN:$PATH" DEPLOY_LOG="$TMP_DIR/deploy.log" write_manifest >/dev/null 2>&1
+)
+MANIFEST_FILE="$MANIFEST_DIR/deployment-manifest.json"
+if [ -f "$MANIFEST_FILE" ]; then
+  pass "deployment-manifest.json written on success"
+else
+  fail "manifest not written"
+fi
+if [ -f "$MANIFEST_FILE" ] \
+  && grep -q '"git_sha": "abc1234"' "$MANIFEST_FILE" \
+  && grep -q '"git_branch": "chore/deploy-safety-gates"' "$MANIFEST_FILE" \
+  && grep -q '"git_dirty": "clean"' "$MANIFEST_FILE" \
+  && grep -q '"environment": "dev"' "$MANIFEST_FILE" \
+  && grep -q '"expected_ref": "chore/deploy-safety-gates"' "$MANIFEST_FILE" \
+  && grep -q '"started_at": "2026-08-25T10:00:00Z"' "$MANIFEST_FILE" \
+  && grep -q '"completed_at":' "$MANIFEST_FILE" \
+  && grep -q 'citadel-backend-dev' "$MANIFEST_FILE" \
+  && grep -q 'citadel-frontend-dev' "$MANIFEST_FILE"; then
+  pass "manifest carries environment, branch, sha, dirty flag, expected_ref, stack names, and start/complete timestamps"
+else
+  fail "manifest missing required fields: $(cat "$MANIFEST_FILE" 2>/dev/null)"
+fi
+
+# --- provenance manifest: NOT written when a gate refuses (end-to-end) ---
+section "e2e: a refusing gate exits non-zero and writes NO manifest"
+reset_fakes
+write_fake_git
+export FAKE_BRANCH="main" FAKE_SHORT_SHA="abc1234" FAKE_FULL_SHA="abc1234567890abc1234567890abc1234567890a"
+export FAKE_DIRTY="clean" FAKE_HAS_ORIGIN_MAIN=1 FAKE_IS_ANCESTOR=1
+cat > "$FAKE_BIN/aws" <<'FAKE_AWS_EOF'
+#!/bin/bash
+exit 0
+FAKE_AWS_EOF
+chmod +x "$FAKE_BIN/aws"
+E2E_DIR="$TMP_DIR/e2e-fail"
+mkdir -p "$E2E_DIR"
+cp "$DEPLOY_SH" "$E2E_DIR/deploy.sh"
+set +e
+e2e_out=$(
+  cd "$E2E_DIR" || exit 1
+  env -u DEPLOY_SH_SOURCE_ONLY \
+    ENVIRONMENT="dev" CDK_DEFAULT_REGION="us-east-1" CDK_DEFAULT_ACCOUNT="123456789012" \
+    PATH="$FAKE_BIN:$PATH" \
+    bash "$E2E_DIR/deploy.sh" --expect-ref feat/some-other-branch </dev/null 2>&1
+)
+e2e_rc=$?
+set -e 2>/dev/null || true
+e2e_plain=$(echo "$e2e_out" | sed 's/\x1b\[[0-9;]*m//g')
+if [ $e2e_rc -ne 0 ] && echo "$e2e_plain" | grep -qi "Expected-ref MISMATCH"; then
+  pass "wrong --expect-ref exits non-zero at the ref gate (rc=$e2e_rc)"
+else
+  fail "expected mismatch exit; rc=$e2e_rc output=$e2e_plain"
+fi
+if [ ! -f "$E2E_DIR/deployment-manifest.json" ]; then
+  pass "NO deployment-manifest.json written when the deploy is refused"
+else
+  fail "manifest was written despite a refused deploy"
+fi
+
+########################################
+# BITE PROOF (RED): remove the deletion gate and confirm the deletion test
+# no longer catches it — proving the gate + its test are load-bearing.
+########################################
+section "BITE PROOF: with deletion_gate removed, a deletion diff is NOT refused (expected RED)"
+BITE_DIFF="Resources
+[-] AWS::DynamoDB::Table SmokeIdempotencyTable citadel-smoke-idempotency-dev destroy"
+set +e
+bite_rc=$(
+  # Subshell: re-source deploy.sh functions, then OVERRIDE deletion_gate with a
+  # no-op (the "gate removed" version). If the gate is truly what refuses, the
+  # deletion diff now proceeds (rc=0), demonstrating the real gate bites.
+  export DEPLOY_SH_SOURCE_ONLY=1
+  # shellcheck disable=SC1090
+  source "$DEPLOY_SH" >/dev/null 2>&1
+  deletion_gate() { return 0; }   # gate removed
+  deletion_gate "$BITE_DIFF" "false" "true" >/dev/null 2>&1
+  echo $?
+)
+set -e 2>/dev/null || true
+if [ "$bite_rc" = "0" ]; then
+  pass "RED CONFIRMED: gate-removed version does NOT refuse the deletion diff (rc=0) — the real deletion_gate is load-bearing and its test genuinely catches removal"
+else
+  fail "gate-removed version still refused (rc=$bite_rc) — the deletion test is NOT actually exercising the gate"
+fi
+
+########################################
 # Summary
 ########################################
 echo ""


### PR DESCRIPTION
## Summary
Two real incidents in one week, both from the same environment and both silent:

1. A deploy ran from the wrong branch. `deploy.sh` computes the branch and sha live and prints them in a success banner, but nothing compares them against what the operator intended - so a stale worktree produced a confident success message for a no-op redeploy of code already running. A later incident was the mirror image: stale scrollback was read as a completed deploy that had in fact never run (confirmed by zero CloudFormation activity).
2. A deploy from a branch that predated another unmerged branch **deleted** the resources that branch had added - a DynamoDB table, a seeded record, an IAM grant, an env var - while reporting success with every stack `UPDATE_COMPLETE`. CDK reconciles the environment to the deployed tree; the only evidence was in stack events. It was harmless that day because the table was empty. The same path would have taken a populated table's data.

Branch deploys to shared dev are deliberate here (pre-merge validation), so divergent-branch deploys are routine rather than exotic.
## What changed

**`--expect-ref` gate.** An optional argument compared against the resolved HEAD - accepting a branch name, full sha, or short sha, with normalisation - aborting on mismatch and printing both refs. The abort happens before any build or CDK work. Without the flag, the resolved branch and short sha are printed for confirmation; a run with no TTY and no expected ref **refuses** rather than hanging or proceeding unattended. Dirty trees and a HEAD that is not an ancestor of `origin/main` are surfaced per a documented refuse-versus-warn matrix.

**Deletion gate.** `deploy.sh` already ran "cdk diff and only printed it. It now parses that diff for resource deletions and refuses unless explicitly allowed, naming each resource that would be destroyed - the message the earlier incident needed. It **fails closed**: an empty or unparseable diff refuses rather than assuming there is nothing to delete.

**Provenance record.** A deployment manifest is written on success only, holding start and completion timestamps, environment, branch, sha, dirty flag, expected ref, and stack names, so what is running in an environment can be read rather than recalled. Gitignored.

**Retention for data-bearing resources.** The executions, governance-ledger, and tool-execution-ledger tables now carry `RemovalPolicy.RETAIN` plus DynamoDB deletion protection; the tool-results bucket carries RETAIN. Genuinely disposable fixtures (the smoke table, graph snapshots) are deliberately excluded. 

The tradeoff is documented rather than glossed: retention converts silent data loss into an **orphaned** resource, which makes a later deploy that re-adds the same logical resource fail with `AlreadyExists`. That loud failure replacing a silent one is the point, and the runbook gives the recovery path (`cdk import` or rename).

## Testing
The pre-existing deploy harness - which already guarded earlier `deploy.sh` hardening - was extended **additively** (+320 lines, nothing removed), now 35 cases passing. New coverage: expected-ref match, mismatch abort, unattended refusal, dirty-tree behaviour, a deletion diff refused with the resource named, an unparseable diff refused, a clean diff proceeding, and the manifest written on success but absent on refusal.

The deletion gate was **red-proven, then independently re-derived in review**: with the gate neutralised, the deletion case proceeds and six harness cases fail. CDK assertions confirm retention on the protected resources and its absence on the disposable ones. 173 CK tests, `bash -n`, `tsc`, and three stack synths all

## Deployment notes
This changes the only deploy path for a shared environment, so worth reading before the next run: pass `--expect-ref ‹branch-or-sha›` and the deploy verifies it before doing anything. A deploy that would delete a resource now stops and tells you which one. Suggest running the first post-merge deploy *with* `--expect-ref`, so the gate's behaviour is seen on a routine deploy rather than during an incident.