### PR TITLE
feat(governance): per-target circuit breaking for tools and MCP

### DIFF
--- a/arbiter/common/__tests__/test_failure_taxonomy.py
+++ b/arbiter/common/__tests__/test_failure_taxonomy.py
@@ -43,6 +43,40 @@ class TestDispositionMatrix:
         assert ft.disposition(FC.INDETERMINATE) is RD.NEVER
 
 
+class TestCircuitOpenClass:
+    """The NEW CIRCUIT_OPEN class (task 28d624b1, D1): disposition NEVER,
+    reusing the existing NEVER disposition (no parallel disposition invented)."""
+
+    def test_circuit_open_is_never_and_not_auto_retryable(self):
+        assert ft.disposition(FC.CIRCUIT_OPEN) is RD.NEVER
+        assert ft.is_auto_retryable(FC.CIRCUIT_OPEN) is False
+
+    def test_circuit_open_is_forbidden_by_taxonomy_cannot_be_widened(self):
+        # A stale per-node retryableErrors list can NEVER widen an OPEN breaker
+        # into an in-line retry against a known-bad target (narrow-only veto).
+        assert ft.is_retry_forbidden_by_taxonomy("CircuitBreakerOpen") is True
+        assert ft.is_retry_forbidden_by_taxonomy("ToolTargetCircuitOpen") is True
+        assert ft.is_retry_forbidden_by_taxonomy("CircuitOpenError") is True
+
+    def test_circuit_open_is_not_a_governance_smell(self):
+        # OPEN is a target-health signal, not a settled denial.
+        assert ft.is_governance_smell_on_retry(FC.CIRCUIT_OPEN) is False
+
+    def test_circuit_open_classnames_and_value_string(self):
+        assert ft.classify("CircuitBreakerOpen") is FC.CIRCUIT_OPEN
+        assert ft.classify("CircuitOpenError") is FC.CIRCUIT_OPEN
+        assert ft.classify("ToolTargetCircuitOpen") is FC.CIRCUIT_OPEN
+        # value string round-trips via the lower index.
+        assert ft.classify("circuit-open") is FC.CIRCUIT_OPEN
+
+    def test_circuit_open_exception_matches_string_parity(self):
+        class CircuitBreakerOpen(Exception):
+            pass
+
+        assert ft.classify(CircuitBreakerOpen("x")) == ft.classify("CircuitBreakerOpen")
+        assert ft.classify(CircuitBreakerOpen("x")) is FC.CIRCUIT_OPEN
+
+
 # ---------------------------------------------------------------------------
 # Every inventory error type maps as decided
 # ---------------------------------------------------------------------------

--- a/arbiter/common/failure_taxonomy.py
+++ b/arbiter/common/failure_taxonomy.py
@@ -75,6 +75,16 @@ class FailureClass(str, Enum):
     AUTHZ = "authz"
     APPROVAL_ABSENT = "approval-absent"  # human-grantable; retry only after a human acts
     INDETERMINATE = "indeterminate"  # un-tokened side effect, unknown outcome — fail-safe
+    # A per-target circuit breaker is OPEN: the target is known-bad, so the call
+    # was fast-failed WITHOUT touching the target (arbiter/governance/
+    # tool_breaker_*). Disposition NEVER — the in-line retry ladder must never
+    # re-hit a known-bad target — but NON-terminality is realised OUT-OF-BAND by
+    # the future recovery queue (re-enqueue on OPEN->HALF_OPEN/CLOSED), NOT by an
+    # in-line retry disposition (which is exactly why a new RETRY_AFTER_RECOVERY
+    # disposition was REJECTED — that would be a second retry concept at the
+    # retry seam). Until that queue lands the node fails terminally for the
+    # attempt, which is the conservative, verifiable-today behaviour (D1).
+    CIRCUIT_OPEN = "circuit-open"
     UNKNOWN = "unknown"  # unrecognised — fail-safe default for the AUTO path
 
 
@@ -98,6 +108,10 @@ DISPOSITION: dict[FailureClass, RetryDisposition] = {
     FailureClass.AUTHZ: RetryDisposition.NEVER,
     FailureClass.APPROVAL_ABSENT: RetryDisposition.RETRY_AFTER_HUMAN,
     FailureClass.INDETERMINATE: RetryDisposition.NEVER,
+    # CIRCUIT_OPEN reuses the EXISTING NEVER disposition (no parallel
+    # disposition): the auto path never re-hits a known-bad target, and a stale
+    # per-node retryableErrors list can never widen it (is_retry_forbidden).
+    FailureClass.CIRCUIT_OPEN: RetryDisposition.NEVER,
     FailureClass.UNKNOWN: RetryDisposition.NEVER,
 }
 
@@ -148,6 +162,14 @@ _CLASSNAME_TO_CLASS: dict[str, FailureClass] = {
     "CrossOrgResultRefError": FailureClass.AUTHZ,
     # --- governance DENY (deny-list) ----------------------------------------
     POLICY_DENIED_CLASS: FailureClass.POLICY_DENIED,
+    # --- per-target circuit breaker (tool_breaker_*) ------------------------
+    # The supervisor in-memory breaker raises ``CircuitBreakerOpen``; the
+    # tool-target breaker fast-fails with a ``ToolTargetCircuitOpen`` /
+    # ``CircuitOpenError`` result. All map to CIRCUIT_OPEN so the exception path
+    # and the errorClass-string path classify identically (cross-runtime parity).
+    "CircuitBreakerOpen": FailureClass.CIRCUIT_OPEN,
+    "CircuitOpenError": FailureClass.CIRCUIT_OPEN,
+    "ToolTargetCircuitOpen": FailureClass.CIRCUIT_OPEN,
 }
 
 # Case-insensitive fallback index. Includes every canonical class-name AND the

--- a/arbiter/governance/__tests__/test_tool_breaker_logic.py
+++ b/arbiter/governance/__tests__/test_tool_breaker_logic.py
@@ -1,0 +1,126 @@
+"""Pure-logic unit tests for the per-target circuit breaker (task 28d624b1)."""
+from __future__ import annotations
+
+import os
+import sys
+
+_PROJECT_ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "..", ".."))
+if _PROJECT_ROOT not in sys.path:
+    sys.path.insert(0, _PROJECT_ROOT)
+
+from arbiter.common.failure_taxonomy import FailureClass as FC  # noqa: E402
+from arbiter.governance import tool_breaker_logic as L  # noqa: E402
+from arbiter.governance.tool_breaker_logic import BreakerState, BreakerTarget  # noqa: E402
+
+
+class TestResolveBreakerTarget:
+    def test_mcp_binding_resolves_to_mcp_server_kind(self):
+        t = L.resolve_breaker_target(
+            {"toolId": "t1", "integrationBindings": [{"integrationId": "mcp-1", "type": "MCP"}]}
+        )
+        assert t == BreakerTarget(kind="mcp_server", target_id="mcp-1")
+
+    def test_two_tools_one_server_share_the_key(self):
+        cfg_a = {"toolId": "a", "integrationBindings": [{"integrationId": "mcp-1", "type": "mcp"}]}
+        cfg_b = {"toolId": "b", "integrationBindings": [{"integrationId": "mcp-1", "type": "mcp"}]}
+        ta = L.resolve_breaker_target(cfg_a)
+        tb = L.resolve_breaker_target(cfg_b)
+        assert ta == tb
+        assert L.breaker_pk("org1", ta) == L.breaker_pk("org1", tb) == "org1#mcp_server#mcp-1"
+
+    def test_non_mcp_integration_resolves_to_integration_kind(self):
+        t = L.resolve_breaker_target(
+            {"toolId": "t", "integrationBindings": [{"integrationId": "jira-1", "type": "JIRA"}]}
+        )
+        assert t == BreakerTarget(kind="integration", target_id="jira-1")
+
+    def test_datastore_binding_resolves_to_datastore_kind(self):
+        t = L.resolve_breaker_target(
+            {"toolId": "t", "dataStoreBindings": [{"dataStoreId": "ds-1"}]}
+        )
+        assert t == BreakerTarget(kind="datastore", target_id="ds-1")
+
+    def test_local_tool_no_binding_resolves_to_none(self):
+        # D7: a local/deterministic tool with no external binding gets NO breaker.
+        assert L.resolve_breaker_target({"toolId": "calc"}) is None
+        assert L.resolve_breaker_target({"toolId": "calc", "integrationBindings": []}) is None
+        assert L.resolve_breaker_target({}) is None
+        assert L.resolve_breaker_target(None) is None
+
+    def test_integration_preferred_over_datastore(self):
+        t = L.resolve_breaker_target({
+            "toolId": "t",
+            "integrationBindings": [{"integrationId": "i-1"}],
+            "dataStoreBindings": [{"dataStoreId": "ds-1"}],
+        })
+        assert t.kind == "integration" and t.target_id == "i-1"
+
+    def test_multi_binding_logs_and_gates_first(self, caplog):
+        import logging
+        with caplog.at_level(logging.WARNING):
+            t = L.resolve_breaker_target({
+                "toolId": "multi",
+                "integrationBindings": [{"integrationId": "i-1"}, {"integrationId": "i-2"}],
+            })
+        assert t.target_id == "i-1"  # first binding gated (D3 single-target)
+        assert any("multi" in r.message and "external bindings" in r.message for r in caplog.records)
+
+
+class TestWindowStart:
+    def test_coarse_bucket(self):
+        assert L.window_start(1000, 60) == 960
+        assert L.window_start(1059, 60) == 1020
+        assert L.window_start(1020, 60) == 1020
+
+    def test_zero_window_is_identity(self):
+        assert L.window_start(1234, 0) == 1234
+
+
+class TestShouldCountFailure:
+    def test_transient_and_timeout_always_count(self):
+        assert L.should_count_failure(FC.TRANSIENT, include_throttle=False) is True
+        assert L.should_count_failure(FC.TIMEOUT, include_throttle=False) is True
+
+    def test_throttle_gated_off_by_default(self):
+        # D4: THROTTLE does NOT count toward opening by default; env-gated.
+        assert L.should_count_failure(FC.THROTTLE, include_throttle=False) is False
+        assert L.should_count_failure(FC.THROTTLE, include_throttle=True) is True
+
+    def test_neutral_classes_never_count(self):
+        for fc in (FC.VALIDATION, FC.POLICY_DENIED, FC.AUTHZ, FC.APPROVAL_ABSENT,
+                   FC.INDETERMINATE, FC.UNKNOWN, FC.CIRCUIT_OPEN):
+            assert L.should_count_failure(fc, include_throttle=True) is False, fc
+
+
+class TestTransitionPredicates:
+    def test_open_fast_fail_inside_recovery(self):
+        assert L.is_open_fast_fail(BreakerState.OPEN, opened_at=100, now_epoch=120, recovery_seconds=30) is True
+        assert L.is_probe_eligible(BreakerState.OPEN, opened_at=100, now_epoch=120, recovery_seconds=30) is False
+
+    def test_probe_eligible_after_recovery(self):
+        assert L.is_probe_eligible(BreakerState.OPEN, opened_at=100, now_epoch=131, recovery_seconds=30) is True
+        assert L.is_open_fast_fail(BreakerState.OPEN, opened_at=100, now_epoch=131, recovery_seconds=30) is False
+
+    def test_closed_is_never_fast_fail_or_probe(self):
+        assert L.is_open_fast_fail(BreakerState.CLOSED, 0, 999, 30) is False
+        assert L.is_probe_eligible(BreakerState.CLOSED, 0, 999, 30) is False
+
+    def test_crosses_threshold(self):
+        assert L.crosses_threshold(5, 5) is True
+        assert L.crosses_threshold(4, 5) is False
+
+
+class TestCacheFreshness:
+    def test_open_entry_sticky_to_open_ttl(self):
+        # Stale-OPEN acceptable (fails closed): valid up to open_ttl.
+        assert L.cache_entry_fresh(BreakerState.OPEN, cached_at=100, now_epoch=120,
+                                   open_ttl_seconds=30, closed_ttl_seconds=3) is True
+        assert L.cache_entry_fresh(BreakerState.OPEN, cached_at=100, now_epoch=131,
+                                   open_ttl_seconds=30, closed_ttl_seconds=3) is False
+
+    def test_closed_entry_short_ttl(self):
+        # Stale-CLOSED minimised: short TTL.
+        assert L.cache_entry_fresh(BreakerState.CLOSED, cached_at=100, now_epoch=102,
+                                   open_ttl_seconds=30, closed_ttl_seconds=3) is True
+        assert L.cache_entry_fresh(BreakerState.CLOSED, cached_at=100, now_epoch=104,
+                                   open_ttl_seconds=30, closed_ttl_seconds=3) is False

