### PR TITLE
fix(cdk): load backend env file in the app entry point

### DIFF
--- a/backend/bin/app.ts
+++ b/backend/bin/app.ts
@@ -1,5 +1,18 @@
 #!/usr/bin/env node
 import "source-map-support/register";
+import * as path from "path";
+import { loadDotenvIfPresent } from "../lib/load-dotenv";
+
+// Load backend/.env BEFORE any stack is constructed. Bundling (e.g. the
+// arbiter's PythonFunction) runs inside this CDK app process — aws-cdk-lib
+// invokes the container CLI from here — so CDK_DOCKER must be in
+// process.env before that happens. A single-stack `cdk diff`/`synth` still
+// synthesizes the whole app, so this must run unconditionally at module
+// load, not per-stack. Load-if-absent only: never overrides a variable an
+// operator or deploy.sh already exported. A missing file is a silent
+// no-op (e.g. CI has no backend/.env).
+loadDotenvIfPresent(path.join(__dirname, "..", "..", ".env"));
+
 import * as cdk from "aws-cdk-lib";
 // (Aspects accessed via cdk.Aspects)
 import { AwsSolutionsChecks, NagSuppressions } from "cdk-nag";

--- a/backend/lib/__tests__/app-env-load-order.test.ts
+++ b/backend/lib/__tests__/app-env-load-order.test.ts
@@ -1,0 +1,54 @@
+/**
+ * Structural assertion (not an execution test — see note below) that
+ * backend/bin/app.ts loads backend/.env BEFORE constructing any CDK stack.
+ *
+ * Why structural rather than executed: bin/app.ts has broad side effects
+ * (constructs ~9 real CDK stacks, requires ENVIRONMENT/CDK_DEFAULT_ACCOUNT
+ * context, runs cdk-nag) and is intentionally outside the jest `roots`
+ * config (`lib`, `src`, `test`, `scripts`) used by every other suite in
+ * this package — actually importing it here would mean the FIRST execution
+ * of the module (with all the ordering guarantees Node module evaluation
+ * implies) happens inside a test runner rather than under `cdk synth`,
+ * which is exactly the environment the fix targets. A source-position
+ * assertion instead pins the property that actually matters: the
+ * `loadDotenvIfPresent(...)` call textually precedes `new BackendStack(`,
+ * the first stack constructed in the file. Since CDK stacks are
+ * constructed synchronously and in file order at module-evaluation time,
+ * textual order here IS execution order — there is no async indirection
+ * between them.
+ */
+import * as fs from "fs";
+import * as path from "path";
+
+describe("backend/bin/app.ts — env load ordering", () => {
+  const appSource = fs.readFileSync(
+    path.join(__dirname, "..", "..", "bin", "app.ts"),
+    "utf8",
+  );
+
+  it("imports loadDotenvIfPresent from lib/load-dotenv", () => {
+    expect(appSource).toMatch(
+      /import\s*\{\s*loadDotenvIfPresent\s*\}\s*from\s*["']\.\.\/lib\/load-dotenv["']/,
+    );
+  });
+
+  it("calls loadDotenvIfPresent(...) before constructing the first stack", () => {
+    const loadCallIndex = appSource.indexOf("loadDotenvIfPresent(");
+    const firstStackIndex = appSource.indexOf("new BackendStack(");
+
+    expect(loadCallIndex).toBeGreaterThan(-1);
+    expect(firstStackIndex).toBeGreaterThan(-1);
+    expect(loadCallIndex).toBeLessThan(firstStackIndex);
+  });
+
+  it("calls loadDotenvIfPresent(...) before `new cdk.App()` stacks are given a chance to synth", () => {
+    // Belt-and-suspenders: also assert it precedes the AwsSolutionsChecks
+    // aspect application, so no code path between module load and full
+    // synth can run without .env already loaded.
+    const loadCallIndex = appSource.indexOf("loadDotenvIfPresent(");
+    const nagChecksIndex = appSource.indexOf("new AwsSolutionsChecks(");
+
+    expect(nagChecksIndex).toBeGreaterThan(-1);
+    expect(loadCallIndex).toBeLessThan(nagChecksIndex);
+  });
+});

--- a/backend/lib/__tests__/load-dotenv.test.ts
+++ b/backend/lib/__tests__/load-dotenv.test.ts
@@ -1,0 +1,138 @@
+/**
+ * Unit tests for loadDotenvIfPresent (finding: CDK_DOCKER=docker in
+ * backend/.env is not read by a bare `npx cdk diff/synth`, only by
+ * deploy.sh).
+ *
+ * Covers: load-if-absent (never overrides process.env), missing-file
+ * no-op, and parity with deploy.sh's `load_env` bash function for the
+ * ordinary .env shapes it already tolerates (comments, blank lines,
+ * quoted values, values containing '=', and the two shapes deploy.sh
+ * itself silently drops: `export `-prefixed lines and space-before-`=`
+ * lines).
+ */
+import * as fs from "fs";
+import * as os from "os";
+import * as path from "path";
+import { loadDotenvIfPresent } from "../load-dotenv";
+
+describe("loadDotenvIfPresent", () => {
+  let tmpDir: string;
+  const ownedKeys: string[] = [];
+
+  beforeEach(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "load-dotenv-test-"));
+  });
+
+  afterEach(() => {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+    for (const key of ownedKeys) {
+      delete process.env[key];
+    }
+    ownedKeys.length = 0;
+  });
+
+  function writeEnv(contents: string): string {
+    const file = path.join(tmpDir, ".env");
+    fs.writeFileSync(file, contents);
+    return file;
+  }
+
+  function track(...keys: string[]): void {
+    ownedKeys.push(...keys);
+  }
+
+  it("sets a key that is absent from process.env", () => {
+    track("LOADER_TEST_ABSENT_KEY");
+    const file = writeEnv("LOADER_TEST_ABSENT_KEY=hello\n");
+    loadDotenvIfPresent(file);
+    expect(process.env.LOADER_TEST_ABSENT_KEY).toBe("hello");
+  });
+
+  it("does NOT override a key already present in process.env", () => {
+    track("LOADER_TEST_EXISTING_KEY");
+    process.env.LOADER_TEST_EXISTING_KEY = "from-shell";
+    const file = writeEnv("LOADER_TEST_EXISTING_KEY=from-file\n");
+    loadDotenvIfPresent(file);
+    expect(process.env.LOADER_TEST_EXISTING_KEY).toBe("from-shell");
+  });
+
+  it("is a silent no-op when the file is missing (never throws)", () => {
+    const missing = path.join(tmpDir, "does-not-exist.env");
+    expect(() => loadDotenvIfPresent(missing)).not.toThrow();
+  });
+
+  it("skips comment and blank lines", () => {
+    track("LOADER_TEST_AFTER_COMMENT");
+    const file = writeEnv(
+      [
+        "# a full-line comment",
+        "",
+        "   ",
+        "LOADER_TEST_AFTER_COMMENT=value",
+      ].join("\n"),
+    );
+    loadDotenvIfPresent(file);
+    expect(process.env.LOADER_TEST_AFTER_COMMENT).toBe("value");
+  });
+
+  it("strips inline comments the same way deploy.sh's ${line%%#*} does", () => {
+    track("LOADER_TEST_INLINE_COMMENT");
+    const file = writeEnv("LOADER_TEST_INLINE_COMMENT=abc # trailing note\n");
+    loadDotenvIfPresent(file);
+    expect(process.env.LOADER_TEST_INLINE_COMMENT).toBe("abc");
+  });
+
+  it("strips one layer of surrounding double quotes, matching xargs", () => {
+    track("LOADER_TEST_DQUOTE");
+    const file = writeEnv('LOADER_TEST_DQUOTE="quoted value"\n');
+    loadDotenvIfPresent(file);
+    expect(process.env.LOADER_TEST_DQUOTE).toBe("quoted value");
+  });
+
+  it("strips one layer of surrounding single quotes, matching xargs", () => {
+    track("LOADER_TEST_SQUOTE");
+    const file = writeEnv("LOADER_TEST_SQUOTE='single quoted'\n");
+    loadDotenvIfPresent(file);
+    expect(process.env.LOADER_TEST_SQUOTE).toBe("single quoted");
+  });
+
+  it("preserves embedded '=' characters in the value", () => {
+    track("LOADER_TEST_EMBEDDED_EQ");
+    const file = writeEnv("LOADER_TEST_EMBEDDED_EQ=key=val=extra\n");
+    loadDotenvIfPresent(file);
+    expect(process.env.LOADER_TEST_EMBEDDED_EQ).toBe("key=val=extra");
+  });
+
+  it("drops an `export `-prefixed line, exactly as deploy.sh's regex does", () => {
+    track("LOADER_TEST_EXPORT_PREFIXED");
+    const file = writeEnv("export LOADER_TEST_EXPORT_PREFIXED=value\n");
+    loadDotenvIfPresent(file);
+    // deploy.sh's `^([A-Za-z_][A-Za-z0-9_]*)=(.*)$` never matches a line
+    // starting with `export `, so the whole line is silently skipped —
+    // the loader must reproduce that exact (non-)behavior for parity.
+    expect(process.env.LOADER_TEST_EXPORT_PREFIXED).toBeUndefined();
+  });
+
+  it("drops a line with a space before '=', exactly as deploy.sh's regex does", () => {
+    track("LOADER_TEST_SPACED_EQ");
+    const file = writeEnv("LOADER_TEST_SPACED_EQ = value\n");
+    loadDotenvIfPresent(file);
+    expect(process.env.LOADER_TEST_SPACED_EQ).toBeUndefined();
+  });
+
+  it("loads multiple keys from a realistic backend/.env-shaped file", () => {
+    track("LOADER_TEST_ENVIRONMENT", "LOADER_TEST_CDK_DOCKER");
+    const file = writeEnv(
+      [
+        "# Environment for deployment",
+        "LOADER_TEST_ENVIRONMENT=dev",
+        "",
+        "# Container build tool (finch or docker)",
+        "LOADER_TEST_CDK_DOCKER=docker",
+      ].join("\n"),
+    );
+    loadDotenvIfPresent(file);
+    expect(process.env.LOADER_TEST_ENVIRONMENT).toBe("dev");
+    expect(process.env.LOADER_TEST_CDK_DOCKER).toBe("docker");
+  });
+});

