### PR TITLE
fix(arbiter): hash seed module content into change detection

### DIFF
--- a/backend/lib/arbiter-stack.ts
+++ b/backend/lib/arbiter-stack.ts
@@ -51,6 +51,41 @@ function resolveArbiterRoot(startDir: string): string {
 }
 const ARBITER_ROOT = resolveArbiterRoot(__dirname);
 
+// ---------------------------------------------------------------------------
+// Seed-module content digest (finding 588c7fb8)
+// ---------------------------------------------------------------------------
+// The seed custom resource (SeedAgentConfigResource, below) uploads agent
+// module files from arbiter/seedConfig/ to the code bucket at
+// agents/<filename> — today demo_echo_agent.py AND smoke_idempotency_agent.py
+// (both ride this exact path), plus any future sibling module the seed handler
+// uploads. Historically the custom resource's ONLY change-detection input was
+// a hand-bumped `Version` string, so editing a module's SOURCE changed no
+// custom-resource property: CloudFormation reported the resource unchanged and
+// never re-invoked the handler, so a repository fix to a module never reached
+// S3 (the module stayed at whatever bytes were last uploaded). This is the
+// finding-588c7fb8 defect.
+//
+// Making a content digest of the seed source part of the custom resource's
+// properties forces a re-upload on the next deploy whenever ANY seed source
+// file changes. The digest uses CDK's own source-fingerprint primitive
+// (cdk.FileSystem.fingerprint) — the same content-addressing CDK uses for
+// AssetHashType.SOURCE assets (the established idiom in this stack, used by
+// the PythonFunctions above) — over the WHOLE seedConfig directory, so the
+// digest covers EVERY uploaded module file (not just one entry point) plus the
+// handler itself. __pycache__/__tests__/*.pyc are excluded so byte-compiled
+// caches and local test runs never churn the digest.
+export const SEED_MODULE_FINGERPRINT_EXCLUDES: readonly string[] = [
+  "__pycache__",
+  "__tests__",
+  "*.pyc",
+];
+
+export function computeSeedModuleDigest(seedConfigDir: string): string {
+  return cdk.FileSystem.fingerprint(seedConfigDir, {
+    exclude: [...SEED_MODULE_FINGERPRINT_EXCLUDES],
+  });
+}
+
 interface ArbiterStackProps extends cdk.StackProps {
   agentEventBus: events.EventBus;
   agentConfigTable: dynamodb.Table;
@@ -1267,14 +1302,30 @@ export class ArbiterStack extends cdk.Stack {
     // Bumped Version v1.3.0 → v1.4.0 so the CFN Update event fires on the
     // next non-prod deploy and the diagnostic smoke-idempotency-agent (gated
     // on SMOKE_FIXTURES_ENABLED) is seeded in existing non-prod environments.
+    //
+    // finding 588c7fb8: the change-detection inputs are now TWO levers:
+    //   * `Version` — a manual lever (bump to force a re-seed even when no
+    //     source changed, e.g. to re-run a seed after an out-of-band table
+    //     wipe). Kept for backward-compat with the deploy runbook.
+    //   * `ModuleDigest` — an AUTOMATIC content digest of the seed source
+    //     (every uploaded agent module + the handler). Any source edit changes
+    //     this digest, so CloudFormation re-invokes the seed handler on the
+    //     next deploy and the corrected module bytes actually reach S3. This
+    //     closes the stale-module defect: previously only `Version` gated the
+    //     re-run, so a module source fix that left `Version` untouched never
+    //     re-uploaded. The digest covers EVERY uploaded file (not just one
+    //     entry point) — see computeSeedModuleDigest above.
+    const seedModuleDigest = computeSeedModuleDigest(
+      path.join(ARBITER_ROOT, "seedConfig"),
+    );
     const seedAgentConfigResource = new cdk.CustomResource(
       this,
       "SeedAgentConfigResource",
       {
         serviceToken: seedAgentConfigLambda.functionArn,
         properties: {
-          // O-05: Use content hash instead of Date.now() to avoid unnecessary re-runs
           Version: "v1.4.0",
+          ModuleDigest: seedModuleDigest,
         },
       },
     );

--- a/backend/test/arbiter-stack-seed-module-digest.test.ts
+++ b/backend/test/arbiter-stack-seed-module-digest.test.ts
@@ -1,0 +1,240 @@
+/**
+ * Seed-module content-digest change detection (finding 588c7fb8, HIGH).
+ *
+ * DEFECT: the seed custom resource (SeedAgentConfigResource in
+ * arbiter-stack.ts) uploads agent module files (demo_echo_agent.py,
+ * smoke_idempotency_agent.py) from arbiter/seedConfig/ to the code bucket at
+ * agents/<filename>. Its ONLY change-detection input used to be a hand-bumped
+ * `Version` string, so editing a module's SOURCE changed no custom-resource
+ * property — CloudFormation reported the resource unchanged and never
+ * re-invoked the handler, so the repository fix never reached S3.
+ *
+ * FIX: a content digest of the seed source (computeSeedModuleDigest, over the
+ * whole seedConfig dir via cdk.FileSystem.fingerprint) is now a custom-resource
+ * property (`ModuleDigest`). Any source edit changes the digest, forcing a
+ * re-upload on the next deploy.
+ *
+ * WHAT THESE TESTS CATCH / DO NOT CATCH:
+ *   - They prove the synthesized template carries a real, source-derived
+ *     content digest (not a constant), that it moves when a seed module source
+ *     changes, and that it covers every uploaded file (not just one entry
+ *     point).
+ *   - The "drift assertion" (below) proves the synthesized ModuleDigest equals
+ *     a digest independently recomputed from the on-disk seed source. Because
+ *     these tests synthesize from the SAME live source, they cannot see what is
+ *     ACTUALLY in the S3 bucket at deploy time (that would require an AWS call);
+ *     they guard the synth-time contract only. The runtime re-upload is what
+ *     the CFN change-detection + the seed handler's idempotent put_object
+ *     provide.
+ */
+import * as cdk from "aws-cdk-lib";
+import { Template } from "aws-cdk-lib/assertions";
+import * as dynamodb from "aws-cdk-lib/aws-dynamodb";
+import * as events from "aws-cdk-lib/aws-events";
+import { Bucket } from "aws-cdk-lib/aws-s3";
+import * as fs from "fs";
+import * as os from "os";
+import * as path from "path";
+import {
+  scaffoldBackendAssetDirs,
+  scaffoldArbiterStubs,
+} from "./helpers/scaffold-stub-assets";
+
+scaffoldBackendAssetDirs(["dist/lambda", "src/schema"]);
+scaffoldArbiterStubs();
+
+import {
+  ArbiterStack,
+  computeSeedModuleDigest,
+  SEED_MODULE_FINGERPRINT_EXCLUDES,
+} from "../lib/arbiter-stack";
+
+const SEED_CONFIG_DIR = path.resolve(
+  __dirname,
+  "..",
+  "..",
+  "arbiter",
+  "seedConfig",
+);
+const HEX64 = /^[0-9a-f]{64}$/;
+
+function buildStack(environment = "test"): cdk.Stack {
+  const app = new cdk.App({ context: { "aws:cdk:bundling-stacks": [] } });
+  const backendStack = new cdk.Stack(app, "MockBackendStack", {
+    env: { account: "123456789012", region: "us-east-1" },
+  });
+  const agentEventBus = new events.EventBus(backendStack, "AgentEventBus", {
+    eventBusName: `citadel-agents-${environment}`,
+  });
+  const mkTable = (id: string, name: string, pk: string) =>
+    new dynamodb.Table(backendStack, id, {
+      tableName: name,
+      partitionKey: { name: pk, type: dynamodb.AttributeType.STRING },
+      billingMode: dynamodb.BillingMode.PAY_PER_REQUEST,
+      removalPolicy: cdk.RemovalPolicy.DESTROY,
+    });
+  const agentConfigTable = mkTable(
+    "AgentConfigTable",
+    `citadel-agents-${environment}`,
+    "agentId",
+  );
+  const executionSpecificationsTable = mkTable(
+    "ExecutionSpecificationsTable",
+    `citadel-execution-specifications-${environment}`,
+    "specId",
+  );
+  const codeBucket = new Bucket(backendStack, "CodeBucket", {
+    bucketName: `citadel-code-${environment}`,
+  });
+  return new ArbiterStack(app, "TestArbiterStack", {
+    environment,
+    env: { account: "123456789012", region: "us-east-1" },
+    agentEventBus,
+    agentConfigTable,
+    codeBucket,
+    executionSpecificationsTable,
+  });
+}
+
+/** The single SeedAgentConfigResource custom resource's Properties. */
+function seedResourceProps(template: Template): Record<string, unknown> {
+  const resources = template.findResources(
+    "AWS::CloudFormation::CustomResource",
+  );
+  const entry = Object.entries(resources).find(([key]) =>
+    key.startsWith("SeedAgentConfigResource"),
+  );
+  if (!entry) throw new Error("SeedAgentConfigResource not found");
+  return (
+    (entry[1] as { Properties?: Record<string, unknown> }).Properties ?? {}
+  );
+}
+
+/** Fresh temp dir seeded with the given files; auto-cleaned by the caller. */
+function mkTempSeedDir(files: Record<string, string>): string {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), "seed-digest-"));
+  for (const [name, body] of Object.entries(files)) {
+    const full = path.join(dir, name);
+    fs.mkdirSync(path.dirname(full), { recursive: true });
+    fs.writeFileSync(full, body);
+  }
+  return dir;
+}
+
+describe("ArbiterStack — seed-module content digest (finding 588c7fb8)", () => {
+  describe("synthesized template wiring", () => {
+    let template: Template;
+    beforeAll(() => {
+      template = Template.fromStack(buildStack());
+    });
+
+    test("seed custom resource carries a ModuleDigest that is a real sha256 (not a version string)", () => {
+      const props = seedResourceProps(template);
+      expect(typeof props.ModuleDigest).toBe("string");
+      expect(props.ModuleDigest as string).toMatch(HEX64);
+    });
+
+    test("drift assertion: synthesized ModuleDigest equals a digest recomputed from the on-disk seed source", () => {
+      // Catches a hardcoded/stale digest and a digest computed over the wrong
+      // directory. Does NOT (and cannot, without an AWS call) verify what is
+      // actually stored in the S3 bucket — that is guarded at runtime by the
+      // CFN change-detection re-invoke + the handler's idempotent put_object.
+      const props = seedResourceProps(template);
+      expect(props.ModuleDigest).toBe(computeSeedModuleDigest(SEED_CONFIG_DIR));
+    });
+
+    test("Version lever retained alongside the digest (two-lever change detection)", () => {
+      // Version is the manual force-reseed lever; ModuleDigest is the automatic
+      // content lever. Both live in the custom resource properties.
+      expect(seedResourceProps(template).Version).toBe("v1.4.0");
+    });
+  });
+
+  describe("digest function properties (deterministic, temp dirs)", () => {
+    const cleanup: string[] = [];
+    afterAll(() => {
+      for (const d of cleanup) fs.rmSync(d, { recursive: true, force: true });
+    });
+
+    test("changing a module source file changes the digest", () => {
+      // This is the property the pre-fix `Version`-only change detection
+      // lacked: a constant string is blind to source content, so a fixed
+      // module never re-uploaded. The digest is content-sensitive.
+      const dir = mkTempSeedDir({ "demo_echo_agent.py": "return 'v1'\n" });
+      cleanup.push(dir);
+      const before = computeSeedModuleDigest(dir);
+      fs.writeFileSync(path.join(dir, "demo_echo_agent.py"), "return 'v2'\n");
+      const after = computeSeedModuleDigest(dir);
+      expect(after).not.toBe(before);
+    });
+
+    test("digest covers ALL uploaded files, not just one entry point (adding a second module moves the digest)", () => {
+      const dir = mkTempSeedDir({ "demo_echo_agent.py": "return 'echo'\n" });
+      cleanup.push(dir);
+      const oneFile = computeSeedModuleDigest(dir);
+      // Add the second real rider of the S3-upload path.
+      fs.writeFileSync(
+        path.join(dir, "smoke_idempotency_agent.py"),
+        "return 'smoke'\n",
+      );
+      const twoFiles = computeSeedModuleDigest(dir);
+      expect(twoFiles).not.toBe(oneFile);
+    });
+
+    test("byte-compiled caches / test dirs are excluded so the digest does not churn", () => {
+      const dir = mkTempSeedDir({ "demo_echo_agent.py": "return 'echo'\n" });
+      cleanup.push(dir);
+      const before = computeSeedModuleDigest(dir);
+      fs.mkdirSync(path.join(dir, "__pycache__"), { recursive: true });
+      fs.writeFileSync(path.join(dir, "__pycache__", "demo.pyc"), "bytecode");
+      fs.mkdirSync(path.join(dir, "__tests__"), { recursive: true });
+      fs.writeFileSync(path.join(dir, "__tests__", "test_x.py"), "assert True");
+      fs.writeFileSync(path.join(dir, "demo_echo_agent.pyc"), "bytecode2");
+      const after = computeSeedModuleDigest(dir);
+      expect(after).toBe(before);
+      expect(SEED_MODULE_FINGERPRINT_EXCLUDES).toEqual(
+        expect.arrayContaining(["__pycache__", "__tests__", "*.pyc"]),
+      );
+    });
+  });
+
+  describe("end-to-end bite: editing a real seed module moves the SYNTHESIZED digest", () => {
+    // The strongest proof, and the direct RED/GREEN discriminator vs the
+    // pre-fix stack: against the old `Version`-only resource, editing a module
+    // source leaves every custom-resource property unchanged (Version is a
+    // constant), so this assertion FAILS (RED). With ModuleDigest wired, the
+    // synthesized digest moves while Version stays constant (GREEN) — proving
+    // the digest, not Version, is what carries source content into change
+    // detection.
+    const moduleFile = path.join(SEED_CONFIG_DIR, "demo_echo_agent.py");
+
+    test("appending to demo_echo_agent.py changes ModuleDigest but not Version", () => {
+      const baseline = Template.fromStack(buildStack());
+      const baseProps = seedResourceProps(baseline);
+
+      const original = fs.readFileSync(moduleFile);
+      try {
+        fs.writeFileSync(
+          moduleFile,
+          Buffer.concat([
+            original,
+            Buffer.from(`\n# digest-bite ${Date.now()}\n`),
+          ]),
+        );
+        const mutated = Template.fromStack(buildStack());
+        const mutatedProps = seedResourceProps(mutated);
+
+        expect(mutatedProps.ModuleDigest).not.toBe(baseProps.ModuleDigest);
+        // Version is source-blind — unchanged. This is exactly why the
+        // pre-fix Version-only detection missed module edits.
+        expect(mutatedProps.Version).toBe(baseProps.Version);
+      } finally {
+        // Restore byte-identical original regardless of assertion outcome.
+        fs.writeFileSync(moduleFile, original);
+      }
+
+      // Confirm the restore was byte-exact.
+      expect(fs.readFileSync(moduleFile).equals(original)).toBe(true);
+    });
+  });
+});


