### PR TITLE
feat(arbiter): unify the failure taxonomy across retry consumers

### DIFF
--- a/arbiter/common/__tests__/test_failure_taxonomy.py
+++ b/arbiter/common/__tests__/test_failure_taxonomy.py
@@ -1,0 +1,171 @@
+"""Unit tests for arbiter/common/failure_taxonomy.py — the unified failure
+taxonomy (board task 9099b8cb).
+
+Covers the invariants the story asserts:
+  * every error type from the inventory maps to the decided FailureClass;
+  * the three-valued disposition (84494854): APPROVAL_ABSENT -> RETRY_AFTER_HUMAN,
+    INDETERMINATE -> NEVER;
+  * APPROVAL_ABSENT vs DENY differential (absent approval is NOT a DENY and NOT
+    a governance smell);
+  * classify(exception) == classify(class-name string) parity;
+  * an unknown class defaults to never-auto-retry (fail-safe);
+  * the narrow-only veto (843a959e): a recognised never-retry class is forbidden,
+    an unknown class is NOT (defers to the per-node list).
+"""
+
+from common import failure_taxonomy as ft
+from common.failure_taxonomy import FailureClass as FC, RetryDisposition as RD
+
+
+# ---------------------------------------------------------------------------
+# Disposition matrix (84494854): three-valued, INDETERMINATE -> NEVER
+# ---------------------------------------------------------------------------
+
+
+class TestDispositionMatrix:
+    def test_auto_retry_classes(self):
+        for fc in (FC.TRANSIENT, FC.THROTTLE, FC.TIMEOUT):
+            assert ft.disposition(fc) is RD.RETRY_WITH_BACKOFF
+            assert ft.is_auto_retryable(fc) is True
+
+    def test_never_classes(self):
+        for fc in (FC.VALIDATION, FC.POLICY_DENIED, FC.AUTHZ, FC.INDETERMINATE, FC.UNKNOWN):
+            assert ft.disposition(fc) is RD.NEVER
+            assert ft.is_auto_retryable(fc) is False
+
+    def test_approval_absent_is_retry_after_human(self):
+        assert ft.disposition(FC.APPROVAL_ABSENT) is RD.RETRY_AFTER_HUMAN
+        # NOT auto-retryable (no storm) and NOT a governance smell.
+        assert ft.is_auto_retryable(FC.APPROVAL_ABSENT) is False
+        assert ft.is_governance_smell_on_retry(FC.APPROVAL_ABSENT) is False
+
+    def test_indeterminate_maps_to_never_failsafe(self):
+        assert ft.disposition(FC.INDETERMINATE) is RD.NEVER
+
+
+# ---------------------------------------------------------------------------
+# Every inventory error type maps as decided
+# ---------------------------------------------------------------------------
+
+
+class TestInventoryMapping:
+    def test_bedrock_codes(self):
+        assert ft.classify("ThrottlingException") is FC.THROTTLE
+        assert ft.classify("ServiceUnavailableException") is FC.TRANSIENT
+        assert ft.classify("InternalServerException") is FC.TRANSIENT
+        assert ft.classify("ModelStreamErrorException") is FC.TRANSIENT
+        assert ft.classify("ModelTimeoutException") is FC.TIMEOUT
+        assert ft.classify("ValidationException") is FC.VALIDATION
+        assert ft.classify("AccessDeniedException") is FC.AUTHZ
+
+    def test_governance_ledger_hierarchy(self):
+        assert ft.classify("LedgerError") is FC.TRANSIENT
+        assert ft.classify("LedgerWriteError") is FC.TRANSIENT
+        assert ft.classify("ApprovalReadError") is FC.TRANSIENT
+        assert ft.classify("RetryableNoExecutionError") is FC.TRANSIENT
+        assert ft.classify("OutcomeIndeterminateError") is FC.INDETERMINATE
+        assert ft.classify("StaleWorkerFencedError") is FC.INDETERMINATE
+        assert ft.classify("CrossOrgResultRefError") is FC.AUTHZ
+
+    def test_approval_required_is_absent_not_deny(self):
+        # APPROVAL_ABSENT, explicitly NOT policy-denied.
+        assert ft.classify("ApprovalRequiredError") is FC.APPROVAL_ABSENT
+        assert ft.classify("ApprovalRequiredError") is not FC.POLICY_DENIED
+
+    def test_governance_deny(self):
+        assert ft.classify(ft.POLICY_DENIED_CLASS) is FC.POLICY_DENIED
+        assert ft.classify("policy-denied") is FC.POLICY_DENIED
+
+    def test_tool_crash_and_domain_error_defer_to_policy(self):
+        # A bare crash / tool-returned domain error is UNKNOWN so the per-node
+        # policy governs (documented deliberate absence).
+        assert ft.classify("ToolExecutionError") is FC.UNKNOWN
+        assert ft.classify("AgentExecutionError") is FC.UNKNOWN
+        assert ft.classify("tool_error_result") is FC.UNKNOWN
+
+
+# ---------------------------------------------------------------------------
+# classify(exception) == classify(string) parity + case-insensitivity
+# ---------------------------------------------------------------------------
+
+
+class TestClassifyParity:
+    def test_exception_type_name_matches_string(self):
+        class ApprovalRequiredError(Exception):
+            pass
+
+        assert ft.classify(ApprovalRequiredError("x")) == ft.classify("ApprovalRequiredError")
+        assert ft.classify(ApprovalRequiredError("x")) is FC.APPROVAL_ABSENT
+
+    def test_botocore_response_code_matches_string(self):
+        class ClientError(Exception):
+            def __init__(self, code):
+                super().__init__(code)
+                self.response = {"Error": {"Code": code}}
+
+        exc = ClientError("ThrottlingException")
+        assert ft.classify(exc) == ft.classify("ThrottlingException")
+        assert ft.classify(exc) is FC.THROTTLE
+
+    def test_case_insensitive_midstream_codes(self):
+        # Bedrock reports mid-stream faults in camelCase.
+        assert ft.classify("throttlingException") is FC.THROTTLE
+        assert ft.classify("modelStreamErrorException") is FC.TRANSIENT
+        assert ft.classify("internalServerException") is FC.TRANSIENT
+
+
+# ---------------------------------------------------------------------------
+# Unknown -> never-auto-retry (fail-safe)
+# ---------------------------------------------------------------------------
+
+
+class TestUnknownFailsafe:
+    def test_unknown_string_is_unknown_and_not_auto_retryable(self):
+        assert ft.classify("SomeNovelError") is FC.UNKNOWN
+        assert ft.is_auto_retryable(ft.classify("SomeNovelError")) is False
+
+    def test_none_and_empty_classify_unknown(self):
+        assert ft.classify(None) is FC.UNKNOWN
+        assert ft.classify("") is FC.UNKNOWN
+
+
+# ---------------------------------------------------------------------------
+# Narrow-only veto (843a959e)
+# ---------------------------------------------------------------------------
+
+
+class TestNarrowOnlyVeto:
+    def test_recognised_never_classes_are_forbidden(self):
+        for token in (
+            "AccessDeniedException",      # authz
+            "ValidationException",        # validation
+            ft.POLICY_DENIED_CLASS,       # policy-denied
+            "OutcomeIndeterminateError",  # indeterminate
+            "ApprovalRequiredError",      # approval-absent (retry-after-human, not auto)
+            "CrossOrgResultRefError",     # authz
+        ):
+            assert ft.is_retry_forbidden_by_taxonomy(token) is True, token
+
+    def test_auto_retryable_classes_are_not_forbidden(self):
+        for token in ("ThrottlingException", "InternalServerException", "ModelTimeoutException"):
+            assert ft.is_retry_forbidden_by_taxonomy(token) is False, token
+
+    def test_unknown_is_not_forbidden_defers_to_author_list(self):
+        # The load-bearing distinction: an unrecognised error is NOT vetoed, so
+        # the per-node retryableErrors list still governs it (narrow-only).
+        assert ft.is_retry_forbidden_by_taxonomy("TimeoutError") is False
+        assert ft.is_retry_forbidden_by_taxonomy("SomeNovelError") is False
+
+
+# ---------------------------------------------------------------------------
+# Governance-smell-on-retry only for settled denials
+# ---------------------------------------------------------------------------
+
+
+class TestGovernanceSmell:
+    def test_only_policy_denied_and_authz_are_smells(self):
+        assert ft.is_governance_smell_on_retry(FC.POLICY_DENIED) is True
+        assert ft.is_governance_smell_on_retry(FC.AUTHZ) is True
+        for fc in (FC.VALIDATION, FC.INDETERMINATE, FC.APPROVAL_ABSENT,
+                   FC.TRANSIENT, FC.THROTTLE, FC.TIMEOUT, FC.UNKNOWN):
+            assert ft.is_governance_smell_on_retry(fc) is False, fc

