### PR TITLE
feat(alarms): configurable alarm delivery and action coverage

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -41,3 +41,32 @@ AGENT_MODEL=us.anthropic.claude-sonnet-4-6
 # Application Host URL (for email templates and frontend)
 # This URL will be used in email templates for logo and login links
 HOST_URL=https://your-domain.com
+
+# ---------------------------------------------------------------------------
+# Alarm delivery — where CloudWatch alarms reach a human asynchronously.
+# ---------------------------------------------------------------------------
+# Selects the external destination subscribed to the platform SNS alarm
+# topics (citadel-alarms-<env> and the CMK-encrypted
+# citadel-governance-escalations-<env>). Read by both deploy.sh and the CDK
+# app (bin/app.ts loads backend/.env before stack construction).
+#
+# ALARM_DELIVERY   one of: email | slack | none
+#   email  -> requires ALARM_EMAIL (an SNS email subscription is created; the
+#             address owner must click the confirmation link once).
+#   slack  -> requires ALARM_SLACK_WORKSPACE_ID and ALARM_SLACK_CHANNEL_ID
+#             (an AWS Chatbot Slack channel configuration is created).
+#             ONE-TIME CONSOLE PREREQUISITE: authorise the Slack workspace for
+#             AWS Chatbot in the AWS console first (Chatbot -> Configure new
+#             client -> Slack -> OAuth). CDK CANNOT perform that OAuth step;
+#             the resulting workspace id is what ALARM_SLACK_WORKSPACE_ID holds.
+#   none   -> explicit opt-out: topics exist and alarms are actioned, but no
+#             external subscriber is created.
+#
+# UNCONFIGURED CASE: leaving ALARM_DELIVERY unset is treated as 'none' for
+# dev/test (so this dev clone and CI synth cleanly), but is a HARD synth
+# failure for staging/prod — set it explicitly (even to 'none') there.
+# ALARM_DELIVERY=none
+# ALARM_EMAIL=oncall@your-domain.com
+# ALARM_SLACK_WORKSPACE_ID=T0XXXXXXX
+# ALARM_SLACK_CHANNEL_ID=C0XXXXXXX
+

--- a/backend/bin/app.ts
+++ b/backend/bin/app.ts
@@ -31,6 +31,7 @@ import {
   resolveFrontendOrigin,
   shouldWarnOnPlaceholder,
 } from "../lib/frontend-origin";
+import { resolveAlarmDeliveryConfig } from "../lib/alarm-delivery";
 
 const app = new cdk.App();
 
@@ -51,10 +52,24 @@ const stackProps = {
   environment: environment,
 };
 
+// Alarm-delivery destination (email | slack | none) resolved ONCE here from
+// backend/.env (loaded above) / CDK context, then passed down to the two
+// alarm-topic-owning stacks — same "resolve in app, pass as prop" shape as
+// frontendOrigin below. Resolution THROWS for staging/prod when the
+// destination is unset/placeholder (a muted alarm must not ship silently);
+// for dev/test/CI an unset destination degrades to 'none' so this dev clone
+// and CI (which have no/placeholder .env) still synth cleanly. The explicit
+// ALARM_DELIVERY=none opt-out is honoured everywhere.
+const alarmDelivery = resolveAlarmDeliveryConfig({
+  environment,
+  context: (key) => app.node.tryGetContext(key),
+});
+
 // Backend infrastructure stack (deployed first)
 const backendStack = new BackendStack(app, `citadel-backend-${environment}`, {
   ...stackProps,
   description: `Backend infrastructure for Citadel - ${environment}`,
+  alarmDelivery,
 });
 
 // Projects satellite stack — backend-stack-split phase 1 (decision 30e6d067).
@@ -80,6 +95,10 @@ const projectsStack = new ProjectsStack(
     executionSpecificationsTable: backendStack.executionSpecificationsTable,
     agentDesignAssessmentsTable: backendStack.agentDesignAssessmentsTable,
     userPool: backendStack.userPool,
+    // Actionless-alarm wiring: the two ProjectResolver operational alarms
+    // (moved here with the resolver) page to BackendStack's shared alarm
+    // topic.
+    alarmTopic: backendStack.alarmTopic,
   },
 );
 projectsStack.addStackDependency(backendStack);
@@ -247,6 +266,13 @@ const arbiterStack = new ArbiterStack(app, `citadel-arbiter-${environment}`, {
   releaseDefaultOrgId:
     process.env.RELEASE_DEFAULT_ORG_ID ??
     (app.node.tryGetContext("releaseDefaultOrgId") as string | undefined),
+  // Actionless-alarm wiring: the six operational Lambda/DLQ alarms page to
+  // BackendStack's shared alarm topic (the escalation topic keeps only the
+  // governance OffFrontierEscalation alarm).
+  alarmTopic: backendStack.alarmTopic,
+  // Configurable external destination for the CMK-encrypted escalation topic
+  // (resolved once above; see BackendStack for the same prop).
+  alarmDelivery,
 });
 
 // Telemetry stack — invocation cost ledger + cost query API/budgets

