### PR TITLE
fix(deploy): anchor the deletion gate to resource-level lines

### DIFF
--- a/deploy.sh
+++ b/deploy.sh
@@ -822,19 +822,49 @@ check_tree_state() {
 }
 
 # --- Parse cdk diff output for resource DELETIONS ---
-# CDK renders a removed resource as a line whose first non-whitespace token is
-# the removal marker "[-]", e.g.:
+# CDK renders a REMOVED RESOURCE as a line anchored at column 1 whose marker
+# is immediately followed by a CloudFormation type token, e.g.:
 #   [-] AWS::DynamoDB::Table SmokeTable citadelsmoke0AB12CD3 destroy
+#
+# It ALSO reuses the same "[-]" glyph, indented, for every removed-VALUE line
+# inside an unrelated "[~] <Resource>" (modified) block — property diffs,
+# nested JSON/array fragments (IAM Statement Changes tables render literal
+# `"Resource": {` / `"Fn::ImportValue": ...` / closing `}` lines this way
+# too), Lambda asset .S3Key hash swaps, layer-version ARN bumps, etc. Those
+# are NOT deletions and must never trip this gate (finding: PR #90 shipped
+# `^[[:space:]]*\[-\][[:space:]]`, which matched the indented case and
+# false-positived on every ordinary deploy).
+#
+# Anchor to column 1 AND require a CloudFormation type token
+# ("Namespace::Service::Type", e.g. AWS::DynamoDB::Table or
+# Custom::MyResource) immediately after the marker — that shape only ever
+# appears on cdk's own top-level resource-removal line, never inside a
+# nested property diff. Verified against a live 9-stack diff for this repo
+# (see incident notes) containing zero genuine deletions and dozens of
+# indented [-] property lines: the old pattern matched all of them, this one
+# matches none.
+#
 # Echoes one "<Type> <Name...>" per deleted resource (marker stripped). Emits
 # nothing when there are no deletions.
+#
+# NOTE on the parsing approach itself: `cdk diff` has no machine-readable
+# diff mode (`--json` only affects the printed template, not the diff), so
+# this is inherently regex-over-text and will always be one rendering change
+# away from breaking. The authoritative alternative is a changeset-based
+# gate — synth, `aws cloudformation create-change-set` + `describe-change-
+# set`, and inspect the structured `Changes[].ResourceChange.Action ==
+# "Remove"` list instead of parsing cdk's pretty-printer output. Not built
+# here (out of scope for this fix); the next person hitting a false
+# positive/negative in this function should reach for that instead of
+# patching the regex further.
 extract_cdk_deletions() {
   local diff_text="$1"
   # Strip ANSI colour escapes first (cdk diff colourizes the [-] marker red),
-  # then match lines whose first non-whitespace token is the removal marker.
+  # then match column-1 "[-] <Type>::<Type>::<Type>" resource-removal lines.
   printf '%s\n' "$diff_text" \
     | sed -E 's/\x1b\[[0-9;]*[mK]//g' \
-    | grep -E '^[[:space:]]*\[-\][[:space:]]' \
-    | sed -E 's/^[[:space:]]*\[-\][[:space:]]+//'
+    | grep -E '^\[-\][[:space:]]+[A-Za-z0-9]+::' \
+    | sed -E 's/^\[-\][[:space:]]+//'
 }
 
 # --- Deletion gate (finding 9c92a738) — FAIL CLOSED ---

--- a/scripts/test-deploy-sh.sh
+++ b/scripts/test-deploy-sh.sh
@@ -586,6 +586,99 @@ else
   fail "expected ANSI deletion to be caught; rc=$ansi_rc output=$ansi_out"
 fi
 