--- a/arbiter/common/__tests__/test_jitter_parity.py
+++ b/arbiter/common/__tests__/test_jitter_parity.py
@@ -1,0 +1,75 @@
+"""Jitter parity + throttle-backs-off-with-jitter (board task 9099b8cb).
+
+Decision 5ac980e0: the three verbatim full-jitter copies are NOT deduplicated
+in this story (the taxonomy adds no backoff math). This test PINS that the
+copies stay numerically equivalent — if one drifts, this bites. The three
+copies live in separately-bundled Lambdas:
+
+  * stepRunner/retry.py::calculate_backoff              (the canonical home)
+  * fabricator/transient_retry.py::calculate_backoff    (verbatim copy)
+  * supervisor/circuit_breaker.py::CircuitBreaker._backoff_delay (copy)
+
+Also asserts a throttle is auto-retryable per the taxonomy and the circuit
+breaker still retries it after dropping its private error-code tuple.
+"""
+import random
+
+# conftest.py seeds stepRunner/, fabricator/, supervisor/ onto sys.path.
+import retry as step_retry  # stepRunner/retry.py
+import transient_retry  # fabricator/transient_retry.py
+from circuit_breaker import CircuitBreaker  # supervisor/circuit_breaker.py
+from common import failure_taxonomy as ft
+
+
+class TestJitterParity:
+    def test_three_copies_are_numerically_equivalent(self):
+        # Seed identically before each call: random.uniform(0, ceiling) with an
+        # identical ceiling formula must produce identical draws.
+        cb = CircuitBreaker(base_delay=1.0, max_delay=30.0)
+        for attempt in range(0, 8):
+            base, cap = 1.0, 30.0
+
+            random.seed(1234)
+            a = step_retry.calculate_backoff(attempt, base, cap)
+            random.seed(1234)
+            b = transient_retry.calculate_backoff(attempt, base, cap)
+            random.seed(1234)
+            c = cb._backoff_delay(attempt)
+
+            assert a == b == c, f"jitter copies diverged at attempt={attempt}"
+
+    def test_copies_share_the_same_ceiling(self):
+        # Different base/cap still agree across the copies.
+        cb = CircuitBreaker(base_delay=2.5, max_delay=12.0)
+        for attempt in range(0, 6):
+            random.seed(99)
+            a = step_retry.calculate_backoff(attempt, 2.5, 12.0)
+            random.seed(99)
+            c = cb._backoff_delay(attempt)
+            assert a == c
+
+
+class TestThrottleBacksOffWithJitter:
+    def test_throttle_is_auto_retryable(self):
+        assert ft.classify("ThrottlingException") is ft.FailureClass.THROTTLE
+        assert ft.is_auto_retryable(ft.classify("ThrottlingException")) is True
+
+    def test_backoff_within_full_jitter_bounds(self):
+        for attempt in range(0, 10):
+            delay = step_retry.calculate_backoff(attempt, 1.0, 30.0)
+            assert 0.0 <= delay <= min(1.0 * (2 ** attempt), 30.0)
+
+    def test_circuit_breaker_still_retries_throttling_after_taxonomy_adoption(self):
+        cb = CircuitBreaker(max_retries=3, base_delay=0.0, max_delay=0.0)
+        calls = []
+
+        def flaky():
+            calls.append(1)
+            if len(calls) < 2:
+                err = Exception("throttled")
+                err.response = {"Error": {"Code": "ThrottlingException"}}
+                raise err
+            return "ok"
+
+        assert cb.call(flaky) == "ok"
+        assert len(calls) == 2  # retried once after the throttle

--- a/arbiter/common/__tests__/test_metrics_constants.py
+++ b/arbiter/common/__tests__/test_metrics_constants.py
@@ -18,6 +18,10 @@ def test_metric_names_are_pinned():
     assert mc.METRIC_NODE_COLD_START == 'NodeColdStart'
 
 
+def test_retry_governance_smell_metric_is_pinned():
+    assert mc.METRIC_RETRY_GOVERNANCE_SMELL == 'RetryGovernanceSmell'
+
+
 def test_units_are_pinned():
     assert mc.UNIT_MILLISECONDS == 'Milliseconds'
     assert mc.UNIT_COUNT == 'Count'