--- a/backend/lib/load-dotenv.ts
+++ b/backend/lib/load-dotenv.ts
@@ -1,0 +1,90 @@
+import * as fs from "fs";
+
+/**
+ * Loads KEY=VALUE pairs from a dotenv-style file into process.env,
+ * WITHOUT overriding any variable already present in process.env.
+ *
+ * This intentionally mirrors deploy.sh's `load_env` bash function
+ * line-for-line so the two loaders can never disagree:
+ *   - Blank lines and lines whose first non-space char is `#` are skipped.
+ *   - An inline `#` truncates the rest of the line (bash `${line%%#*}`).
+ *   - The remaining line is trimmed of leading/trailing whitespace via a
+ *     `xargs`-equivalent pass, which ALSO strips one layer of surrounding
+ *     single or double quotes from the trimmed value (`xargs` re-tokenizes
+ *     with shell word-splitting/quote-removal semantics).
+ *   - Only lines matching `^[A-Za-z_][A-Za-z0-9_]*=.*$` are treated as
+ *     KEY=VALUE pairs. This means, matching deploy.sh's real behavior:
+ *       * an `export ` prefix is NOT special-cased and causes the whole
+ *         line to be skipped (it doesn't start with a bare identifier);
+ *       * a space before `=` (e.g. `KEY = value`) also fails to match
+ *         and is skipped.
+ *   - Existing process.env keys are never overwritten (load-if-absent).
+ *
+ * A missing file is a silent no-op — never throws, never logs. This is
+ * required so CI (which has no backend/.env) is unaffected.
+ */
+export function loadDotenvIfPresent(envFile: string): void {
+  let raw: string;
+  try {
+    raw = fs.readFileSync(envFile, "utf8");
+  } catch {
+    // Missing (or unreadable) file: silent no-op, matching deploy.sh's
+    // `[ ! -f "$env_file" ]` early return.
+    return;
+  }
+
+  const lines = raw.split(/\r?\n/);
+  for (const rawLine of lines) {
+    // Skip blank lines and comment lines (first non-space char `#`).
+    if (/^\s*$/.test(rawLine) || /^\s*#/.test(rawLine)) {
+      continue;
+    }
+
+    // Strip inline comments: bash `${line%%#*}` removes from the first `#`
+    // to the end of the line.
+    const hashIndex = rawLine.indexOf("#");
+    const withoutComment =
+      hashIndex === -1 ? rawLine : rawLine.slice(0, hashIndex);
+
+    // `xargs`-equivalent trim: collapse leading/trailing whitespace, and
+    // strip one layer of surrounding quotes from the trimmed result.
+    const trimmed = xargsTrim(withoutComment);
+
+    const match = /^([A-Za-z_][A-Za-z0-9_]*)=(.*)$/.exec(trimmed);
+    if (!match) {
+      continue;
+    }
+    const [, key, rawVal] = match;
+    const val = stripSurroundingQuotes(rawVal);
+
+    // Load-if-absent: never override a variable already set (explicit env,
+    // deploy.sh export, or `CDK_DOCKER=docker npx cdk ...`).
+    if (process.env[key] === undefined) {
+      process.env[key] = val;
+    }
+  }
+}
+
+// Mirrors `echo "$line" | xargs` for the plain-word case: trims outer
+// whitespace. `xargs` also collapses internal runs of whitespace between
+// words, but that only matters for lines with no `=` sign at all (which
+// are dropped by the KEY=VALUE match below regardless), so a simple
+// leading/trailing trim reproduces the observable behavior here.
+function xargsTrim(s: string): string {
+  return s.trim();
+}
+
+// `xargs` removes one layer of surrounding quotes as part of its own
+// word-splitting/quote-removal when the value is passed through the
+// no-arg `echo ... | xargs` idiom. Reproduce that specifically for a
+// value that is ENTIRELY wrapped in a single matching quote pair.
+function stripSurroundingQuotes(s: string): string {
+  if (
+    s.length >= 2 &&
+    ((s[0] === '"' && s[s.length - 1] === '"') ||
+      (s[0] === "'" && s[s.length - 1] === "'"))
+  ) {
+    return s.slice(1, -1);
+  }
+  return s;
+}


