### PR TITLE
fix(worker): configure logging in the agent subprocess

### DIFF
--- a/arbiter/workerWrapper/__tests__/test_agent_subprocess_log_level.py
+++ b/arbiter/workerWrapper/__tests__/test_agent_subprocess_log_level.py
@@ -1,0 +1,194 @@
+"""Proves EMISSION (not mere configuration) of tool-seam INFO log records
+from the real agent-subprocess entry path.
+
+Root cause (diagnosed): ``tool_idempotency_hook.py`` does
+``logging.getLogger(__name__)`` and emits at INFO, but the hook runs inside
+the ``agent_runner`` subprocess (launched by ``index.run_agent_in_subprocess``
+via ``subprocess.run``), and nothing in that process configured a logging
+level — so Python's implicit root-logger default (WARNING) silently dropped
+every INFO record before it could reach stderr, and therefore before
+``index.py`` could forward it into the parent's captured output.
+
+These tests run ``agent_runner.py`` as a REAL subprocess — exactly the shape
+``index.run_agent_in_subprocess`` invokes it (``[sys.executable,
+AGENT_RUNNER_PATH]``, JSON on stdin, response on stdout, everything else on
+stderr) — with a fixture agent module whose ``handler()`` calls
+``logging.getLogger('tool_idempotency_hook').info(...)``: the SAME logger
+object name ``tool_idempotency_hook.py`` constructs via
+``logging.getLogger(__name__)`` when loaded as a top-level bundle module (the
+deployed layout; see ``test_deployed_bundle_importability.py``). This is the
+smallest faithful equivalent to driving the real tool-call seam (which would
+require the full strands + DynamoDB-ledger machinery to reach the same
+``logger.info(...)`` call) while still exercising the REAL subprocess
+logging pipeline end to end: env var -> ``agent_runner._configure_logging`` ->
+root logger handler -> stderr -> (mirroring ``index.py``) captured output.
+
+A test that only asserts ``setLevel`` was called, or that inspects
+``logging.getLogger(...).level`` in-process, would NOT catch the actual
+defect (the defect was the total ABSENCE of a configured handler/level in the
+subprocess, not a wrong argument to a mock) — so every assertion here is on
+the actual captured stderr TEXT of a real child process.
+"""
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import sys
+import textwrap
+
+import pytest
+
+_HERE = os.path.dirname(os.path.abspath(__file__))
+_WORKER_DIR = os.path.abspath(os.path.join(_HERE, ".."))
+_AGENT_RUNNER_PATH = os.path.join(_WORKER_DIR, "agent_runner.py")
+
+_FIXTURE_MODULE_SRC = textwrap.dedent(
+    """
+    import logging
+
+    def handler(**kwargs):
+        # Same logger-name convention tool_idempotency_hook.py uses
+        # (logging.getLogger(__name__) as a top-level bundle module).
+        logging.getLogger('tool_idempotency_hook').info(
+            "tool-ledger reserve outcome=%s pk=%s sk=%s gen=%s",
+            "WON", "org#exec", "node#tool", 3,
+        )
+        return "ok"
+    """
+)
+
+
+def _write_fixture_module(tmp_path) -> str:
+    path = os.path.join(tmp_path, "fixture_agent_module.py")
+    with open(path, "w", encoding="utf-8") as f:
+        f.write(_FIXTURE_MODULE_SRC)
+    return path
+
+
+def _run_agent_runner_subprocess(module_path: str, *, extra_env: dict | None = None):
+    """Invoke agent_runner.py exactly as index.run_agent_in_subprocess does:
+    real subprocess, JSON payload on stdin, capture stdout/stderr as text."""
+    child_env = os.environ.copy()
+    # Deterministic default-path testing: strip any AGENT_LOG_LEVEL leaking
+    # in from the test runner's own shell environment, so the "no env var
+    # set" test genuinely exercises the default rather than an ambient value.
+    child_env.pop("AGENT_LOG_LEVEL", None)
+    # Ensure the bundle dir + repo root are importable exactly like the real
+    # subprocess launch (index.py propagates parent sys.path onto PYTHONPATH).
+    parent_roots = [p for p in sys.path if p]
+    inherited_pp = child_env.get("PYTHONPATH", "")
+    if inherited_pp:
+        parent_roots.append(inherited_pp)
+    child_env["PYTHONPATH"] = os.pathsep.join(dict.fromkeys(parent_roots))
+    if extra_env:
+        child_env.update(extra_env)
+
+    runner_input = json.dumps({"modulePath": module_path, "request": {}})
+    return subprocess.run(
+        [sys.executable, _AGENT_RUNNER_PATH],
+        input=runner_input,
+        capture_output=True,
+        text=True,
+        timeout=30,
+        env=child_env,
+    )
+
+
+class TestAgentSubprocessLogLevelEmission:
+    def test_info_seam_log_reaches_stderr_with_default_env(self, tmp_path):
+        """No AGENT_LOG_LEVEL set -> defaults to INFO -> the seam INFO record
+        is present in the subprocess's captured stderr (the RED case before
+        the fix: this assertion fails because the record never reaches
+        stderr at all under the implicit WARNING root-logger default)."""
+        module_path = _write_fixture_module(str(tmp_path))
+        result = _run_agent_runner_subprocess(module_path)
+
+        assert result.returncode == 0, result.stderr
+        assert "tool-ledger reserve outcome=WON" in result.stderr
+        assert "pk=org#exec" in result.stderr
+        assert "sk=node#tool" in result.stderr
+        assert "gen=3" in result.stderr
+        # Stdout carries ONLY the JSON response envelope — logging must never
+        # pollute it.
+        assert '"response"' in result.stdout
+        assert "tool-ledger" not in result.stdout
+
+    def test_info_seam_log_reaches_stderr_with_explicit_info_env(self, tmp_path):
+        """AGENT_LOG_LEVEL=INFO explicitly set -> same emission."""
+        module_path = _write_fixture_module(str(tmp_path))
+        result = _run_agent_runner_subprocess(
+            module_path, extra_env={"AGENT_LOG_LEVEL": "INFO"}
+        )
+
+        assert result.returncode == 0, result.stderr
+        assert "tool-ledger reserve outcome=WON" in result.stderr
+
+    def test_info_seam_log_suppressed_when_level_raised_to_warning(self, tmp_path):
+        """AGENT_LOG_LEVEL=WARNING -> the INFO seam record does NOT appear.
+
+        Proves the fix is a real, effective level gate — not a handler that
+        always emits regardless of configured level."""
+        module_path = _write_fixture_module(str(tmp_path))
+        result = _run_agent_runner_subprocess(
+            module_path, extra_env={"AGENT_LOG_LEVEL": "WARNING"}
+        )
+
+        assert result.returncode == 0, result.stderr
+        assert "tool-ledger reserve outcome=WON" not in result.stderr
+
+    def test_invalid_log_level_falls_back_to_info_default(self, tmp_path):
+        """A garbage AGENT_LOG_LEVEL value must not crash the subprocess and
+        must degrade to the INFO default (defensive parsing requirement)."""
+        module_path = _write_fixture_module(str(tmp_path))
+        result = _run_agent_runner_subprocess(
+            module_path, extra_env={"AGENT_LOG_LEVEL": "not-a-real-level"}
+        )
+
+        assert result.returncode == 0, result.stderr
+        assert "tool-ledger reserve outcome=WON" in result.stderr
+
+    def test_lowercase_log_level_value_is_accepted(self, tmp_path):
+        """Case-insensitive parsing: 'warning' behaves like 'WARNING'."""
+        module_path = _write_fixture_module(str(tmp_path))
+        result = _run_agent_runner_subprocess(
+            module_path, extra_env={"AGENT_LOG_LEVEL": "warning"}
+        )
+
+        assert result.returncode == 0, result.stderr
+        assert "tool-ledger reserve outcome=WON" not in result.stderr
+
+
+class TestConfigureLoggingUnit:
+    """Narrow unit coverage of the pure level-resolution helper, additive to
+    the subprocess proofs above (which are the tests that actually bite)."""
+
+    def test_resolve_log_level_default_is_info(self, monkeypatch):
+        monkeypatch.delenv("AGENT_LOG_LEVEL", raising=False)
+        sys.path.insert(0, _WORKER_DIR)
+        import importlib
+        import agent_runner
+        importlib.reload(agent_runner)
+        import logging as _logging
+
+        assert agent_runner._resolve_log_level() == _logging.INFO
+
+    def test_resolve_log_level_invalid_falls_back_to_info(self, monkeypatch):
+        monkeypatch.setenv("AGENT_LOG_LEVEL", "banana")
+        sys.path.insert(0, _WORKER_DIR)
+        import importlib
+        import agent_runner
+        importlib.reload(agent_runner)
+        import logging as _logging
+
+        assert agent_runner._resolve_log_level() == _logging.INFO
+
+    def test_resolve_log_level_honours_warning(self, monkeypatch):
+        monkeypatch.setenv("AGENT_LOG_LEVEL", "WARNING")
+        sys.path.insert(0, _WORKER_DIR)
+        import importlib
+        import agent_runner
+        importlib.reload(agent_runner)
+        import logging as _logging
+
+        assert agent_runner._resolve_log_level() == _logging.WARNING