--- a/arbiter/common/__tests__/test_no_parallel_retryable_lists.py
+++ b/arbiter/common/__tests__/test_no_parallel_retryable_lists.py
@@ -1,0 +1,105 @@
+"""No-parallel-retryable-list guard (board task 9099b8cb).
+
+The whole point of the unified failure taxonomy is that retry classification
+lives in ONE place (``common/failure_taxonomy.py``). This guard FAILS if any
+consumer reintroduces its own hardcoded collection of error-code string
+literals — the exact "second parallel list" this story removed (the failure
+mode that let layer-2 governance drift inert, finding 027c4a89).
+
+Detection is STRUCTURAL (AST), not text matching: it flags any tuple / list /
+set / frozenset(...) / set(...) literal that contains >= 2 string constants
+that look like error codes (ending in ``Exception`` or ``Error``, any casing).
+That is precisely the shape of the private sets that were removed:
+``("ThrottlingException", "InternalServerException", ...)`` and
+``frozenset({"internalserverexception", ...})``.
+
+Bite-proof: a positive control asserts the detector fires on a reintroduced
+literal set; the real-file scan asserts every guarded consumer is clean.
+"""
+import ast
+import os
+import re
+
+import pytest
+
+_ARBITER_ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), "..", ".."))
+
+# The consumers that MUST source retryability from the taxonomy, never a
+# private literal set. (failure_taxonomy.py itself is intentionally excluded —
+# it IS the single source of truth and legitimately holds the mapping.)
+_GUARDED_FILES = [
+    os.path.join(_ARBITER_ROOT, "supervisor", "circuit_breaker.py"),
+    os.path.join(_ARBITER_ROOT, "fabricator", "transient_retry.py"),
+    os.path.join(_ARBITER_ROOT, "stepRunner", "executor.py"),
+]
+
+_ERROR_CODE_RE = re.compile(r"(exception|error)$", re.IGNORECASE)
+
+
+def _string_elts(node: ast.AST):
+    """Yield the string-constant values directly contained in a collection
+    literal node (Tuple/List/Set), or in a frozenset(...)/set(...) call whose
+    single argument is such a literal."""
+    target = node
+    if isinstance(node, ast.Call):
+        func = node.func
+        name = getattr(func, "id", None) or getattr(func, "attr", None)
+        if name not in ("frozenset", "set", "tuple", "list"):
+            return
+        if len(node.args) != 1:
+            return
+        target = node.args[0]
+    if isinstance(target, (ast.Tuple, ast.List, ast.Set)):
+        for elt in target.elts:
+            if isinstance(elt, ast.Constant) and isinstance(elt.value, str):
+                yield elt.value
+
+
+def find_error_code_literal_collections(source: str) -> list[list[str]]:
+    """Return each collection literal in *source* that holds >= 2 error-code-
+    looking string constants (the reintroduced-parallel-list shape)."""
+    tree = ast.parse(source)
+    offenders: list[list[str]] = []
+    for node in ast.walk(tree):
+        if isinstance(node, (ast.Tuple, ast.List, ast.Set, ast.Call)):
+            codes = [s for s in _string_elts(node) if _ERROR_CODE_RE.search(s)]
+            if len(codes) >= 2:
+                offenders.append(codes)
+    return offenders
+
+
+class TestGuardBitesOnReintroducedLiteralSet:
+    """Positive control — the detector MUST fire on a parallel list."""
+
+    def test_tuple_form_detected(self):
+        src = (
+            "RETRYABLE = (\n"
+            "    'ThrottlingException',\n"
+            "    'InternalServerException',\n"
+            ")\n"
+        )
+        assert find_error_code_literal_collections(src)
+
+    def test_frozenset_form_detected(self):
+        src = (
+            "CODES = frozenset({'throttlingexception', 'modelstreamerrorexception'})\n"
+        )
+        assert find_error_code_literal_collections(src)
+
+    def test_benign_collections_not_flagged(self):
+        # A single error-ish string, or non-error strings, must NOT trip it.
+        assert not find_error_code_literal_collections("X = ('ThrottlingException',)")
+        assert not find_error_code_literal_collections("Y = ['pending', 'failed', 'running']")
+        assert not find_error_code_literal_collections("Z = {'a': 1, 'b': 2}")
+
+
+class TestGuardedConsumersHaveNoParallelList:
+    @pytest.mark.parametrize("path", _GUARDED_FILES, ids=lambda p: os.path.basename(p))
+    def test_no_error_code_literal_collection(self, path):
+        with open(path, "r", encoding="utf-8") as fh:
+            source = fh.read()
+        offenders = find_error_code_literal_collections(source)
+        assert offenders == [], (
+            f"{os.path.basename(path)} reintroduced a private retryable set "
+            f"{offenders}; classify via common.failure_taxonomy instead."
+        )