--- a/arbiter/governance/__tests__/test_tool_breaker_store_moto.py
+++ b/arbiter/governance/__tests__/test_tool_breaker_store_moto.py
@@ -1,0 +1,366 @@
+"""Real-client (moto) contract tests for the tool-target circuit-breaker store
+(task 28d624b1).
+
+Uses a REAL boto3 client backed by moto against ONE real-shaped table (never a
+fake dict store), so conditional-write semantics, attribute typing, and float
+marshalling are all exercised faithfully — the agent boundary is NOT stubbed.
+
+conftest note (mirrors test_ledger_contract_moto.py): arbiter/conftest.py stubs
+module-level boto3.client/resource for the whole suite, but leaves boto3.Session
+intact. We build the REAL moto-backed resource via boto3.Session(...).resource(...)
+inside mock_aws() and point the store's lazy _get_dynamodb_resource seam at it.
+"""
+from __future__ import annotations
+
+import os
+import sys
+import time
+
+import boto3
+import pytest
+
+try:
+    from moto import mock_aws
+except ImportError:  # pragma: no cover
+    pytest.skip("moto not installed", allow_module_level=True)
+
+_PROJECT_ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "..", ".."))
+if _PROJECT_ROOT not in sys.path:
+    sys.path.insert(0, _PROJECT_ROOT)
+
+from arbiter.common.failure_taxonomy import FailureClass  # noqa: E402
+from arbiter.governance import tool_breaker_store as store_mod  # noqa: E402
+from arbiter.governance.tool_breaker_store import (  # noqa: E402
+    BreakerConfig,
+    BreakerTransition,
+    PreCheckDecision,
+    ToolBreakerStore,
+    __reset_breaker_client_for_test,
+)
+from arbiter.governance.tool_breaker_logic import BreakerState, BreakerTarget  # noqa: E402
+
+TABLE = "citadel-tool-breaker-state-moto"
+TARGET = BreakerTarget(kind="mcp_server", target_id="mcp-1")
+PK = "org1#mcp_server#mcp-1"
+
+
+def _make_table(resource):
+    resource.create_table(
+        TableName=TABLE,
+        KeySchema=[
+            {"AttributeName": "pk", "KeyType": "HASH"},
+            {"AttributeName": "sk", "KeyType": "RANGE"},
+        ],
+        AttributeDefinitions=[
+            {"AttributeName": "pk", "AttributeType": "S"},
+            {"AttributeName": "sk", "AttributeType": "S"},
+        ],
+        BillingMode="PAY_PER_REQUEST",
+    )
+
+
+@pytest.fixture
+def moto_resource(monkeypatch):
+    with mock_aws():
+        resource = boto3.Session(region_name="us-east-1").resource("dynamodb")
+        _make_table(resource)
+        __reset_breaker_client_for_test()
+        monkeypatch.setattr(store_mod, "_get_dynamodb_resource", lambda: resource)
+        try:
+            yield resource
+        finally:
+            __reset_breaker_client_for_test()
+
+
+def _raw_item(pk):
+    client = boto3.Session(region_name="us-east-1").client("dynamodb")
+    resp = client.get_item(TableName=TABLE, Key={"pk": {"S": pk}, "sk": {"S": "STATE"}})
+    return resp.get("Item")
+
+
+def _seed(resource, *, state, opened_at=0, failure_count=0, state_version=1,
+          probe_owner=None, probe_expiry=None, window_start=0):
+    item = {
+        "pk": PK, "sk": "STATE", "state": state, "openedAt": int(opened_at),
+        "failureCount": int(failure_count), "stateVersion": int(state_version),
+        "windowStart": int(window_start), "updatedAt": int(opened_at), "ttl": int(opened_at) + 86400,
+    }
+    if probe_owner is not None:
+        item["probeLeaseOwner"] = probe_owner
+        item["probeLeaseExpiresAt"] = int(probe_expiry)
+    resource.Table(TABLE).put_item(Item=item)
+
+
+def _store(resource, *, clock, threshold=3, window=60, recovery=30, lease=30,
+           on_transition=None, org="org1"):
+    return ToolBreakerStore(
+        table_name=TABLE, org_id=org,
+        config=BreakerConfig(
+            failure_threshold=threshold, window_seconds=window, recovery_seconds=recovery,
+            probe_lease_seconds=lease, closed_cache_ttl_seconds=3, ttl_seconds=86400,
+            include_throttle=False,
+        ),
+        on_transition=on_transition, clock=clock,
+    )
+
+
+# ---------------------------------------------------------------------------
+# A1 — opens after N failures in window W  (exactly one CLOSED->OPEN finding)
+# ---------------------------------------------------------------------------
+
+
+class TestOpensAfterNInWindow:
+    def test_opens_after_threshold_and_files_one_finding(self, moto_resource):
+        transitions = []
+        s = _store(moto_resource, clock=lambda: 1000.0, threshold=3,
+                   on_transition=transitions.append)
+        for _ in range(2):
+            s.observe_failure(TARGET, FailureClass.TRANSIENT, is_probe=False)
+        # Not yet open after 2.
+        assert _raw_item(PK)["state"]["S"] == "CLOSED"
+        assert transitions == []
+        # 3rd failure crosses the threshold -> OPEN.
+        s.observe_failure(TARGET, FailureClass.TRANSIENT, is_probe=False)
+        raw = _raw_item(PK)
+        assert raw["state"]["S"] == "OPEN"
+        assert len(transitions) == 1
+        t = transitions[0]
+        assert (t.from_state, t.to_state) == (BreakerState.CLOSED, BreakerState.OPEN)
+
+    def test_neutral_class_never_counts_toward_opening(self, moto_resource):
+        transitions = []
+        s = _store(moto_resource, clock=lambda: 1000.0, threshold=1,
+                   on_transition=transitions.append)
+        # A business/validation error is breaker-neutral even at threshold 1.
+        for fc in (FailureClass.VALIDATION, FailureClass.POLICY_DENIED, FailureClass.THROTTLE):
+            s.observe_failure(TARGET, fc, is_probe=False)
+        assert _raw_item(PK) is None or _raw_item(PK)["state"]["S"] == "CLOSED"
+        assert transitions == []
+
+
+# ---------------------------------------------------------------------------
+# A2 — OPEN fast-fails WITHOUT touching target, ZERO DDB on cached OPEN, <100ms
+# ---------------------------------------------------------------------------
+
+
+class TestOpenFastFailIsLocal:
+    def test_cached_open_fast_fail_does_zero_ddb_and_is_under_100ms(self, moto_resource):
+        clock = {"t": 1000.0}
+        s = _store(moto_resource, clock=lambda: clock["t"], recovery=30)
+        _seed(moto_resource, state="OPEN", opened_at=1000, state_version=1)
+
+        # First call: one GetItem (cache miss), OPEN inside recovery -> fast-fail.
+        clock["t"] = 1005.0
+        pre1 = s.pre_check(TARGET, probe_owner="w1")
+        assert pre1.decision is PreCheckDecision.FAST_FAIL
+        assert s.ddb_op_count == 1
+
+        # Second call: served from cache -> ZERO additional DDB, and <100ms.
+        clock["t"] = 1006.0
+        start = time.monotonic()
+        pre2 = s.pre_check(TARGET, probe_owner="w1")
+        elapsed = time.monotonic() - start
+        assert pre2.decision is PreCheckDecision.FAST_FAIL
+        assert s.ddb_op_count == 1          # structural: NO DynamoDB call on cached OPEN
+        assert pre2.observing is False       # nothing runs, nothing to observe
+        assert elapsed < 0.1                 # generous wall-clock bound (secondary)
+
+    def test_closed_proceeds(self, moto_resource):
+        s = _store(moto_resource, clock=lambda: 1000.0)
+        pre = s.pre_check(TARGET, probe_owner="w1")  # no row -> CLOSED
+        assert pre.decision is PreCheckDecision.PROCEED
+        assert pre.observing is True
+
+
+# ---------------------------------------------------------------------------
+# A3 — recovery closes via a bounded probe; probe failure reopens
+# ---------------------------------------------------------------------------
+
+
+class TestHalfOpenProbe:
+    def test_probe_success_closes(self, moto_resource):
+        transitions = []
+        s = _store(moto_resource, clock=lambda: 1040.0, recovery=30,
+                   on_transition=transitions.append)
+        _seed(moto_resource, state="OPEN", opened_at=1000, state_version=2)  # now 1040 >= 1000+30
+        pre = s.pre_check(TARGET, probe_owner="w1")
+        assert pre.decision is PreCheckDecision.PROBE and pre.is_probe is True
+        assert _raw_item(PK)["state"]["S"] == "HALF_OPEN"
+        # Probe succeeds -> CLOSED, one recovered finding.
+        s.observe_success(TARGET, is_probe=True)
+        assert _raw_item(PK)["state"]["S"] == "CLOSED"
+        assert [(t.from_state, t.to_state) for t in transitions] == [
+            (BreakerState.HALF_OPEN, BreakerState.CLOSED)
+        ]
+
+    def test_probe_failure_reopens(self, moto_resource):
+        transitions = []
+        s = _store(moto_resource, clock=lambda: 1040.0, recovery=30,
+                   on_transition=transitions.append)
+        _seed(moto_resource, state="OPEN", opened_at=1000, state_version=2)
+        pre = s.pre_check(TARGET, probe_owner="w1")
+        assert pre.decision is PreCheckDecision.PROBE
+        s.observe_failure(TARGET, FailureClass.TIMEOUT, is_probe=True)
+        assert _raw_item(PK)["state"]["S"] == "OPEN"
+        assert [(t.from_state, t.to_state) for t in transitions] == [
+            (BreakerState.HALF_OPEN, BreakerState.OPEN)
+        ]
+
+
+# ---------------------------------------------------------------------------
+# A4 — TWO CONCURRENT WORKERS NEVER DOUBLE-PROBE (+ adversarial RED bite)
+# ---------------------------------------------------------------------------
+
+
+class TestNeverDoubleProbe:
+    def test_two_workers_exactly_one_wins_the_lease(self, moto_resource):
+        _seed(moto_resource, state="OPEN", opened_at=1000, state_version=2)
+        a = _store(moto_resource, clock=lambda: 1040.0, recovery=30)
+        b = _store(moto_resource, clock=lambda: 1040.0, recovery=30)
+        pre_a = a.pre_check(TARGET, probe_owner="wA")
+        pre_b = b.pre_check(TARGET, probe_owner="wB")
+        decisions = sorted([pre_a.decision.value, pre_b.decision.value])
+        assert decisions == ["fast_fail", "probe"]  # exactly one prober
+        raw = _raw_item(PK)
+        assert raw["state"]["S"] == "HALF_OPEN"
+        assert raw["probeLeaseOwner"]["S"] in ("wA", "wB")
+
+    def test_RED_bite_unconditional_lease_double_probes(self, moto_resource, monkeypatch):
+        """Adversarial proof the conditional lease is load-bearing: replace the
+        lease conditional write with an UNCONDITIONAL one and BOTH workers win
+        the probe (the double-probe the AC forbids)."""
+        _seed(moto_resource, state="OPEN", opened_at=1000, state_version=2)
+
+        def _unconditional_lease(self, pk, *, owner, now):
+            self.ddb_op_count += 1
+            self._table().update_item(
+                Key={"pk": pk, "sk": "STATE"},
+                UpdateExpression=(
+                    "SET #state = :half, probeLeaseOwner = :owner, "
+                    "probeLeaseExpiresAt = :expiry, updatedAt = :now ADD stateVersion :one"
+                ),
+                # NO ConditionExpression — the bite.
+                ExpressionAttributeNames={"#state": "state"},
+                ExpressionAttributeValues={
+                    ":half": "HALF_OPEN", ":owner": owner,
+                    ":expiry": now + 30, ":now": now, ":one": 1,
+                },
+            )
+            return True
+
+        monkeypatch.setattr(ToolBreakerStore, "_try_acquire_probe_lease", _unconditional_lease)
+        a = _store(moto_resource, clock=lambda: 1040.0, recovery=30)
+        b = _store(moto_resource, clock=lambda: 1040.0, recovery=30)
+        pre_a = a.pre_check(TARGET, probe_owner="wA")
+        pre_b = b.pre_check(TARGET, probe_owner="wB")
+        # BOTH probe -> the vulnerability the conditional lease prevents.
+        assert pre_a.decision is PreCheckDecision.PROBE
+        assert pre_b.decision is PreCheckDecision.PROBE
+
+
+# ---------------------------------------------------------------------------
+# Storm-proof: exactly one CLOSED->OPEN finding under concurrency (+ RED bite)
+# ---------------------------------------------------------------------------
+
+
+class TestStormProof:
+    def test_two_workers_crossing_threshold_file_one_finding(self, moto_resource):
+        # Pre-seed a CLOSED row at failureCount = threshold-1 so a single further
+        # failure from each of two workers races the CLOSED->OPEN transition.
+        _seed(moto_resource, state="CLOSED", failure_count=2, state_version=0, window_start=960)
+        ta, tb = [], []
+        a = _store(moto_resource, clock=lambda: 1000.0, threshold=3, window=60, on_transition=ta.append)
+        b = _store(moto_resource, clock=lambda: 1000.0, threshold=3, window=60, on_transition=tb.append)
+        a.observe_failure(TARGET, FailureClass.TRANSIENT, is_probe=False)
+        b.observe_failure(TARGET, FailureClass.TRANSIENT, is_probe=False)
+        # Exactly one transition finding total (single-writer stateVersion CAS).
+        assert len(ta) + len(tb) == 1
+        assert _raw_item(PK)["state"]["S"] == "OPEN"
+
+    def test_flapping_open_files_no_extra_findings(self, moto_resource):
+        transitions = []
+        s = _store(moto_resource, clock=lambda: 1000.0, threshold=1, on_transition=transitions.append)
+        s.observe_failure(TARGET, FailureClass.TRANSIENT, is_probe=False)  # opens (1 finding)
+        # Many further failures while OPEN write no finding (they'd fast-fail;
+        # a direct observe while OPEN increments nothing — guarded CLOSED-only).
+        for _ in range(10):
+            s.observe_failure(TARGET, FailureClass.TRANSIENT, is_probe=False)
+        assert len(transitions) == 1
+
+    def test_RED_bite_unconditional_open_files_two_findings(self, moto_resource, monkeypatch):
+        """Adversarial proof the stateVersion CAS is load-bearing: replace the
+        conditional CLOSED->OPEN write with an UNCONDITIONAL one and two racing
+        workers each file a finding (a storm)."""
+        _seed(moto_resource, state="CLOSED", failure_count=2, state_version=0, window_start=960)
+
+        def _unconditional_open(self, pk, target, *, now):
+            # Mirror _count_and_maybe_open but with an UNCONDITIONAL transition.
+            from arbiter.governance.tool_breaker_logic import window_start as _ws
+            cur = _ws(now, self._config.window_seconds)
+            self._increment_failure(pk, now=now, cur_window=cur, item_ttl=now + 86400)
+            self.ddb_op_count += 1
+            resp = self._table().update_item(
+                Key={"pk": pk, "sk": "STATE"},
+                UpdateExpression="SET #state = :open, openedAt = :now ADD stateVersion :one",
+                ExpressionAttributeNames={"#state": "state"},
+                ExpressionAttributeValues={":open": "OPEN", ":now": now, ":one": 1},
+                ReturnValues="ALL_NEW",
+            )
+            new = resp.get("Attributes", {}) or {}
+            self._emit(target, BreakerState.CLOSED, BreakerState.OPEN, int(new.get("stateVersion", 0) or 0), now)
+
+        monkeypatch.setattr(ToolBreakerStore, "_count_and_maybe_open", _unconditional_open)
+        ta, tb = [], []
+        a = _store(moto_resource, clock=lambda: 1000.0, threshold=3, window=60, on_transition=ta.append)
+        b = _store(moto_resource, clock=lambda: 1000.0, threshold=3, window=60, on_transition=tb.append)
+        a.observe_failure(TARGET, FailureClass.TRANSIENT, is_probe=False)
+        b.observe_failure(TARGET, FailureClass.TRANSIENT, is_probe=False)
+        assert len(ta) + len(tb) == 2  # storm: two findings for one logical open
+
+
+# ---------------------------------------------------------------------------
+# Float-safety — int-epoch attributes, never a float
+# ---------------------------------------------------------------------------
+
+
+class TestFloatSafety:
+    def test_transition_writes_are_int_typed(self, moto_resource):
+        # A fractional clock must still persist int-epoch attributes (no float).
+        s = _store(moto_resource, clock=lambda: 1000.75, threshold=1)
+        s.observe_failure(TARGET, FailureClass.TRANSIENT, is_probe=False)
+        raw = _raw_item(PK)
+        assert raw["state"]["S"] == "OPEN"
+        for attr in ("openedAt", "stateVersion", "failureCount", "updatedAt", "ttl", "windowStart"):
+            assert "N" in raw[attr], attr
+            assert "." not in raw[attr]["N"], (attr, raw[attr])  # integer, no float tail
+
+
+# ---------------------------------------------------------------------------
+# D7 — a breaker-store outage FAILS OPEN (never a fleet outage)
+# ---------------------------------------------------------------------------
+
+
+class TestStoreUnavailableFailsOpen:
+    def test_missing_table_proceeds(self, moto_resource):
+        # Point the store at a non-existent table -> GetItem raises -> fail-open.
+        s = ToolBreakerStore(
+            table_name="does-not-exist-table", org_id="org1",
+            config=BreakerConfig(recovery_seconds=30), clock=lambda: 1000.0,
+        )
+        pre = s.pre_check(TARGET, probe_owner="w1")
+        assert pre.decision is PreCheckDecision.PROCEED  # fail-open, never block
+
+    def test_transition_write_failure_is_swallowed(self, moto_resource, monkeypatch):
+        # A write error during observe must not raise (fail-open, best-effort):
+        # the store's own conditional-write methods catch store errors and
+        # degrade to a no-op. Force _table() to raise a transport error so the
+        # real internal try/except path is exercised.
+        s = _store(moto_resource, clock=lambda: 1000.0, threshold=1)
+
+        def _boom():
+            raise store_mod.BotoCoreError()
+
+        monkeypatch.setattr(s, "_table", _boom)
+        # Must not raise (a breaker-store outage never fails the tool call).
+        s.observe_failure(TARGET, FailureClass.TRANSIENT, is_probe=False)
+        s.observe_success(TARGET, is_probe=True)