--- a/arbiter/workerWrapper/agent_runner.py
+++ b/arbiter/workerWrapper/agent_runner.py
@@ -10,10 +10,80 @@ Writes the agent response as a JSON line to stdout.
 """
 
 import json
+import logging
 import sys
 import os
 import time
 import importlib.util
+
+# Valid stdlib logging level names accepted from AGENT_LOG_LEVEL. Restricted to
+# the standard named levels (never a bare numeric string) so an operator typo
+# fails closed to the default rather than silently no-op'ing logging.
+_VALID_LOG_LEVEL_NAMES = frozenset({
+    'CRITICAL', 'ERROR', 'WARNING', 'INFO', 'DEBUG', 'NOTSET',
+})
+_DEFAULT_LOG_LEVEL_NAME = 'INFO'
+
+
+def _resolve_log_level() -> int:
+    """Resolve the effective logging level from ``AGENT_LOG_LEVEL``.
+
+    Defensive by contract: an unset, blank, or unrecognized value falls back
+    to ``INFO`` rather than raising — a malformed operator-supplied value must
+    never crash the agent subprocess (finding: tool-seam INFO logs never
+    reached CloudWatch because nothing in this process configured a logging
+    level, so Python's implicit root-logger default of WARNING silently
+    dropped every INFO record from tool_idempotency_hook / governance_tool_hook
+    / worker_governance).
+    """
+    raw = os.environ.get('AGENT_LOG_LEVEL', _DEFAULT_LOG_LEVEL_NAME)
+    name = (raw or '').strip().upper()
+    if name not in _VALID_LOG_LEVEL_NAMES:
+        name = _DEFAULT_LOG_LEVEL_NAME
+    return getattr(logging, name)
+
+
+def _configure_logging() -> None:
+    """Configure the subprocess's root logger so INFO records emitted by
+    ``logging.getLogger(__name__)`` callers (tool_idempotency_hook.py,
+    governance_tool_hook.py, worker_governance.py, ...) actually reach the
+    parent's captured output — and, from there, CloudWatch.
+
+    Root cause: this subprocess (launched by
+    ``index.run_agent_in_subprocess`` via ``subprocess.run``) never called
+    ``logging.basicConfig``/``setLevel`` anywhere, so every ``logger.info(...)``
+    call across the tool-call seam was silently dropped by Python's implicit
+    root-logger default (WARNING) — the log statements and their levels are
+    NOT the bug and are deliberately left unchanged here.
+
+    Writes to ``sys.stderr`` explicitly (never ``sys.stdout``, which is
+    reserved for exactly one JSON response line consumed by
+    ``index._interpret_agent_result``) so records land where
+    ``index.run_agent_in_subprocess`` already reads and forwards subprocess
+    output (``result.stderr`` -> ``print(f"[agent stderr] {result.stderr}")``,
+    itself captured as the parent Lambda's stdout -> CloudWatch).
+
+    Level is driven by ``AGENT_LOG_LEVEL`` (default ``INFO``), parsed
+    defensively via ``_resolve_log_level`` so a bad value degrades to the
+    default instead of raising. Idempotent: safe if ``main()`` is invoked more
+    than once in the same interpreter (tests) — clears any handlers this
+    function previously added instead of accumulating duplicates.
+    """
+    root = logging.getLogger()
+    for handler in list(root.handlers):
+        if getattr(handler, '_citadel_agent_log_handler', False):
+            root.removeHandler(handler)
+
+    handler = logging.StreamHandler(stream=sys.stderr)
+    handler.setFormatter(logging.Formatter(
+        '%(asctime)s %(levelname)s %(name)s %(message)s'
+    ))
+    handler._citadel_agent_log_handler = True  # marks ours for idempotent reconfig
+
+    level = _resolve_log_level()
+    root.addHandler(handler)
+    root.setLevel(level)
+
 
 # Module-global sink for usage records captured during this subprocess's
 # lifetime. Reset per-process (one agent_runner.main() invocation == one
@@ -742,6 +812,13 @@ def _drain_tool_crashes() -> list:
 
 
 def main():
+    # Configure logging FIRST, before anything else in this subprocess emits
+    # a log record (in particular before _install_tool_call_hooks() below,
+    # which constructs the tool_idempotency_hook / governance_tool_hook
+    # loggers). See _configure_logging's docstring for the root-cause and
+    # why stderr is the correct destination.
+    _configure_logging()
+
     # Read input from stdin (single JSON line)
     raw = sys.stdin.read()
     payload = json.loads(raw)

--- a/backend/lib/arbiter-stack.ts
+++ b/backend/lib/arbiter-stack.ts
@@ -2104,6 +2104,22 @@ export class ArbiterStack extends cdk.Stack {
       "APPROVAL_REQUIRED_TOOLS",
       (this.node.tryGetContext("approvalRequiredTools") as string) ?? "",
     );
+    // Agent-subprocess logging level: the tool-seam INFO log lines
+    // (tool_idempotency_hook.py, governance_tool_hook.py, worker_governance.py)
+    // never reached CloudWatch because nothing in the agent_runner subprocess
+    // configured a logging level, so Python's implicit root-logger default
+    // (WARNING) silently dropped every INFO record. Delivered SERVER-SIDE on
+    // the static function env (never via the S3 tool module, never via the
+    // per-dispatch build_subprocess_env path) so it is present for every
+    // subprocess launch regardless of dispatch shape. Defaults to INFO;
+    // operators can raise it via CDK context `agentLogLevel` (e.g. "WARNING"
+    // to silence the seam again without a code change). agent_runner.py
+    // parses this defensively — an invalid value falls back to INFO rather
+    // than crashing the subprocess.
+    workerAgentWrapperLambda.addEnvironment(
+      "AGENT_LOG_LEVEL",
+      (this.node.tryGetContext("agentLogLevel") as string) ?? "INFO",
+    );
     workerAgentWrapperLambda.addToRolePolicy(
       new iam.PolicyStatement({
         effect: iam.Effect.ALLOW,

--- a/backend/test/arbiter-stack-env-parity.test.ts
+++ b/backend/test/arbiter-stack-env-parity.test.ts
@@ -292,4 +292,26 @@ describe("ArbiterStack — handler env-var parity (deployment contract)", () => 
     const provided = functionEnvKeys(template, "WorkerAgentWrapper");
     expect(provided.has("GOVERNANCE_LEDGER_TABLE")).toBe(true);
   });
+
+  test("AGENT_LOG_LEVEL is wired on the worker (agent-subprocess log-level fix)", () => {
+    // The tool-seam INFO log lines (tool_idempotency_hook.py et al.) never
+    // reached CloudWatch because nothing configured a logging level in the
+    // agent_runner subprocess. Delivered server-side on the static function
+    // env — pinned here so a future edit that drops it fails loudly.
+    const fns = template.findResources("AWS::Lambda::Function");
+    const match = Object.entries(fns).find(([id]) =>
+      id.startsWith("WorkerAgentWrapper"),
+    );
+    expect(match).toBeDefined();
+    const vars =
+      (
+        match![1] as {
+          Properties?: {
+            Environment?: { Variables?: Record<string, unknown> };
+          };
+        }
+      ).Properties?.Environment?.Variables ?? {};
+    expect(vars).toHaveProperty("AGENT_LOG_LEVEL");
+    expect(vars.AGENT_LOG_LEVEL).toBe("INFO");
+  });
 });


### PR DESCRIPTION
## Summary

The tool-seam log lines added last change never appeared in Cloudwatch. They shipped correctly: the hook emits at `INFO`. But it runs inside the agent subprocess, where nothing configured a logging level, so Python's `WARNING` default dropped every record before it could be written.

Confirmed Live on execution against `f0ca8650`: the seam demonstrably reserved and finalized (the DynamoDB rows prove it) while zero seam lines reached the log group. It also explains why earlier *warning*-level Lines - `hook skipped`, `governance ledger write failed` - did surface during previous incidents.

## What changed

`AGENT_LOG_LEVEL` (default `INFO`), delivered server-side via CK and pinned by the env-parity assertion, configures logging in the subprocess entry point. A malformed value falls back rather than crashing the subprocess. The hook's log statements are untouched.

## Testing

The test proves **emission**, not configuration: a real subprocess, with the record asserted present at "INFO' and absent at
"WARNING' - no "setLevel' or effective-level assertions, since "configured but silent" was the entire defect. Red proof re-derived in review by disabling only the configuration, which fails three emission tests.

Two things verified rather than assumed: the handler targets the stream the parent actually captures and re-prints (a record emitted where nobody reads is the same bug relocated), and the seam lines still carry only key, generation and tool - no payloads. 

pytest 364; jest env-parity 4 and arbiter-stack 183; `tsc` and synth clean, with the template pinning the variable.