--- a/arbiter/common/failure_taxonomy.py
+++ b/arbiter/common/failure_taxonomy.py
@@ -1,0 +1,237 @@
+"""Unified failure taxonomy — the SINGLE source of truth for classifying an
+arbiter failure and deciding whether it may be retried.
+
+Why this module exists
+----------------------
+Before this module, retry classification was FORKED across four consumers,
+each with its own hardcoded set of error strings:
+
+* ``supervisor/circuit_breaker.py`` — a ``retryable_errors`` tuple.
+* ``fabricator/transient_retry.py`` — a ``TRANSIENT_BEDROCK_ERROR_CODES``
+  frozenset.
+* ``stepRunner/executor.py`` — a per-node, author-supplied ``retryableErrors``
+  list matched by exact class-name string, with no central authority.
+* the layer-2 tool seam (governance + idempotency) — a scatter of typed
+  ``LedgerError`` subclasses each carrying its own ``retryable`` bit.
+
+A second parallel list is exactly how the layer-2 governance surface drifted
+INERT once (finding 027c4a89): two independent classifications diverged. This
+module removes the ability to diverge by being the ONE place that maps an error
+(exception OR class-name string) to a :class:`FailureClass`, and a
+:class:`FailureClass` to a :class:`RetryDisposition`.
+
+Binding decisions encoded here
+------------------------------
+* 84494854 — the taxonomy carries the story's six members PLUS
+  ``APPROVAL_ABSENT`` and ``INDETERMINATE``, over THREE dispositions
+  (``RETRY_WITH_BACKOFF`` / ``RETRY_AFTER_HUMAN`` / ``NEVER``).
+  ``INDETERMINATE`` maps to ``NEVER`` (fail-safe: never auto-re-execute an
+  un-tokened side effect of unknown outcome). Consumers read a SINGLE
+  disposition lookup (``disposition`` / ``is_auto_retryable`` /
+  ``is_retry_forbidden_by_taxonomy`` / ``is_governance_smell_on_retry``) and
+  MUST NOT branch on individual members.
+* 843a959e — the taxonomy is AUTHORITATIVE over a stored workflow's per-node
+  ``retryableErrors``. A definition may only NARROW retries (opt OUT of an
+  otherwise-auto-retryable class), never WIDEN a never-retry class. See
+  :func:`is_retry_forbidden_by_taxonomy`.
+* 5ac980e0 — this module adds NO backoff math. The canonical full-jitter
+  ``calculate_backoff`` stays in ``stepRunner/retry.py``; the three verbatim
+  copies are intentionally NOT deduplicated here (a parity test asserts they
+  stay numerically equivalent).
+
+Packaging note (verified, not inferred)
+----------------------------------------
+Every consumer Lambda mounts the shared ``ArbiterCatalogLayer`` (staging
+``common``/``governance``/``catalog`` at ``/opt/python``): supervisor, worker,
+fabricator, and stepRunner all list ``layers: [catalogLayer]`` in
+``backend/lib/arbiter-stack.ts``. So ``from common.failure_taxonomy import ...``
+resolves in every deployed bundle (and under pytest via ``arbiter/conftest.py``,
+which appends the arbiter root to ``sys.path``). The taxonomy and its
+never-retry guard are themselves fail-closed controls, so this mount is
+load-bearing. The remaining gap is importability TEST coverage for three of the
+four bundles, filed separately as a finding — NOT an unverified layer mount.
+
+All functions here are pure (no side effects, no AWS calls).
+"""
+
+from __future__ import annotations
+
+from enum import Enum
+from typing import Any
+
+
+class FailureClass(str, Enum):
+    """The exhaustive set of failure classes an arbiter failure maps to.
+
+    ``str`` mixin per repo convention so a member compares/serialises as its
+    value across module-identity boundaries.
+    """
+
+    TRANSIENT = "transient"
+    THROTTLE = "throttle"
+    TIMEOUT = "timeout"
+    VALIDATION = "validation"
+    POLICY_DENIED = "policy-denied"  # a settled governance DENY
+    AUTHZ = "authz"
+    APPROVAL_ABSENT = "approval-absent"  # human-grantable; retry only after a human acts
+    INDETERMINATE = "indeterminate"  # un-tokened side effect, unknown outcome — fail-safe
+    UNKNOWN = "unknown"  # unrecognised — fail-safe default for the AUTO path
+
+
+class RetryDisposition(str, Enum):
+    """What a :class:`FailureClass` permits. Read via :func:`disposition`."""
+
+    RETRY_WITH_BACKOFF = "retry_with_backoff"  # auto, full jitter
+    RETRY_AFTER_HUMAN = "retry_after_human"  # NOT auto; a human action unblocks it
+    NEVER = "never"
+
+
+# The one class -> disposition matrix. ``UNKNOWN`` is NEVER for the automatic
+# retry path (a novel error must not be auto-retried); the executor's
+# author-list path treats UNKNOWN specially (see is_retry_forbidden_by_taxonomy).
+DISPOSITION: dict[FailureClass, RetryDisposition] = {
+    FailureClass.TRANSIENT: RetryDisposition.RETRY_WITH_BACKOFF,
+    FailureClass.THROTTLE: RetryDisposition.RETRY_WITH_BACKOFF,
+    FailureClass.TIMEOUT: RetryDisposition.RETRY_WITH_BACKOFF,
+    FailureClass.VALIDATION: RetryDisposition.NEVER,
+    FailureClass.POLICY_DENIED: RetryDisposition.NEVER,
+    FailureClass.AUTHZ: RetryDisposition.NEVER,
+    FailureClass.APPROVAL_ABSENT: RetryDisposition.RETRY_AFTER_HUMAN,
+    FailureClass.INDETERMINATE: RetryDisposition.NEVER,
+    FailureClass.UNKNOWN: RetryDisposition.NEVER,
+}
+
+# Public token a governance DENY is recorded/classified under. A policy DENY
+# does not raise a typed exception (it COMPLETES the node with a deny error
+# ToolResult), so when a DENY class does reach a retry decision — e.g. a stale
+# per-node retryableErrors listing it, or a duplicate delivery — it is
+# identified by this stable string.
+POLICY_DENIED_CLASS = "GovernanceDenied"
+
+# The ONE source of truth mapping an error class-name / Bedrock error code to a
+# FailureClass. Keys are the canonical (CamelCase) forms; a case-insensitive
+# fallback index (built below) also matches Bedrock's mid-stream camelCase
+# variants (e.g. ``throttlingException``, ``modelStreamErrorException``).
+#
+# Deliberately ABSENT (classify -> UNKNOWN, so the per-node retryableErrors list
+# still governs, and the AUTO path never auto-retries):
+#   * ``ToolExecutionError`` / ``AgentExecutionError`` — a bare tool/agent CRASH
+#     is a DETERMINATE node failure that retry.py MAY retry per the node's
+#     policy; it is not a governance class, so the taxonomy holds no veto.
+#   * ``RecordedToolFailure`` — a memoized replay of a prior terminal failure;
+#     it never reaches a FRESH node-retry decision.
+#   * ``tool_error_result`` — a tool-RETURNED domain error; the node COMPLETES,
+#     so it never reaches the node-retry decision at all.
+_CLASSNAME_TO_CLASS: dict[str, FailureClass] = {
+    # --- Bedrock request-level + mid-stream fault codes ---------------------
+    "ThrottlingException": FailureClass.THROTTLE,
+    "ServiceUnavailableException": FailureClass.TRANSIENT,
+    "InternalServerException": FailureClass.TRANSIENT,
+    "ModelStreamErrorException": FailureClass.TRANSIENT,
+    "ModelTimeoutException": FailureClass.TIMEOUT,
+    "ValidationException": FailureClass.VALIDATION,
+    "AccessDeniedException": FailureClass.AUTHZ,
+    # --- governance approval gate (tool_approval.py) ------------------------
+    # ABSENT approval is human-grantable — distinct from a settled DENY.
+    "ApprovalRequiredError": FailureClass.APPROVAL_ABSENT,
+    "ApprovalReadError": FailureClass.TRANSIENT,  # infra: transport blip may recover
+    # --- governance / tool-execution ledger hierarchy ----------------------
+    "LedgerError": FailureClass.TRANSIENT,  # base infra refusal — fail-closed, retryable
+    "LedgerWriteError": FailureClass.TRANSIENT,  # audit write fail-closed — infra
+    "RetryableNoExecutionError": FailureClass.TRANSIENT,  # concurrent loser, no side effect
+    "OutcomeIndeterminateError": FailureClass.INDETERMINATE,  # unknown outcome — fail-safe
+    # Designed exactly-once carve-out: a stale re-dispatched-away worker,
+    # refused at the reserve fence BEFORE any side effect. Terminal for THIS
+    # worker (its generation can never become current again). Never re-execute.
+    "StaleWorkerFencedError": FailureClass.INDETERMINATE,
+    # Confused-deputy cross-org resultRef pointer — an authorization failure.
+    "CrossOrgResultRefError": FailureClass.AUTHZ,
+    # --- governance DENY (deny-list) ----------------------------------------
+    POLICY_DENIED_CLASS: FailureClass.POLICY_DENIED,
+}
+
+# Case-insensitive fallback index. Includes every canonical class-name AND the
+# enum value strings themselves (so classify("policy-denied") == POLICY_DENIED).
+_LOWER_INDEX: dict[str, FailureClass] = {
+    name.lower(): fc for name, fc in _CLASSNAME_TO_CLASS.items()
+}
+_LOWER_INDEX.update({fc.value.lower(): fc for fc in FailureClass})
+
+
+def _extract_code(err: Any) -> str | None:
+    """Derive the classification key from an exception OR a bare string.
+
+    An exception is normalised to its botocore ``response['Error']['Code']``
+    when present (Bedrock/ClientError/EventStreamError), else ``type().__name__``
+    — the SAME derivation the circuit breaker used, so an exception on the
+    breaker path and an ``errorClass`` string on the node path classify
+    identically (cross-runtime parity).
+    """
+    if err is None:
+        return None
+    if isinstance(err, str):
+        return err or None
+    response = getattr(err, "response", None)
+    if isinstance(response, dict):
+        error = response.get("Error")
+        if isinstance(error, dict):
+            code = error.get("Code")
+            if code:
+                return str(code)
+    return type(err).__name__
+
+
+def classify(err: Any) -> FailureClass:
+    """Classify an exception OR a class-name/error-code string.
+
+    Unrecognised input classifies to :attr:`FailureClass.UNKNOWN` (fail-safe:
+    the AUTO retry path never auto-retries it). Case-insensitive so Bedrock's
+    mid-stream camelCase codes classify the same as request-level CamelCase.
+    """
+    code = _extract_code(err)
+    if not code:
+        return FailureClass.UNKNOWN
+    fc = _CLASSNAME_TO_CLASS.get(code)
+    if fc is not None:
+        return fc
+    return _LOWER_INDEX.get(code.lower(), FailureClass.UNKNOWN)
+
+
+def disposition(fc: FailureClass) -> RetryDisposition:
+    """The single disposition lookup. Unknown members fail safe to NEVER."""
+    return DISPOSITION.get(fc, RetryDisposition.NEVER)
+
+
+def is_auto_retryable(fc: FailureClass) -> bool:
+    """True iff the class may be retried AUTOMATICALLY (with full-jitter
+    backoff). The circuit breaker and the transient-retry helper gate on this.
+    ``UNKNOWN`` -> False (fail-safe)."""
+    return disposition(fc) is RetryDisposition.RETRY_WITH_BACKOFF
+
+
+def is_retry_forbidden_by_taxonomy(err: Any) -> bool:
+    """Authoritative veto for the per-node ``retryableErrors`` path (843a959e).
+
+    True iff ``err`` classifies to a RECOGNISED failure class whose disposition
+    is NOT ``RETRY_WITH_BACKOFF`` (validation / policy-denied / authz /
+    indeterminate / approval-absent). An UNRECOGNISED error (``UNKNOWN``)
+    returns False: the taxonomy holds no opinion, so the author's per-node list
+    still governs. This is precisely "narrow-only" — a stored definition can
+    never WIDEN a recognised never-retry class into a retry, but may still
+    configure retries for error strings the taxonomy does not classify (and may
+    still opt OUT of an auto-retryable class by omitting it from the list).
+    """
+    fc = classify(err)
+    if fc is FailureClass.UNKNOWN:
+        return False
+    return disposition(fc) is not RetryDisposition.RETRY_WITH_BACKOFF
+
+
+def is_governance_smell_on_retry(fc: FailureClass) -> bool:
+    """True iff reaching a RETRY decision for this class is a governance smell
+    — i.e. something asked to retry a SETTLED denial. Only ``POLICY_DENIED`` and
+    ``AUTHZ`` qualify: an absent approval (human-grantable) and an indeterminate
+    outcome (fail-safe) are legitimate non-retry reasons, not smells, and a
+    validation error is an author mistake, not a governance breach.
+    """
+    return fc in (FailureClass.POLICY_DENIED, FailureClass.AUTHZ)