--- a/arbiter/governance/tool_breaker_logic.py
+++ b/arbiter/governance/tool_breaker_logic.py
@@ -1,0 +1,202 @@
+"""Pure decision logic for the per-target tool circuit breaker (task 28d624b1).
+
+This module holds ONLY pure, I/O-free logic — target resolution, the coarse
+failure window, whether a failure class is a target-health signal, and the
+transition predicates. The DynamoDB conditional writes, the per-subprocess
+cache, and the fail-open behaviour live in ``tool_breaker_store.py``; the
+Strands-seam glue lives in ``arbiter/workerWrapper/tool_breaker_hook.py``.
+
+Design (grounded in the task-28d624b1 level-2 design):
+
+* The breaker isolates a TARGET (an MCP server / integration / datastore),
+  never an individual tool: tools that share one external binding resolve to
+  the SAME key, so a failing server is isolated once, not per-tool.
+* Failure counting REUSES ``common.failure_taxonomy`` (no parallel notion of
+  failure): a tool outcome increments the breaker iff its class is a genuine
+  target-health signal (TRANSIENT / TIMEOUT, and THROTTLE only when explicitly
+  enabled — D4). CIRCUIT_OPEN itself is never counted (a fast-fail is not a
+  fresh target failure), and business/validation/policy classes are neutral.
+* Single-target resolution only (D3 — YAGNI on multi-binding fan-out): a tool
+  bound to more than one external target resolves to its FIRST binding and the
+  ambiguity is logged loudly (no evidenced multi-binding instance exists).
+* Local/deterministic tools with NO external binding get NO breaker (D7):
+  :func:`resolve_breaker_target` returns ``None`` and the store/seam skip the
+  breaker phase entirely (zero DynamoDB reads for them).
+"""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass
+from enum import Enum
+
+from common.failure_taxonomy import FailureClass
+
+logger = logging.getLogger(__name__)
+
+
+class BreakerState(str, Enum):
+    """The three breaker states. ``str`` mixin per repo convention so a member
+    compares/serialises as its value across module-identity boundaries."""
+
+    CLOSED = "CLOSED"
+    OPEN = "OPEN"
+    HALF_OPEN = "HALF_OPEN"
+
+
+# Target kinds. ``tool`` is defined for completeness but is NOT produced by
+# :func:`resolve_breaker_target` — a local tool with no external binding is
+# excluded from the breaker (D7). The three external kinds are what the breaker
+# isolates.
+TARGET_KIND_MCP_SERVER = "mcp_server"
+TARGET_KIND_INTEGRATION = "integration"
+TARGET_KIND_DATASTORE = "datastore"
+
+SK_STATE = "STATE"  # single item per target ⇒ each target is its own partition
+
+
+@dataclass(frozen=True)
+class BreakerTarget:
+    """The resolved external target a tool call is gated on."""
+
+    kind: str
+    target_id: str
+
+
+def _binding_is_mcp(binding: dict) -> bool:
+    """True when an integration binding names an MCP server integration.
+
+    The MCP integration RECORD id is the stable breaker key (never the endpoint
+    URL, which rotates and is secret-adjacent). We detect MCP via the binding's
+    declared type/kind; an unknown/absent type falls back to the generic
+    ``integration`` kind (still correct — two tools on the same integration id
+    share the key regardless)."""
+    for key in ("integrationType", "type", "kind", "protocol"):
+        value = binding.get(key)
+        if isinstance(value, str) and value.strip().lower() in (
+            "mcp", "mcp_server", "agentcore_mcp", "external_mcp",
+        ):
+            return True
+    return False
+
+
+def resolve_breaker_target(tool_config: dict) -> BreakerTarget | None:
+    """Resolve the SINGLE external target a tool is gated on, or ``None``.
+
+    Returns ``None`` for a local/deterministic tool with no external binding
+    (D7 — the breaker phase is then skipped entirely, zero DynamoDB reads).
+
+    Single-target (D3): an integration binding is preferred over a datastore
+    binding, and the FIRST binding wins. If a tool config carries MORE THAN ONE
+    external binding, that ambiguity is logged loudly (WARN) — no evidenced
+    multi-binding instance exists, so multi-binding fan-out is deliberately not
+    built; if one ever appears the log/assert surfaces it for a follow-up.
+    """
+    if not isinstance(tool_config, dict):
+        return None
+    integration_bindings = tool_config.get("integrationBindings") or []
+    datastore_bindings = tool_config.get("dataStoreBindings") or []
+    external_bindings = [
+        b for b in integration_bindings if isinstance(b, dict) and b.get("integrationId")
+    ] + [
+        b for b in datastore_bindings if isinstance(b, dict) and b.get("dataStoreId")
+    ]
+    if not external_bindings:
+        return None  # local tool — no breaker (D7)
+
+    if len(external_bindings) > 1:
+        logger.warning(
+            "tool %r has %d external bindings; single-target breaker gates the "
+            "FIRST only (multi-binding fan-out is intentionally not built — D3). "
+            "This is unexpected: no evidenced multi-binding tool exists.",
+            tool_config.get("toolId", "unknown"), len(external_bindings),
+        )
+
+    first = external_bindings[0]
+    integration_id = first.get("integrationId")
+    if integration_id:
+        kind = TARGET_KIND_MCP_SERVER if _binding_is_mcp(first) else TARGET_KIND_INTEGRATION
+        return BreakerTarget(kind=kind, target_id=str(integration_id))
+    # datastore binding
+    return BreakerTarget(kind=TARGET_KIND_DATASTORE, target_id=str(first["dataStoreId"]))
+
+
+def breaker_pk(org_id: str, target: BreakerTarget) -> str:
+    """The org-scoped partition key ``orgId#targetKind#targetId``.
+
+    ``org_id`` may be empty (executionId-style global uniqueness); the org
+    prefix is defense-in-depth cross-org isolation, not the uniqueness
+    guarantee. It is always resolved server-side, never from a subprocess
+    payload.
+    """
+    return f"{org_id}#{target.kind}#{target.target_id}"
+
+
+def window_start(now_epoch: int, window_seconds: int) -> int:
+    """Coarse fixed-window bucket start (bounds counter cardinality)."""
+    if window_seconds <= 0:
+        return int(now_epoch)
+    return (int(now_epoch) // window_seconds) * window_seconds
+
+
+def should_count_failure(failure_class: FailureClass, *, include_throttle: bool) -> bool:
+    """True iff a tool-call outcome is a genuine TARGET-HEALTH signal that
+    should increment the breaker's failure counter.
+
+    TRANSIENT and TIMEOUT are always health signals (D4). THROTTLE counts ONLY
+    when ``include_throttle`` is set (env-gated, default OFF): a throttle is
+    provider backpressure, not a broken target, so by default it surfaces as a
+    distinct metric rather than opening the breaker. Every other class —
+    VALIDATION / POLICY_DENIED / AUTHZ / APPROVAL_ABSENT / INDETERMINATE /
+    UNKNOWN and CIRCUIT_OPEN itself — is breaker-NEUTRAL (a fast-fail is not a
+    fresh failure; a business/validation error is not target health).
+    """
+    if failure_class in (FailureClass.TRANSIENT, FailureClass.TIMEOUT):
+        return True
+    if failure_class == FailureClass.THROTTLE:
+        return include_throttle
+    return False
+
+
+def is_probe_eligible(
+    state: str, opened_at: int, now_epoch: int, recovery_seconds: int
+) -> bool:
+    """True when an OPEN breaker has waited out its recovery window and a single
+    HALF_OPEN probe may now be attempted (the lease decides the sole prober)."""
+    return state == BreakerState.OPEN and int(now_epoch) >= int(opened_at) + int(recovery_seconds)
+
+
+def is_open_fast_fail(
+    state: str, opened_at: int, now_epoch: int, recovery_seconds: int
+) -> bool:
+    """True when an OPEN breaker is still inside its recovery window ⇒ the call
+    must fast-fail WITHOUT touching the target and WITHOUT any DynamoDB write."""
+    return state == BreakerState.OPEN and int(now_epoch) < int(opened_at) + int(recovery_seconds)
+
+
+def crosses_threshold(failure_count: int, threshold: int) -> bool:
+    """True when a windowed failure count has reached the open threshold."""
+    return int(failure_count) >= int(threshold)
+
+
+def cache_entry_fresh(
+    state: str,
+    cached_at: int,
+    now_epoch: int,
+    *,
+    open_ttl_seconds: int,
+    closed_ttl_seconds: int,
+) -> bool:
+    """Asymmetric cache freshness (D5, security lens): an OPEN entry is sticky
+    up to ``open_ttl_seconds`` (stale-OPEN fails closed — bounded, self-
+    correcting, safe), while a CLOSED/HALF_OPEN entry is only fresh for the
+    short ``closed_ttl_seconds`` (stale-CLOSED would hit a known-bad target, so
+    it is minimised). Process lifetime is the real bound; the TTL is a safety
+    cap on top of it.
+    """
+    age = int(now_epoch) - int(cached_at)
+    if age < 0:
+        return False
+    if state == BreakerState.OPEN:
+        return age < int(open_ttl_seconds)
+    return age < int(closed_ttl_seconds)

--- a/arbiter/governance/tool_breaker_store.py
+++ b/arbiter/governance/tool_breaker_store.py
@@ -1,0 +1,526 @@
+"""DynamoDB-backed per-target circuit-breaker store (task 28d624b1).
+
+Shares breaker state across the short-lived worker subprocesses via conditional
+writes, exactly as ``tool_execution_ledger.py`` shares idempotency state. This
+module owns ALL I/O (DynamoDB reads/writes + a per-subprocess in-process cache);
+the pure decision logic is in ``tool_breaker_logic.py`` and the Strands-seam
+glue is in ``arbiter/workerWrapper/tool_breaker_hook.py``.
+
+Load-bearing invariants (grounded in the level-2 design):
+
+* **Fast-fail is local.** A steady-state OPEN target fast-fails from the
+  per-subprocess cache with ZERO DynamoDB calls and without touching the
+  target — the <100ms budget is met structurally, not by a wall-clock race.
+* **Two concurrent workers never double-probe.** OPEN→HALF_OPEN is a single
+  conditional-write lease (guarded on the lease expiry); exactly one worker
+  wins and becomes the sole prober, every other worker's conditional write is
+  refused and it fast-fails as OPEN. An EXPIRED lease is re-acquirable so a
+  crashed prober can never wedge the breaker.
+* **Transitions are single-writer ⇒ findings are storm-proof.** Every state
+  transition is a conditional write guarded on the monotonic ``stateVersion``
+  (or the probe-lease owner), so exactly one worker performs it and emits
+  exactly one transition side-effect — regardless of call volume.
+* **Fail-OPEN (D7).** The breaker is an availability optimisation, NOT a
+  security control. If its OWN store is unavailable, every store operation
+  degrades to "proceed" (treat as CLOSED) so a breaker-store outage can never
+  become a fleet-wide tool-call outage. The genuine controls (deny-list,
+  failure taxonomy) are independent of this store and still run.
+* **Float-safe writes.** Every item write goes through
+  ``common.ddb_marshalling.marshal_ddb_item`` with int-epoch timestamps.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+import time
+from dataclasses import dataclass
+from enum import Enum
+from typing import Any, Callable
+
+import boto3
+from botocore.exceptions import BotoCoreError, ClientError
+
+from common.ddb_marshalling import marshal_ddb_item
+from governance.tool_breaker_logic import (
+    BreakerState,
+    BreakerTarget,
+    breaker_pk,
+    cache_entry_fresh,
+    crosses_threshold,
+    is_open_fast_fail,
+    is_probe_eligible,
+    window_start,
+)
+
+logger = logging.getLogger(__name__)
+
+SK_STATE = "STATE"
+
+# --- Tunables (env-overridable, delivered CDK -> Lambda env -> subprocess) ---
+
+DEFAULT_FAILURE_THRESHOLD = 5           # N failures in window W ⇒ OPEN
+DEFAULT_WINDOW_SECONDS = 60             # W — coarse failure-count bucket
+DEFAULT_RECOVERY_SECONDS = 30           # OPEN dwell before a probe is eligible
+DEFAULT_PROBE_LEASE_SECONDS = 30        # HALF_OPEN probe lease lifetime
+DEFAULT_CACHE_TTL_SECONDS = 3           # SAFETY CAP for a CLOSED/HALF_OPEN cache entry
+DEFAULT_TTL_SECONDS = 24 * 3600         # idle-row self-clean (RETAIN guards the table)
+
+
+def _int_env(name: str, default: int) -> int:
+    raw = os.environ.get(name)
+    if raw is None:
+        return default
+    try:
+        value = int(raw)
+    except (TypeError, ValueError):
+        return default
+    return value if value > 0 else default
+
+
+def _bool_env(name: str) -> bool:
+    return os.environ.get(name, "").strip().lower() in ("1", "true", "yes", "on")
+
+
+@dataclass(frozen=True)
+class BreakerConfig:
+    """Resolved breaker tunables. ``open_cache_ttl_seconds`` is the recovery
+    window (an OPEN cache entry is sticky until a probe becomes eligible, then
+    a DynamoDB read is forced anyway); ``closed_cache_ttl_seconds`` is the short
+    SAFETY CAP that minimises the stale-CLOSED window (D5)."""
+
+    failure_threshold: int = DEFAULT_FAILURE_THRESHOLD
+    window_seconds: int = DEFAULT_WINDOW_SECONDS
+    recovery_seconds: int = DEFAULT_RECOVERY_SECONDS
+    probe_lease_seconds: int = DEFAULT_PROBE_LEASE_SECONDS
+    closed_cache_ttl_seconds: int = DEFAULT_CACHE_TTL_SECONDS
+    ttl_seconds: int = DEFAULT_TTL_SECONDS
+    include_throttle: bool = False
+
+    @property
+    def open_cache_ttl_seconds(self) -> int:
+        # Stale-OPEN is acceptable (fails closed, self-correcting); the cap is
+        # the recovery window — past it a probe is eligible and we must read.
+        return self.recovery_seconds
+
+    @classmethod
+    def from_env(cls) -> "BreakerConfig":
+        return cls(
+            failure_threshold=_int_env("TOOL_BREAKER_FAILURE_THRESHOLD", DEFAULT_FAILURE_THRESHOLD),
+            window_seconds=_int_env("TOOL_BREAKER_WINDOW_SECONDS", DEFAULT_WINDOW_SECONDS),
+            recovery_seconds=_int_env("TOOL_BREAKER_RECOVERY_SECONDS", DEFAULT_RECOVERY_SECONDS),
+            probe_lease_seconds=_int_env("TOOL_BREAKER_PROBE_LEASE_SECONDS", DEFAULT_PROBE_LEASE_SECONDS),
+            closed_cache_ttl_seconds=_int_env("TOOL_BREAKER_CACHE_TTL_SECONDS", DEFAULT_CACHE_TTL_SECONDS),
+            ttl_seconds=_int_env("TOOL_BREAKER_TTL_SECONDS", DEFAULT_TTL_SECONDS),
+            include_throttle=_bool_env("TOOL_BREAKER_OPEN_ON_THROTTLE"),
+        )
+
+
+class PreCheckDecision(str, Enum):
+    PROCEED = "proceed"      # CLOSED (or fail-open): run the tool, observe outcome
+    FAST_FAIL = "fast_fail"  # OPEN (or lease lost): fast-fail, do NOT touch target
+    PROBE = "probe"          # this worker won the HALF_OPEN lease: run + observe
+
+
+@dataclass
+class PreCheck:
+    decision: PreCheckDecision
+    target: BreakerTarget
+    state: str = BreakerState.CLOSED
+
+    @property
+    def fast_fail(self) -> bool:
+        return self.decision is PreCheckDecision.FAST_FAIL
+
+    @property
+    def observing(self) -> bool:
+        # We observe (and may transition) on the CLOSED path and on the probe
+        # path — never on a fast-fail (nothing ran).
+        return self.decision in (PreCheckDecision.PROCEED, PreCheckDecision.PROBE)
+
+    @property
+    def is_probe(self) -> bool:
+        return self.decision is PreCheckDecision.PROBE
+
+
+@dataclass
+class BreakerTransition:
+    target: BreakerTarget
+    from_state: str
+    to_state: str
+    state_version: int
+    now: int
+
+
+@dataclass
+class _CacheEntry:
+    state: str
+    opened_at: int
+    state_version: int
+    cached_at: int
+
+
+# --- Lazy boto3 resource (mirrors the ledger's lazy seam) --------------------
+
+_ddb_resource: Any = None
+
+
+def _get_dynamodb_resource() -> Any:
+    global _ddb_resource
+    if _ddb_resource is None:
+        _ddb_resource = boto3.resource("dynamodb")
+    return _ddb_resource
+
+
+def __reset_breaker_client_for_test() -> None:
+    """Test-only: clear the cached boto3 resource."""
+    global _ddb_resource
+    _ddb_resource = None
+
+
+class ToolBreakerStore:
+    """Conditional-write breaker store with a per-instance (per-subprocess)
+    cache. One instance is built per worker subprocess (like the idempotency
+    hook), so the cache is process-scoped by construction.
+    """
+
+    def __init__(
+        self,
+        *,
+        table_name: str,
+        org_id: str = "",
+        config: BreakerConfig | None = None,
+        on_transition: Callable[[BreakerTransition], None] | None = None,
+        clock: Callable[[], float] = time.time,
+    ):
+        self._table_name = table_name
+        self._org_id = org_id or ""
+        self._config = config or BreakerConfig()
+        self._on_transition = on_transition
+        self._clock = clock
+        self._cache: dict[str, _CacheEntry] = {}
+        # Observability for tests + telemetry: DynamoDB op count on this store.
+        self.ddb_op_count = 0
+        # Set True by _get_row when the store read failed (drives fail-open).
+        self._store_unavailable = False
+
+    # --- table access --------------------------------------------------------
+
+    def _table(self) -> Any:
+        return _get_dynamodb_resource().Table(self._table_name)
+
+    def _now(self) -> int:
+        return int(self._clock())
+
+    # --- pre-check -----------------------------------------------------------
+
+    def pre_check(self, target: BreakerTarget, *, probe_owner: str) -> PreCheck:
+        """Decide fast-fail / proceed / probe for a target.
+
+        A steady-state OPEN target fast-fails from cache with ZERO DynamoDB
+        calls. On a cache miss/stale entry a single eventually-consistent
+        GetItem resolves the state (fail-OPEN on any store error). An
+        OPEN-past-recovery target attempts the single conditional probe lease.
+        """
+        pk = breaker_pk(self._org_id, target)
+        now = self._now()
+        cfg = self._config
+
+        cached = self._cache.get(pk)
+        if cached is not None and cache_entry_fresh(
+            cached.state, cached.cached_at, now,
+            open_ttl_seconds=cfg.open_cache_ttl_seconds,
+            closed_ttl_seconds=cfg.closed_cache_ttl_seconds,
+        ):
+            if is_open_fast_fail(cached.state, cached.opened_at, now, cfg.recovery_seconds):
+                # Cached OPEN, still inside recovery ⇒ fast-fail, ZERO DDB.
+                return PreCheck(PreCheckDecision.FAST_FAIL, target, BreakerState.OPEN)
+            if cached.state == BreakerState.CLOSED:
+                return PreCheck(PreCheckDecision.PROCEED, target, BreakerState.CLOSED)
+            # Cached OPEN-past-recovery or HALF_OPEN: fall through to DDB (a
+            # probe-lease decision must be made against authoritative state).
+
+        row = self._get_row(pk)
+        if row is None and self._store_unavailable:
+            # FAIL-OPEN: store unreachable ⇒ treat as CLOSED, never block.
+            return PreCheck(PreCheckDecision.PROCEED, target, BreakerState.CLOSED)
+        if not row:
+            self._cache[pk] = _CacheEntry(BreakerState.CLOSED, 0, 0, now)
+            return PreCheck(PreCheckDecision.PROCEED, target, BreakerState.CLOSED)
+
+        state = str(row.get("state", BreakerState.CLOSED))
+        opened_at = int(row.get("openedAt", 0) or 0)
+        state_version = int(row.get("stateVersion", 0) or 0)
+        self._cache[pk] = _CacheEntry(state, opened_at, state_version, now)
+
+        if state == BreakerState.CLOSED:
+            return PreCheck(PreCheckDecision.PROCEED, target, BreakerState.CLOSED)
+
+        if is_open_fast_fail(state, opened_at, now, cfg.recovery_seconds):
+            return PreCheck(PreCheckDecision.FAST_FAIL, target, BreakerState.OPEN)
+
+        if is_probe_eligible(state, opened_at, now, cfg.recovery_seconds) or (
+            state == BreakerState.HALF_OPEN
+        ):
+            # OPEN past recovery, or a HALF_OPEN whose prober may be dead:
+            # attempt the single conditional probe lease.
+            if self._try_acquire_probe_lease(pk, owner=probe_owner, now=now):
+                return PreCheck(PreCheckDecision.PROBE, target, BreakerState.HALF_OPEN)
+            # Lost the lease ⇒ another worker is the sole prober ⇒ fast-fail.
+            return PreCheck(PreCheckDecision.FAST_FAIL, target, BreakerState.OPEN)
+
+        return PreCheck(PreCheckDecision.PROCEED, target, state)
+
+    # --- observation (drives transitions) ------------------------------------
+
+    def observe_success(self, target: BreakerTarget, *, is_probe: bool) -> None:
+        """Record a healthy outcome. On the probe path this closes the breaker
+        (HALF_OPEN→CLOSED). On the CLOSED happy path it is WRITE-QUIET (no DDB
+        write) so a healthy target never contends the hot item."""
+        if not is_probe:
+            return  # write-quiet when healthy
+        pk = breaker_pk(self._org_id, target)
+        now = self._now()
+        self._transition_from_probe(
+            pk, target, to_state=BreakerState.CLOSED, now=now, owner_required=True,
+            reset_failures=True,
+        )
+
+    def observe_failure(
+        self, target: BreakerTarget, failure_class: Any, *, is_probe: bool
+    ) -> None:
+        """Record a target-health failure. On the probe path this reopens the
+        breaker (HALF_OPEN→OPEN). On the CLOSED path it increments the windowed
+        counter and, on crossing the threshold, opens (CLOSED→OPEN)."""
+        from governance.tool_breaker_logic import should_count_failure
+
+        if not should_count_failure(failure_class, include_throttle=self._config.include_throttle):
+            return  # neutral class — not a target-health signal
+        pk = breaker_pk(self._org_id, target)
+        now = self._now()
+        if is_probe:
+            self._transition_from_probe(
+                pk, target, to_state=BreakerState.OPEN, now=now, owner_required=True,
+                reset_failures=False,
+            )
+            return
+        self._count_and_maybe_open(pk, target, now=now)
+
+    # --- conditional writes --------------------------------------------------
+
+    def _get_row(self, pk: str) -> dict[str, Any] | None:
+        self._store_unavailable = False
+        try:
+            self.ddb_op_count += 1
+            resp = self._table().get_item(Key={"pk": pk, "sk": SK_STATE})
+        except (ClientError, BotoCoreError) as exc:
+            # FAIL-OPEN: a read failure must not block the call.
+            logger.error("tool-breaker get_item FAILED (fail-open) pk=%s: %s", pk, exc)
+            self._store_unavailable = True
+            return None
+        item = resp.get("Item")
+        return item if isinstance(item, dict) else None
+
+    def _try_acquire_probe_lease(self, pk: str, *, owner: str, now: int) -> bool:
+        """OPEN→HALF_OPEN single-prober lease. Guarded on the lease being absent
+        or EXPIRED so exactly one worker wins and a dead prober can't wedge the
+        breaker. Returns True iff this worker acquired the lease.
+
+        This conditional guard is the two-workers-never-double-probe control —
+        replacing it with an unconditional write is the adversarial RED bite."""
+        lease_expiry = now + self._config.probe_lease_seconds
+        item_ttl = now + self._config.ttl_seconds
+        try:
+            self.ddb_op_count += 1
+            self._table().update_item(
+                Key={"pk": pk, "sk": SK_STATE},
+                UpdateExpression=(
+                    "SET #state = :half, probeLeaseOwner = :owner, "
+                    "probeLeaseExpiresAt = :expiry, updatedAt = :now, #ttl = :itl "
+                    "ADD stateVersion :one"
+                ),
+                ConditionExpression=(
+                    "#state IN (:open, :half) AND "
+                    "(attribute_not_exists(probeLeaseExpiresAt) OR probeLeaseExpiresAt < :now)"
+                ),
+                ExpressionAttributeNames={"#state": "state", "#ttl": "ttl"},
+                ExpressionAttributeValues=marshal_ddb_item({
+                    ":half": BreakerState.HALF_OPEN.value,
+                    ":open": BreakerState.OPEN.value,
+                    ":owner": owner,
+                    ":expiry": lease_expiry,
+                    ":now": now,
+                    ":itl": item_ttl,
+                    ":one": 1,
+                }),
+            )
+            self._cache.pop(pk, None)
+            return True
+        except ClientError as exc:
+            if exc.response.get("Error", {}).get("Code") == "ConditionalCheckFailedException":
+                return False
+            logger.error("tool-breaker lease acquire FAILED (fail-open) pk=%s: %s", pk, exc)
+            return False
+        except BotoCoreError as exc:
+            logger.error("tool-breaker lease acquire transport error (fail-open) pk=%s: %s", pk, exc)
+            return False
+
+    def _transition_from_probe(
+        self, pk: str, target: BreakerTarget, *, to_state: str, now: int,
+        owner_required: bool, reset_failures: bool,
+    ) -> None:
+        """HALF_OPEN→{CLOSED,OPEN} guarded on ``state=HALF_OPEN`` — only the
+        current prober transitions. Best-effort (fail-open) but single-writer,
+        so exactly one recovered/reopen finding is emitted."""
+        item_ttl = now + self._config.ttl_seconds
+        to_value = to_state.value if isinstance(to_state, BreakerState) else str(to_state)
+        set_parts = ["#state = :to", "updatedAt = :now", "#ttl = :itl"]
+        values: dict[str, Any] = {
+            ":to": to_value, ":half": BreakerState.HALF_OPEN.value,
+            ":now": now, ":itl": item_ttl, ":one": 1,
+        }
+        if reset_failures:
+            set_parts.append("failureCount = :zero")
+            values[":zero"] = 0
+        if to_state == BreakerState.OPEN:
+            set_parts.append("openedAt = :now")
+        expr = "SET " + ", ".join(set_parts) + " ADD stateVersion :one REMOVE probeLeaseOwner, probeLeaseExpiresAt"
+        try:
+            self.ddb_op_count += 1
+            resp = self._table().update_item(
+                Key={"pk": pk, "sk": SK_STATE},
+                UpdateExpression=expr,
+                ConditionExpression="#state = :half",
+                ExpressionAttributeNames={"#state": "state", "#ttl": "ttl"},
+                ExpressionAttributeValues=marshal_ddb_item(values),
+                ReturnValues="ALL_NEW",
+            )
+        except ClientError as exc:
+            if exc.response.get("Error", {}).get("Code") == "ConditionalCheckFailedException":
+                return  # not the prober / already transitioned
+            logger.error("tool-breaker probe transition FAILED (fail-open) pk=%s: %s", pk, exc)
+            return
+        except BotoCoreError as exc:
+            logger.error("tool-breaker probe transition transport error (fail-open) pk=%s: %s", pk, exc)
+            return
+        new = resp.get("Attributes", {}) or {}
+        self._cache.pop(pk, None)
+        self._emit(target, BreakerState.HALF_OPEN, to_state, int(new.get("stateVersion", 0) or 0), now)
+
+    def _count_and_maybe_open(self, pk: str, target: BreakerTarget, *, now: int) -> None:
+        """Increment the windowed failure counter (CLOSED only) then, on
+        crossing the threshold, transition CLOSED→OPEN via a ``stateVersion``-
+        guarded conditional write (exactly one worker opens ⇒ one finding).
+
+        Removing the ``stateVersion = :seen`` guard on the CLOSED→OPEN write is
+        the adversarial RED bite (a storm files >1 finding)."""
+        cfg = self._config
+        cur_window = window_start(now, cfg.window_seconds)
+        item_ttl = now + cfg.ttl_seconds
+        new_row = self._increment_failure(pk, now=now, cur_window=cur_window, item_ttl=item_ttl)
+        if new_row is None:
+            return  # not CLOSED (already OPEN/HALF_OPEN) or store error — fail-open
+        failure_count = int(new_row.get("failureCount", 0) or 0)
+        state_version = int(new_row.get("stateVersion", 0) or 0)
+        if str(new_row.get("state", BreakerState.CLOSED)) != BreakerState.CLOSED:
+            return
+        if not crosses_threshold(failure_count, cfg.failure_threshold):
+            return
+        try:
+            self.ddb_op_count += 1
+            resp = self._table().update_item(
+                Key={"pk": pk, "sk": SK_STATE},
+                UpdateExpression=(
+                    "SET #state = :open, openedAt = :now, updatedAt = :now, #ttl = :itl "
+                    "ADD stateVersion :one"
+                ),
+                ConditionExpression="#state = :closed AND stateVersion = :seen",
+                ExpressionAttributeNames={"#state": "state", "#ttl": "ttl"},
+                ExpressionAttributeValues=marshal_ddb_item({
+                    ":open": BreakerState.OPEN.value,
+                    ":closed": BreakerState.CLOSED.value,
+                    ":now": now,
+                    ":itl": item_ttl,
+                    ":seen": state_version,
+                    ":one": 1,
+                }),
+                ReturnValues="ALL_NEW",
+            )
+        except ClientError as exc:
+            if exc.response.get("Error", {}).get("Code") == "ConditionalCheckFailedException":
+                return  # another worker opened it (or a stale snapshot) — no dup finding
+            logger.error("tool-breaker open transition FAILED (fail-open) pk=%s: %s", pk, exc)
+            return
+        except BotoCoreError as exc:
+            logger.error("tool-breaker open transition transport error (fail-open) pk=%s: %s", pk, exc)
+            return
+        new = resp.get("Attributes", {}) or {}
+        self._cache.pop(pk, None)
+        self._emit(target, BreakerState.CLOSED, BreakerState.OPEN, int(new.get("stateVersion", 0) or 0), now)
+
+    def _increment_failure(
+        self, pk: str, *, now: int, cur_window: int, item_ttl: int
+    ) -> dict[str, Any] | None:
+        """Windowed ADD failureCount, only while CLOSED. Returns the new row
+        (ALL_NEW) or None (not CLOSED / store error). Two attempts: increment
+        within the current window, else roll/create the window."""
+        try:
+            self.ddb_op_count += 1
+            resp = self._table().update_item(
+                Key={"pk": pk, "sk": SK_STATE},
+                UpdateExpression="SET updatedAt = :now, #ttl = :itl ADD failureCount :one",
+                ConditionExpression="#state = :closed AND windowStart = :cur",
+                ExpressionAttributeNames={"#state": "state", "#ttl": "ttl"},
+                ExpressionAttributeValues=marshal_ddb_item({
+                    ":now": now, ":itl": item_ttl, ":one": 1,
+                    ":closed": BreakerState.CLOSED.value, ":cur": cur_window,
+                }),
+                ReturnValues="ALL_NEW",
+            )
+            return resp.get("Attributes", {}) or {}
+        except ClientError as exc:
+            if exc.response.get("Error", {}).get("Code") != "ConditionalCheckFailedException":
+                logger.error("tool-breaker failure incr FAILED (fail-open) pk=%s: %s", pk, exc)
+                return None
+        except BotoCoreError as exc:
+            logger.error("tool-breaker failure incr transport error (fail-open) pk=%s: %s", pk, exc)
+            return None
+        # Window rolled, or the row does not yet exist: create/reset the window
+        # (still CLOSED). Guarded so we never resurrect an OPEN/HALF_OPEN row.
+        try:
+            self.ddb_op_count += 1
+            resp = self._table().update_item(
+                Key={"pk": pk, "sk": SK_STATE},
+                UpdateExpression=(
+                    "SET #state = if_not_exists(#state, :closed), windowStart = :cur, "
+                    "failureCount = :one, stateVersion = if_not_exists(stateVersion, :zero), "
+                    "openedAt = if_not_exists(openedAt, :zero), updatedAt = :now, #ttl = :itl"
+                ),
+                ConditionExpression=(
+                    "attribute_not_exists(pk) OR "
+                    "(#state = :closed AND (attribute_not_exists(windowStart) OR windowStart < :cur))"
+                ),
+                ExpressionAttributeNames={"#state": "state", "#ttl": "ttl"},
+                ExpressionAttributeValues=marshal_ddb_item({
+                    ":closed": BreakerState.CLOSED.value, ":cur": cur_window,
+                    ":one": 1, ":zero": 0, ":now": now, ":itl": item_ttl,
+                }),
+                ReturnValues="ALL_NEW",
+            )
+            return resp.get("Attributes", {}) or {}
+        except ClientError as exc:
+            if exc.response.get("Error", {}).get("Code") == "ConditionalCheckFailedException":
+                return None  # not CLOSED — already OPEN/HALF_OPEN
+            logger.error("tool-breaker window roll FAILED (fail-open) pk=%s: %s", pk, exc)
+            return None
+        except BotoCoreError as exc:
+            logger.error("tool-breaker window roll transport error (fail-open) pk=%s: %s", pk, exc)
+            return None
+
+    def _emit(self, target: BreakerTarget, from_state: str, to_state: str, state_version: int, now: int) -> None:
+        if self._on_transition is None:
+            return
+        try:
+            self._on_transition(BreakerTransition(target, from_state, to_state, state_version, now))
+        except Exception as exc:  # noqa: BLE001 — emission must never crash the call
+            logger.error("tool-breaker transition emit failed %s->%s: %s", from_state, to_state, exc)

--- a/arbiter/workerWrapper/__tests__/test_composed_tool_breaker_seam.py
+++ b/arbiter/workerWrapper/__tests__/test_composed_tool_breaker_seam.py
@@ -1,0 +1,271 @@
+"""Seam tests for the per-target breaker composed into the REAL ComposedToolHook
+(task 28d624b1).
+
+The agent boundary is NOT stubbed: these drive the real ``ComposedToolHook`` +
+``GovernanceEvaluator`` + ``ToolBreaker`` (backed by a REAL moto client, real-
+shaped rows), asserting the exact ordering
+    deny-list → breaker pre-check → approval-consume → idempotency reserve →
+    outermost breaker observer
+and the invariants: a breaker fast-fail burns no approval single-use and leaves
+no ledger reservation; a deny precedes (and masks) the breaker; a local tool
+with no external binding skips the breaker entirely (zero DynamoDB).
+"""
+from __future__ import annotations
+
+import asyncio
+import os
+import sys
+import types
+
+import boto3
+import pytest
+
+try:
+    from moto import mock_aws
+except ImportError:  # pragma: no cover
+    pytest.skip("moto not installed", allow_module_level=True)
+
+_PROJECT_ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "..", ".."))
+if _PROJECT_ROOT not in sys.path:
+    sys.path.insert(0, _PROJECT_ROOT)
+_HERE_WW = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
+if _HERE_WW not in sys.path:
+    sys.path.insert(0, _HERE_WW)
+
+import governed_tool_handler  # noqa: E402
+import tool_idempotency_hook  # noqa: E402
+import tool_breaker_hook  # noqa: E402  # noqa: F401
+from governance_tool_hook import GovernanceEvaluator, _GovernanceDeniedTool  # noqa: E402
+from tool_idempotency_hook import (  # noqa: E402
+    ComposedToolHook, IdempotencyToolHook, _IdempotentToolWrapper,
+)
+from tool_breaker_hook import ToolBreaker, _CircuitOpenTool, _BreakerObserverTool  # noqa: E402
+from arbiter.governance import tool_breaker_store as store_mod  # noqa: E402
+from arbiter.governance.tool_breaker_store import (  # noqa: E402
+    BreakerConfig, ToolBreakerStore, __reset_breaker_client_for_test,
+)
+from arbiter.governance.tool_breaker_logic import BreakerTarget  # noqa: E402
+
+ledger = tool_idempotency_hook.ledger
+
+TABLE = "citadel-tool-breaker-seam-moto"
+MCP_TARGET = BreakerTarget(kind="mcp_server", target_id="mcp-1")
+PK = "org1#mcp_server#mcp-1"
+
+
+@pytest.fixture(autouse=True)
+def _governance_writes_succeed(monkeypatch):
+    monkeypatch.setattr(governed_tool_handler, "write_finding", lambda *a, **k: None)
+    tool_idempotency_hook.drain_governance_refusals()
+    yield
+    tool_idempotency_hook.drain_governance_refusals()
+
+
+@pytest.fixture
+def moto_breaker(monkeypatch):
+    with mock_aws():
+        resource = boto3.Session(region_name="us-east-1").resource("dynamodb")
+        resource.create_table(
+            TableName=TABLE,
+            KeySchema=[{"AttributeName": "pk", "KeyType": "HASH"},
+                       {"AttributeName": "sk", "KeyType": "RANGE"}],
+            AttributeDefinitions=[{"AttributeName": "pk", "AttributeType": "S"},
+                                  {"AttributeName": "sk", "AttributeType": "S"}],
+            BillingMode="PAY_PER_REQUEST",
+        )
+        __reset_breaker_client_for_test()
+        monkeypatch.setattr(store_mod, "_get_dynamodb_resource", lambda: resource)
+        try:
+            yield resource
+        finally:
+            __reset_breaker_client_for_test()
+
+
+class _FakeEvent:
+    def __init__(self, name, selected_tool, tool_use_id="tu", tool_input=None):
+        self.tool_use = {"name": name, "toolUseId": tool_use_id, "input": tool_input or {}}
+        self.selected_tool = selected_tool
+
+
+class _FakeInnerTool:
+    def __init__(self, name, executed_log):
+        self._name = name
+        self._log = executed_log
+
+    @property
+    def tool_name(self):
+        return self._name
+
+    async def stream(self, tool_use, invocation_state, **kwargs):
+        from strands.types._events import ToolResultEvent
+        self._log.append(self._name)
+        yield ToolResultEvent({"toolUseId": "tu", "status": "success", "content": [{"text": "ran"}]})
+
+
+@pytest.fixture
+def fake_tool_result_event(monkeypatch):
+    mod = types.ModuleType("strands.types._events")
+
+    class ToolResultEvent:
+        def __init__(self, tool_result):
+            self.tool_result = tool_result
+
+    mod.ToolResultEvent = ToolResultEvent
+    strands_mod = sys.modules.get("strands") or types.ModuleType("strands")
+    types_mod = sys.modules.get("strands.types") or types.ModuleType("strands.types")
+    monkeypatch.setitem(sys.modules, "strands", strands_mod)
+    monkeypatch.setitem(sys.modules, "strands.types", types_mod)
+    monkeypatch.setitem(sys.modules, "strands.types._events", mod)
+    return ToolResultEvent
+
+
+def _drain(agen):
+    async def _run():
+        return [ev async for ev in agen]
+    return asyncio.run(_run())
+
+
+def _seed_open(resource, opened_at=1000, state_version=1):
+    resource.Table(TABLE).put_item(Item={
+        "pk": PK, "sk": "STATE", "state": "OPEN", "openedAt": opened_at,
+        "failureCount": 5, "stateVersion": state_version, "windowStart": 0,
+        "updatedAt": opened_at, "ttl": opened_at + 86400,
+    })
+
+
+def _breaker(resource, *, targets, clock=lambda: 1005.0):
+    store = ToolBreakerStore(
+        table_name=TABLE, org_id="org1",
+        config=BreakerConfig(recovery_seconds=30, closed_cache_ttl_seconds=3),
+        clock=clock,
+    )
+    return ToolBreaker(
+        store=store,
+        target_resolver=lambda name: targets.get(name),
+        probe_owner="exec1#node1",
+    ), store
+
+
+def _evaluator(denied=()):
+    return GovernanceEvaluator(
+        agent_id="a", workflow_id="wf", denied_tools=set(denied), eval_run_id=None,
+    )
+
+
+def _idempotency():
+    return IdempotencyToolHook(org_id="org1", execution_id="exec1", node_id="node1")
+
+
+class TestBreakerFastFailOrdering:
+    def test_open_breaker_fast_fails_without_approval_or_reservation(self, moto_breaker, monkeypatch):
+        _seed_open(moto_breaker)
+        breaker, store = _breaker(moto_breaker, targets={"remote_tool": MCP_TARGET})
+        evaluator = _evaluator()
+
+        approval_calls = []
+        monkeypatch.setattr(evaluator, "evaluate_approval",
+                            lambda *a, **k: approval_calls.append((a, k)) or False)
+        reserve_calls = []
+        monkeypatch.setattr(ledger, "reserve", lambda *a, **k: reserve_calls.append((a, k)))
+
+        inner = _FakeInnerTool("remote_tool", [])
+        event = _FakeEvent("remote_tool", inner)
+        ComposedToolHook(
+            governance=evaluator, idempotency=_idempotency(), breaker=breaker,
+        )._on_before_tool_call(event)
+
+        assert isinstance(event.selected_tool, _CircuitOpenTool)
+        assert approval_calls == []   # no approval single-use burned
+        assert reserve_calls == []    # no ledger reservation
+
+    def test_circuit_open_tool_stream_never_calls_inner_and_records_refusal(
+        self, moto_breaker, fake_tool_result_event
+    ):
+        _seed_open(moto_breaker)
+        breaker, store = _breaker(moto_breaker, targets={"remote_tool": MCP_TARGET})
+        executed = []
+        inner = _FakeInnerTool("remote_tool", executed)
+        event = _FakeEvent("remote_tool", inner)
+        ComposedToolHook(governance=_evaluator(), idempotency=_idempotency(),
+                         breaker=breaker)._on_before_tool_call(event)
+        assert isinstance(event.selected_tool, _CircuitOpenTool)
+
+        events = _drain(event.selected_tool.stream(event.tool_use, {}))
+
+        assert executed == []  # target never called
+        assert len(events) == 1 and events[0].tool_result["status"] == "error"
+        assert "circuit is OPEN" in events[0].tool_result["content"][0]["text"]
+        refusals = tool_idempotency_hook.drain_governance_refusals()
+        assert any(r["errorClass"] == "CircuitOpenError" for r in refusals)
+
+
+class TestDenyPrecedesBreaker:
+    def test_denied_tool_reports_deny_not_circuit_open_and_skips_breaker(self, moto_breaker):
+        _seed_open(moto_breaker)
+        breaker, store = _breaker(moto_breaker, targets={"remote_tool": MCP_TARGET})
+        inner = _FakeInnerTool("remote_tool", [])
+        event = _FakeEvent("remote_tool", inner)
+        ComposedToolHook(
+            governance=_evaluator(denied=("remote_tool",)),
+            idempotency=_idempotency(), breaker=breaker,
+        )._on_before_tool_call(event)
+        assert isinstance(event.selected_tool, _GovernanceDeniedTool)
+        assert store.ddb_op_count == 0  # breaker never consulted on a deny
+
+
+class TestClosedPathObserverIsOutermost:
+    def test_closed_wraps_observer_over_idempotency(self, moto_breaker):
+        breaker, store = _breaker(moto_breaker, targets={"remote_tool": MCP_TARGET})
+        inner = _FakeInnerTool("remote_tool", [])
+        event = _FakeEvent("remote_tool", inner)
+        ComposedToolHook(governance=_evaluator(), idempotency=_idempotency(),
+                         breaker=breaker)._on_before_tool_call(event)
+        assert isinstance(event.selected_tool, _BreakerObserverTool)
+        assert isinstance(event.selected_tool._inner, _IdempotentToolWrapper)
+
+
+class TestLocalToolSkipsBreaker:
+    def test_local_tool_no_target_skips_breaker_zero_ddb(self, moto_breaker):
+        breaker, store = _breaker(moto_breaker, targets={})  # "calc" resolves to None
+        inner = _FakeInnerTool("calc", [])
+        event = _FakeEvent("calc", inner)
+        ComposedToolHook(governance=_evaluator(), idempotency=_idempotency(),
+                         breaker=breaker)._on_before_tool_call(event)
+        assert isinstance(event.selected_tool, _IdempotentToolWrapper)
+        assert not isinstance(event.selected_tool, _BreakerObserverTool)
+        assert store.ddb_op_count == 0
+
+
+class TestAgentRunnerBreakerWiring:
+    def _agent_runner(self):
+        sys.modules.pop("agent_runner", None)
+        import agent_runner
+        return agent_runner
+
+    def test_no_table_yields_no_breaker(self, monkeypatch):
+        monkeypatch.delenv("TOOL_BREAKER_TABLE", raising=False)
+        assert self._agent_runner()._build_tool_breaker("exec1", "node1") is None
+
+    def test_table_but_no_targets_yields_no_breaker(self, monkeypatch):
+        monkeypatch.setenv("TOOL_BREAKER_TABLE", TABLE)
+        monkeypatch.delenv("TOOL_BREAKER_TARGETS", raising=False)
+        assert self._agent_runner()._build_tool_breaker("exec1", "node1") is None
+
+    def test_table_and_targets_build_a_resolving_breaker(self, monkeypatch):
+        import json as _json
+        monkeypatch.setenv("TOOL_BREAKER_TABLE", TABLE)
+        monkeypatch.setenv("TOOL_BREAKER_TARGETS", _json.dumps({
+            "remote_tool": ["mcp_server", "mcp-1"],
+        }))
+        monkeypatch.setenv("CITADEL_ORG_ID", "org1")
+        ar = self._agent_runner()
+        breaker = ar._build_tool_breaker("exec1", "node1")
+        assert isinstance(breaker, ToolBreaker)
+        # The resolver maps the known tool to its target and unknown to None.
+        # Compare by fields: agent_runner's BreakerTarget is imported via the
+        # deployed 'governance.*' path, a distinct class object from this test's
+        # 'arbiter.governance.*' import (module-identity), so dataclass eq would
+        # be False across identities even for identical fields.
+        resolved = breaker._target_resolver("remote_tool")
+        assert (resolved.kind, resolved.target_id) == (MCP_TARGET.kind, MCP_TARGET.target_id)
+        assert breaker._target_resolver("calc") is None

--- a/arbiter/workerWrapper/__tests__/test_tool_idempotency_threading.py
+++ b/arbiter/workerWrapper/__tests__/test_tool_idempotency_threading.py
@@ -42,6 +42,33 @@ class TestSubprocessEnvThreading:
         assert env["CITADEL_NODE_ID"] == "n"
         assert "CITADEL_ORG_ID" not in env
 
+    def test_breaker_targets_serialized_to_json_env(self):
+        # task 28d624b1: the per-dispatch tool NAME -> [kind, id] map is
+        # serialized to TOOL_BREAKER_TARGETS (delivered like DENIED_TOOLS,
+        # NEVER via the S3 tool module).
+        import json
+        env = build_subprocess_env({}, tool_breaker_targets={
+            "remote_tool": ["mcp_server", "mcp-1"],
+            "jira_tool": ("integration", "jira-1"),
+        })
+        parsed = json.loads(env["TOOL_BREAKER_TARGETS"])
+        assert parsed["remote_tool"] == ["mcp_server", "mcp-1"]
+        assert parsed["jira_tool"] == ["integration", "jira-1"]
+
+    def test_breaker_targets_absent_is_backcompat(self):
+        env = build_subprocess_env({}, agent_id="a")
+        assert "TOOL_BREAKER_TARGETS" not in env
+
+    def test_breaker_targets_malformed_entries_dropped(self):
+        import json
+        env = build_subprocess_env({}, tool_breaker_targets={
+            "ok": ["mcp_server", "m1"],
+            "bad_len": ["only-one"],
+            "empty_id": ["mcp_server", ""],
+        })
+        parsed = json.loads(env["TOOL_BREAKER_TARGETS"])
+        assert parsed == {"ok": ["mcp_server", "m1"]}
+
 
 class TestServerSideOrgResolution:
     def _index(self):

--- a/arbiter/workerWrapper/agent_runner.py
+++ b/arbiter/workerWrapper/agent_runner.py
@@ -433,6 +433,78 @@ def _read_dispatch_generation():
         return None
 
 
+def _parse_breaker_targets_env():
+    """Parse ``TOOL_BREAKER_TARGETS`` (a JSON object mapping tool NAME ->
+    ``[targetKind, targetId]``) into ``{tool_name: BreakerTarget}``.
+
+    Assembled server-side per dispatch (index.py) and delivered like
+    DENIED_TOOLS — NEVER via the S3-hosted tool module. Fail-safe: any parse
+    error yields an empty map (the breaker then resolves every tool to None and
+    is skipped — the breaker is an availability optimisation, never fail the
+    node on its account)."""
+    raw = os.environ.get('TOOL_BREAKER_TARGETS')
+    if not raw:
+        return {}
+    try:
+        from governance.tool_breaker_logic import BreakerTarget
+    except ImportError:
+        return {}
+    try:
+        data = json.loads(raw)
+    except (ValueError, TypeError):
+        return {}
+    if not isinstance(data, dict):
+        return {}
+    result = {}
+    for name, spec in data.items():
+        if isinstance(spec, (list, tuple)) and len(spec) == 2 and spec[0] and spec[1]:
+            result[str(name)] = BreakerTarget(kind=str(spec[0]), target_id=str(spec[1]))
+    return result
+
+
+def _build_tool_breaker(execution_id, node_id):
+    """Build the per-target ToolBreaker, or None when it is not configured.
+
+    FAIL-OPEN by construction (D7): the breaker is an availability optimisation,
+    not a security control, so — unlike governance/idempotency, which fail LOUD
+    inside their envelope — a missing table, an unimportable breaker module, or
+    an empty target map yields ``None`` (breaker skipped) and NEVER aborts the
+    node."""
+    breaker_table = os.environ.get('TOOL_BREAKER_TABLE')
+    if not breaker_table:
+        return None
+    try:
+        from tool_breaker_hook import ToolBreaker, build_transition_emitter
+        from governance.tool_breaker_store import ToolBreakerStore, BreakerConfig
+    except ImportError as exc:
+        sys.stderr.write(
+            f'[agent_runner] WARN tool breaker skipped (fail-open) — '
+            f'module import failed: {exc}\n'
+        )
+        return None
+    target_map = _parse_breaker_targets_env()
+    if not target_map:
+        return None  # no external-bound tools for this dispatch — nothing to gate
+    org_id = os.environ.get('CITADEL_ORG_ID', '')
+    emitter = build_transition_emitter(
+        org_id=org_id,
+        workflow_id=os.environ.get('CITADEL_WORKFLOW_ID', 'unknown-workflow'),
+        agent_id=os.environ.get('CITADEL_AGENT_ID', 'unknown-agent'),
+        event_bus_name=os.environ.get('COMPLETION_BUS_NAME') or None,
+        eval_run_id=os.environ.get('CITADEL_EVAL_RUN_ID') or None,
+    )
+    store = ToolBreakerStore(
+        table_name=breaker_table, org_id=org_id,
+        config=BreakerConfig.from_env(), on_transition=emitter,
+    )
+    probe_owner = f"{execution_id or ''}#{node_id or ''}"
+    return ToolBreaker(
+        store=store,
+        target_resolver=lambda name: target_map.get(name),
+        probe_owner=probe_owner,
+    )
+
+
 def _install_tool_call_hooks():
     """Install the SINGLE composed ``BeforeToolCallEvent`` seam that applies
     layer-2 tool governance THEN tool-call idempotency (finding 027c4a89).
@@ -562,7 +634,11 @@ def _install_tool_call_hooks():
             f'envelope is present: {exc}'
         ) from exc
 