+########################################
+# REGRESSION: finding — extract_cdk_deletions() previously matched INDENTED
+# [-] lines inside [~] modified-resource property diffs (leading
+# `[[:space:]]*` in the old grep), causing hard-refuse false positives on
+# ordinary deploys with zero genuine deletions. Fixtures below are the
+# ACTUAL lines captured from the live citadel-gateway-dev / citadel-backend-
+# dev diff during that incident, used verbatim.
+########################################
+section "extract_cdk_deletions: property-diff false positives are IGNORED (regression)"
+
+# The indented Lambda asset .S3Key hash swap (appeared on ~30 functions).
+ASSET_ZIP_DIFF='[~] AWS::Lambda::Function RegistryProvisionerFunction RegistryProvisionerFunctionE3F562F6
+ └─ [~] Code
+     └─ [~] .S3Key:
+         ├─ [-] 02ad290bbad20c98533eca320b22aa9905aa479f067a0be3b0eb98a5ff39675f.zip
+         └─ [+] 3d75b07052b2d0183a7437a38be7dea763082f4b5a27ea8490cd6c9584a478ae.zip'
+set +e
+assetzip_out=$(extract_cdk_deletions "$ASSET_ZIP_DIFF")
+set -e 2>/dev/null || true
+if [ -z "$assetzip_out" ]; then
+  pass "indented asset-zip .S3Key [-] line is ignored (not a resource deletion)"
+else
+  fail "asset-zip .S3Key line was incorrectly flagged as a deletion: $assetzip_out"
+fi
+
+# The indented layer-version ARN bump (:58 -> :59 shape), plus the raw JSON
+# fragments cdk's IAM Statement Changes table renders as indented [-] lines.
+LAYER_AND_JSON_DIFF='            [-]   "Resource": {
+            [-]     "Fn::ImportValue": "citadel-backend-dev:ExportsOutputFnGetAttExecutionsTableA2EE59C2Arn25D40C91"
+            [-]   }
+ └─ [~] Layers
+     └─ [~] .0:
+         ├─ [-] arn:aws:lambda:us-west-2:257192363080:layer:ArbiterCatalogLayer:58
+         └─ [+] arn:aws:lambda:us-west-2:257192363080:layer:ArbiterCatalogLayer:59'
+set +e
+layerjson_out=$(extract_cdk_deletions "$LAYER_AND_JSON_DIFF")
+set -e 2>/dev/null || true
+if [ -z "$layerjson_out" ]; then
+  pass "indented layer-ARN bump and IAM-table JSON fragments ('\"Resource\": {', 'Fn::ImportValue', closing '}') are all ignored"
+else
+  fail "layer-ARN/JSON fragment lines were incorrectly flagged as deletions: $layerjson_out"
+fi
+
+# Full deploy against these fixtures must PROCEED (deletion_gate returns 0),
+# matching the real incident: zero genuine deletions across all 9 stacks.
+REGRESSION_NO_DELETIONS_DIFF="Stack citadel-gateway-dev
+Resources
+[~] AWS::Lambda::Function AppApiAuthorizer AppApiAuthorizer603DF97E
+ └─ [~] Code
+     └─ [~] .S3Key:
+         ├─ [-] 02ad290bbad20c98533eca320b22aa9905aa479f067a0be3b0eb98a5ff39675f.zip
+         └─ [+] 3d75b07052b2d0183a7437a38be7dea763082f4b5a27ea8490cd6c9584a478ae.zip
+[~] AWS::DynamoDB::Table ExecutionsTable ExecutionsTableA2EE59C2
+ ├─ [+] DeletionProtectionEnabled
+ │   └─ true
+ ├─ [~] DeletionPolicy
+ │   ├─ [-] Delete
+ │   └─ [+] Retain
+ └─ [~] UpdateReplacePolicy
+     ├─ [-] Delete
+     └─ [+] Retain
+            [-]   \"Resource\": {
+            [-]     \"Fn::ImportValue\": \"citadel-backend-dev:ExportsOutputFnGetAttExecutionsTableA2EE59C2Arn25D40C91\"
+            [-]   }"
+set +e
+regr_out=$(deletion_gate "$REGRESSION_NO_DELETIONS_DIFF" "false" "true" 2>&1); regr_rc=$?
+set -e 2>/dev/null || true
+if [ $regr_rc -eq 0 ] && echo "$regr_out" | sed 's/\x1b\[[0-9;]*m//g' | grep -qi "no resource deletions"; then
+  pass "real-incident-shaped diff (asset hashes, DeletionPolicy flip, IAM JSON fragment) now PROCEEDS — false positive fixed"
+else
+  fail "expected the incident-shaped diff to proceed with no deletions; rc=$regr_rc output=$regr_out"
+fi
+
+# --- RED bite proof: a genuine column-1 resource deletion is STILL caught ---
+section "extract_cdk_deletions: genuine column-1 resource deletion still REFUSES (bite proof)"
+GENUINE_DELETION_DIFF="Stack citadel-arbiter-dev
+Resources
+[-] AWS::DynamoDB::Table SmokeTable citadelsmoke0AB12CD3 destroy
+[~] AWS::Lambda::Function RegistryProvisionerFunction RegistryProvisionerFunctionE3F562F6
+ └─ [~] Code
+     └─ [~] .S3Key:
+         ├─ [-] 02ad290bbad20c98533eca320b22aa9905aa479f067a0be3b0eb98a5ff39675f.zip
+         └─ [+] 3d75b07052b2d0183a7437a38be7dea763082f4b5a27ea8490cd6c9584a478ae.zip"
+set +e
+genuine_out=$(deletion_gate "$GENUINE_DELETION_DIFF" "false" "true" 2>&1); genuine_rc=$?
+set -e 2>/dev/null || true
+genuine_plain=$(echo "$genuine_out" | sed 's/\x1b\[[0-9;]*m//g')
+if [ $genuine_rc -ne 0 ] && echo "$genuine_plain" | grep -q "citadelsmoke0AB12CD3"; then
+  pass "RED PROOF: genuine column-1 resource deletion (SmokeTable citadelsmoke0AB12CD3) still REFUSES amid the same property-diff noise — narrowing the match did not blind the gate"
+else
+  fail "narrowed pattern failed to catch a genuine deletion; rc=$genuine_rc output=$genuine_plain"
+fi
+
 # --- provenance manifest: written with the right fields on success ---
 section "write_manifest: writes deployment-manifest.json with required fields"
 reset_fakes