### PR DESCRIPTION
## Summary
`CDK_DOCKER=docker` lives in `backend/.env`, which `deploy.sh` loads - but a bare `npx cdk diff/synth` does not, so CDK fell back to a stopped container runtime and failed while bundling. Worse, running cdk without that file loaded makes the app fall back to default values: a cdk diff in that state proposes blanking `ADMIN_EMAIL`, rewriting the admin secret template, and *replacing* the admin-seeding custom resource. The deletion gate would not catch that, because it is a modify-with-replacement rather than a deletion.

## What changed

The app entry point loads `backend/.env` before any stack is constructed, so
- **Load-if-absent only** - anything already in the environment wins, explicit `CDK_DOCKER-docker` or a variable exported by `deploy.sh` so an is never overridden.
- **A missing file is a silent no-op** - CI has no `.env` and must not break. Verified by renaming the file away and re-running synth.
- **Parsing matches "deploy.sh'** - comments, blanks, `export` prefixes, quoted values and embedded `=` all agree, so the two loaders cannot diverge. One deliberate difference is noted: `deploy.sh` overwrites set-but-empty variables while this does not, which is required by the no-override rule.
- No dependency added; nothing logged on the happy path.

## Testing

`tsc` clean; jest 6,513 passing; synth clean both with and without the file present, the latter re-derived during review. Load order asserted in both source and compiled output.