-    composed = ComposedToolHook(governance=governance, idempotency=idempotency)
+    composed = ComposedToolHook(
+        governance=governance,
+        idempotency=idempotency,
+        breaker=_build_tool_breaker(execution_id, node_id),
+    )
 
     original_init = strands.Agent.__init__
 

--- a/arbiter/workerWrapper/governance_tool_hook.py
+++ b/arbiter/workerWrapper/governance_tool_hook.py
@@ -32,6 +32,7 @@ from __future__ import annotations
 import logging
 import os
 import sys
+from dataclasses import dataclass
 from typing import Any
 
 _HERE = os.path.dirname(os.path.abspath(__file__))
@@ -50,6 +51,50 @@ from governed_tool_handler import (  # noqa: E402
 )
 
 logger = logging.getLogger(__name__)
+
+# --- D2 SECURITY CONDITION: token-gated denylist→approval split --------------
+# Splitting a security control's entry point creates a bypass class where a
+# future caller invokes the approval phase WITHOUT the deny-list phase, silently
+# defeating the deny-list. To make that STRUCTURALLY IMPOSSIBLE, the deny-list
+# phase mints an opaque ``DenylistPassed`` token that the approval phase
+# REQUIRES. The token is not constructible by callers (its ``__init__`` demands
+# a module-private mint key), so ``evaluate_approval`` can only ever run after
+# ``evaluate_denylist`` produced a permit. A regex/naming convention would not
+# be enough; this is a type-level gate.
+_DENYLIST_MINT_KEY = object()
+
+
+class DenylistPassed:
+    """Opaque proof that the deny-list phase PERMITTED a specific tool call.
+
+    Minted ONLY by :meth:`GovernanceEvaluator.evaluate_denylist` (via the
+    module-private mint key). :meth:`GovernanceEvaluator.evaluate_approval`
+    requires an instance, so the approval phase cannot be reached without a
+    deny-list pass having produced one — invoking approval standalone is
+    structurally impossible."""
+
+    __slots__ = ("tool_name", "tool_use_id", "selected")
+
+    def __init__(self, _mint_key: Any, *, tool_name: str, tool_use_id: str, selected: Any):
+        if _mint_key is not _DENYLIST_MINT_KEY:
+            raise TypeError(
+                "DenylistPassed is not constructible by callers; it is minted "
+                "only by GovernanceEvaluator.evaluate_denylist (deny-list phase)"
+            )
+        self.tool_name = tool_name
+        self.tool_use_id = tool_use_id
+        self.selected = selected
+
+
+@dataclass
+class DenylistOutcome:
+    """Result of the deny-list phase. ``refused`` ⇒ the tool was swapped for a
+    deny/audit-unavailable tool and the caller must stop. Otherwise ``token`` is
+    the :class:`DenylistPassed` proof required by the approval phase — or
+    ``None`` when there was no real tool to gate (a no-op passthrough)."""
+
+    refused: bool
+    token: DenylistPassed | None = None
 
 try:
     from strands.hooks import BeforeToolCallEvent  # type: ignore