### PR DESCRIPTION
## Summary
The deletion gate shipped in the previous PR blocked a routine deploy. Its pattern allowed leading whitespace before the `[-]` marker, so it matched property-diff sub-lines inside `[~]` modified resources - Lambda asset `.S3Key` hash swaps, a layer version bump, and raw JSON fragments like `"Resource": {` Asset hashes change on every deploy, so this would have refused every deploy. Verified against the live diff: zero genuine resource deletions across all nine stacks. A hard-blocking false positive is worse than the silent risk it replaced.
## What changed
- The match is now anchored to column 1 followed by a CloudFormation type token, which is the shape of a real resource removal (`[-] AWS: :DynamoDB: :Table ...`).
Indented property diffs are ignored.
- Fail-closed behaviour on an empty or failed diff is unchanged.
- Regression cases use the actual lines from the incident verbatim; a genuine column-1 deletion line must still refuse and name the resource.
- Added a note that 'ck diff has no machine-readable diff mode, so this is regex-over-text by necessity - the authoritative fix is a changeset-based gate (`describe-change-set`, `ResourceChange.Action == "Remove"`). Not built here; recorded so the next person reaches for that instead of patching the regex.
## Testing
Deploy harness green including the new regression and bite-proof cases; `bash -n` clean; the real `cdk diff` now passes the gate.
## Note
The original gate was tested against fixture Lines I wrote from an assumed rendering of `cdk diff`, not captured output - which is why 35 passing harness cases still shipped a broken control.