--- a/backend/lib/alarm-delivery.ts
+++ b/backend/lib/alarm-delivery.ts
@@ -72,28 +72,63 @@ export function isProdLikeEnvironment(environment: string): boolean {
 }
 
 /**
+ * RFC 2606-reserved documentation domains. Any of these, or a subdomain of
+ * one, is a placeholder — never a real delivery destination.
+ */
+const RESERVED_EXAMPLE_DOMAINS = ["example.com", "example.net", "example.org"];
+
+/**
+ * True when `domain` (already lowercased) IS one of the reserved
+ * documentation domains, or is a subdomain of one (e.g. `mail.example.com`).
+ * Boundary-anchored: uses equality or a `.`-prefixed suffix match, so
+ * `notexample.community` and `example.com.attacker.io` — which merely
+ * CONTAIN the reserved token as a substring — are correctly NOT matched.
+ */
+function isReservedExampleDomain(domain: string): boolean {
+  return RESERVED_EXAMPLE_DOMAINS.some(
+    (reserved) => domain === reserved || domain.endsWith(`.${reserved}`),
+  );
+}
+
+/**
  * Heuristic placeholder detector. A value is a placeholder (treated as
- * "unset") when it is empty/whitespace or contains a well-known scaffold
- * token. Keeps `backend/.env.example`'s commented sample values and the
- * common `example.com` / `your-...` shapes from being mistaken for a real
+ * "unset") when it is empty/whitespace, contains a well-known scaffold
+ * token, or — for email-shaped values — has a domain equal to (or a
+ * subdomain of) an RFC 2606-reserved documentation domain
+ * (example.com/.net/.org). Keeps `backend/.env.example`'s commented sample
+ * values and the common `your-...` shapes from being mistaken for a real
  * destination.
+ *
+ * The domain check is boundary-anchored (equality or `.`-suffix) rather than
+ * a raw substring match, so it only matches the reserved domain itself or a
+ * genuine subdomain — not a domain that merely contains "example.com" as a
+ * substring (e.g. `example.com.attacker.io`, `notexample.community`), which
+ * CodeQL rule js/incomplete-url-substring-sanitization flags substring
+ * matching for.
  */
 export function isPlaceholderValue(value: string | undefined): boolean {
   if (value === undefined) return true;
   const v = value.trim();
   if (v === "") return true;
   const lower = v.toLowerCase();
-  return (
+  if (
     lower.includes("your-") ||
     lower.includes("your_") ||
     lower.includes("changeme") ||
-    lower.includes("example.com") ||
     lower.includes("workspace-id") ||
     lower.includes("channel-id") ||
     lower === "xxxx" ||
     lower === "todo" ||
     lower === "placeholder"
-  );
+  ) {
+    return true;
+  }
+  const atIndex = lower.lastIndexOf("@");
+  if (atIndex !== -1) {
+    const domain = lower.slice(atIndex + 1);
+    if (isReservedExampleDomain(domain)) return true;
+  }
+  return false;
 }
 
 export interface ResolveAlarmDeliveryOptions {

--- a/backend/lib/alarm-delivery.ts
+++ b/backend/lib/alarm-delivery.ts
@@ -1,0 +1,325 @@
+import { Construct } from "constructs";
+import * as sns from "aws-cdk-lib/aws-sns";
+import * as subscriptions from "aws-cdk-lib/aws-sns-subscriptions";
+import * as kms from "aws-cdk-lib/aws-kms";
+import * as iam from "aws-cdk-lib/aws-iam";
+import * as chatbot from "aws-cdk-lib/aws-chatbot";
+import { NagSuppressions } from "cdk-nag";
+
+/**
+ * Configurable alarm-delivery destination for Citadel's SNS alarm topics.
+ *
+ * Both platform alarm topics (`citadel-alarms-<env>` in BackendStack and the
+ * CMK-encrypted `citadel-governance-escalations-<env>` in ArbiterStack) had
+ * ZERO subscriptions repo-wide, so no CloudWatch alarm ever reached a human
+ * asynchronously. This module resolves an operator-selected destination from
+ * env/CDK-context and subscribes the given topic(s) to it:
+ *
+ *   - `email`  — an SNS EMAIL subscription on each topic. Delivery from a
+ *                CMK-encrypted topic ALSO requires the `sns.amazonaws.com`
+ *                service principal to hold `kms:Decrypt` + `kms:GenerateDataKey*`
+ *                on the topic's CMK, or SNS drops the notification SILENTLY.
+ *                This module adds that grant for every encrypted topic.
+ *   - `slack`  — an AWS Chatbot Slack channel configuration (the STABLE
+ *                `aws-cdk-lib/aws-chatbot` `SlackChannelConfiguration` L2 —
+ *                promoted out of alpha; no `@aws-cdk/aws-chatbot-alpha`
+ *                package is required or installed) subscribed to the topic(s).
+ *                One-time console prerequisite: the Slack workspace must be
+ *                authorised for AWS Chatbot via the AWS console OAuth flow
+ *                first (this cannot be done by CDK); the resulting workspace
+ *                id is what `ALARM_SLACK_WORKSPACE_ID` carries.
+ *   - `none`   — no subscription (alarms stay wired to their topic, but no
+ *                external destination). The explicit opt-out.
+ *
+ * ## Unconfigured-case policy (decision)
+ *
+ * An unset/placeholder destination is NOT a hard synth failure in
+ * dev/test/local, because this OSS dev clone's `backend/.env` holds
+ * placeholders and CI has no `.env` at all — both must still `cdk synth`
+ * cleanly. It IS a hard synth failure (throw) for `staging`/`prod`, where a
+ * muted alarm is an on-call hazard and a mere CDK warning would be ignored.
+ * The explicit `ALARM_DELIVERY=none` opt-out is always honoured everywhere.
+ *
+ * This mirrors the repo's existing env-scoped `shouldWarnOnPlaceholder`
+ * pattern in `frontend-origin.ts`, but ESCALATES warn->throw for prod-like
+ * envs: an unrouted alarm fails silently at the worst time, unlike the
+ * cosmetic CORS gap, so the gap must be impossible to miss where it matters
+ * while keeping dev + CI green.
+ */
+
+export type AlarmDeliveryMode = "email" | "slack" | "none";
+
+export type AlarmDeliveryConfig =
+  | { readonly mode: "email"; readonly email: string }
+  | {
+      readonly mode: "slack";
+      readonly workspaceId: string;
+      readonly channelId: string;
+    }
+  | { readonly mode: "none" };
+
+/** Environment variable names — the single source of truth for the config. */
+export const ALARM_DELIVERY_ENV = {
+  MODE: "ALARM_DELIVERY",
+  EMAIL: "ALARM_EMAIL",
+  SLACK_WORKSPACE_ID: "ALARM_SLACK_WORKSPACE_ID",
+  SLACK_CHANNEL_ID: "ALARM_SLACK_CHANNEL_ID",
+} as const;
+
+/** Environments where an unconfigured/placeholder destination is fatal. */
+export function isProdLikeEnvironment(environment: string): boolean {
+  return environment === "staging" || environment === "prod";
+}
+
+/**
+ * Heuristic placeholder detector. A value is a placeholder (treated as
+ * "unset") when it is empty/whitespace or contains a well-known scaffold
+ * token. Keeps `backend/.env.example`'s commented sample values and the
+ * common `example.com` / `your-...` shapes from being mistaken for a real
+ * destination.
+ */
+export function isPlaceholderValue(value: string | undefined): boolean {
+  if (value === undefined) return true;
+  const v = value.trim();
+  if (v === "") return true;
+  const lower = v.toLowerCase();
+  return (
+    lower.includes("your-") ||
+    lower.includes("your_") ||
+    lower.includes("changeme") ||
+    lower.includes("example.com") ||
+    lower.includes("workspace-id") ||
+    lower.includes("channel-id") ||
+    lower === "xxxx" ||
+    lower === "todo" ||
+    lower === "placeholder"
+  );
+}
+
+export interface ResolveAlarmDeliveryOptions {
+  readonly environment: string;
+  /** Defaults to `process.env`. Injected for unit testing. */
+  readonly env?: Record<string, string | undefined>;
+  /** Optional CDK-context reader (e.g. `app.node.tryGetContext`). */
+  readonly context?: (key: string) => unknown;
+}
+
+function read(
+  opts: ResolveAlarmDeliveryOptions,
+  envKey: string,
+  contextKey: string,
+): string | undefined {
+  const env = opts.env ?? process.env;
+  const fromEnv = env[envKey];
+  if (fromEnv !== undefined && fromEnv.trim() !== "") return fromEnv.trim();
+  const fromCtx = opts.context?.(contextKey);
+  return typeof fromCtx === "string" && fromCtx.trim() !== ""
+    ? fromCtx.trim()
+    : undefined;
+}
+
+/** Remediation text surfaced in the thrown error for prod-like envs. */
+export function alarmDeliveryRemediation(environment: string): string {
+  return (
+    `Alarm delivery is not configured for '${environment}'. Set ` +
+    `${ALARM_DELIVERY_ENV.MODE} in backend/.env (or -c alarmDelivery=...) to ` +
+    `one of: 'email' (+ ${ALARM_DELIVERY_ENV.EMAIL}), 'slack' (+ ` +
+    `${ALARM_DELIVERY_ENV.SLACK_WORKSPACE_ID} and ` +
+    `${ALARM_DELIVERY_ENV.SLACK_CHANNEL_ID}), or 'none' to explicitly opt ` +
+    `out. Refusing to synth a ${environment} deployment whose CloudWatch ` +
+    `alarms have a topic but no destination (a muted alarm fails silently).`
+  );
+}
+
+/**
+ * Resolve the alarm-delivery config from env/context.
+ *
+ * Throws for prod-like environments when the destination is unset/placeholder
+ * or incomplete, or for ANY environment when the value is a recognised-but-
+ * invalid mode (a typo, which should never pass silently). Returns
+ * `{ mode: 'none' }` for a dev/test/local unset/placeholder destination so
+ * the OSS dev clone and CI both synth cleanly.
+ */
+export function resolveAlarmDeliveryConfig(
+  opts: ResolveAlarmDeliveryOptions,
+): AlarmDeliveryConfig {
+  const environment = opts.environment;
+  const rawMode = read(opts, ALARM_DELIVERY_ENV.MODE, "alarmDelivery");
+
+  const unconfigured = (): AlarmDeliveryConfig => {
+    if (isProdLikeEnvironment(environment)) {
+      throw new Error(alarmDeliveryRemediation(environment));
+    }
+    return { mode: "none" };
+  };
+
+  if (rawMode === undefined || isPlaceholderValue(rawMode)) {
+    return unconfigured();
+  }
+
+  const mode = rawMode.toLowerCase();
+
+  if (mode === "none") {
+    return { mode: "none" };
+  }
+
+  if (mode === "email") {
+    const email = read(opts, ALARM_DELIVERY_ENV.EMAIL, "alarmEmail");
+    if (email === undefined || isPlaceholderValue(email)) {
+      return unconfigured();
+    }
+    return { mode: "email", email };
+  }
+
+  if (mode === "slack") {
+    const workspaceId = read(
+      opts,
+      ALARM_DELIVERY_ENV.SLACK_WORKSPACE_ID,
+      "alarmSlackWorkspaceId",
+    );
+    const channelId = read(
+      opts,
+      ALARM_DELIVERY_ENV.SLACK_CHANNEL_ID,
+      "alarmSlackChannelId",
+    );
+    if (
+      workspaceId === undefined ||
+      isPlaceholderValue(workspaceId) ||
+      channelId === undefined ||
+      isPlaceholderValue(channelId)
+    ) {
+      return unconfigured();
+    }
+    return { mode: "slack", workspaceId, channelId };
+  }
+
+  // Recognised-but-invalid value: a typo is always fatal, in every env, so it
+  // never silently degrades to no-delivery.
+  throw new Error(
+    `Invalid ${ALARM_DELIVERY_ENV.MODE}='${rawMode}'. Expected one of: ` +
+      `email, slack, none.`,
+  );
+}
+
+/** A topic to wire a destination onto, plus its CMK if it is encrypted. */
+export interface AlarmTopicRef {
+  readonly topic: sns.ITopic;
+  /**
+   * A short, unique, DNS/name-safe hint used to name the per-topic Slack
+   * channel configuration (e.g. `backend`, `escalation`). Chatbot
+   * configuration names must be unique per account.
+   */
+  readonly nameHint: string;
+  /**
+   * The topic's customer-managed KMS key, present IFF the topic is
+   * CMK-encrypted. When present, the `sns.amazonaws.com` service principal is
+   * granted decrypt on it so email delivery does not fail silently.
+   */
+  readonly encryptionKey?: kms.IKey;
+}
+
+/**
+ * Grant the SNS service principal decrypt on a topic CMK so SNS-native
+ * delivery (email) can read the encrypted message. Missing this grant makes
+ * delivery from a CMK-encrypted topic fail SILENTLY — hence the dedicated
+ * assertion in the alarm-delivery tests.
+ */
+export function grantSnsDeliveryDecrypt(key: kms.IKey): void {
+  key.addToResourcePolicy(
+    new iam.PolicyStatement({
+      sid: "AllowSnsDeliveryDecrypt",
+      effect: iam.Effect.ALLOW,
+      principals: [new iam.ServicePrincipal("sns.amazonaws.com")],
+      actions: ["kms:Decrypt", "kms:GenerateDataKey*"],
+      resources: ["*"],
+    }),
+    /* allowNoOp */ true,
+  );
+}
+
+export interface AttachAlarmDeliveryOptions {
+  readonly config: AlarmDeliveryConfig;
+  readonly environment: string;
+  readonly topics: AlarmTopicRef[];
+}
+
+/**
+ * Subscribe the given topic(s) to the resolved destination. No-op for
+ * `mode: 'none'` (alarms remain actioned to their topic; there is simply no
+ * external subscriber).
+ */
+export function attachAlarmDelivery(
+  scope: Construct,
+  opts: AttachAlarmDeliveryOptions,
+): void {
+  const { config, environment, topics } = opts;
+
+  if (config.mode === "none") {
+    return;
+  }
+
+  if (config.mode === "email") {
+    for (const t of topics) {
+      t.topic.addSubscription(
+        new subscriptions.EmailSubscription(config.email),
+      );
+      if (t.encryptionKey) {
+        grantSnsDeliveryDecrypt(t.encryptionKey);
+      }
+    }
+    return;
+  }
+
+  // config.mode === "slack"
+  for (const t of topics) {
+    const cfg = new chatbot.SlackChannelConfiguration(
+      scope,
+      `AlarmSlack${pascalCase(t.nameHint)}`,
+      {
+        slackChannelConfigurationName: `citadel-alarms-${t.nameHint}-${environment}`,
+        slackWorkspaceId: config.workspaceId,
+        slackChannelId: config.channelId,
+        notificationTopics: [t.topic],
+        loggingLevel: chatbot.LoggingLevel.ERROR,
+      },
+    );
+    // Chatbot delivery from a CMK-encrypted topic needs the configuration's
+    // own role to decrypt. (The sns.amazonaws.com grant covers SNS-native
+    // email delivery; this covers the Chatbot path.)
+    if (t.encryptionKey) {
+      t.encryptionKey.grantDecrypt(cfg.grantPrincipal);
+    }
+    // The Chatbot L2 auto-creates a scoped role/policy (CloudWatch read +
+    // notifications-only). cdk-nag flags the managed-policy/DefaultPolicy
+    // wildcards the construct owns; suppress narrowly on the construct we
+    // just created rather than widening any stack-level suppression.
+    NagSuppressions.addResourceSuppressions(
+      cfg,
+      [
+        {
+          id: "AwsSolutions-IAM4",
+          reason:
+            "AWS Chatbot SlackChannelConfiguration L2 attaches the " +
+            "AWS-managed read-only CloudWatch policy for notification " +
+            "rendering; construct-owned, not application-controlled.",
+        },
+        {
+          id: "AwsSolutions-IAM5",
+          reason:
+            "AWS Chatbot SlackChannelConfiguration L2 role uses the " +
+            "AWS-documented notifications/CloudWatch read wildcards; " +
+            "construct-owned, cannot be narrowed without breaking Chatbot.",
+        },
+      ],
+      true,
+    );
+  }
+}
+
+function pascalCase(s: string): string {
+  return s
+    .split(/[^a-zA-Z0-9]+/)
+    .filter(Boolean)
+    .map((w) => w.charAt(0).toUpperCase() + w.slice(1))
+    .join("");
+}

--- a/backend/lib/arbiter-stack.ts
+++ b/backend/lib/arbiter-stack.ts
@@ -24,6 +24,10 @@ import { SqsEventSource } from "aws-cdk-lib/aws-lambda-event-sources";
 import { BlockPublicAccess, Bucket } from "aws-cdk-lib/aws-s3";
 import { Construct } from "constructs";
 import { NagSuppressions } from "cdk-nag";
+import {
+  attachAlarmDelivery,
+  type AlarmDeliveryConfig,
+} from "./alarm-delivery";
 import * as path from "path";
 import * as fs from "fs";
 
@@ -145,6 +149,22 @@ interface ArbiterStackProps extends cdk.StackProps {
   // RELEASE_DEFAULT_ORG_ID is omitted and every resolve_release lookup
   // falls to NO_POINTER (see release_resolution.py) — never a crash.
   releaseDefaultOrgId?: string;
+  /**
+   * Shared platform alarm topic (`citadel-alarms-<env>`, owned by
+   * BackendStack). The six operational Lambda/DLQ alarms below (Step Runner,
+   * timeout watchdog, worker DLQ depth, supervisor, fabricator, worker error
+   * rate) page to it. Optional so test paths that construct ArbiterStack in
+   * isolation still synth; when absent, those alarms fall back to the
+   * in-stack CMK-encrypted escalation topic so no alarm is ever left muted.
+   */
+  alarmTopic?: sns.ITopic;
+  /**
+   * Resolved alarm-delivery destination (email | slack | none) for the
+   * CMK-encrypted escalation topic, resolved ONCE in bin/app.ts and passed
+   * down (same pattern as BackendStack). Optional so tests synth without it;
+   * absent is treated as 'none'.
+   */
+  alarmDelivery?: AlarmDeliveryConfig;
 }
 
 export class ArbiterStack extends cdk.Stack {
@@ -1370,6 +1390,11 @@ export class ArbiterStack extends cdk.Stack {
     agentActivateRule.addTarget(new targets.LambdaFunction(activatorLambda));
 
     // --- Step Runner Lambda (Task 1.6) ---
+    // Collects every operational Lambda/DLQ alarm in this stack so they can
+    // all be actioned to a single destination topic once it is resolved
+    // below (Step Runner + watchdog alarms are declared inside the guard
+    // block; DLQ/supervisor/fabricator/worker alarms unconditionally).
+    const operationalAlarms: cloudwatch.Alarm[] = [];
     if (
       props.workflowsTable &&
       props.executionsTable &&
@@ -1696,18 +1721,23 @@ export class ArbiterStack extends cdk.Stack {
       // Supervisor/Fabricator pattern: Errors metric, 5-minute period,
       // NOT_BREACHING, threshold 3 (the Step Runner is invoked on every
       // workflow lifecycle event, so a burst of errors is the signal).
-      new cloudwatch.Alarm(this, "StepRunnerErrorAlarm", {
-        alarmName: `citadel-step-runner-errors-${props.environment}`,
-        metric: stepRunnerFunction.metricErrors({
-          period: cdk.Duration.minutes(5),
-        }),
-        threshold: 3,
-        evaluationPeriods: 1,
-        comparisonOperator:
-          cloudwatch.ComparisonOperator.GREATER_THAN_OR_EQUAL_TO_THRESHOLD,
-        treatMissingData: cloudwatch.TreatMissingData.NOT_BREACHING,
-        alarmDescription: "Step Runner Lambda error rate exceeded threshold",
-      });
+      const stepRunnerErrorAlarm = new cloudwatch.Alarm(
+        this,
+        "StepRunnerErrorAlarm",
+        {
+          alarmName: `citadel-step-runner-errors-${props.environment}`,
+          metric: stepRunnerFunction.metricErrors({
+            period: cdk.Duration.minutes(5),
+          }),
+          threshold: 3,
+          evaluationPeriods: 1,
+          comparisonOperator:
+            cloudwatch.ComparisonOperator.GREATER_THAN_OR_EQUAL_TO_THRESHOLD,
+          treatMissingData: cloudwatch.TreatMissingData.NOT_BREACHING,
+          alarmDescription: "Step Runner Lambda error rate exceeded threshold",
+        },
+      );
+      operationalAlarms.push(stepRunnerErrorAlarm);
 
       // Error-rate alarm for the workflow timeout watchdog. Threshold is 1
       // (not 3 like the request-driven Lambdas): the watchdog runs once per
@@ -1715,19 +1745,24 @@ export class ArbiterStack extends cdk.Stack {
       // period could never be reached and the alarm would be dead. A single
       // failed sweep means stuck executions aren't being reaped, which is
       // itself worth paging on. Same Errors metric / NOT_BREACHING pattern.
-      new cloudwatch.Alarm(this, "WorkflowTimeoutWatchdogErrorAlarm", {
-        alarmName: `citadel-workflow-timeout-watchdog-errors-${props.environment}`,
-        metric: workflowTimeoutWatchdogFunction.metricErrors({
-          period: cdk.Duration.minutes(5),
-        }),
-        threshold: 1,
-        evaluationPeriods: 1,
-        comparisonOperator:
-          cloudwatch.ComparisonOperator.GREATER_THAN_OR_EQUAL_TO_THRESHOLD,
-        treatMissingData: cloudwatch.TreatMissingData.NOT_BREACHING,
-        alarmDescription:
-          "Workflow timeout watchdog Lambda error rate exceeded threshold",
-      });
+      const workflowTimeoutWatchdogErrorAlarm = new cloudwatch.Alarm(
+        this,
+        "WorkflowTimeoutWatchdogErrorAlarm",
+        {
+          alarmName: `citadel-workflow-timeout-watchdog-errors-${props.environment}`,
+          metric: workflowTimeoutWatchdogFunction.metricErrors({
+            period: cdk.Duration.minutes(5),
+          }),
+          threshold: 1,
+          evaluationPeriods: 1,
+          comparisonOperator:
+            cloudwatch.ComparisonOperator.GREATER_THAN_OR_EQUAL_TO_THRESHOLD,
+          treatMissingData: cloudwatch.TreatMissingData.NOT_BREACHING,
+          alarmDescription:
+            "Workflow timeout watchdog Lambda error rate exceeded threshold",
+        },
+      );
+      operationalAlarms.push(workflowTimeoutWatchdogErrorAlarm);
     }
 
     // O-03: Enable X-Ray active tracing on all Lambda functions
@@ -1745,45 +1780,51 @@ export class ArbiterStack extends cdk.Stack {
     });
 
     // O-01: CloudWatch alarms for DLQ depth and critical Lambda errors
-    new cloudwatch.Alarm(this, "WorkerDLQDepthAlarm", {
-      alarmName: `citadel-worker-dlq-depth-${props.environment}`,
-      metric: workerAgentDLQ.metricApproximateNumberOfMessagesVisible({
-        period: cdk.Duration.minutes(5),
+    operationalAlarms.push(
+      new cloudwatch.Alarm(this, "WorkerDLQDepthAlarm", {
+        alarmName: `citadel-worker-dlq-depth-${props.environment}`,
+        metric: workerAgentDLQ.metricApproximateNumberOfMessagesVisible({
+          period: cdk.Duration.minutes(5),
+        }),
+        threshold: 1,
+        evaluationPeriods: 1,
+        comparisonOperator:
+          cloudwatch.ComparisonOperator.GREATER_THAN_OR_EQUAL_TO_THRESHOLD,
+        treatMissingData: cloudwatch.TreatMissingData.NOT_BREACHING,
+        alarmDescription:
+          "Worker agent DLQ has messages — indicates failed processing",
       }),
-      threshold: 1,
-      evaluationPeriods: 1,
-      comparisonOperator:
-        cloudwatch.ComparisonOperator.GREATER_THAN_OR_EQUAL_TO_THRESHOLD,
-      treatMissingData: cloudwatch.TreatMissingData.NOT_BREACHING,
-      alarmDescription:
-        "Worker agent DLQ has messages — indicates failed processing",
-    });
+    );
 
-    new cloudwatch.Alarm(this, "SupervisorErrorAlarm", {
-      alarmName: `citadel-supervisor-errors-${props.environment}`,
-      metric: supervisorLambda.metricErrors({
-        period: cdk.Duration.minutes(5),
+    operationalAlarms.push(
+      new cloudwatch.Alarm(this, "SupervisorErrorAlarm", {
+        alarmName: `citadel-supervisor-errors-${props.environment}`,
+        metric: supervisorLambda.metricErrors({
+          period: cdk.Duration.minutes(5),
+        }),
+        threshold: 3,
+        evaluationPeriods: 1,
+        comparisonOperator:
+          cloudwatch.ComparisonOperator.GREATER_THAN_OR_EQUAL_TO_THRESHOLD,
+        treatMissingData: cloudwatch.TreatMissingData.NOT_BREACHING,
+        alarmDescription: "Supervisor Lambda error rate exceeded threshold",
       }),
-      threshold: 3,
-      evaluationPeriods: 1,
-      comparisonOperator:
-        cloudwatch.ComparisonOperator.GREATER_THAN_OR_EQUAL_TO_THRESHOLD,
-      treatMissingData: cloudwatch.TreatMissingData.NOT_BREACHING,
-      alarmDescription: "Supervisor Lambda error rate exceeded threshold",
-    });
+    );
 
-    new cloudwatch.Alarm(this, "FabricatorErrorAlarm", {
-      alarmName: `citadel-fabricator-errors-${props.environment}`,
-      metric: fabricatorLambda.metricErrors({
-        period: cdk.Duration.minutes(5),
+    operationalAlarms.push(
+      new cloudwatch.Alarm(this, "FabricatorErrorAlarm", {
+        alarmName: `citadel-fabricator-errors-${props.environment}`,
+        metric: fabricatorLambda.metricErrors({
+          period: cdk.Duration.minutes(5),
+        }),
+        threshold: 3,
+        evaluationPeriods: 1,
+        comparisonOperator:
+          cloudwatch.ComparisonOperator.GREATER_THAN_OR_EQUAL_TO_THRESHOLD,
+        treatMissingData: cloudwatch.TreatMissingData.NOT_BREACHING,
+        alarmDescription: "Fabricator Lambda error rate exceeded threshold",
       }),
-      threshold: 3,
-      evaluationPeriods: 1,
-      comparisonOperator:
-        cloudwatch.ComparisonOperator.GREATER_THAN_OR_EQUAL_TO_THRESHOLD,
-      treatMissingData: cloudwatch.TreatMissingData.NOT_BREACHING,
-      alarmDescription: "Fabricator Lambda error rate exceeded threshold",
-    });
+    );
 
     // Worker agent Lambda error-rate alarm (workflow dispatch path). Mirrors
     // the Supervisor/Fabricator pattern: Errors metric, 5-minute period,
@@ -1791,18 +1832,20 @@ export class ArbiterStack extends cdk.Stack {
     // separately by WorkerDLQDepthAlarm; this alarm surfaces in-invocation
     // failures (bad dispatch payload, agent crash) that are retried and may
     // never reach the DLQ.
-    new cloudwatch.Alarm(this, "WorkerErrorAlarm", {
-      alarmName: `citadel-worker-errors-${props.environment}`,
-      metric: workerAgentWrapperLambda.metricErrors({
-        period: cdk.Duration.minutes(5),
+    operationalAlarms.push(
+      new cloudwatch.Alarm(this, "WorkerErrorAlarm", {
+        alarmName: `citadel-worker-errors-${props.environment}`,
+        metric: workerAgentWrapperLambda.metricErrors({
+          period: cdk.Duration.minutes(5),
+        }),
+        threshold: 3,
+        evaluationPeriods: 1,
+        comparisonOperator:
+          cloudwatch.ComparisonOperator.GREATER_THAN_OR_EQUAL_TO_THRESHOLD,
+        treatMissingData: cloudwatch.TreatMissingData.NOT_BREACHING,
+        alarmDescription: "Worker agent Lambda error rate exceeded threshold",
       }),
-      threshold: 3,
-      evaluationPeriods: 1,
-      comparisonOperator:
-        cloudwatch.ComparisonOperator.GREATER_THAN_OR_EQUAL_TO_THRESHOLD,
-      treatMissingData: cloudwatch.TreatMissingData.NOT_BREACHING,
-      alarmDescription: "Worker agent Lambda error rate exceeded threshold",
-    });
+    );
 
     // ============================================================
     // Jagged-Frontier escalation alarm (follow-up #8)
@@ -1915,6 +1958,41 @@ export class ArbiterStack extends cdk.Stack {
       kmsPublishSuppression,
       true,
     );
+
+    // ============================================================
+    // Alarm delivery — action the operational alarms + subscribe topics
+    // ============================================================
+    // The six operational Lambda/DLQ alarms are infrastructure-health
+    // signals, not governance escalations, so they page to the shared
+    // platform alarm topic (`citadel-alarms-<env>`, BackendStack) when it is
+    // wired through props. In an isolated ArbiterStack (test paths that omit
+    // alarmTopic) they fall back to the in-stack escalation topic so no
+    // alarm is ever left actionless. The OffFrontierEscalation alarm stays
+    // on the escalation topic — its audience (governance/on-call for agents
+    // stepping off the AI-analytical frontier) is distinct from ops health.
+    const operationalAlarmTopic: sns.ITopic =
+      props.alarmTopic ?? escalationTopic;
+    for (const alarm of operationalAlarms) {
+      alarm.addAlarmAction(new cw_actions.SnsAction(operationalAlarmTopic));
+    }
+
+    // Subscribe the CMK-encrypted escalation topic to the configurable
+    // external destination (email | slack | none). Email delivery from a
+    // CMK-encrypted topic requires the sns.amazonaws.com decrypt grant that
+    // attachAlarmDelivery adds via the escalationTopicKey passed here — miss
+    // it and delivery fails silently. Unconfigured case is env-scoped (throw
+    // for staging/prod, no-op for dev/test/CI) — see alarm-delivery.ts.
+    attachAlarmDelivery(this, {
+      config: props.alarmDelivery ?? { mode: "none" },
+      environment: props.environment,
+      topics: [
+        {
+          topic: escalationTopic,
+          nameHint: "escalation",
+          encryptionKey: escalationTopicKey,
+        },
+      ],
+    });
 
     // ============================================================
     // Governance authority/ledger tables (Δ8)

--- a/backend/lib/backend-stack.ts
+++ b/backend/lib/backend-stack.ts
@@ -9,7 +9,12 @@ import * as iam from "aws-cdk-lib/aws-iam";
 import * as logs from "aws-cdk-lib/aws-logs";
 import * as ssm from "aws-cdk-lib/aws-ssm";
 import * as cloudwatch from "aws-cdk-lib/aws-cloudwatch";
+import * as cw_actions from "aws-cdk-lib/aws-cloudwatch-actions";
 import * as sns from "aws-cdk-lib/aws-sns";
+import {
+  attachAlarmDelivery,
+  type AlarmDeliveryConfig,
+} from "./alarm-delivery";
 import { BlockPublicAccess, Bucket } from "aws-cdk-lib/aws-s3";
 import { Asset } from "aws-cdk-lib/aws-s3-assets";
 import { CfnGraphQLSchema } from "aws-cdk-lib/aws-appsync";
@@ -19,6 +24,13 @@ import { NagSuppressions } from "cdk-nag";
 
 interface BackendStackProps extends cdk.StackProps {
   environment: string;
+  /**
+   * Resolved alarm-delivery destination (email | slack | none) for the
+   * shared alarm topic, resolved ONCE in bin/app.ts from backend/.env / CDK
+   * context and passed down (same pattern as the resolved frontendOrigin).
+   * Optional so tests synth without it; absent is treated as 'none'.
+   */
+  alarmDelivery?: AlarmDeliveryConfig;
 }
 
 export class BackendStack extends cdk.Stack {
@@ -1977,22 +1989,28 @@ export class BackendStack extends cdk.Stack {
 
     // Alarm on the fan-out publish-failure metric so GraphQL-level publish
     // errors (which return HTTP 200) surface, not just Lambda-level exceptions.
-    new cloudwatch.Alarm(this, "WorkflowProgressFanoutFailureAlarm", {
-      alarmName: `citadel-workflow-fanout-publish-failure-${props.environment}`,
-      metric: new cloudwatch.Metric({
-        namespace: "Citadel/Workflows",
-        metricName: "FanoutPublishFailure",
-        period: cdk.Duration.minutes(5),
-        statistic: "Sum",
-      }),
-      threshold: 1,
-      evaluationPeriods: 1,
-      comparisonOperator:
-        cloudwatch.ComparisonOperator.GREATER_THAN_OR_EQUAL_TO_THRESHOLD,
-      treatMissingData: cloudwatch.TreatMissingData.NOT_BREACHING,
-      alarmDescription:
-        "Workflow progress fan-out failed to publish to AppSync (transport or GraphQL error).",
-    });
+    // Actioned to the shared alarm topic below, once it is constructed (the
+    // topic is created later in this stack, near the other O-01 alarms).
+    const workflowProgressFanoutFailureAlarm = new cloudwatch.Alarm(
+      this,
+      "WorkflowProgressFanoutFailureAlarm",
+      {
+        alarmName: `citadel-workflow-fanout-publish-failure-${props.environment}`,
+        metric: new cloudwatch.Metric({
+          namespace: "Citadel/Workflows",
+          metricName: "FanoutPublishFailure",
+          period: cdk.Duration.minutes(5),
+          statistic: "Sum",
+        }),
+        threshold: 1,
+        evaluationPeriods: 1,
+        comparisonOperator:
+          cloudwatch.ComparisonOperator.GREATER_THAN_OR_EQUAL_TO_THRESHOLD,
+        treatMissingData: cloudwatch.TreatMissingData.NOT_BREACHING,
+        alarmDescription:
+          "Workflow progress fan-out failed to publish to AppSync (transport or GraphQL error).",
+      },
+    );
 
     // Lambda function for handling agent messages
     const agentMessageHandlerFunction = new lambda.Function(
@@ -3024,7 +3042,7 @@ export class BackendStack extends cdk.Stack {
           cloudwatch.ComparisonOperator.GREATER_THAN_OR_EQUAL_TO_THRESHOLD,
         treatMissingData: cloudwatch.TreatMissingData.NOT_BREACHING,
         alarmDescription: `${name} Lambda error rate exceeded threshold`,
-      });
+      }).addAlarmAction(new cw_actions.SnsAction(this.alarmTopic));
 
       new cloudwatch.Alarm(this, `${name}ThrottleAlarm`, {
         alarmName: `citadel-${name}-throttles-${props.environment}`,
@@ -3035,7 +3053,7 @@ export class BackendStack extends cdk.Stack {
           cloudwatch.ComparisonOperator.GREATER_THAN_OR_EQUAL_TO_THRESHOLD,
         treatMissingData: cloudwatch.TreatMissingData.NOT_BREACHING,
         alarmDescription: `${name} Lambda throttle rate exceeded threshold`,
-      });
+      }).addAlarmAction(new cw_actions.SnsAction(this.alarmTopic));
     }
 
     // DynamoDB throttle alarms for critical tables
@@ -3058,7 +3076,7 @@ export class BackendStack extends cdk.Stack {
           cloudwatch.ComparisonOperator.GREATER_THAN_OR_EQUAL_TO_THRESHOLD,
         treatMissingData: cloudwatch.TreatMissingData.NOT_BREACHING,
         alarmDescription: `${name} DynamoDB read throttles exceeded threshold`,
-      });
+      }).addAlarmAction(new cw_actions.SnsAction(this.alarmTopic));
     }
 
     // AppSync 4xx/5xx alarms
@@ -3077,6 +3095,25 @@ export class BackendStack extends cdk.Stack {
         cloudwatch.ComparisonOperator.GREATER_THAN_OR_EQUAL_TO_THRESHOLD,
       treatMissingData: cloudwatch.TreatMissingData.NOT_BREACHING,
       alarmDescription: "AppSync 4xx error rate exceeded threshold",
+    }).addAlarmAction(new cw_actions.SnsAction(this.alarmTopic));
+
+    // Wire the earlier-declared fan-out publish-failure alarm to the topic
+    // now that the topic exists (the alarm is constructed near the workflow
+    // fan-out Lambda, well before this O-01 block).
+    workflowProgressFanoutFailureAlarm.addAlarmAction(
+      new cw_actions.SnsAction(this.alarmTopic),
+    );
+
+    // Configurable external destination (email | slack | none) for the
+    // shared alarm topic. `citadel-alarms-<env>` is NOT CMK-encrypted (no
+    // masterKey on the Topic above), so no KMS grant is required here — only
+    // the CMK-encrypted escalation topic in ArbiterStack needs that. The
+    // unconfigured case is env-scoped: throws for staging/prod, no-op for
+    // dev/test/CI (see alarm-delivery.ts).
+    attachAlarmDelivery(this, {
+      config: props.alarmDelivery ?? { mode: "none" },
+      environment: props.environment,
+      topics: [{ topic: this.alarmTopic, nameHint: "backend" }],
     });
 
     // AppSync 5xx alarm intentionally removed from here — TelemetryStack's

--- a/backend/lib/projects-stack.ts
+++ b/backend/lib/projects-stack.ts
@@ -41,6 +41,8 @@ import * as appsync from "aws-cdk-lib/aws-appsync";
 // pattern, applied there to the governance domain).
 import { aws_appsync as appsyncCfn } from "aws-cdk-lib";
 import * as cloudwatch from "aws-cdk-lib/aws-cloudwatch";
+import * as cw_actions from "aws-cdk-lib/aws-cloudwatch-actions";
+import * as sns from "aws-cdk-lib/aws-sns";
 import * as cognito from "aws-cdk-lib/aws-cognito";
 import * as dynamodb from "aws-cdk-lib/aws-dynamodb";
 import * as events from "aws-cdk-lib/aws-events";
@@ -66,6 +68,13 @@ export interface ProjectsStackProps extends cdk.StackProps {
   executionSpecificationsTable: dynamodb.ITable;
   agentDesignAssessmentsTable: dynamodb.ITable;
   userPool: cognito.IUserPool;
+  /**
+   * Shared platform alarm topic (`citadel-alarms-<env>`, owned by
+   * BackendStack). The two ProjectResolver operational alarms below page to
+   * it — they moved out of BackendStack with the resolver but their SNS
+   * action did not follow until now.
+   */
+  alarmTopic: sns.ITopic;
 }
 
 export class ProjectsStack extends cdk.Stack {
@@ -885,7 +894,7 @@ export class ProjectsStack extends cdk.Stack {
         cloudwatch.ComparisonOperator.GREATER_THAN_OR_EQUAL_TO_THRESHOLD,
       treatMissingData: cloudwatch.TreatMissingData.NOT_BREACHING,
       alarmDescription: "ProjectResolver Lambda error rate exceeded threshold",
-    });
+    }).addAlarmAction(new cw_actions.SnsAction(props.alarmTopic));
 
     new cloudwatch.Alarm(this, "ProjectResolverThrottleAlarm", {
       alarmName: `citadel-ProjectResolver-throttles-${props.environment}`,
@@ -899,7 +908,7 @@ export class ProjectsStack extends cdk.Stack {
       treatMissingData: cloudwatch.TreatMissingData.NOT_BREACHING,
       alarmDescription:
         "ProjectResolver Lambda throttle rate exceeded threshold",
-    });
+    }).addAlarmAction(new cw_actions.SnsAction(props.alarmTopic));
 
     // cdk-nag suppressions for this stack's IAM4/IAM5 findings are applied
     // centrally in bin/app.ts via the shared `appLambdaSuppressions` stack

--- a/backend/test/alarm-delivery-stacks.test.ts
+++ b/backend/test/alarm-delivery-stacks.test.ts
@@ -1,0 +1,164 @@
+/**
+ * Real-stack alarm-delivery wiring: proves the `alarmDelivery` prop threaded
+ * from bin/app.ts reaches attachAlarmDelivery inside the topic-owning stacks.
+ *
+ * ArbiterStack is the KMS-critical path (its escalation topic is
+ * CMK-encrypted), so email mode here must both create an email subscription
+ * AND grant sns.amazonaws.com decrypt on the escalation CMK. BackendStack's
+ * alarm topic is plaintext, so it only needs the subscription.
+ */
+import * as cdk from "aws-cdk-lib";
+import { Template, Match } from "aws-cdk-lib/assertions";
+import * as dynamodb from "aws-cdk-lib/aws-dynamodb";
+import * as events from "aws-cdk-lib/aws-events";
+import * as lambda from "aws-cdk-lib/aws-lambda";
+import * as appsync from "aws-cdk-lib/aws-appsync";
+import * as sns from "aws-cdk-lib/aws-sns";
+import { Bucket } from "aws-cdk-lib/aws-s3";
+import * as path from "path";
+import {
+  scaffoldBackendAssetDirs,
+  scaffoldArbiterStubs,
+} from "./helpers/scaffold-stub-assets";
+import type { AlarmDeliveryConfig } from "../lib/alarm-delivery";
+
+scaffoldBackendAssetDirs(["dist/lambda", "src/schema"]);
+scaffoldArbiterStubs();
+
+import { ArbiterStack } from "../lib/arbiter-stack";
+import { BackendStack } from "../lib/backend-stack";
+
+function buildArbiter(alarmDelivery: AlarmDeliveryConfig): Template {
+  const app = new cdk.App({ context: { "aws:cdk:bundling-stacks": [] } });
+  const backend = new cdk.Stack(app, "MockBackend", {
+    env: { account: "123456789012", region: "us-east-1" },
+  });
+  const agentEventBus = new events.EventBus(backend, "Bus", {
+    eventBusName: "citadel-agents-test",
+  });
+  const agentConfigTable = new dynamodb.Table(backend, "AgentConfig", {
+    partitionKey: { name: "agentId", type: dynamodb.AttributeType.STRING },
+    billingMode: dynamodb.BillingMode.PAY_PER_REQUEST,
+  });
+  const codeBucket = new Bucket(backend, "CodeBucket");
+  const workflowsTable = new dynamodb.Table(backend, "Workflows", {
+    partitionKey: { name: "workflowId", type: dynamodb.AttributeType.STRING },
+    billingMode: dynamodb.BillingMode.PAY_PER_REQUEST,
+  });
+  const executionsTable = new dynamodb.Table(backend, "Executions", {
+    partitionKey: { name: "executionId", type: dynamodb.AttributeType.STRING },
+    billingMode: dynamodb.BillingMode.PAY_PER_REQUEST,
+  });
+  const executionSpecificationsTable = new dynamodb.Table(backend, "Specs", {
+    partitionKey: { name: "specId", type: dynamodb.AttributeType.STRING },
+    billingMode: dynamodb.BillingMode.PAY_PER_REQUEST,
+  });
+  const fanoutFunction = new lambda.Function(backend, "Fanout", {
+    runtime: lambda.Runtime.NODEJS_24_X,
+    handler: "workflow-progress-fanout.handler",
+    code: lambda.Code.fromAsset("dist/lambda"),
+  });
+  const appSyncApi = new appsync.GraphqlApi(backend, "Api", {
+    name: "mock-api",
+    definition: appsync.Definition.fromFile(
+      path.resolve(__dirname, "../src/schema/schema.graphql"),
+    ),
+  });
+  const alarmTopic = new sns.Topic(backend, "AlarmTopic", {
+    topicName: "citadel-alarms-test",
+  });
+
+  const arbiter = new ArbiterStack(app, "citadel-arbiter-test", {
+    environment: "test",
+    env: { account: "123456789012", region: "us-east-1" },
+    agentEventBus,
+    agentConfigTable,
+    codeBucket,
+    workflowsTable,
+    executionsTable,
+    fanoutFunction,
+    appSyncEndpoint: appSyncApi.graphqlUrl,
+    executionSpecificationsTable,
+    alarmTopic,
+    alarmDelivery,
+  });
+  return Template.fromStack(arbiter);
+}
+
+describe("ArbiterStack escalation topic — alarmDelivery prop wiring", () => {
+  test("email: email subscription on the escalation topic + sns.amazonaws.com CMK decrypt grant", () => {
+    const template = buildArbiter({
+      mode: "email",
+      email: "oncall@citadel.io",
+    });
+    template.hasResourceProperties("AWS::SNS::Subscription", {
+      Protocol: "email",
+      Endpoint: "oncall@citadel.io",
+    });
+    template.hasResourceProperties("AWS::KMS::Key", {
+      KeyPolicy: {
+        Statement: Match.arrayWith([
+          Match.objectLike({
+            Effect: "Allow",
+            Principal: { Service: "sns.amazonaws.com" },
+            Action: Match.arrayWith(["kms:Decrypt", "kms:GenerateDataKey*"]),
+          }),
+        ]),
+      },
+    });
+  });
+
+  test("slack: a Chatbot Slack config and NO email subscription", () => {
+    const template = buildArbiter({
+      mode: "slack",
+      workspaceId: "T012ABC",
+      channelId: "C099XYZ",
+    });
+    template.hasResourceProperties("AWS::Chatbot::SlackChannelConfiguration", {
+      SlackWorkspaceId: "T012ABC",
+      SlackChannelId: "C099XYZ",
+    });
+    const emailSubs = Object.values(
+      template.findResources("AWS::SNS::Subscription"),
+    ).filter((s) => s.Properties?.Protocol === "email");
+    expect(emailSubs).toHaveLength(0);
+  });
+
+  test("none: escalation topic keeps no external subscriber, alarms still actioned", () => {
+    const template = buildArbiter({ mode: "none" });
+    const emailSubs = Object.values(
+      template.findResources("AWS::SNS::Subscription"),
+    ).filter((s) => s.Properties?.Protocol === "email");
+    expect(emailSubs).toHaveLength(0);
+    template.resourceCountIs("AWS::Chatbot::SlackChannelConfiguration", 0);
+    // Every alarm still has an action (the operational alarms fall to the
+    // provided alarmTopic; OffFrontier to the escalation topic).
+    const alarms = template.findResources("AWS::CloudWatch::Alarm");
+    for (const a of Object.values(alarms)) {
+      expect((a.Properties?.AlarmActions ?? []).length).toBeGreaterThan(0);
+    }
+  });
+});
+
+describe("BackendStack alarm topic — alarmDelivery prop wiring", () => {
+  test("email: email subscription on the plaintext alarm topic (no CMK grant needed)", () => {
+    const app = new cdk.App();
+    const backend = new BackendStack(app, "citadel-backend-test", {
+      environment: "test",
+      env: { account: "123456789012", region: "us-east-1" },
+      alarmDelivery: { mode: "email", email: "oncall@citadel.io" },
+    });
+    const template = Template.fromStack(backend);
+    template.hasResourceProperties("AWS::SNS::Subscription", {
+      Protocol: "email",
+      Endpoint: "oncall@citadel.io",
+    });
+    // The alarm topic is not CMK-encrypted, so it carries no KmsMasterKeyId.
+    const topics = template.findResources("AWS::SNS::Topic");
+    const alarmTopic = Object.values(topics).find(
+      (t) => t.Properties?.TopicName === "citadel-alarms-test",
+    );
+    expect(alarmTopic).toBeDefined();
+    expect(alarmTopic!.Properties?.KmsMasterKeyId).toBeUndefined();
+  });
+});

--- a/backend/test/alarm-delivery.test.ts
+++ b/backend/test/alarm-delivery.test.ts
@@ -134,6 +134,26 @@ describe("resolveAlarmDeliveryConfig", () => {
     expect(isPlaceholderValue("your-channel-id")).toBe(true);
     expect(isPlaceholderValue("oncall@citadel.io")).toBe(false);
   });
+
+  // Boundary-anchored domain matching (CodeQL js/incomplete-url-substring-
+  // sanitization, alert #49): equality or subdomain of a reserved RFC 2606
+  // documentation domain is a placeholder; a domain that merely CONTAINS the
+  // reserved token as a substring is a legitimate, non-placeholder domain.
+  test.each([
+    ["admin@example.com", true],
+    ["admin@mail.example.com", true],
+    ["admin@example.net", true],
+    ["admin@example.org", true],
+    ["admin@deep.sub.example.com", true],
+    ["someone@notexample.community", false],
+    ["someone@example.com.attacker.io", false],
+    ["oncall@citadel.io", false],
+  ])(
+    "isPlaceholderValue(%s) classifies as placeholder=%s",
+    (email, expected) => {
+      expect(isPlaceholderValue(email)).toBe(expected);
+    },
+  );
 });
 
 // A representative two-topic setup: one CMK-encrypted (the escalation-topic

--- a/backend/test/alarm-delivery.test.ts
+++ b/backend/test/alarm-delivery.test.ts
@@ -1,0 +1,248 @@
+/**
+ * Alarm-delivery: config resolution + subscription/KMS wiring.
+ *
+ * Covers the four contract points from the alarm-delivery build:
+ *   1. resolveAlarmDeliveryConfig — env/context resolution, the env-scoped
+ *      unconfigured-case policy (throw for staging/prod, none for dev/CI),
+ *      and typo-is-always-fatal.
+ *   2. email mode — an SNS email subscription on the topic(s) AND the CMK
+ *      policy grants sns.amazonaws.com decrypt (the silent-failure guard).
+ *   3. slack mode — an AWS Chatbot Slack channel configuration referencing
+ *      the configured workspace/channel, and NO email subscription.
+ *   4. none mode — nothing subscribed (topics/alarms untouched).
+ */
+import * as cdk from "aws-cdk-lib";
+import { Template, Match } from "aws-cdk-lib/assertions";
+import * as sns from "aws-cdk-lib/aws-sns";
+import * as kms from "aws-cdk-lib/aws-kms";
+import {
+  resolveAlarmDeliveryConfig,
+  attachAlarmDelivery,
+  isPlaceholderValue,
+  isProdLikeEnvironment,
+  type AlarmDeliveryConfig,
+} from "../lib/alarm-delivery";
+
+describe("resolveAlarmDeliveryConfig", () => {
+  test("unset destination in dev resolves to 'none' (keeps dev + CI green)", () => {
+    expect(resolveAlarmDeliveryConfig({ environment: "dev", env: {} })).toEqual(
+      { mode: "none" },
+    );
+  });
+
+  test("unset destination in test resolves to 'none'", () => {
+    expect(
+      resolveAlarmDeliveryConfig({ environment: "test", env: {} }),
+    ).toEqual({ mode: "none" });
+  });
+
+  test.each(["staging", "prod"])(
+    "unset destination in %s THROWS (a muted alarm must not ship silently)",
+    (environment) => {
+      expect(() =>
+        resolveAlarmDeliveryConfig({ environment, env: {} }),
+      ).toThrow(/Alarm delivery is not configured/);
+    },
+  );
+
+  test("explicit 'none' is always honoured, even in prod (the opt-out)", () => {
+    expect(
+      resolveAlarmDeliveryConfig({
+        environment: "prod",
+        env: { ALARM_DELIVERY: "none" },
+      }),
+    ).toEqual({ mode: "none" });
+  });
+
+  test("email mode with a real address resolves to email", () => {
+    expect(
+      resolveAlarmDeliveryConfig({
+        environment: "prod",
+        env: { ALARM_DELIVERY: "email", ALARM_EMAIL: "oncall@citadel.io" },
+      }),
+    ).toEqual({ mode: "email", email: "oncall@citadel.io" });
+  });
+
+  test("email mode with a placeholder address THROWS in prod", () => {
+    expect(() =>
+      resolveAlarmDeliveryConfig({
+        environment: "prod",
+        env: { ALARM_DELIVERY: "email", ALARM_EMAIL: "you@example.com" },
+      }),
+    ).toThrow(/not configured/);
+  });
+
+  test("email mode with a missing address falls back to none in dev", () => {
+    expect(
+      resolveAlarmDeliveryConfig({
+        environment: "dev",
+        env: { ALARM_DELIVERY: "email" },
+      }),
+    ).toEqual({ mode: "none" });
+  });
+
+  test("slack mode with workspace + channel resolves to slack", () => {
+    expect(
+      resolveAlarmDeliveryConfig({
+        environment: "prod",
+        env: {
+          ALARM_DELIVERY: "slack",
+          ALARM_SLACK_WORKSPACE_ID: "T012ABC",
+          ALARM_SLACK_CHANNEL_ID: "C099XYZ",
+        },
+      }),
+    ).toEqual({ mode: "slack", workspaceId: "T012ABC", channelId: "C099XYZ" });
+  });
+
+  test("slack mode missing a channel id THROWS in prod", () => {
+    expect(() =>
+      resolveAlarmDeliveryConfig({
+        environment: "prod",
+        env: { ALARM_DELIVERY: "slack", ALARM_SLACK_WORKSPACE_ID: "T012ABC" },
+      }),
+    ).toThrow(/not configured/);
+  });
+
+  test("an invalid mode is ALWAYS fatal, even in dev (typo never degrades)", () => {
+    expect(() =>
+      resolveAlarmDeliveryConfig({
+        environment: "dev",
+        env: { ALARM_DELIVERY: "slakc" },
+      }),
+    ).toThrow(/Invalid ALARM_DELIVERY/);
+  });
+
+  test("config resolves from CDK context when env is empty", () => {
+    const context = (k: string) =>
+      ({ alarmDelivery: "email", alarmEmail: "ops@citadel.io" })[k];
+    expect(
+      resolveAlarmDeliveryConfig({ environment: "prod", env: {}, context }),
+    ).toEqual({ mode: "email", email: "ops@citadel.io" });
+  });
+
+  test("isProdLikeEnvironment only flags staging/prod", () => {
+    expect(isProdLikeEnvironment("staging")).toBe(true);
+    expect(isProdLikeEnvironment("prod")).toBe(true);
+    expect(isProdLikeEnvironment("dev")).toBe(false);
+    expect(isProdLikeEnvironment("test")).toBe(false);
+  });
+
+  test("isPlaceholderValue catches common scaffold shapes", () => {
+    expect(isPlaceholderValue(undefined)).toBe(true);
+    expect(isPlaceholderValue("")).toBe(true);
+    expect(isPlaceholderValue("you@example.com")).toBe(true);
+    expect(isPlaceholderValue("your-channel-id")).toBe(true);
+    expect(isPlaceholderValue("oncall@citadel.io")).toBe(false);
+  });
+});
+
+// A representative two-topic setup: one CMK-encrypted (the escalation-topic
+// shape) and one plaintext (the alarms-topic shape), wired via the shared
+// attachAlarmDelivery helper for each mode.
+function synthWithDelivery(config: AlarmDeliveryConfig): Template {
+  const app = new cdk.App();
+  const stack = new cdk.Stack(app, "DeliveryTestStack", {
+    env: { account: "123456789012", region: "us-east-1" },
+  });
+  const key = new kms.Key(stack, "EscalationKey", { enableKeyRotation: true });
+  const encryptedTopic = new sns.Topic(stack, "EscalationTopic", {
+    topicName: "citadel-governance-escalations-test",
+    masterKey: key,
+  });
+  const plainTopic = new sns.Topic(stack, "AlarmTopic", {
+    topicName: "citadel-alarms-test",
+  });
+  attachAlarmDelivery(stack, {
+    config,
+    environment: "test",
+    topics: [
+      { topic: encryptedTopic, nameHint: "escalation", encryptionKey: key },
+      { topic: plainTopic, nameHint: "backend" },
+    ],
+  });
+  return Template.fromStack(stack);
+}
+
+describe("attachAlarmDelivery — email mode", () => {
+  let template: Template;
+  beforeAll(() => {
+    template = synthWithDelivery({ mode: "email", email: "oncall@citadel.io" });
+  });
+
+  test("creates an SNS email subscription on each topic", () => {
+    const subs = template.findResources("AWS::SNS::Subscription");
+    const emailSubs = Object.values(subs).filter(
+      (s) => s.Properties?.Protocol === "email",
+    );
+    expect(emailSubs).toHaveLength(2);
+    for (const s of emailSubs) {
+      expect(s.Properties?.Endpoint).toBe("oncall@citadel.io");
+    }
+  });
+
+  test("grants sns.amazonaws.com decrypt + GenerateDataKey on the CMK (silent-failure guard)", () => {
+    template.hasResourceProperties("AWS::KMS::Key", {
+      KeyPolicy: {
+        Statement: Match.arrayWith([
+          Match.objectLike({
+            Effect: "Allow",
+            Principal: { Service: "sns.amazonaws.com" },
+            Action: Match.arrayWith(["kms:Decrypt", "kms:GenerateDataKey*"]),
+          }),
+        ]),
+      },
+    });
+  });
+
+  test("creates no Chatbot Slack configuration", () => {
+    template.resourceCountIs("AWS::Chatbot::SlackChannelConfiguration", 0);
+  });
+});
+
+describe("attachAlarmDelivery — slack mode", () => {
+  let template: Template;
+  beforeAll(() => {
+    template = synthWithDelivery({
+      mode: "slack",
+      workspaceId: "T012ABC",
+      channelId: "C099XYZ",
+    });
+  });
+
+  test("creates a Chatbot Slack config per topic referencing the workspace/channel", () => {
+    const configs = template.findResources(
+      "AWS::Chatbot::SlackChannelConfiguration",
+    );
+    expect(Object.keys(configs)).toHaveLength(2);
+    for (const c of Object.values(configs)) {
+      expect(c.Properties?.SlackWorkspaceId).toBe("T012ABC");
+      expect(c.Properties?.SlackChannelId).toBe("C099XYZ");
+      // Each references exactly one notification topic.
+      expect(c.Properties?.SnsTopicArns).toHaveLength(1);
+    }
+  });
+
+  test("creates NO email subscription", () => {
+    const subs = template.findResources("AWS::SNS::Subscription");
+    const emailSubs = Object.values(subs).filter(
+      (s) => s.Properties?.Protocol === "email",
+    );
+    expect(emailSubs).toHaveLength(0);
+  });
+});
+
+describe("attachAlarmDelivery — none mode", () => {
+  let template: Template;
+  beforeAll(() => {
+    template = synthWithDelivery({ mode: "none" });
+  });
+
+  test("creates no subscription and no Chatbot config (topics stay bare)", () => {
+    template.resourceCountIs("AWS::SNS::Subscription", 0);
+    template.resourceCountIs("AWS::Chatbot::SlackChannelConfiguration", 0);
+  });
+
+  test("the topics themselves still synth", () => {
+    template.resourceCountIs("AWS::SNS::Topic", 2);
+  });
+});

--- a/backend/test/every-alarm-has-action.test.ts
+++ b/backend/test/every-alarm-has-action.test.ts
@@ -1,0 +1,174 @@
+/**
+ * Structural guard: EVERY CloudWatch alarm must have at least one action.
+ *
+ * This is the guard that stops a muted alarm shipping again. 20 alarm
+ * construct sites across backend/projects/arbiter were historically wired to
+ * a topic with ZERO subscriptions (and 20 had no SNS action at all); this
+ * test synthesizes the alarm-bearing stacks exactly as bin/app.ts wires them
+ * and fails if any alarm has an empty/absent AlarmActions list.
+ *
+ * A companion bite proof (bottom) demonstrates the assertion actually fires
+ * when an alarm's action is removed — a green suite against an unbitten
+ * guard proves nothing.
+ */
+import * as cdk from "aws-cdk-lib";
+import { Template } from "aws-cdk-lib/assertions";
+import * as cloudwatch from "aws-cdk-lib/aws-cloudwatch";
+import * as sns from "aws-cdk-lib/aws-sns";
+import * as cw_actions from "aws-cdk-lib/aws-cloudwatch-actions";
+import {
+  scaffoldBackendAssetDirs,
+  scaffoldArbiterStubs,
+} from "./helpers/scaffold-stub-assets";
+
+scaffoldBackendAssetDirs(["dist/lambda", "src/schema"]);
+scaffoldArbiterStubs();
+
+import { BackendStack } from "../lib/backend-stack";
+import { ProjectsStack } from "../lib/projects-stack";
+import { ArbiterStack } from "../lib/arbiter-stack";
+
+/**
+ * Returns the logical ids of every AWS::CloudWatch::Alarm in `resources`
+ * whose AlarmActions is absent or empty. The single predicate shared by the
+ * structural guard and the bite proof.
+ */
+export function findActionlessAlarms(
+  resources: Record<
+    string,
+    { Type: string; Properties?: Record<string, unknown> }
+  >,
+): string[] {
+  const out: string[] = [];
+  for (const [logicalId, resource] of Object.entries(resources)) {
+    if (resource.Type !== "AWS::CloudWatch::Alarm") continue;
+    const actions = (resource.Properties?.AlarmActions ?? []) as unknown[];
+    if (!Array.isArray(actions) || actions.length === 0) {
+      out.push(logicalId);
+    }
+  }
+  return out;
+}
+
+describe("every CloudWatch alarm has at least one action (muted-alarm regression guard)", () => {
+  let backendTemplate: Template;
+  let projectsTemplate: Template;
+  let arbiterTemplate: Template;
+
+  beforeAll(() => {
+    // Disable Docker bundling of the arbiter's PythonFunctions so the suite
+    // runs without a container runtime (same context flag the arbiter-stack
+    // tests use).
+    const app = new cdk.App({
+      context: { "aws:cdk:bundling-stacks": [] },
+    });
+    const env = { account: "123456789012", region: "us-east-1" };
+
+    const backend = new BackendStack(app, "citadel-backend-test", {
+      environment: "test",
+      env,
+    });
+
+    const projects = new ProjectsStack(app, "citadel-projects-test", {
+      environment: "test",
+      env,
+      appSyncApi: backend.appSyncApi,
+      agentEventBus: backend.agentEventBus,
+      projectsTable: backend.projectsTable,
+      conversationsTable: backend.conversationsTable,
+      agentStatusTable: backend.agentStatusTable,
+      documentBucket: backend.documentBucket,
+      idempotencyTable: backend.idempotencyTable,
+      adrsTable: backend.adrsTable,
+      executionSpecificationsTable: backend.executionSpecificationsTable,
+      agentDesignAssessmentsTable: backend.agentDesignAssessmentsTable,
+      userPool: backend.userPool,
+      alarmTopic: backend.alarmTopic,
+    });
+
+    const arbiter = new ArbiterStack(app, "citadel-arbiter-test", {
+      environment: "test",
+      env,
+      agentEventBus: backend.agentEventBus,
+      agentConfigTable: backend.agentConfigTable,
+      codeBucket: backend.codeBucket,
+      workflowsTable: backend.workflowsTable,
+      executionsTable: backend.executionsTable,
+      fanoutFunction: backend.workflowProgressFanoutFunction,
+      appSyncEndpoint: backend.appSyncApi.graphqlUrl,
+      appsTable: backend.appsTable,
+      executionSpecificationsTable: backend.executionSpecificationsTable,
+      registryArn: backend.registryArn,
+      registryId: backend.registryId,
+      alarmTopic: backend.alarmTopic,
+    });
+
+    backendTemplate = Template.fromStack(backend);
+    projectsTemplate = Template.fromStack(projects);
+    arbiterTemplate = Template.fromStack(arbiter);
+  });
+
+  test("BackendStack: 12 alarms, none actionless", () => {
+    backendTemplate.resourceCountIs("AWS::CloudWatch::Alarm", 12);
+    expect(findActionlessAlarms(backendTemplate.toJSON().Resources)).toEqual(
+      [],
+    );
+  });
+
+  test("ProjectsStack: 2 alarms, none actionless", () => {
+    projectsTemplate.resourceCountIs("AWS::CloudWatch::Alarm", 2);
+    expect(findActionlessAlarms(projectsTemplate.toJSON().Resources)).toEqual(
+      [],
+    );
+  });
+
+  test("ArbiterStack: 7 alarms, none actionless", () => {
+    arbiterTemplate.resourceCountIs("AWS::CloudWatch::Alarm", 7);
+    expect(findActionlessAlarms(arbiterTemplate.toJSON().Resources)).toEqual(
+      [],
+    );
+  });
+});
+
+describe("bite proof: the every-alarm-has-an-action assertion fires when an action is removed", () => {
+  function synthOneAlarm(withAction: boolean): Template {
+    const app = new cdk.App();
+    const stack = new cdk.Stack(app, "BiteStack", {
+      env: { account: "123456789012", region: "us-east-1" },
+    });
+    const topic = new sns.Topic(stack, "T", { topicName: "bite-test" });
+    const alarm = new cloudwatch.Alarm(stack, "BiteAlarm", {
+      alarmName: "citadel-bite-test",
+      metric: new cloudwatch.Metric({
+        namespace: "Citadel/Test",
+        metricName: "X",
+        period: cdk.Duration.minutes(5),
+        statistic: "Sum",
+      }),
+      threshold: 1,
+      evaluationPeriods: 1,
+      comparisonOperator:
+        cloudwatch.ComparisonOperator.GREATER_THAN_OR_EQUAL_TO_THRESHOLD,
+      treatMissingData: cloudwatch.TreatMissingData.NOT_BREACHING,
+    });
+    if (withAction) {
+      alarm.addAlarmAction(new cw_actions.SnsAction(topic));
+    }
+    return Template.fromStack(stack);
+  }
+
+  test("RED: an alarm with no action IS flagged by the guard predicate", () => {
+    const flagged = findActionlessAlarms(
+      synthOneAlarm(false).toJSON().Resources,
+    );
+    expect(flagged.length).toBe(1);
+    // And the assertion the structural tests use would fail on it.
+    expect(() => expect(flagged).toEqual([])).toThrow();
+  });
+
+  test("GREEN: the same alarm WITH an action is not flagged", () => {
+    expect(
+      findActionlessAlarms(synthOneAlarm(true).toJSON().Resources),
+    ).toEqual([]);
+  });
+});

--- a/backend/test/projects-stack-ingestion-table-wiring.test.ts
+++ b/backend/test/projects-stack-ingestion-table-wiring.test.ts
@@ -28,6 +28,7 @@ import * as appsync from "aws-cdk-lib/aws-appsync";
 import * as cognito from "aws-cdk-lib/aws-cognito";
 import * as dynamodb from "aws-cdk-lib/aws-dynamodb";
 import * as events from "aws-cdk-lib/aws-events";
+import * as sns from "aws-cdk-lib/aws-sns";
 import { Bucket } from "aws-cdk-lib/aws-s3";
 import * as path from "path";
 import { scaffoldBackendAssetDirs } from "./helpers/scaffold-stub-assets";
@@ -153,6 +154,9 @@ describe("ProjectsStack — document-upload resolver jobs-table read path", () =
       executionSpecificationsTable,
       agentDesignAssessmentsTable,
       userPool,
+      alarmTopic: new sns.Topic(backendStack, "AlarmTopic", {
+        topicName: "citadel-alarms-test",
+      }),
     });
     template = Template.fromStack(stack);
   });