@@ -156,11 +201,32 @@ class GovernanceEvaluator:
         """Return True if the call was REFUSED (and ``selected_tool`` swapped) —
         by the deny-list decision OR the approval gate. On PERMIT (not denied
         AND, for a gated tool, a valid approval was consumed) returns False and
-        leaves the event untouched so idempotency wrapping proceeds."""
+        leaves the event untouched so idempotency wrapping proceeds.
+
+        ADDITIVE SPLIT (D2, 47b6abac): this keeps its EXACT current
+        denylist-then-approval behaviour — it is the live contract for the
+        standalone supervisor-path ``GovernanceToolHook`` and the existing tests
+        (which must not change). It is now implemented on top of the two public
+        phase methods (:meth:`evaluate_denylist` / :meth:`evaluate_approval`) so
+        the ``ComposedToolHook`` can insert the breaker BETWEEN them; the token
+        gate makes calling approval without the deny-list structurally
+        impossible."""
+        outcome = self.evaluate_denylist(event)
+        if outcome.refused:
+            return True
+        if outcome.token is None:
+            return False  # nothing to gate (no real tool on the event)
+        return self.evaluate_approval(event, outcome.token)
+
+    def evaluate_denylist(self, event: Any) -> DenylistOutcome:
+        """Deny-list phase ONLY. Writes the PERMIT/DENY audit finding and, on
+        DENY (or an audit-write failure), swaps ``selected_tool`` for a
+        deny/audit-unavailable tool. Returns a :class:`DenylistOutcome`: on
+        PERMIT its ``token`` is the opaque proof the approval phase requires."""
         tool_use = getattr(event, "tool_use", None)
         selected = getattr(event, "selected_tool", None)
         if tool_use is None or selected is None:
-            return False
+            return DenylistOutcome(refused=False, token=None)
         if hasattr(tool_use, "get"):
             tool_name = tool_use.get("name", "") or ""
             tool_use_id = tool_use.get("toolUseId", "") or ""
@@ -177,12 +243,29 @@ class GovernanceEvaluator:
         )
         if denied and error_result is not None:
             event.selected_tool = _GovernanceDeniedTool(selected, error_result)
-            return True
-        # PERMITTED by the deny-list. Now the approval gate — runs INSIDE the
-        # governance evaluation, BEFORE any idempotency reserve, so a refusal
-        # leaves ZERO ledger reservations (inherits the deny-before-reserve
-        # invariant, finding 027c4a89).
-        return self._evaluate_approval(event, selected, tool_name, tool_use_id)
+            return DenylistOutcome(refused=True, token=None)
+        # PERMITTED by the deny-list — mint the opaque proof the approval phase
+        # requires (structurally impossible to reach approval without it).
+        token = DenylistPassed(
+            _DENYLIST_MINT_KEY,
+            tool_name=tool_name, tool_use_id=tool_use_id, selected=selected,
+        )
+        return DenylistOutcome(refused=False, token=token)
+
+    def evaluate_approval(self, event: Any, token: DenylistPassed) -> bool:
+        """Approval phase ONLY. REQUIRES the :class:`DenylistPassed` token the
+        deny-list phase minted — passing anything else raises ``TypeError``, so
+        this phase can never run without a deny-list pass (D2 security
+        condition). Returns True if the call was REFUSED by the approval gate."""
+        if not isinstance(token, DenylistPassed):
+            raise TypeError(
+                "evaluate_approval requires the opaque DenylistPassed token from "
+                "evaluate_denylist — the approval phase must never run without "
+                "the deny-list phase (D2 security condition)"
+            )
+        return self._evaluate_approval(
+            event, token.selected, token.tool_name, token.tool_use_id,
+        )
 
     def _evaluate_approval(
         self, event: Any, selected: Any, tool_name: str, tool_use_id: str,

--- a/arbiter/workerWrapper/tool_breaker_hook.py
+++ b/arbiter/workerWrapper/tool_breaker_hook.py
@@ -1,0 +1,293 @@
+"""Strands-seam glue for the per-target tool circuit breaker (task 28d624b1).
+
+Binds the pure logic (``governance.tool_breaker_logic``) and the DynamoDB store
+(``governance.tool_breaker_store``) to the live ``BeforeToolCallEvent`` seam.
+Composed with governance + idempotency behind the ONE ``ComposedToolHook``
+callback (``tool_idempotency_hook``), at the ordering:
+
+    deny-list → breaker pre-check → approval-consume → idempotency
+    reserve/execute/finalize → outermost breaker OBSERVER.
+
+A breaker fast-fail happens at the pre-check phase — BEFORE approval-consume and
+BEFORE the idempotency reserve — so it burns no approval single-use and leaves
+no ledger reservation, and it never touches the target.
+
+Degrades to a no-op import when ``strands`` is unavailable (dev/CI), mirroring
+the sibling hooks.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+import sys
+from typing import Any, Callable
+
+_HERE = os.path.dirname(os.path.abspath(__file__))
+if _HERE not in sys.path:
+    sys.path.insert(0, _HERE)
+
+from common.failure_taxonomy import classify  # noqa: E402
+from governance.tool_breaker_logic import BreakerState, BreakerTarget  # noqa: E402
+from governance.tool_breaker_store import (  # noqa: E402
+    PreCheck,
+    ToolBreakerStore,
+    BreakerTransition,
+)
+
+logger = logging.getLogger(__name__)
+
+# DISTINCT finding scope (design §6): a breaker state change is never conflated
+# with a deny-list ('worker-tool-handler') or approval ('worker-tool-approval')
+# decision when querying findings by scope.
+SCOPE_TOOL_TARGET_BREAKER = "tool-target-breaker"
+
+# EventBridge state-change event (console/fleet surfacing itself is DEFERRED to
+# a follow-up per scope discipline — only the event + finding are emitted here).
+BREAKER_EVENT_SOURCE = "citadel.tool.breaker"
+BREAKER_EVENT_DETAIL_TYPE = "citadel.tool.breaker.state_changed"
+
+try:
+    from strands.hooks import BeforeToolCallEvent  # type: ignore  # noqa: F401
+    from strands.types.tools import AgentTool  # type: ignore
+
+    _STRANDS_AVAILABLE = True
+except ImportError:  # pragma: no cover — dev/CI without strands-agents
+    _STRANDS_AVAILABLE = False
+    AgentTool = object  # type: ignore[assignment,misc]
+
+
+class CircuitOpenError(Exception):
+    """The per-target breaker is OPEN: the call was fast-failed without touching
+    the target. Its class name classifies to ``FailureClass.CIRCUIT_OPEN``
+    (disposition NEVER). Recorded into the node-failure refusal sink so the node
+    fails terminally for THIS attempt (non-terminality is the deferred recovery
+    queue, not built here)."""
+
+    retryable = False
+
+
+def _circuit_open_result(tool_use_id: str, tool_name: str, target: BreakerTarget) -> dict[str, Any]:
+    """A ToolResult-shaped error DISTINCT from a policy denial and an approval
+    refusal — so an OPEN breaker is never mistaken for a policy denial."""
+    return {
+        "toolUseId": tool_use_id,
+        "status": "error",
+        "content": [{"text": (
+            f"Tool '{tool_name}' target circuit is OPEN "
+            f"({target.kind}:{target.target_id}) — fast-failed without calling "
+            "the target (known-bad; will be re-attempted after recovery)."
+        )}],
+    }
+
+
+class _CircuitOpenTool(AgentTool):  # type: ignore[misc]
+    """Replacement tool installed on a breaker fast-fail. Its ``stream()`` yields
+    the CIRCUIT_OPEN error result and records a node-failing refusal; it never
+    delegates to the real tool (no target call, no side effect). Mirrors
+    ``_GovernanceDeniedTool``/``_CircuitOpenTool`` peers."""
+
+    def __init__(self, inner: Any, target: BreakerTarget):
+        try:
+            super().__init__()
+        except TypeError:  # pragma: no cover — base signature drift
+            pass
+        self._inner = inner
+        self._target = target
+
+    @property
+    def tool_name(self) -> str:  # pragma: no cover — thin delegation
+        return self._inner.tool_name
+
+    @property
+    def tool_spec(self) -> Any:  # pragma: no cover
+        return self._inner.tool_spec
+
+    @property
+    def tool_type(self) -> str:  # pragma: no cover
+        return self._inner.tool_type
+
+    def get_display_properties(self) -> dict[str, str]:  # pragma: no cover
+        return self._inner.get_display_properties()
+
+    async def stream(self, tool_use: Any, invocation_state: dict[str, Any], **kwargs: Any):  # pragma: no cover — requires strands runtime
+        from strands.types._events import ToolResultEvent
+
+        tool_use_id = str(tool_use.get("toolUseId", "")) if hasattr(tool_use, "get") else ""
+        tool_name = str(tool_use.get("name", "")) if hasattr(tool_use, "get") else ""
+        # Fail the node with CIRCUIT_OPEN (interim conservative behaviour until
+        # the recovery queue lands). Reuse the shared node-failure refusal sink.
+        try:
+            from tool_idempotency_hook import _record_governance_refusal
+            _record_governance_refusal(CircuitOpenError(
+                f"tool-target circuit OPEN for {self._target.kind}:{self._target.target_id}"
+            ))
+        except Exception:  # noqa: BLE001 — best-effort; the block itself is the guarantee
+            pass
+        yield ToolResultEvent(_circuit_open_result(tool_use_id, tool_name, self._target))
+
+
+class _BreakerObserverTool(AgentTool):  # type: ignore[misc]
+    """OUTERMOST wrapper (installed after idempotency wrapping) that observes the
+    terminal outcome of a tool call and drives breaker transitions.
+
+    An exception ESCAPING the inner stream is a target-health failure signal
+    (classified via the taxonomy — only TRANSIENT/TIMEOUT, and THROTTLE when
+    enabled, actually count); a completed stream (even one returning a business
+    ``status:error`` result) means the target RESPONDED and is a success signal.
+    The observer never suppresses an exception — it re-raises after recording."""
+
+    def __init__(self, inner: Any, store: ToolBreakerStore, target: BreakerTarget, is_probe: bool):
+        try:
+            super().__init__()
+        except TypeError:  # pragma: no cover
+            pass
+        self._inner = inner
+        self._store = store
+        self._target = target
+        self._is_probe = is_probe
+
+    @property
+    def tool_name(self) -> str:  # pragma: no cover
+        return self._inner.tool_name
+
+    @property
+    def tool_spec(self) -> Any:  # pragma: no cover
+        return self._inner.tool_spec
+
+    @property
+    def tool_type(self) -> str:  # pragma: no cover
+        return self._inner.tool_type
+
+    def get_display_properties(self) -> dict[str, str]:  # pragma: no cover
+        return self._inner.get_display_properties()
+
+    async def stream(self, tool_use: Any, invocation_state: dict[str, Any], **kwargs: Any):  # pragma: no cover — requires strands runtime
+        try:
+            async for event in self._inner.stream(tool_use, invocation_state, **kwargs):
+                yield event
+        except BaseException as exc:  # noqa: BLE001 — observe then re-raise
+            self._store.observe_failure(self._target, classify(exc), is_probe=self._is_probe)
+            raise
+        # Completed without an escaping exception ⇒ the target responded.
+        self._store.observe_success(self._target, is_probe=self._is_probe)
+
+
+class ToolBreaker:
+    """Seam-side breaker collaborator composed into ``ComposedToolHook``.
+
+    ``target_resolver`` maps a tool NAME to a :class:`BreakerTarget` or ``None``
+    (a local tool with no external binding ⇒ ``None`` ⇒ the breaker phase is
+    skipped entirely, zero DynamoDB reads — D7). ``probe_owner`` is a stable
+    per-worker id (``executionId#nodeId``) used as the HALF_OPEN lease owner.
+    """
+
+    def __init__(
+        self,
+        *,
+        store: ToolBreakerStore,
+        target_resolver: Callable[[str], BreakerTarget | None],
+        probe_owner: str,
+    ):
+        self._store = store
+        self._target_resolver = target_resolver
+        self._probe_owner = probe_owner or "unknown-worker"
+
+    def pre_check(self, event: Any) -> PreCheck | None:
+        """Resolve the target and consult the breaker. Returns ``None`` when the
+        tool has no external target (breaker skipped, zero DDB)."""
+        tool_use = getattr(event, "tool_use", None)
+        if tool_use is None:
+            return None
+        tool_name = tool_use.get("name", "") if hasattr(tool_use, "get") else getattr(tool_use, "name", "")
+        target = self._target_resolver(tool_name or "")
+        if target is None:
+            return None  # local tool — no breaker (D7)
+        return self._store.pre_check(target, probe_owner=self._probe_owner)
+
+    def circuit_open_tool(self, inner: Any, pre: PreCheck) -> Any:
+        return _CircuitOpenTool(inner, pre.target)
+
+    def wrap_observer(self, inner: Any, pre: PreCheck) -> Any:
+        return _BreakerObserverTool(inner, self._store, pre.target, pre.is_probe)
+
+
+def build_transition_emitter(
+    *,
+    org_id: str,
+    workflow_id: str,
+    agent_id: str,
+    event_bus_name: str | None,
+    eval_run_id: str | None = None,
+) -> Callable[[BreakerTransition], None]:
+    """Build the ``on_transition`` callback the store fires exactly once per
+    state change (single-writer ⇒ storm-proof). Emits a DISTINCT-scope
+    GovernanceFinding AND a best-effort EventBridge state-change event. Console/
+    fleet GraphQL surfacing is DEFERRED to a follow-up (scope discipline)."""
+
+    def _emit(t: BreakerTransition) -> None:
+        _emit_finding(t, org_id=org_id, workflow_id=workflow_id, agent_id=agent_id, eval_run_id=eval_run_id)
+        _emit_event(t, org_id=org_id, event_bus_name=event_bus_name, workflow_id=workflow_id)
+
+    return _emit
+
+
+def _emit_finding(
+    t: BreakerTransition, *, org_id: str, workflow_id: str, agent_id: str, eval_run_id: str | None,
+) -> None:
+    try:
+        from governance.models import ArbitrationDecision, GovernanceFinding
+        from governance.ledger import write_finding
+    except ImportError as exc:  # pragma: no cover — layer-staged package
+        logger.error("tool-breaker finding import failed: %s", exc)
+        return
+    # A recovered (→CLOSED) transition is a PERMIT; opening/reopening (→OPEN) is
+    # a DENY. Single-writer guarantees exactly one finding per transition.
+    decision = (
+        ArbitrationDecision.PERMIT if t.to_state == BreakerState.CLOSED
+        else ArbitrationDecision.DENY
+    )
+    try:
+        write_finding(GovernanceFinding.create(
+            workflow_id=workflow_id or "unknown-workflow",
+            decision=decision,
+            requesting_agent=agent_id or "unknown-agent",
+            target_agent=f"{t.target.kind}:{t.target.target_id}",
+            reason=(
+                f"circuit_{t.to_state.lower()}:{t.target.kind}:{t.target.target_id}"
+                f":v{t.state_version}"
+            ),
+            scope_evaluated=SCOPE_TOOL_TARGET_BREAKER,
+            contract_evaluated=None,
+            eval_run_id=eval_run_id,
+        ))
+    except Exception as exc:  # noqa: BLE001 — best-effort; single-writer keeps it storm-proof
+        logger.error("tool-breaker finding write failed %s->%s: %s", t.from_state, t.to_state, exc)
+
+
+def _emit_event(
+    t: BreakerTransition, *, org_id: str, event_bus_name: str | None, workflow_id: str,
+) -> None:
+    if not event_bus_name:
+        return
+    try:
+        import boto3
+        client = boto3.client("events")
+        client.put_events(Entries=[{
+            "Source": BREAKER_EVENT_SOURCE,
+            "DetailType": BREAKER_EVENT_DETAIL_TYPE,
+            "EventBusName": event_bus_name,
+            "Detail": json.dumps({
+                "orgId": org_id,
+                "targetKind": t.target.kind,
+                "targetId": t.target.target_id,
+                "fromState": str(t.from_state),
+                "toState": str(t.to_state),
+                "stateVersion": t.state_version,
+                "workflowId": workflow_id,
+                "timestamp": t.now,
+            }),
+        }])
+    except Exception as exc:  # noqa: BLE001 — best-effort surfacing, never fail the call
+        logger.error("tool-breaker state-change event emit failed: %s", exc)