--- a/arbiter/common/metrics_constants.py
+++ b/arbiter/common/metrics_constants.py
@@ -52,6 +52,15 @@ METRIC_NODE_COLD_START = 'NodeColdStart'
 # constant at the emission call site, never hand-type the string literal.
 METRIC_UNSTAMPED_DISPATCH = 'UnstampedDispatch'
 
+# Governance-smell backstop (board task 9099b8cb, failure taxonomy): emitted
+# WARN-level exactly once when a node-failure retry decision is reached for a
+# SETTLED denial (policy-denied / authz) — i.e. a stale/tampered per-node
+# retryableErrors tried to WIDEN a never-retry governance class. Observability
+# only; the taxonomy already refuses the retry (fail-closed). Low-cardinality
+# (WorkflowId dimension only), pinned by literal-value tests — never hand-type
+# the string at the emission site.
+METRIC_RETRY_GOVERNANCE_SMELL = 'RetryGovernanceSmell'
+
 # --- Units ---------------------------------------------------------------
 
 UNIT_MILLISECONDS = 'Milliseconds'

--- a/arbiter/fabricator/__tests__/test_transient_retry.py
+++ b/arbiter/fabricator/__tests__/test_transient_retry.py
@@ -32,7 +32,6 @@ sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
 
 from transient_retry import (
     MAX_ATTEMPTS,
-    TRANSIENT_BEDROCK_ERROR_CODES,
     bedrock_error_code,
     calculate_backoff,
     call_with_transient_retry,
@@ -235,7 +234,7 @@ class TestBackoffProperties:
     @given(code=st.text(min_size=1, max_size=40))
     @settings(max_examples=100)
     def test_should_retry_only_listed_codes(self, code):
-        retryable = sorted(TRANSIENT_BEDROCK_ERROR_CODES)
+        retryable = ["internalserverexception", "throttlingexception"]
         if code not in retryable:
             assert should_retry(code, retryable, 0, 3) is False
 
@@ -250,9 +249,6 @@ class TestConflictExceptionIsNotTransient:
     retrying it 92-110× consumed ~825-834s of the 900s Lambda budget. The
     condition never resolves within a run — it must NEVER be classified
     transient here."""
-
-    def test_conflict_exception_not_in_transient_frozenset(self):
-        assert "conflictexception" not in TRANSIENT_BEDROCK_ERROR_CODES
 
     def test_conflict_exception_not_classified_transient(self):
         err = _client_error(

--- a/arbiter/fabricator/transient_retry.py
+++ b/arbiter/fabricator/transient_retry.py
@@ -19,12 +19,23 @@ deliberately NOT re-retried here.
 
 ``calculate_backoff`` and ``should_retry`` are copied verbatim from
 ``arbiter/stepRunner/retry.py`` — each arbiter module bundles as a separate
-Lambda, so a cross-module import would couple packaging.
+Lambda, so a cross-module import would couple packaging. Per decision
+5ac980e0 these full-jitter copies are intentionally NOT deduplicated; a
+parity test asserts they stay numerically equivalent.
+
+Transient classification is NO LONGER a private frozenset (board task
+9099b8cb): it delegates to the unified failure taxonomy
+(``common.failure_taxonomy``) — the single source of truth every retry
+consumer reads — so this helper can never drift from the circuit breaker or
+the step runner. The taxonomy resolves in the deployed fabricator bundle via
+the shared ``ArbiterCatalogLayer`` (``common`` staged at ``/opt/python``).
 """
 
 import logging
 import random
 import time
+
+from common.failure_taxonomy import classify, is_auto_retryable
 
 logger = logging.getLogger(__name__)
 
@@ -33,17 +44,6 @@ MAX_ATTEMPTS = 3
 # Full-jitter exponential backoff ceilings between attempts: ~1s, ~2s.
 BASE_DELAY_SECONDS = 1.0
 MAX_DELAY_SECONDS = 8.0
-
-# Transient Bedrock fault codes, lowercased. Comparison is case-insensitive
-# because Bedrock reports request-level faults in CamelCase
-# (ThrottlingException) and mid-stream event faults in camelCase
-# (throttlingException, modelStreamErrorException).
-TRANSIENT_BEDROCK_ERROR_CODES = frozenset({
-    "internalserverexception",
-    "serviceunavailableexception",
-    "throttlingexception",
-    "modelstreamerrorexception",
-})
 
 
 # --- copied verbatim from arbiter/stepRunner/retry.py (pure functions) ------
@@ -101,9 +101,15 @@ def bedrock_error_code(exc: BaseException) -> str | None:
 
 
 def is_transient_bedrock_error(exc: BaseException) -> bool:
-    """True only for the four transient Bedrock fault codes (any casing)."""
-    code = bedrock_error_code(exc)
-    return code is not None and code.lower() in TRANSIENT_BEDROCK_ERROR_CODES
+    """True iff the fault is AUTO-retryable per the unified failure taxonomy.
+
+    Delegates to ``is_auto_retryable(classify(exc))`` — no private code set.
+    ``classify`` reads the botocore ``response['Error']['Code']`` (covering
+    ``ClientError`` and its mid-stream ``EventStreamError`` subclass, any
+    casing) then the exception type name; a code that maps to throttle /
+    transient / timeout is auto-retryable, everything else (validation, authz,
+    unrecognised) is not."""
+    return is_auto_retryable(classify(exc))
 
 
 def call_with_transient_retry(
@@ -152,8 +158,11 @@ def call_with_transient_retry(
         try:
             return operation()
         except Exception as exc:  # noqa: BLE001 — classified below; re-raised unless transient
-            code = (bedrock_error_code(exc) or "").lower()
-            if not should_retry(code, TRANSIENT_BEDROCK_ERROR_CODES, attempt, max_attempts - 1):
+            code = bedrock_error_code(exc)
+            # Taxonomy is the single classifier (board task 9099b8cb): fail fast
+            # on the last attempt OR any non-auto-retryable fault (validation,
+            # authz, unrecognised). No private code set.
+            if attempt >= max_attempts - 1 or not is_transient_bedrock_error(exc):
                 raise
             delay = calculate_backoff(attempt, base_delay, max_delay)
             if deadline is not None and not deadline.can_fit(delay):

--- a/arbiter/stepRunner/__tests__/test_failure_taxonomy_executor.py
+++ b/arbiter/stepRunner/__tests__/test_failure_taxonomy_executor.py
@@ -1,0 +1,175 @@
+"""Executor-level failure-taxonomy tests (board task 9099b8cb).
+
+The unified taxonomy is AUTHORITATIVE over a stored workflow's per-node
+``retryableErrors`` (decision 843a959e): a definition may NARROW retries but
+can never WIDEN a never-retry class. And when a stale/tampered list tries to
+widen a SETTLED denial (policy-denied / authz), the executor files exactly ONE
+governance-smell signal (storm-proof by construction) then goes terminal.
+
+These run the REAL ``handle_node_failure`` against moto so the terminal-failure
+UpdateItem is exercised for real (the FakeTable stand-ins do not validate it).
+"""
+import json
+import os
+import sys
+
+import boto3
+import pytest
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+
+try:
+    from moto import mock_aws
+except ImportError:  # pragma: no cover
+    pytest.skip("moto not installed", allow_module_level=True)
+
+import executor  # noqa: E402
+from common.failure_taxonomy import POLICY_DENIED_CLASS  # noqa: E402
+from common.metrics_constants import METRIC_RETRY_GOVERNANCE_SMELL  # noqa: E402
+
+EXEC_TABLE = "citadel-executions-tax-moto"
+WF_TABLE = "citadel-workflows-tax-moto"
+
+
+@pytest.fixture
+def moto_executor(monkeypatch):
+    with mock_aws():
+        resource = boto3.Session(region_name="us-east-1").resource("dynamodb")
+        exec_table = resource.create_table(
+            TableName=EXEC_TABLE,
+            KeySchema=[{"AttributeName": "executionId", "KeyType": "HASH"}],
+            AttributeDefinitions=[{"AttributeName": "executionId", "AttributeType": "S"}],
+            BillingMode="PAY_PER_REQUEST",
+        )
+        wf_table = resource.create_table(
+            TableName=WF_TABLE,
+            KeySchema=[{"AttributeName": "workflowId", "KeyType": "HASH"}],
+            AttributeDefinitions=[{"AttributeName": "workflowId", "AttributeType": "S"}],
+            BillingMode="PAY_PER_REQUEST",
+        )
+        monkeypatch.setattr(executor, "_executions_table", exec_table)
+        monkeypatch.setattr(executor, "_workflows_table", wf_table)
+        yield {"exec_table": exec_table, "wf_table": wf_table}
+
+
+def _seed(exec_table, wf_table, *, retryable_errors, max_retries=3):
+    wf_table.put_item(
+        Item={
+            "workflowId": "wf1",
+            "definition": json.dumps({
+                "nodes": [{
+                    "id": "node1",
+                    "data": {"retryPolicy": {
+                        "maxRetries": max_retries,
+                        "retryableErrors": retryable_errors,
+                    }},
+                }],
+                "edges": [],
+            }),
+        }
+    )
+    exec_table.put_item(
+        Item={
+            "executionId": "exec1",
+            "workflowId": "wf1",
+            "status": "running",
+            "nodeResults": {"node1": {"status": "running", "agentId": "agentA", "retryCount": 0}},
+        }
+    )
+
+
+def _node_status(exec_table):
+    row = exec_table.get_item(Key={"executionId": "exec1"}).get("Item", {})
+    return row["nodeResults"]["node1"]["status"], row.get("status")
+
+
+@pytest.fixture
+def capture(monkeypatch):
+    metrics = []
+    retries = []
+    monkeypatch.setattr(
+        executor, "_emit_metric",
+        lambda name, value, unit, **k: metrics.append((name, value)),
+    )
+    monkeypatch.setattr(
+        executor.events, "publish_node_retrying",
+        lambda **k: retries.append(k),
+    )
+    return {"metrics": metrics, "retries": retries}
+
+
+class TestPerNodeListCannotWidenNeverRetryClass:
+    @pytest.mark.parametrize("never_class", [
+        "AccessDeniedException",       # authz
+        "ValidationException",         # validation
+        POLICY_DENIED_CLASS,           # policy-denied
+        "OutcomeIndeterminateError",   # indeterminate
+        "ApprovalRequiredError",       # approval-absent (retry-after-human)
+    ])
+    def test_never_retry_class_in_list_does_not_enable_retry(
+        self, moto_executor, capture, never_class
+    ):
+        # A per-node retryableErrors entry naming a never-retry class must NOT
+        # enable a retry — the taxonomy vetoes it (843a959e).
+        _seed(moto_executor["exec_table"], moto_executor["wf_table"],
+              retryable_errors=[never_class])
+
+        executor.handle_node_failure("exec1", "node1", never_class)
+
+        node_status, exec_status = _node_status(moto_executor["exec_table"])
+        assert node_status == "failed"       # terminal, not retried
+        assert exec_status == "failed"
+        assert capture["retries"] == []      # no node.retrying published
+
+    def test_unknown_error_still_honours_author_list(self):
+        # Narrow-only, proved at the pure retry gate (avoids the retry-branch's
+        # unrelated moto Decimal-retryCount path): an UNRECOGNISED error the
+        # taxonomy has no opinion on is still governed by the author's list,
+        # while a recognised never-retry class is vetoed regardless of the list.
+        from retry import should_retry
+        assert should_retry("TimeoutError", ["TimeoutError"], 0, 3) is True
+        assert should_retry("AccessDeniedException", ["AccessDeniedException"], 0, 3) is False
+        assert should_retry(POLICY_DENIED_CLASS, [POLICY_DENIED_CLASS], 0, 3) is False
+        # An auto-retryable class still requires the author opt-in (narrow):
+        assert should_retry("ThrottlingException", [], 0, 3) is False
+        assert should_retry("ThrottlingException", ["ThrottlingException"], 0, 3) is True
+
+
+class TestGovernanceSmellNoStorm:
+    def test_widening_a_denial_files_exactly_one_smell_then_terminal(
+        self, moto_executor, capture
+    ):
+        # A stale list listing a settled DENY class: the retry is refused AND a
+        # single governance-smell signal is filed.
+        _seed(moto_executor["exec_table"], moto_executor["wf_table"],
+              retryable_errors=[POLICY_DENIED_CLASS])
+
+        executor.handle_node_failure("exec1", "node1", POLICY_DENIED_CLASS)
+
+        smells = [m for m in capture["metrics"] if m[0] == METRIC_RETRY_GOVERNANCE_SMELL]
+        assert smells == [(METRIC_RETRY_GOVERNANCE_SMELL, 1.0)]  # exactly one
+        assert _node_status(moto_executor["exec_table"])[0] == "failed"
+
+    def test_duplicate_delivery_does_not_storm(self, moto_executor, capture):
+        # A duplicate node-failed delivery (at-least-once) must NOT re-file the
+        # smell: the terminal-status idempotency guard returns early.
+        _seed(moto_executor["exec_table"], moto_executor["wf_table"],
+              retryable_errors=["authz"])
+
+        executor.handle_node_failure("exec1", "node1", "authz")
+        executor.handle_node_failure("exec1", "node1", "authz")  # replay
+
+        smells = [m for m in capture["metrics"] if m[0] == METRIC_RETRY_GOVERNANCE_SMELL]
+        assert len(smells) == 1  # no storm across the duplicate delivery
+
+    def test_non_smell_never_class_files_no_smell(self, moto_executor, capture):
+        # validation / indeterminate / approval-absent are never-retry but NOT
+        # governance smells — no smell metric, just terminal.
+        _seed(moto_executor["exec_table"], moto_executor["wf_table"],
+              retryable_errors=["ValidationException"])
+
+        executor.handle_node_failure("exec1", "node1", "ValidationException")
+
+        smells = [m for m in capture["metrics"] if m[0] == METRIC_RETRY_GOVERNANCE_SMELL]
+        assert smells == []
+        assert _node_status(moto_executor["exec_table"])[0] == "failed"

--- a/arbiter/stepRunner/executor.py
+++ b/arbiter/stepRunner/executor.py
@@ -36,12 +36,14 @@ from dag import (
 from condition import evaluate_condition
 from retry import calculate_backoff, should_retry
 from common import workflow_contract
+from common import failure_taxonomy
 from common.usage import aggregate_usage, parse_usage_array
 from common.metrics_constants import (
     METRIC_NAMESPACE,
     METRIC_NODE_DURATION_MS,
     METRIC_NODE_FAILURE,
     METRIC_NODE_QUEUE_WAIT_MS,
+    METRIC_RETRY_GOVERNANCE_SMELL,
     METRIC_UNSTAMPED_DISPATCH,
     METRIC_RELEASE_DISPATCH_EVALUATED,
     METRIC_RELEASE_DISPATCH_WOULD_BLOCK,
@@ -1181,6 +1183,34 @@ def handle_node_failure(execution_id: str, node_id: str, error: str) -> None:
     backoff_max = retry_policy.get('backoffMax', 60.0)
 
     now = _now_iso()
+
+    # Governance-smell backstop (board task 9099b8cb, decision 843a959e /
+    # design storm-proof path). A SETTLED denial (policy-denied / authz) is
+    # never-retry; if a stale or tampered per-node ``retryableErrors`` lists
+    # such a class, that is an attempt to WIDEN a never-retry governance class —
+    # the taxonomy refuses the retry (should_retry vetoes below), and reaching
+    # this decision at all is the signal to file. Storm-proof BY CONSTRUCTION:
+    # a never-retry class fails the node immediately (no node.retrying
+    # scheduled), and the terminal-status idempotency guard above returns on a
+    # duplicate delivery — so at most ONE smell is emitted per node-failure.
+    failure_class = failure_taxonomy.classify(error)
+    if (
+        error in retryable_errors
+        and failure_taxonomy.is_governance_smell_on_retry(failure_class)
+    ):
+        _log_event(
+            'retry_governance_smell',
+            executionId=execution_id,
+            workflowId=execution.get('workflowId', ''),
+            nodeId=node_id,
+            agentId=agent_id or None,
+            errorClass=error,
+            failureClass=failure_class.value,
+        )
+        _emit_metric(
+            METRIC_RETRY_GOVERNANCE_SMELL, 1.0, UNIT_COUNT,
+            workflow_id=execution.get('workflowId', ''),
+        )
 
     if should_retry(error, retryable_errors, retry_count, max_retries):
         # Retry the node

--- a/arbiter/stepRunner/retry.py
+++ b/arbiter/stepRunner/retry.py
@@ -7,6 +7,8 @@ All functions are pure (no side effects, no AWS calls).
 
 import random
 
+from common.failure_taxonomy import is_retry_forbidden_by_taxonomy
+
 
 def calculate_backoff(attempt: int, base: float, max_delay: float) -> float:
     """Exponential backoff with full jitter: uniform(0, min(base * 2^attempt, max_delay)).
@@ -34,7 +36,17 @@ def should_retry(error_type: str, retryable_errors: list[str], attempt: int, max
 
     Returns:
         True if the error is retryable and attempts are not exhausted.
+
+    Authority (843a959e): the unified failure taxonomy is AUTHORITATIVE over the
+    author-supplied ``retryable_errors`` list. If ``error_type`` classifies to a
+    recognised never-retry class (validation / policy-denied / authz /
+    indeterminate / approval-absent), retry is refused REGARDLESS of the list —
+    a stored definition can NARROW retries but can never WIDEN a never-retry
+    class. An unrecognised error is not vetoed here, so the list still governs
+    it (see ``failure_taxonomy.is_retry_forbidden_by_taxonomy``).
     """
     if attempt >= max_retries:
+        return False
+    if is_retry_forbidden_by_taxonomy(error_type):
         return False
     return error_type in retryable_errors

--- a/arbiter/supervisor/circuit_breaker.py
+++ b/arbiter/supervisor/circuit_breaker.py
@@ -17,6 +17,8 @@ import threading
 from enum import Enum
 from typing import Any, Callable
 
+from common.failure_taxonomy import classify, is_auto_retryable
+
 
 class CircuitState(Enum):
     CLOSED = "CLOSED"
@@ -37,19 +39,15 @@ class CircuitBreaker:
         max_retries: int = 3,
         base_delay: float = 1.0,
         max_delay: float = 30.0,
-        retryable_errors: tuple = (
-            "ThrottlingException",
-            "ServiceUnavailableException",
-            "ModelTimeoutException",
-            "InternalServerException",
-        ),
     ):
         self.failure_threshold = failure_threshold
         self.recovery_timeout = recovery_timeout
         self.max_retries = max_retries
         self.base_delay = base_delay
         self.max_delay = max_delay
-        self.retryable_errors = retryable_errors
+        # NO private retryable set (board task 9099b8cb): retryability is
+        # decided by the unified failure taxonomy (classify + is_auto_retryable),
+        # not a hardcoded tuple that could drift from the other consumers.
 
         self._state = CircuitState.CLOSED
         self._failure_count = 0
@@ -81,9 +79,12 @@ class CircuitBreaker:
                 )
 
     def _is_retryable(self, error: Exception) -> bool:
-        error_code = getattr(error, "response", {}).get("Error", {}).get("Code", "")
-        error_name = type(error).__name__
-        return error_code in self.retryable_errors or error_name in self.retryable_errors
+        """Retryability is the taxonomy's single disposition lookup — the
+        breaker keeps NO private error-code set (board task 9099b8cb).
+        ``classify`` extracts the botocore ``response['Error']['Code']`` first,
+        then the exception type name, so a live Bedrock exception and an
+        ``errorClass`` string on the node path classify identically."""
+        return is_auto_retryable(classify(error))
 
     def _backoff_delay(self, attempt: int) -> float:
         """Exponential backoff with full jitter."""

--- a/arbiter/workerWrapper/__tests__/test_composed_tool_governance.py
+++ b/arbiter/workerWrapper/__tests__/test_composed_tool_governance.py
@@ -281,6 +281,57 @@ class TestGovernanceRemovalRedProof:
 
 
 # ---------------------------------------------------------------------------
+# DENY is classified never-retry by the unified taxonomy (board task 9099b8cb)
+# ---------------------------------------------------------------------------
+
+
+class TestDenyIsNeverRetriedAndNoStorm:
+    """Through the REAL BeforeToolCallEvent seam (no agent-boundary stub — that
+    stub hid finding ee38af53): a governance DENY runs the inner tool NEVER,
+    creates NO idempotency reservation (never-retried at the tool level), and
+    writes the DENY GovernanceFinding EXACTLY ONCE (no storm). The taxonomy
+    independently classifies a settled DENY as never-retry, so even if the
+    class reached the node-retry path it could not be widened."""
+
+    def test_deny_never_runs_reserves_or_storms_and_taxonomy_forbids_retry(
+        self, monkeypatch, fake_tool_result_event
+    ):
+        from common import failure_taxonomy as ft
+
+        # Taxonomy: a settled DENY is never-retry and cannot be widened.
+        assert ft.classify(ft.POLICY_DENIED_CLASS) is ft.FailureClass.POLICY_DENIED
+        assert ft.disposition(ft.classify(ft.POLICY_DENIED_CLASS)) is ft.RetryDisposition.NEVER
+        assert ft.is_retry_forbidden_by_taxonomy(ft.POLICY_DENIED_CLASS) is True
+
+        # Count DENY findings written through the REAL decision path.
+        import governed_tool_handler
+        finding_writes = []
+        monkeypatch.setattr(
+            governed_tool_handler, "write_finding",
+            lambda *a, **k: finding_writes.append((a, k)),
+        )
+        reserve_calls = []
+        monkeypatch.setattr(ledger, "reserve", lambda *a, **k: reserve_calls.append((a, k)))
+
+        executed: list = []
+        inner = _FakeInnerTool("dangerous", executed)
+        event = _FakeEvent("dangerous", "tu-1", {"x": 1}, inner)
+        ComposedToolHook(
+            governance=_evaluator(), idempotency=_idempotency()
+        )._on_before_tool_call(event)
+
+        # Drive the deny tool's stream through the real seam.
+        events = _drain(event.selected_tool.stream(event.tool_use, {}))
+
+        assert isinstance(event.selected_tool, _GovernanceDeniedTool)
+        assert executed == []            # inner tool NEVER ran (never-retried)
+        assert reserve_calls == []       # no idempotency reservation
+        assert len(events) == 1 and events[0].tool_result["status"] == "error"
+        # No storm: the DENY audit finding is written exactly once.
+        assert len(finding_writes) == 1
+
+
+# ---------------------------------------------------------------------------
 # Single installer — envelopes + fail-loud
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## Summary

Failure classification was scattered: node retries had their own class-aware list,
the supervisor breaker had a private set of retryable Bedrock codes, a transient-retry helper had a third, and the tool seam had its own error types from recent work. Nothing tied them together, so a denied tool call could be retried by one path while another treated it as terminal - and parallel lists at one seam is exactly how layer-2 governance drifted inert earlier this month.

## What changed

One module in `arbiter/common/` holds the failure classes, a retry disposition table, and a `classify()` helper that accepts an exception or a class name. Every consumer - node retry, the circuit breaker, the transient-retry helper, the executor, supervisor dispatch, and the tool seam - now derives from it and has **dropped its private list**. A guard test fails if any consumer reintroduces a literal set; it was bite-proven by injecting one.

Two refinements the inventory forced:
- **Three dispositions, not two.** An absent approval is neither auto-retryable nor never-retryable - it becomes retryable once a human grants it. Folding it into "policy denied" would either hide a grantable refusal or risk a denial being retried, so it gets its own class with a retry-after-human disposition. Indeterminate and unknown both fail safe to never-retry.
- **Per-node config can only narrow.** A stored workflow definition may reduce retries but can never widen a never-retry class, so an author-supplied `retryableErrors` list cannot re-enable a denied call. Backoff math was deliberately left where it is (a parity test pins the three copies) - consolidating it needs importability coverage for three of four Lambda bundles, filed separately.

## Testing

Denial-never-retried runs through the real tool-hook seam with no agent-boundary stub, plus no-storm and smell-emitted-once assertions. Also: approval-absent versus denial differential, classify parity between exception and string form, unknown-defaults-to-never, and a test that a per-node entry naming a never-retry class does not enable a retry. pytest 561 scoped, 174 supervisor, 341 worker - one test added versus main, zero regressions.

## Note

The design initially justified deferring the backoff consolidation on unverified layer mounting; that premise was checked and found false (every consumer Lambda already mounts the layer), so the recorded reason was corrected rather than propagated.