@@ -184,13 +188,19 @@ describe("ProjectsStack — document-upload resolver jobs-table read path", () =
 
   test("document-upload resolver jobs-table policy grants NO write actions (least privilege)", () => {
     const policies = template.findResources("AWS::IAM::Policy");
-    const hasWriteOnJobsTable = Object.values(policies).some((policy: any) =>
-      (policy.Properties.PolicyDocument.Statement as any[]).some((stmt) => {
+    type PolicyStmtLike = { Action?: string | string[]; Resource?: unknown };
+    type CfnPolicyLike = {
+      Properties?: { PolicyDocument?: { Statement?: PolicyStmtLike[] } };
+    };
+    const hasWriteOnJobsTable = Object.values(policies).some((policy) =>
+      (
+        (policy as CfnPolicyLike).Properties?.PolicyDocument?.Statement ?? []
+      ).some((stmt) => {
         const resourceStr = JSON.stringify(stmt.Resource ?? "");
         if (!resourceStr.includes(tableName)) return false;
         const actions: string[] = Array.isArray(stmt.Action)
           ? stmt.Action
-          : [stmt.Action];
+          : [stmt.Action ?? ""];
         return actions.some((a) =>
           [
             "dynamodb:PutItem",

--- a/backend/test/projects-stack.test.ts
+++ b/backend/test/projects-stack.test.ts
@@ -18,6 +18,7 @@ import * as appsync from "aws-cdk-lib/aws-appsync";
 import * as cognito from "aws-cdk-lib/aws-cognito";
 import * as dynamodb from "aws-cdk-lib/aws-dynamodb";
 import * as events from "aws-cdk-lib/aws-events";
+import * as sns from "aws-cdk-lib/aws-sns";
 import { Bucket } from "aws-cdk-lib/aws-s3";
 import * as path from "path";
 import { scaffoldBackendAssetDirs } from "./helpers/scaffold-stub-assets";
@@ -25,6 +26,14 @@ import { scaffoldBackendAssetDirs } from "./helpers/scaffold-stub-assets";
 scaffoldBackendAssetDirs(["dist/lambda", "src/schema"]);
 
 import { ProjectsStack } from "../lib/projects-stack";
+
+// Minimal CloudFormation resource shapes for template assertions (avoids
+// explicit `any` — enforced by lint-staged's --max-warnings 0).
+type PolicyStmtLike = { Action?: string | string[]; Resource?: unknown };
+type CfnPolicyLike = {
+  Properties?: { PolicyDocument?: { Statement?: PolicyStmtLike[] } };
+};
+type CfnRoleLike = { Properties?: { ManagedPolicyArns?: unknown } };
 
 function createFixture(app: cdk.App) {
   const backendStack = new cdk.Stack(app, "MockBackendStack", {
@@ -126,6 +135,10 @@ function createFixture(app: cdk.App) {
     userPoolName: "citadel-test-pool",
   });
 
+  const alarmTopic = new sns.Topic(backendStack, "AlarmTopic", {
+    topicName: "citadel-alarms-test",
+  });
+
   return {
     appSyncApi,
     agentEventBus,
@@ -138,6 +151,7 @@ function createFixture(app: cdk.App) {
     executionSpecificationsTable,
     agentDesignAssessmentsTable,
     userPool,
+    alarmTopic,
   };
 }
 
@@ -243,11 +257,12 @@ describe("ProjectsStack — backend-stack-split phase 1", () => {
     const matches = Object.values(policies);
     expect(matches.length).toBeGreaterThan(0);
     for (const policy of matches) {
-      const statements = (policy as any).Properties.PolicyDocument.Statement;
+      const statements =
+        (policy as CfnPolicyLike).Properties?.PolicyDocument?.Statement ?? [];
       const cognitoStmt = statements.find(
-        (s: any) => s.Action === "cognito-idp:AdminGetUser",
+        (s) => s.Action === "cognito-idp:AdminGetUser",
       );
-      expect(cognitoStmt.Resource).not.toBe("*");
+      expect(cognitoStmt?.Resource).not.toBe("*");
     }
   });
 
@@ -269,7 +284,8 @@ describe("ProjectsStack — backend-stack-split phase 1", () => {
   test("no IAM policy statement grants a full-service wildcard action (iam:*, dynamodb:*, or s3:*)", () => {
     const policies = template.findResources("AWS::IAM::Policy");
     for (const policy of Object.values(policies)) {
-      const statements = (policy as any).Properties?.PolicyDocument?.Statement;
+      const statements = (policy as CfnPolicyLike).Properties?.PolicyDocument
+        ?.Statement;
       if (!Array.isArray(statements)) continue;
       for (const stmt of statements) {
         const actions = Array.isArray(stmt.Action)
@@ -315,7 +331,7 @@ describe("ProjectsStack — backend-stack-split phase 1", () => {
     const lambdaRoles = Object.values(roles);
     expect(lambdaRoles.length).toBeGreaterThan(0);
     for (const role of lambdaRoles) {
-      const managedArns = (role as any).Properties.ManagedPolicyArns;
+      const managedArns = (role as CfnRoleLike).Properties?.ManagedPolicyArns;
       expect(Array.isArray(managedArns)).toBe(true);
     }
   });


### PR DESCRIPTION
## Summary
Alarms notified nobody. An audit found only 9 of 29 physical alarms had any SNS action, and *neither* alarm topic had a subscriber - so even the wired ones published into a void. That nullified the alerting assumption behind several controls shipped this month: the auto-rollback evaluator's write-failure alarm, the per-target breaker's state changes, the SLO alarms, and the DLQ-depth alarm covering all seven dead-letter queues.

Detection worked; notification didn't - the worst combination, because dashboards and tests both look healthy.

## What changed

**Every alarm now has an action.** The 20 actionless alarms (arbiter 6, projects 2, backend 12) are wired to the appropriate topic. Confirmed by counting the synthesized templates: 9 of 29 before, 29 of 29 after.

**A destination you can configure.** Either an SNS email subscription or a Slack channel via AWS Chatbot, selected by configuration. The stable `aws-cdk-lib/aws-chatbot` module covers it, so no dependency was added. The Slack workspace Auth authorisation is a one-time console step CDK cannot perform, and is documented.

**KMS grant for email delivery.** The escalation topic uses a customer-managed key, so `sns. amazonaws.com` needs `kms:Decrypt` and `kms: GenerateDataKey*` on it. Without that, email delivery fails *silently* - so it's asserted in a test, not just added.

**Unconfigured behaviour is environment-aware.** Staging and production throw if no destination is set; development and CI degrade to none. So a muted configuration cannot reach an environment where it matters, while the open-source development clone (whose `.env` is placeholders by design) and CI both still synthesise cleanly. An invalid value always throws.

## Testing

The guard against regression is structural: it iterates every `AWS::CloudWatch::Alarm` in the synthesized template rather than checking a maintained list, and its bite proof was re-derived in review by removing one alarm's action and observing the failure. Email mode asserts both the subscription and the KMS policy statement; Slack mode asserts the Chatbot configuration and the *absence* of email subscriptions; the unconfigured mode asserts alarms remain actioned.

`tsc` clean; jest 6,914 passing across 454 suites; synth clean in all three destination modes.

## Deployment notes

Set the destination variables before deploying to a real environment - staging and prod will refuse to synthesise without them, which is intentional. For Slack, authorise the workspace in the AWS Chatbot console first. After deploying, confirm the email subscription is **CONFIRMED** rather than merely created: an unconfirmed subscription is silently equivalent to none.

## Follow-up

This makes alarms deliverable. Separately tracked: the governance notifier still has no asynchronous delivery path of its own - it fans out to admin-UI WebSocket subscribers only, so governance events reach a human only if a browser tab happens to be open.