--- a/arbiter/workerWrapper/tool_idempotency_hook.py
+++ b/arbiter/workerWrapper/tool_idempotency_hook.py
@@ -580,9 +580,11 @@ class ComposedToolHook:
         *,
         governance: Any | None = None,
         idempotency: "IdempotencyToolHook | None" = None,
+        breaker: Any | None = None,
     ):
         self._governance = governance
         self._idempotency = idempotency
+        self._breaker = breaker
 
     @property
     def governance(self) -> Any | None:  # pragma: no cover — accessor
@@ -592,6 +594,10 @@ class ComposedToolHook:
     def idempotency(self) -> "IdempotencyToolHook | None":  # pragma: no cover
         return self._idempotency
 
+    @property
+    def breaker(self) -> Any | None:  # pragma: no cover — accessor
+        return self._breaker
+
     def register_hooks(self, registry: Any, **_kwargs: Any) -> None:
         if not _STRANDS_AVAILABLE:  # pragma: no cover — dev/CI guard
             logger.warning("composed tool hook skipped — strands unavailable")
@@ -599,13 +605,51 @@ class ComposedToolHook:
         registry.add_callback(BeforeToolCallEvent, self._on_before_tool_call)
 
     def _on_before_tool_call(self, event: Any) -> None:
-        # 1) Governance decision FIRST. On DENY the evaluator swaps
-        #    ``event.selected_tool`` for a deny-only tool and returns True; we
-        #    then RETURN so idempotency's reserve/wrap never runs (deny before
-        #    reserve — no reservation, no side effect).
-        if self._governance is not None:
-            if self._governance.evaluate(event):
+        # LEGACY path (no breaker configured): byte-identical to the pre-breaker
+        # behaviour — governance.evaluate() (deny-list THEN approval) then
+        # idempotency. Preserves the finding-027c4a89 / c947aa77 invariants and
+        # the existing composed-governance tests unchanged.
+        if self._breaker is None:
+            if self._governance is not None and self._governance.evaluate(event):
                 return