### PR DESCRIPTION
## Summary
The smoke tool's code is uploaded to S3 by a seeding custom resource that only re-uploads when its own inputs change. Repository fixes to the tool therefore never reached the running system: an identical error persisted across deploys that contained the fix, while the module in S3 stayed at its 22 August upload.

This blocks live validation of three deployed capabilities - tool-call idempotency, approval gating, and the new per-target breaker - because the only workflow exercising that seam runs stale code.

## What changed
A digest of the uploaded module sources is now part of the custom resource's properties, so any source change forces a re-upload on the next deploy. A test asserts the synthesized digest matches a digest computed from source, so a stale module fails a test rather than surfacing as a runtime error days later.

## Testing
Proven sensitive in both directions: re-synthesising with no edit leaves the digest unchanged; editing a module file moves it *while the version string stays put* (the case that was silently failing); adding a new file moves it again, confirming the digest covers every uploaded file rather than just the entry point. Red proof re-derived against main, where the assertion fails on an undefined digest.

Class coverage checked rather than assumed: the other seed custom resources are DynamoDB-only, so this module was the sole rider on the upload path.

Seeding remains idempotent; pre-existing seed tests are byte-identical. seedConfig pytest 50, arbiter-stack jest 153, `tsc` and synth clean.

## Limits, stated

The assertion compares source against the synthesized template. It cannot verify what is actually stored in the S3 bucket without an AWS call, and says so.

## Deployment notes

The next deploy will re-upload the module because its digest now differs from the recorded one - that is the fix working. After it lands, one smoke workflow run validates all three seams.