-        # 2) PERMIT → idempotency reserve/execute/finalize wrapping.
+            if self._idempotency is not None:
+                self._idempotency._on_before_tool_call(event)
+            return
+
+        # BREAKER-ENABLED path. Ordering (task 28d624b1), exactly:
+        #   deny-list → breaker pre-check → approval-consume →
+        #   idempotency reserve/execute/finalize → outermost breaker observer.
+        # A breaker fast-fail happens BEFORE approval-consume and BEFORE the
+        # reserve, so it burns no approval single-use and leaves no reservation.
+
+        # 1) Deny-list phase (mints the opaque approval token on PERMIT).
+        token = None
+        if self._governance is not None:
+            outcome = self._governance.evaluate_denylist(event)
+            if outcome.refused:
+                return  # DENY: no breaker read, no approval, no reserve
+            token = outcome.token
+
+        # 2) Breaker pre-check — BEFORE approval-consume and BEFORE reserve.
+        pre = self._breaker.pre_check(event)
+        if pre is not None and pre.fast_fail:
+            selected = getattr(event, "selected_tool", None)
+            if selected is not None:
+                event.selected_tool = self._breaker.circuit_open_tool(selected, pre)
+            return  # fast-fail: no approval consumed, no reservation
+
+        # 3) Approval-consume phase (requires the deny-list token).
+        if self._governance is not None and token is not None:
+            if self._governance.evaluate_approval(event, token):
+                return
+
+        # 4) Idempotency reserve → execute → finalize (wraps selected_tool).
         if self._idempotency is not None:
             self._idempotency._on_before_tool_call(event)
+
+        # 5) OUTERMOST breaker observer — wraps the (idempotency-wrapped) tool so
+        #    the terminal outcome drives CLOSED→OPEN / HALF_OPEN transitions.
+        if pre is not None and pre.observing:
+            selected = getattr(event, "selected_tool", None)
+            if selected is not None:
+                event.selected_tool = self._breaker.wrap_observer(selected, pre)

--- a/arbiter/workerWrapper/worker_governance.py
+++ b/arbiter/workerWrapper/worker_governance.py
@@ -178,6 +178,7 @@ def build_subprocess_env(
     dispatch_generation: int | None = None,
     approval_required_tools: list[str] | None = None,
     workflow_definition_id: str | None = None,
+    tool_breaker_targets: dict | None = None,
 ) -> dict:
     """Build the subprocess environment with governance and config overrides.
 
@@ -316,5 +317,24 @@ def build_subprocess_env(
             env['APPROVAL_REQUIRED_TOOLS'] = ','.join(cleaned_approval)
     if isinstance(workflow_definition_id, str) and workflow_definition_id:
         env['CITADEL_WORKFLOW_DEFINITION_ID'] = workflow_definition_id
+
+    # Per-target circuit breaker (task 28d624b1). The per-dispatch map of tool
+    # NAME -> [targetKind, targetId] the worker's breaker resolves against.
+    # Assembled server-side (index.py, from each tool config's external
+    # binding) and delivered like DENIED_TOOLS — NEVER via the S3-hosted tool
+    # module (finding 588c7fb8). Additive/optional: absent leaves the
+    # pre-feature env untouched, and a tool with no entry resolves to no target
+    # (breaker skipped for it — local/deterministic tools, D7). The TOOL_BREAKER_*
+    # tunables + TOOL_BREAKER_TABLE are Lambda env vars already present in
+    # ``base_env`` (delivered CDK -> function env), so they propagate to the
+    # subprocess via ``dict(base_env)`` above without explicit threading here.
+    if tool_breaker_targets:
+        cleaned_targets = {
+            str(name): [str(spec[0]), str(spec[1])]
+            for name, spec in tool_breaker_targets.items()
+            if isinstance(spec, (list, tuple)) and len(spec) == 2 and spec[0] and spec[1]
+        }
+        if cleaned_targets:
+            env['TOOL_BREAKER_TARGETS'] = json.dumps(cleaned_targets, sort_keys=True)
 
     return env

--- a/backend/lib/arbiter-stack.ts
+++ b/backend/lib/arbiter-stack.ts
@@ -452,6 +452,32 @@ export class ArbiterStack extends cdk.Stack {
       },
     );
 
+    // Per-target tool circuit-breaker state (task 28d624b1). One item per
+    // external target (PK = orgId#targetKind#targetId, SK = "STATE"), so each
+    // target is its own partition. Shared across the short-lived worker
+    // subprocesses via conditional writes (single-prober HALF_OPEN lease,
+    // stateVersion-guarded transitions). RETAIN + deletionProtection like the
+    // ledger, but the justification is STRONGER: these rows are LIVE OPEN state
+    // that concurrent workers depend on for the fast-fail — a silent
+    // whole-table delete on a divergent-branch deploy would drop every OPEN
+    // state and let the fleet stampede a known-bad target. The `ttl` attribute
+    // still self-cleans idle rows, so RETAIN only blocks silent teardown, not
+    // operational cleanup.
+    const toolBreakerStateTable = new dynamodb.Table(
+      this,
+      "ToolBreakerStateTable",
+      {
+        tableName: `citadel-tool-breaker-state-${props.environment}`,
+        partitionKey: { name: "pk", type: dynamodb.AttributeType.STRING },
+        sortKey: { name: "sk", type: dynamodb.AttributeType.STRING },
+        billingMode: dynamodb.BillingMode.PAY_PER_REQUEST,
+        timeToLiveAttribute: "ttl",
+        encryption: dynamodb.TableEncryption.AWS_MANAGED,
+        pointInTimeRecoverySpecification: { pointInTimeRecoveryEnabled: true },
+        removalPolicy: cdk.RemovalPolicy.RETAIN,
+        deletionProtection: true,
+      },
+    );
     // Tool-result offload (PR2). Oversized tool results (> inline cap) are
     // offloaded here instead of being truncated, so a deduped/replayed caller
     // receives the FULL recorded body. Security condition C3: a dedicated CMK
@@ -616,6 +642,21 @@ export class ArbiterStack extends cdk.Stack {
           // no-ops offload when unset and small results always stay inline.
           TOOL_RESULT_BUCKET: toolResultsBucket.bucketName,
           TOOL_RESULT_KMS_KEY_ID: toolResultsKey.keyArn,
+          // Per-target circuit breaker (task 28d624b1). Table + tunables
+          // delivered CDK -> function env -> build_subprocess_env -> worker
+          // subprocess (NEVER the S3 tool module). Always wired; the breaker is
+          // itself gated on a per-dispatch external-binding target map
+          // (TOOL_BREAKER_TARGETS), so a dispatch with only local tools is a
+          // no-op. THROTTLE is excluded from opening by default (D4) — it
+          // surfaces as a distinct metric; TRANSIENT/TIMEOUT are the health
+          // signals. Fail-open: if this table is unreachable the worker
+          // proceeds (a breaker-store outage never becomes a fleet outage).
+          TOOL_BREAKER_TABLE: toolBreakerStateTable.tableName,
+          TOOL_BREAKER_FAILURE_THRESHOLD: "5",
+          TOOL_BREAKER_WINDOW_SECONDS: "60",
+          TOOL_BREAKER_RECOVERY_SECONDS: "30",
+          TOOL_BREAKER_PROBE_LEASE_SECONDS: "30",
+          TOOL_BREAKER_CACHE_TTL_SECONDS: "3",
           ...(props.registryId && { REGISTRY_ID: props.registryId }),
           ...(props.registryId && { REGISTRY_ENABLED: "true" }),
           // Idempotency-seam smoke fixture (non-prod only): the worker's
@@ -754,6 +795,25 @@ export class ArbiterStack extends cdk.Stack {
           "dynamodb:UpdateItem",
         ],
         resources: [toolExecutionLedgerTable.tableArn],
+      }),
+    );
+
+    // Per-target circuit breaker (task 28d624b1): least-privilege grant on the
+    // breaker-state table. The worker reads state (GetItem), and transitions it
+    // via conditional writes (PutItem/UpdateItem). DELIBERATELY NOT
+    // grantReadWriteData: NO dynamodb:DeleteItem (transitions are conditional
+    // updates; the `ttl` attribute handles row expiry, mirroring the ledger
+    // grant) and NO dynamodb:Scan/Query (all access is by exact key). Scoped to
+    // this one table ARN, as a DISTINCT statement.
+    workerAgentWrapperLambda.addToRolePolicy(
+      new iam.PolicyStatement({
+        effect: iam.Effect.ALLOW,
+        actions: [
+          "dynamodb:PutItem",
+          "dynamodb:GetItem",
+          "dynamodb:UpdateItem",
+        ],
+        resources: [toolBreakerStateTable.tableArn],
       }),
     );
 

--- a/backend/test/arbiter-stack-env-parity.test.ts
+++ b/backend/test/arbiter-stack-env-parity.test.ts
@@ -97,7 +97,12 @@ function functionEnvKeys(
       `no synthesized function with logical id prefix ${logicalIdPrefix}`,
     );
   }
-  const vars = (match[1] as any).Properties?.Environment?.Variables ?? {};
+  const vars =
+    (
+      match[1] as {
+        Properties?: { Environment?: { Variables?: Record<string, unknown> } };
+      }
+    ).Properties?.Environment?.Variables ?? {};
   return new Set(Object.keys(vars));
 }
 
@@ -149,6 +154,9 @@ const TARGETS: Target[] = [
       "governance/ledger.py",
       // Tool-idempotency ledger the worker reserves/finalizes against.
       "governance/tool_execution_ledger.py",
+      // Per-target circuit breaker store the worker consults at the tool seam
+      // (task 28d624b1). Reads the TOOL_BREAKER_* tunables via BreakerConfig.
+      "governance/tool_breaker_store.py",
     ],
     optional: new Set<string>([
       // Feature-gated / defensive reads (os.environ.get(...) with None/default,
@@ -164,6 +172,15 @@ const TARGETS: Target[] = [
       "TOOL_LEDGER_LEASE_SECONDS",
       "TOOL_LEDGER_POLL_TIMEOUT_SECONDS",
       "TOOL_LEDGER_POLL_INTERVAL_SECONDS",
+      // tool-target breaker (task 28d624b1): TARGETS is subprocess-injected per
+      // dispatch (build_subprocess_env, like DENIED_TOOLS — never a CDK env
+      // var); TTL_SECONDS and OPEN_ON_THROTTLE have defaults (_int_env/_bool_env)
+      // so are not required on the function env. The remaining TOOL_BREAKER_*
+      // (TABLE/THRESHOLD/WINDOW/RECOVERY/PROBE_LEASE/CACHE_TTL) ARE set on the
+      // function env, so parity holds for them.
+      "TOOL_BREAKER_TARGETS",
+      "TOOL_BREAKER_TTL_SECONDS",
+      "TOOL_BREAKER_OPEN_ON_THROTTLE",
       // governance ledger correlation id — best-effort, absent-tolerant:
       "ENVIRONMENT",
     ]),

--- a/backend/test/arbiter-stack-step-runner.test.ts
+++ b/backend/test/arbiter-stack-step-runner.test.ts
@@ -454,15 +454,18 @@ describe("ArbiterStack — Step Runner Lambda and EventBridge rules (Task 1.6)",
       // it must NOT be used, on the executions table or anywhere else.
       expect(actions.has("dynamodb:DeleteItem")).toBe(false);
       expect(actions.has("dynamodb:BatchWriteItem")).toBe(false);
-      // PutItem is now present in THREE statements: the tool-execution-ledger
-      // grant (PR1, Put/Get/Update trio), the idempotency-seam smoke
-      // fixture's grant (non-prod only, PutItem-ONLY on its own dedicated
-      // table), and the governance-ledger legibility-record grant (this
-      // branch, PutItem-ONLY on the governance ledger table — write-once via
+      // PutItem is now present in FOUR statements: the tool-execution-ledger
+      // grant (PR1, Put/Get/Update trio), the per-target circuit-breaker
+      // grant (task 28d624b1, Put/Get/Update trio on its OWN dedicated
+      // ToolBreakerStateTable — a distinct statement, not folded into the
+      // ledger grant), the idempotency-seam smoke fixture's grant (non-prod
+      // only, PutItem-ONLY on its own dedicated table), and the
+      // governance-ledger legibility-record grant (PutItem-ONLY on the
+      // governance ledger table — write-once via
       // attribute_not_exists(findingId), so no UpdateItem/DeleteItem/Query/
-      // Scan). None may leak Delete/Scan/Query/BatchWrite, and both
-      // single-action statements must never widen beyond PutItem, nor may
-      // either resolve to a wildcard or GSI (/index/*) resource.
+      // Scan). None may leak Delete/Scan/Query/BatchWrite, the two
+      // single-action statements must never widen beyond PutItem, and none
+      // of the four may resolve to a wildcard or GSI (/index/*) resource.
       const policies = template.findResources("AWS::IAM::Policy");
       const putStatements: any[] = [];
       for (const p of Object.values(policies) as any[]) {
@@ -477,20 +480,52 @@ describe("ArbiterStack — Step Runner Lambda and EventBridge rules (Task 1.6)",
             putStatements.push({ actions: acts, resources: s.Resource });
         }
       }
-      expect(putStatements.length).toBe(3);
-      const ledgerStatement = putStatements.find((s) => s.actions.length === 3);
+      expect(putStatements.length).toBe(4);
+      const trioStatements = putStatements.filter((s) => s.actions.length === 3);
       const singleActionStatements = putStatements.filter(
         (s) => s.actions.length === 1,
       );
+      expect(trioStatements.length).toBe(2);
       expect(singleActionStatements.length).toBe(2);
-      expect(ledgerStatement.actions).toEqual([
+      for (const s of trioStatements) {
+        expect(s.actions).toEqual([
+          "dynamodb:PutItem",
+          "dynamodb:GetItem",
+          "dynamodb:UpdateItem",
+        ]);
+      }
+      for (const s of singleActionStatements) {
+        expect(s.actions).toEqual(["dynamodb:PutItem"]);
+      }
+      // Pin the per-target circuit-breaker statement precisely by its
+      // resource ARN (Fn::GetAtt on ToolBreakerStateTable's logical id) so
+      // it cannot be confused with the tool-execution-ledger trio — exact
+      // Actions AND exact Resource, no wildcard, no /index/* GSI suffix, and
+      // critically NO dynamodb:DeleteItem and NO dynamodb:BatchWriteItem
+      // anywhere in this statement.
+      const breakerStatement = trioStatements.find((s) => {
+        const arn = s.resources?.["Fn::GetAtt"]?.[0];
+        return typeof arn === "string" && arn.startsWith("ToolBreakerStateTable");
+      });
+      expect(breakerStatement).toBeDefined();
+      expect(breakerStatement.actions).toEqual([
         "dynamodb:PutItem",
         "dynamodb:GetItem",
         "dynamodb:UpdateItem",
       ]);
-      for (const s of singleActionStatements) {
-        expect(s.actions).toEqual(["dynamodb:PutItem"]);
-      }
+      expect(breakerStatement.actions).not.toContain("dynamodb:DeleteItem");
+      expect(breakerStatement.actions).not.toContain("dynamodb:BatchWriteItem");
+      // Resource must be EXACTLY { "Fn::GetAtt": [<ToolBreakerStateTable logical id>, "Arn"] }
+      // — a bare CFN GetAtt reference to the table's own ARN attribute, not a
+      // string, not an array of resources, and no /index/* GSI suffix.
+      expect(typeof breakerStatement.resources).toBe("object");
+      expect(Array.isArray(breakerStatement.resources)).toBe(false);
+      const breakerGetAtt = breakerStatement.resources["Fn::GetAtt"];
+      expect(Array.isArray(breakerGetAtt)).toBe(true);
+      expect(breakerGetAtt.length).toBe(2);
+      expect(breakerGetAtt[0]).toMatch(/^ToolBreakerStateTable/);
+      expect(breakerGetAtt[1]).toBe("Arn");
+      expect(Object.keys(breakerStatement.resources)).toEqual(["Fn::GetAtt"]);
       // Pin the governance-ledger statement precisely by its resource ARN
       // (Fn::GetAtt on GovernanceLedgerTable's logical id) so it cannot be
       // confused with the smoke fixture's own dedicated table — exact

--- a/backend/test/arbiter-stack-tool-breaker.test.ts
+++ b/backend/test/arbiter-stack-tool-breaker.test.ts
@@ -1,0 +1,175 @@
+import * as cdk from "aws-cdk-lib";
+import { Template, Match } from "aws-cdk-lib/assertions";
+import * as dynamodb from "aws-cdk-lib/aws-dynamodb";
+import * as events from "aws-cdk-lib/aws-events";
+import * as lambda from "aws-cdk-lib/aws-lambda";
+import * as appsync from "aws-cdk-lib/aws-appsync";
+import { Bucket } from "aws-cdk-lib/aws-s3";
+import * as path from "path";
+import {
+  scaffoldBackendAssetDirs,
+  scaffoldArbiterStubs,
+} from "./helpers/scaffold-stub-assets";
+
+scaffoldBackendAssetDirs(["dist/lambda", "src/schema"]);
+scaffoldArbiterStubs();
+
+import { ArbiterStack } from "../lib/arbiter-stack";
+
+// Per-target tool circuit breaker (task 28d624b1): the org-scoped state table
+// (RETAIN + deletionProtection + TTL), the CDK->function env delivery of the
+// TOOL_BREAKER_* tunables, and the least-privilege (Put/Get/Update, NO
+// Delete/Scan) worker grant scoped to the one table.
+describe("ArbiterStack — tool-target circuit breaker (task 28d624b1)", () => {
+  let template: Template;
+
+  beforeAll(() => {
+    const app = new cdk.App({ context: { "aws:cdk:bundling-stacks": [] } });
+    const backendStack = new cdk.Stack(app, "MockBackendStack", {
+      env: { account: "123456789012", region: "us-east-1" },
+    });
+    const agentEventBus = new events.EventBus(backendStack, "AgentEventBus", {
+      eventBusName: "citadel-agents-test",
+    });
+    const mkTable = (id: string, name: string, pk: string) =>
+      new dynamodb.Table(backendStack, id, {
+        tableName: name,
+        partitionKey: { name: pk, type: dynamodb.AttributeType.STRING },
+        billingMode: dynamodb.BillingMode.PAY_PER_REQUEST,
+        removalPolicy: cdk.RemovalPolicy.DESTROY,
+      });
+    const agentConfigTable = mkTable(
+      "AgentConfigTable",
+      "citadel-agents-test",
+      "agentId",
+    );
+    const workflowsTable = mkTable(
+      "WorkflowsTable",
+      "citadel-workflows-test",
+      "workflowId",
+    );
+    const executionsTable = mkTable(
+      "ExecutionsTable",
+      "citadel-executions-test",
+      "executionId",
+    );
+    const executionSpecificationsTable = mkTable(
+      "ExecutionSpecificationsTable",
+      "citadel-execution-specifications-test",
+      "specId",
+    );
+    const codeBucket = new Bucket(backendStack, "CodeBucket", {
+      bucketName: "citadel-code-test",
+    });
+    const fanoutFunction = new lambda.Function(backendStack, "FanoutFunction", {
+      runtime: lambda.Runtime.NODEJS_24_X,
+      handler: "workflow-progress-fanout.handler",
+      code: lambda.Code.fromAsset("dist/lambda"),
+      timeout: cdk.Duration.seconds(30),
+    });
+    const appSyncApi = new appsync.GraphqlApi(backendStack, "MockApi", {
+      name: "mock-api",
+      schema: appsync.SchemaFile.fromAsset(
+        path.resolve(__dirname, "../src/schema/schema.graphql"),
+      ),
+    });
+
+    const stack = new ArbiterStack(app, "TestArbiterStack", {
+      environment: "test",
+      env: { account: "123456789012", region: "us-east-1" },
+      agentEventBus,
+      agentConfigTable,
+      codeBucket,
+      workflowsTable,
+      executionsTable,
+      fanoutFunction,
+      appSyncEndpoint: appSyncApi.graphqlUrl,
+      executionSpecificationsTable,
+    });
+    template = Template.fromStack(stack);
+  });
+
+  test("breaker table has org-scoped composite key, TTL, PITR, and SSE", () => {
+    template.hasResourceProperties("AWS::DynamoDB::Table", {
+      TableName: "citadel-tool-breaker-state-test",
+      KeySchema: Match.arrayWith([
+        { AttributeName: "pk", KeyType: "HASH" },
+        { AttributeName: "sk", KeyType: "RANGE" },
+      ]),
+      TimeToLiveSpecification: { AttributeName: "ttl", Enabled: true },
+      PointInTimeRecoverySpecification: { PointInTimeRecoveryEnabled: true },
+      SSESpecification: Match.objectLike({ SSEEnabled: true }),
+      BillingMode: "PAY_PER_REQUEST",
+      DeletionProtectionEnabled: true,
+    });
+  });
+
+  test("breaker table is RETAIN (deletion + update-replace) — no silent teardown", () => {
+    template.hasResource("AWS::DynamoDB::Table", {
+      Properties: Match.objectLike({
+        TableName: "citadel-tool-breaker-state-test",
+      }),
+      DeletionPolicy: "Retain",
+      UpdateReplacePolicy: "Retain",
+    });
+  });
+
+  test("worker env wires the breaker table + tunables (CDK -> function env)", () => {
+    template.hasResourceProperties("AWS::Lambda::Function", {
+      Handler: "index.lambda_handler",
+      Environment: {
+        Variables: Match.objectLike({
+          TOOL_BREAKER_TABLE: Match.anyValue(),
+          TOOL_BREAKER_FAILURE_THRESHOLD: "5",
+          TOOL_BREAKER_WINDOW_SECONDS: "60",
+          TOOL_BREAKER_RECOVERY_SECONDS: "30",
+          TOOL_BREAKER_PROBE_LEASE_SECONDS: "30",
+          TOOL_BREAKER_CACHE_TTL_SECONDS: "3",
+        }),
+      },
+    });
+  });
+
+  test("worker grant on the breaker table has no Delete/Scan on it", () => {
+    // Scan every IAM statement that references the breaker table's logical id
+    // and assert none carries DeleteItem/Scan/Query (least privilege — the
+    // `ttl` attribute handles expiry; transitions are conditional updates).
+    const breakerTables = template.findResources("AWS::DynamoDB::Table", {
+      Properties: { TableName: "citadel-tool-breaker-state-test" },
+    });
+    const breakerLogicalId = Object.keys(breakerTables)[0];
+    expect(breakerLogicalId).toBeDefined();
+
+    const policies = template.findResources("AWS::IAM::Policy");
+    const forbidden = [
+      "dynamodb:DeleteItem",
+      "dynamodb:Scan",
+      "dynamodb:Query",
+    ];
+    let sawBreakerGrant = false;
+    for (const policy of Object.values(policies)) {
+      for (const stmt of policy.Properties.PolicyDocument.Statement) {
+        const refsBreaker = JSON.stringify(stmt.Resource ?? "").includes(
+          breakerLogicalId,
+        );
+        if (refsBreaker) {
+          sawBreakerGrant = true;
+          const actions = Array.isArray(stmt.Action)
+            ? stmt.Action
+            : [stmt.Action];
+          for (const f of forbidden) {
+            expect(actions).not.toContain(f);
+          }
+          expect(actions).toEqual(
+            expect.arrayContaining([
+              "dynamodb:PutItem",
+              "dynamodb:GetItem",
+              "dynamodb:UpdateItem",
+            ]),
+          );
+        }
+      }
+    }
+    expect(sawBreakerGrant).toBe(true);
+  });
+});

--- a/docs/EVENTBRIDGE_CATALOG.md
+++ b/docs/EVENTBRIDGE_CATALOG.md
@@ -888,3 +888,47 @@ Emitted by `backend/src/lambda/cost-budget-evaluator.ts` (hourly `CostBudgetEval
 5. Always include `correlationId` and `timestamp` in the event detail
 6. Use the `IdempotencyGuard` in the consuming Lambda handler
 7. For registry-backed app events, the emission point is `backend/src/lambda/agent-app-shim-resolver.ts::emitEvent` — do not re-introduce legacy `app-resolver.ts` call sites.
+
+## Tool Circuit Breaker Events (source: `citadel.tool.breaker`)
+
+Emitted by the per-target tool circuit breaker at the worker tool-call seam
+(`arbiter/workerWrapper/tool_breaker_hook.py`), exactly once per state
+transition (single-writer conditional write, so these events are storm-proof by
+construction). A companion `GovernanceFinding` at scope `tool-target-breaker` is
+written on the same transitions.
+
+> **Deferred (follow-up):** the console / fleet-view GraphQL surfacing of
+> breaker state (a read-model resolver over the `citadel-tool-breaker-state`
+> table + an AppSync subscription driven by this event) is intentionally OUT OF
+> SCOPE for the initial breaker landing and deferred to a follow-up. Only the
+> EventBridge event and the finding are emitted today. The node-level
+> non-terminality of a `CIRCUIT_OPEN` failure (re-enqueue via a recovery queue)
+> is likewise a separate follow-up; today an OPEN fast-fail fails the node
+> terminally for that attempt.
+
+### Event Types
+
+| detail-type | When |
+| --- | --- |
+| `citadel.tool.breaker.state_changed` | A target breaker transitions CLOSED→OPEN, HALF_OPEN→CLOSED (recovered), or HALF_OPEN→OPEN (re-opened) |
+
+### Event Schema
+
+#### citadel.tool.breaker.state_changed
+
+```json
+{
+  "source": "citadel.tool.breaker",
+  "detail-type": "citadel.tool.breaker.state_changed",
+  "detail": {
+    "orgId": "string (server-resolved; may be empty)",
+    "targetKind": "mcp_server | integration | datastore",
+    "targetId": "string (integration/datastore RECORD id — never an endpoint URL)",
+    "fromState": "CLOSED | OPEN | HALF_OPEN",
+    "toState": "CLOSED | OPEN | HALF_OPEN",
+    "stateVersion": "int (monotonic; dedupe key with targetKind/targetId/toState)",
+    "workflowId": "string",
+    "timestamp": "int (epoch seconds)"
+  }
+}
+```


### PR DESCRIPTION
## Summary

A failing MCP server or integration is currently retried indefinitely: the existing circuit breaker guards only the supervisor's Bedrock calls, and per-target health exists only as one-shot probes. Nothing isolates a degraded target at dispatch time, so every worker keeps paying full timeout cost against something already known to be down.

Worker state can't be held in memory for this - workers are short-lived subprocesses, so a breaker has to be shared.

## What changed

**Shared breaker state.** Per-target state (MCP server, integration, datastore) in DynamoDB, keyed per org, with conditional-write transitions and coarse windows. Tools sharing an MCP server share its breaker.

**Fail fast at the seam, in the right order.** Deny-list → breaker → approval consumption → idempotency reserve/execute/finalize. The ordering is load-bearing and tested: a breaker fast-fail burns no approval's single use, leaves no ledger reservation, and is never reported as a policy denial. Fast-fail is asserted *structurally* - zero target calls and zero DynamoDB reads on a cached open state - rather than by a timing threshold that machine speed could flatter.

**One prober, by construction.** Half-open recovery uses a conditional lease, so of two concurrent workers exactly one probes and the other fast-fails. Proven against a real client via moto, with the red proof re-derived in review by weakening the Lease and observing both probe.

**A new failure class on the existing taxonomy.** 'CIRCUIT_OPEN' with never-retry disposition - no parallel classification, no second breaker concept. Its non-terminality (eventual re-drive) belongs to the recovery queue and is deliberately not built here.

## Three decisions worth reviewing

1. **Throttles do not open a breaker** (env-gated to enable). The panel split on this. The taxonomy already backs throttles off with jitter, so a breaker adds little while risking conversion of a provider quota limit into self-inflicted unavailability. Config-reversible - this is a risk-appetite call, so say if you'd rather it opened.
1. **An unavailable breaker store fails open.** Otherwise one table's blip becomes a fleet-wide tool outage: a control manufacturing the incident it exists to contain. Deny-list and the taxonomy remain independent controls.
1. **Local tools get no breaker.** No external target to isolate, and instrumenting the highest-volume call path would add a read that can never transition. Resolution returns nothing and the phase is skipped entirely.

## Testing

Every acceptance criterion maps to a named test: opens after N failures in window W; subsequent calls fail fast without touching the target; recovery closes via bounded probes; two workers never double-probe. Plus storm-proof findings, the ordering invariants, store-unavailable-fails-open, local-tool-skips-breaker, float-safety through the shared marshalling boundary, and CK assertions for retention and server-side env delivery. Seam tests use the real hook - no agent-boundary stub. 

jest 6,862 across 448 suites; arbiter pytest 924; moto contract plus end-to-end harness 40; `tsc` and both stack synths clean.

## Notes

The worker least-privilege guard caught the new table grant and was **extended exactly** - pinned to the table ARN with explicit actions, no Delete, no wildcard - rather than relaxed. Third time that guard has paid for itself.
Console and fleet surfacing of breaker state is deliberately deferred to a follow-up to keep this change scoped; the state-change event and findings are emitted, so the consumer work is unblocked.

## Deployment notes

Adds one DynamoDB table (Retain plus deletion protection, no Delete grant) and server-delivered env vars. Deploy from main after merge with a freshly-read sha.