### PR TITLE
fix(alarms): grant Cloudwatch publish on the encrypted topic key

### DIFF
--- a/backend/lib/alarm-delivery.ts
+++ b/backend/lib/alarm-delivery.ts
@@ -16,10 +16,13 @@ import { NagSuppressions } from "cdk-nag";
  * env/CDK-context and subscribes the given topic(s) to it:
  *
  *   - `email`  — an SNS EMAIL subscription on each topic. Delivery from a
- *                CMK-encrypted topic ALSO requires the `sns.amazonaws.com`
+ *                CMK-encrypted topic requires the `sns.amazonaws.com`
  *                service principal to hold `kms:Decrypt` + `kms:GenerateDataKey*`
  *                on the topic's CMK, or SNS drops the notification SILENTLY.
- *                This module adds that grant for every encrypted topic.
+ *                This module adds that grant for every encrypted topic,
+ *                UNCONDITIONALLY (see below), because SNS must decrypt the
+ *                message internally before fanning it out through ANY
+ *                protocol, not just email.
  *   - `slack`  — an AWS Chatbot Slack channel configuration (the STABLE
  *                `aws-cdk-lib/aws-chatbot` `SlackChannelConfiguration` L2 —
  *                promoted out of alpha; no `@aws-cdk/aws-chatbot-alpha`
@@ -30,6 +33,28 @@ import { NagSuppressions } from "cdk-nag";
  *                id is what `ALARM_SLACK_WORKSPACE_ID` carries.
  *   - `none`   — no subscription (alarms stay wired to their topic, but no
  *                external destination). The explicit opt-out.
+ *
+ * ## KMS grants are unconditional, not gated on delivery mode
+ *
+ * Two distinct KMS grants are required for a CMK-encrypted alarm topic, and
+ * BOTH are added unconditionally — for every topic passed in, in every
+ * delivery mode, including `none`:
+ *
+ *   - `cloudwatch.amazonaws.com` (`grantCloudWatchAlarmPublish`, added by the
+ *     stack at topic-construction time, alongside the CMK — see
+ *     arbiter-stack.ts) needs `kms:GenerateDataKey*` + `kms:Decrypt` to
+ *     publish the alarm notification onto the topic AT ALL. Without it the
+ *     alarm action fails silently regardless of what (if anything) is
+ *     subscribed downstream.
+ *   - `sns.amazonaws.com` (`grantSnsDeliveryDecrypt`, added by
+ *     `attachAlarmDelivery` below) needs the same actions because SNS must
+ *     decrypt a message internally before it can deliver it through ANY
+ *     subscription protocol — email, an AWS Chatbot subscription, or a
+ *     future PagerDuty/HTTPS bridge. It is not specific to `email` mode.
+ *
+ * Both are must-fix regardless of `mode`, because CloudWatch's publish (the
+ * first grant) is what puts the message on the topic before any downstream
+ * mode-specific branching happens.
  *
  * ## Unconfigured-case policy (decision)
  *
@@ -272,6 +297,39 @@ export function grantSnsDeliveryDecrypt(key: kms.IKey): void {
   );
 }
 
+/**
+ * Grant the CloudWatch service principal `kms:GenerateDataKey*` +
+ * `kms:Decrypt` on a topic CMK so a CloudWatch alarm action can publish to
+ * the encrypted topic at all.
+ *
+ * Unlike {@link grantSnsDeliveryDecrypt} (which only matters for the
+ * SNS-native `email` delivery path), this grant is required
+ * UNCONDITIONALLY, for every alarm-delivery mode (including `slack` and
+ * `none`) — CloudWatch's own publish to the topic is what puts the
+ * notification ON the topic in the first place; every downstream
+ * subscriber (email, Chatbot, a future PagerDuty bridge) depends on that
+ * publish having succeeded. Missing this grant makes the alarm action fail
+ * SILENTLY: the alarm state still transitions in the console, but no
+ * message is ever delivered to the topic, so no subscriber — present or
+ * future — ever sees it.
+ *
+ * Must be called for every CMK-encrypted SNS topic that any CloudWatch
+ * alarm targets, regardless of whether an external destination is
+ * currently configured.
+ */
+export function grantCloudWatchAlarmPublish(key: kms.IKey): void {
+  key.addToResourcePolicy(
+    new iam.PolicyStatement({
+      sid: "AllowCloudWatchAlarmPublish",
+      effect: iam.Effect.ALLOW,
+      principals: [new iam.ServicePrincipal("cloudwatch.amazonaws.com")],
+      actions: ["kms:GenerateDataKey*", "kms:Decrypt"],
+      resources: ["*"],
+    }),
+    /* allowNoOp */ true,
+  );
+}
+
 export interface AttachAlarmDeliveryOptions {
   readonly config: AlarmDeliveryConfig;
   readonly environment: string;
@@ -289,6 +347,22 @@ export function attachAlarmDelivery(
 ): void {
   const { config, environment, topics } = opts;
 
+  // The sns.amazonaws.com decrypt grant is required for EVERY encrypted
+  // topic regardless of delivery mode: SNS must decrypt the published
+  // message internally before it can fan it out through ANY protocol —
+  // email, an AWS Chatbot subscription, or a future PagerDuty/HTTPS
+  // bridge. It is not specific to the `email` branch below (a prior
+  // version of this function only added it there, which meant Slack mode
+  // and any topic reachable only through `mode: 'none'`'s no-op path never
+  // got the grant even though CloudWatch's own publish — see
+  // grantCloudWatchAlarmPublish — deposits messages on the topic in every
+  // mode). Grant it here, unconditionally, before branching on mode.
+  for (const t of topics) {
+    if (t.encryptionKey) {
+      grantSnsDeliveryDecrypt(t.encryptionKey);
+    }
+  }
+
   if (config.mode === "none") {
     return;
   }
@@ -298,9 +372,6 @@ export function attachAlarmDelivery(
       t.topic.addSubscription(
         new subscriptions.EmailSubscription(config.email),
       );
-      if (t.encryptionKey) {
-        grantSnsDeliveryDecrypt(t.encryptionKey);
-      }
     }
     return;
   }

--- a/backend/lib/arbiter-stack.ts
+++ b/backend/lib/arbiter-stack.ts
@@ -26,6 +26,7 @@ import { Construct } from "constructs";
 import { NagSuppressions } from "cdk-nag";
 import {
   attachAlarmDelivery,
+  grantCloudWatchAlarmPublish,
   type AlarmDeliveryConfig,
 } from "./alarm-delivery";
 import * as path from "path";
@@ -1914,6 +1915,16 @@ export class ArbiterStack extends cdk.Stack {
         "should investigate why an agent escalated and whether the underlying " +
         "task belongs on the AI-analytical frontier.",
     }).addAlarmAction(new cw_actions.SnsAction(escalationTopic));
+
+    // CloudWatch itself must be able to publish to this CMK-encrypted
+    // topic, or the alarm action above fails SILENTLY (the alarm still
+    // transitions state; no message ever reaches the topic, so no
+    // subscriber — email, Chatbot, or any future destination — ever sees
+    // it). This is UNCONDITIONAL — not gated on alarmDelivery mode —
+    // because CloudWatch's publish is what puts the notification on the
+    // topic in the first place, before any downstream delivery-mode
+    // branching in attachAlarmDelivery even runs. Scoped to this key only.
+    grantCloudWatchAlarmPublish(escalationTopicKey);
 
     // Expose the topic ARN to both Lambdas that can legitimately emit
     // escalations in the future (today only the worker emits via the

--- a/backend/test/alarm-delivery-stacks.test.ts
+++ b/backend/test/alarm-delivery-stacks.test.ts
@@ -3,9 +3,15 @@
  * from bin/app.ts reaches attachAlarmDelivery inside the topic-owning stacks.
  *
  * ArbiterStack is the KMS-critical path (its escalation topic is
- * CMK-encrypted), so email mode here must both create an email subscription
- * AND grant sns.amazonaws.com decrypt on the escalation CMK. BackendStack's
- * alarm topic is plaintext, so it only needs the subscription.
+ * CMK-encrypted). Two KMS grants on that CMK are UNCONDITIONAL — present in
+ * every alarmDelivery mode, including `none`:
+ *   - cloudwatch.amazonaws.com (grantCloudWatchAlarmPublish, wired at
+ *     topic-construction time in arbiter-stack.ts) — required for the
+ *     OffFrontierEscalation alarm action to publish to the topic at all.
+ *   - sns.amazonaws.com (grantSnsDeliveryDecrypt, wired by
+ *     attachAlarmDelivery) — required for SNS to decrypt+fan out to any
+ *     subscriber protocol.
+ * BackendStack's alarm topic is plaintext, so it needs neither grant.
  */
 import * as cdk from "aws-cdk-lib";
 import { Template, Match } from "aws-cdk-lib/assertions";
@@ -86,15 +92,21 @@ function buildArbiter(alarmDelivery: AlarmDeliveryConfig): Template {
 }
 
 describe("ArbiterStack escalation topic — alarmDelivery prop wiring", () => {
-  test("email: email subscription on the escalation topic + sns.amazonaws.com CMK decrypt grant", () => {
-    const template = buildArbiter({
-      mode: "email",
-      email: "oncall@citadel.io",
+  function expectCloudWatchAlarmPublishGrant(template: Template): void {
+    template.hasResourceProperties("AWS::KMS::Key", {
+      KeyPolicy: {
+        Statement: Match.arrayWith([
+          Match.objectLike({
+            Effect: "Allow",
+            Principal: { Service: "cloudwatch.amazonaws.com" },
+            Action: Match.arrayWith(["kms:GenerateDataKey*", "kms:Decrypt"]),
+          }),
+        ]),
+      },
     });
-    template.hasResourceProperties("AWS::SNS::Subscription", {
-      Protocol: "email",
-      Endpoint: "oncall@citadel.io",
-    });
+  }
+
+  function expectSnsDeliveryDecryptGrant(template: Template): void {
     template.hasResourceProperties("AWS::KMS::Key", {
       KeyPolicy: {
         Statement: Match.arrayWith([
@@ -106,9 +118,22 @@ describe("ArbiterStack escalation topic — alarmDelivery prop wiring", () => {
         ]),
       },
     });
+  }
+
+  test("email: email subscription on the escalation topic + BOTH cloudwatch.amazonaws.com and sns.amazonaws.com CMK grants", () => {
+    const template = buildArbiter({
+      mode: "email",
+      email: "oncall@citadel.io",
+    });
+    template.hasResourceProperties("AWS::SNS::Subscription", {
+      Protocol: "email",
+      Endpoint: "oncall@citadel.io",
+    });
+    expectCloudWatchAlarmPublishGrant(template);
+    expectSnsDeliveryDecryptGrant(template);
   });
 
-  test("slack: a Chatbot Slack config and NO email subscription", () => {
+  test("slack: a Chatbot Slack config, NO email subscription, and BOTH CMK grants still present", () => {
     const template = buildArbiter({
       mode: "slack",
       workspaceId: "T012ABC",
@@ -122,9 +147,11 @@ describe("ArbiterStack escalation topic — alarmDelivery prop wiring", () => {
       template.findResources("AWS::SNS::Subscription"),
     ).filter((s) => s.Properties?.Protocol === "email");
     expect(emailSubs).toHaveLength(0);
+    expectCloudWatchAlarmPublishGrant(template);
+    expectSnsDeliveryDecryptGrant(template);
   });
 
-  test("none: escalation topic keeps no external subscriber, alarms still actioned", () => {
+  test("none: escalation topic keeps no external subscriber, alarms still actioned, and BOTH CMK grants are still present", () => {
     const template = buildArbiter({ mode: "none" });
     const emailSubs = Object.values(
       template.findResources("AWS::SNS::Subscription"),
@@ -137,6 +164,11 @@ describe("ArbiterStack escalation topic — alarmDelivery prop wiring", () => {
     for (const a of Object.values(alarms)) {
       expect((a.Properties?.AlarmActions ?? []).length).toBeGreaterThan(0);
     }
+    // The whole point of this finding: CloudWatch's own publish grant must
+    // be present even when NO external destination is configured, because
+    // it is what lets the alarm action deliver to the topic at all.
+    expectCloudWatchAlarmPublishGrant(template);
+    expectSnsDeliveryDecryptGrant(template);
   });
 });
 

--- a/backend/test/alarm-delivery.test.ts
+++ b/backend/test/alarm-delivery.test.ts
@@ -18,6 +18,7 @@ import * as kms from "aws-cdk-lib/aws-kms";
 import {
   resolveAlarmDeliveryConfig,
   attachAlarmDelivery,
+  grantCloudWatchAlarmPublish,
   isPlaceholderValue,
   isProdLikeEnvironment,
   type AlarmDeliveryConfig,
@@ -249,6 +250,20 @@ describe("attachAlarmDelivery — slack mode", () => {
     );
     expect(emailSubs).toHaveLength(0);
   });
+
+  test("STILL grants sns.amazonaws.com decrypt + GenerateDataKey on the CMK (unconditional, not email-only)", () => {
+    template.hasResourceProperties("AWS::KMS::Key", {
+      KeyPolicy: {
+        Statement: Match.arrayWith([
+          Match.objectLike({
+            Effect: "Allow",
+            Principal: { Service: "sns.amazonaws.com" },
+            Action: Match.arrayWith(["kms:Decrypt", "kms:GenerateDataKey*"]),
+          }),
+        ]),
+      },
+    });
+  });
 });
 
 describe("attachAlarmDelivery — none mode", () => {
@@ -264,5 +279,40 @@ describe("attachAlarmDelivery — none mode", () => {
 
   test("the topics themselves still synth", () => {
     template.resourceCountIs("AWS::SNS::Topic", 2);
+  });
+
+  test("STILL grants sns.amazonaws.com decrypt + GenerateDataKey on the CMK even with no external destination", () => {
+    template.hasResourceProperties("AWS::KMS::Key", {
+      KeyPolicy: {
+        Statement: Match.arrayWith([
+          Match.objectLike({
+            Effect: "Allow",
+            Principal: { Service: "sns.amazonaws.com" },
+            Action: Match.arrayWith(["kms:Decrypt", "kms:GenerateDataKey*"]),
+          }),
+        ]),
+      },
+    });
+  });
+});
+
+describe("grantCloudWatchAlarmPublish", () => {
+  test("grants cloudwatch.amazonaws.com decrypt + GenerateDataKey on the key", () => {
+    const app = new cdk.App();
+    const stack = new cdk.Stack(app, "CwGrantTestStack");
+    const key = new kms.Key(stack, "Key", { enableKeyRotation: true });
+    grantCloudWatchAlarmPublish(key);
+    const template = Template.fromStack(stack);
+    template.hasResourceProperties("AWS::KMS::Key", {
+      KeyPolicy: {
+        Statement: Match.arrayWith([
+          Match.objectLike({
+            Effect: "Allow",
+            Principal: { Service: "cloudwatch.amazonaws.com" },
+            Action: Match.arrayWith(["kms:GenerateDataKey*", "kms:Decrypt"]),
+          }),
+        ]),
+      },
+    });
   });
 });

--- a/backend/test/alarm-topic-kms-publish-guard.test.ts
+++ b/backend/test/alarm-topic-kms-publish-guard.test.ts
@@ -1,0 +1,347 @@
+/**
+ * Structural guard (finding 2ca8d956): every CloudWatch alarm that targets a
+ * CMK-encrypted SNS topic must have a key policy granting
+ * `cloudwatch.amazonaws.com` both `kms:GenerateDataKey*` and `kms:Decrypt` on
+ * that CMK — or the alarm action fails to publish SILENTLY (the alarm still
+ * transitions state in the console; no message ever reaches the topic, so
+ * no subscriber ever sees it).
+ *
+ * This guard is derived FROM THE SYNTHESIZED TEMPLATE — not a maintained
+ * list of "known encrypted topics" — so it keeps holding if a future alarm
+ * is wired to a new CMK-encrypted topic without anyone remembering to add
+ * the grant. It walks:
+ *
+ *   AWS::CloudWatch::Alarm.AlarmActions
+ *     -> (Ref) AWS::SNS::Topic in the SAME template
+ *       -> .KmsMasterKeyId (Fn::GetAtt [KeyLogicalId, "Arn"])
+ *         -> AWS::KMS::Key.KeyPolicy.Statement
+ *           -> must contain an Allow statement for principal
+ *              cloudwatch.amazonaws.com with both required actions.
+ *
+ * An AlarmAction expressed as `Fn::ImportValue` (a cross-stack topic, e.g.
+ * the plaintext BackendStack `AlarmTopic` referenced from ArbiterStack) is
+ * NOT resolvable inside a single synthesized template and is treated as
+ * "not analyzable here" rather than a false failure — that topic is
+ * plaintext in this codebase (see every-alarm-has-action.test.ts /
+ * alarm-delivery-stacks.test.ts), and a genuinely cross-stack encrypted
+ * topic would need the equivalent check run against the STACK THAT OWNS
+ * the key, where the Ref/GetAtt chain is local.
+ *
+ * A companion bite proof (bottom) proves the assertion actually fires when
+ * the grant is missing — a green suite against an unbitten guard proves
+ * nothing.
+ */
+import * as cdk from "aws-cdk-lib";
+import { Template } from "aws-cdk-lib/assertions";
+import * as cloudwatch from "aws-cdk-lib/aws-cloudwatch";
+import * as cw_actions from "aws-cdk-lib/aws-cloudwatch-actions";
+import * as sns from "aws-cdk-lib/aws-sns";
+import * as kms from "aws-cdk-lib/aws-kms";
+import * as iam from "aws-cdk-lib/aws-iam";
+import {
+  scaffoldBackendAssetDirs,
+  scaffoldArbiterStubs,
+} from "./helpers/scaffold-stub-assets";
+import { grantCloudWatchAlarmPublish } from "../lib/alarm-delivery";
+
+scaffoldBackendAssetDirs(["dist/lambda", "src/schema"]);
+scaffoldArbiterStubs();
+
+import { ArbiterStack } from "../lib/arbiter-stack";
+import { BackendStack } from "../lib/backend-stack";
+
+type CfnResource = { Type: string; Properties?: Record<string, unknown> };
+type Resources = Record<string, CfnResource>;
+
+const REQUIRED_ACTIONS = ["kms:GenerateDataKey*", "kms:Decrypt"];
+
+/**
+ * True iff `statement` is an Allow statement naming `principalService` as
+ * (one of) its Principal.Service, and its Action array/string contains
+ * every action in `requiredActions`.
+ */
+function statementGrantsServiceActions(
+  statement: Record<string, unknown>,
+  principalService: string,
+  requiredActions: string[],
+): boolean {
+  if (statement.Effect !== "Allow") return false;
+  const principal = statement.Principal as
+    { Service?: string | string[] } | undefined;
+  const svc = principal?.Service;
+  const services = Array.isArray(svc) ? svc : svc ? [svc] : [];
+  if (!services.includes(principalService)) return false;
+  const action = statement.Action;
+  const actions = Array.isArray(action) ? action : action ? [action] : [];
+  return requiredActions.every((a) => actions.includes(a));
+}
+
+/** Resolve a `{ Ref: logicalId }` token to the referenced resource, or undefined. */
+function resolveRef(
+  resources: Resources,
+  token: unknown,
+): { logicalId: string; resource: CfnResource } | undefined {
+  if (
+    typeof token === "object" &&
+    token !== null &&
+    "Ref" in (token as Record<string, unknown>)
+  ) {
+    const logicalId = (token as { Ref: string }).Ref;
+    const resource = resources[logicalId];
+    if (resource) return { logicalId, resource };
+  }
+  return undefined;
+}
+
+/** Resolve a `{ "Fn::GetAtt": [logicalId, attr] }` token's target resource. */
+function resolveGetAtt(
+  resources: Resources,
+  token: unknown,
+): { logicalId: string; resource: CfnResource } | undefined {
+  if (
+    typeof token === "object" &&
+    token !== null &&
+    "Fn::GetAtt" in (token as Record<string, unknown>)
+  ) {
+    const pair = (token as { "Fn::GetAtt": [string, string] })["Fn::GetAtt"];
+    const logicalId = Array.isArray(pair) ? pair[0] : undefined;
+    const resource = logicalId ? resources[logicalId] : undefined;
+    if (resource) return { logicalId: logicalId!, resource };
+  }
+  return undefined;
+}
+
+export interface UngrantedAlarmTopicKey {
+  alarmLogicalId: string;
+  topicLogicalId: string;
+  keyLogicalId: string;
+}
+
+/**
+ * For every AWS::CloudWatch::Alarm in `resources`, resolve each AlarmAction
+ * that is a same-template `Ref` to an AWS::SNS::Topic. If that topic has a
+ * `KmsMasterKeyId` resolvable (via Fn::GetAtt) to a same-template
+ * AWS::KMS::Key, verify the key's KeyPolicy grants `cloudwatch.amazonaws.com`
+ * both kms:GenerateDataKey* and kms:Decrypt. Returns the list of violations
+ * (empty = guard satisfied).
+ */
+export function findAlarmTopicKeysMissingCloudWatchPublishGrant(
+  resources: Resources,
+): UngrantedAlarmTopicKey[] {
+  const violations: UngrantedAlarmTopicKey[] = [];
+
+  for (const [alarmLogicalId, alarm] of Object.entries(resources)) {
+    if (alarm.Type !== "AWS::CloudWatch::Alarm") continue;
+    const actions = (alarm.Properties?.AlarmActions ?? []) as unknown[];
+    if (!Array.isArray(actions)) continue;
+
+    for (const action of actions) {
+      const topicRef = resolveRef(resources, action);
+      if (!topicRef || topicRef.resource.Type !== "AWS::SNS::Topic") {
+        // Not a same-template topic Ref (e.g. Fn::ImportValue for a
+        // cross-stack topic) — not analyzable from this template; skip.
+        continue;
+      }
+
+      const kmsMasterKeyId = topicRef.resource.Properties?.KmsMasterKeyId;
+      if (kmsMasterKeyId === undefined) {
+        // Plaintext topic — no key policy to check.
+        continue;
+      }
+
+      const keyRef = resolveGetAtt(resources, kmsMasterKeyId);
+      if (!keyRef || keyRef.resource.Type !== "AWS::KMS::Key") {
+        // Encrypted with a key we can't resolve in this template (e.g. an
+        // imported/cross-stack key ARN) — not analyzable from here.
+        continue;
+      }
+
+      const statements = (
+        keyRef.resource.Properties?.KeyPolicy as
+          { Statement?: Record<string, unknown>[] } | undefined
+      )?.Statement;
+      const grants = Array.isArray(statements)
+        ? statements.some((s) =>
+            statementGrantsServiceActions(
+              s,
+              "cloudwatch.amazonaws.com",
+              REQUIRED_ACTIONS,
+            ),
+          )
+        : false;
+
+      if (!grants) {
+        violations.push({
+          alarmLogicalId,
+          topicLogicalId: topicRef.logicalId,
+          keyLogicalId: keyRef.logicalId,
+        });
+      }
+    }
+  }
+
+  return violations;
+}
+
+describe("structural guard: alarm -> encrypted-topic -> key-policy must grant cloudwatch.amazonaws.com publish", () => {
+  test("ArbiterStack: the CMK-encrypted escalation topic's key grants cloudwatch.amazonaws.com (non-vacuous: at least one encrypted topic is actually checked)", () => {
+    const app = new cdk.App({ context: { "aws:cdk:bundling-stacks": [] } });
+    const env = { account: "123456789012", region: "us-east-1" };
+    const backend = new BackendStack(app, "citadel-backend-test", {
+      environment: "test",
+      env,
+    });
+    const arbiter = new ArbiterStack(app, "citadel-arbiter-test", {
+      environment: "test",
+      env,
+      agentEventBus: backend.agentEventBus,
+      agentConfigTable: backend.agentConfigTable,
+      codeBucket: backend.codeBucket,
+      workflowsTable: backend.workflowsTable,
+      executionsTable: backend.executionsTable,
+      fanoutFunction: backend.workflowProgressFanoutFunction,
+      appSyncEndpoint: backend.appSyncApi.graphqlUrl,
+      appsTable: backend.appsTable,
+      executionSpecificationsTable: backend.executionSpecificationsTable,
+      registryArn: backend.registryArn,
+      registryId: backend.registryId,
+      alarmTopic: backend.alarmTopic,
+    });
+    const resources = Template.fromStack(arbiter).toJSON().Resources;
+
+    // Non-vacuousness check: this template must actually contain at least
+    // one alarm whose action Refs an encrypted topic, or the guard below
+    // would trivially pass by never examining anything.
+    const encryptedTopicLogicalIds = Object.entries(resources)
+      .filter(
+        ([, r]) =>
+          r.Type === "AWS::SNS::Topic" &&
+          r.Properties?.KmsMasterKeyId !== undefined,
+      )
+      .map(([id]) => id);
+    expect(encryptedTopicLogicalIds.length).toBeGreaterThan(0);
+
+    const violations =
+      findAlarmTopicKeysMissingCloudWatchPublishGrant(resources);
+    expect(violations).toEqual([]);
+  });
+});
+
+describe("bite proof: the guard fires when the cloudwatch.amazonaws.com key-policy grant is absent", () => {
+  function synthAlarmToEncryptedTopic(withCloudWatchGrant: boolean): Template {
+    const app = new cdk.App();
+    const stack = new cdk.Stack(app, "BiteStack", {
+      env: { account: "123456789012", region: "us-east-1" },
+    });
+    const key = new kms.Key(stack, "BiteKey", { enableKeyRotation: true });
+    const topic = new sns.Topic(stack, "BiteTopic", {
+      topicName: "citadel-bite-encrypted-test",
+      masterKey: key,
+    });
+    if (withCloudWatchGrant) {
+      grantCloudWatchAlarmPublish(key);
+    }
+    new cloudwatch.Alarm(stack, "BiteAlarm", {
+      alarmName: "citadel-bite-encrypted-alarm-test",
+      metric: new cloudwatch.Metric({
+        namespace: "Citadel/Test",
+        metricName: "X",
+        period: cdk.Duration.minutes(5),
+        statistic: "Sum",
+      }),
+      threshold: 1,
+      evaluationPeriods: 1,
+      comparisonOperator:
+        cloudwatch.ComparisonOperator.GREATER_THAN_OR_EQUAL_TO_THRESHOLD,
+      treatMissingData: cloudwatch.TreatMissingData.NOT_BREACHING,
+    }).addAlarmAction(new cw_actions.SnsAction(topic));
+    return Template.fromStack(stack);
+  }
+
+  test("RED: missing the cloudwatch.amazonaws.com grant IS flagged", () => {
+    const violations = findAlarmTopicKeysMissingCloudWatchPublishGrant(
+      synthAlarmToEncryptedTopic(false).toJSON().Resources,
+    );
+    expect(violations.length).toBe(1);
+    expect(violations[0].alarmLogicalId).toMatch(/BiteAlarm/);
+    // And the assertion the structural test uses would fail on it.
+    expect(() => expect(violations).toEqual([])).toThrow();
+  });
+
+  test("GREEN: the same alarm/topic/key WITH the grant is not flagged", () => {
+    expect(
+      findAlarmTopicKeysMissingCloudWatchPublishGrant(
+        synthAlarmToEncryptedTopic(true).toJSON().Resources,
+      ),
+    ).toEqual([]);
+  });
+
+  test("a plaintext topic (no KmsMasterKeyId) is never flagged — nothing to grant", () => {
+    const app = new cdk.App();
+    const stack = new cdk.Stack(app, "BitePlainStack", {
+      env: { account: "123456789012", region: "us-east-1" },
+    });
+    const topic = new sns.Topic(stack, "BitePlainTopic", {
+      topicName: "citadel-bite-plaintext-test",
+    });
+    new cloudwatch.Alarm(stack, "BitePlainAlarm", {
+      alarmName: "citadel-bite-plaintext-alarm-test",
+      metric: new cloudwatch.Metric({
+        namespace: "Citadel/Test",
+        metricName: "X",
+        period: cdk.Duration.minutes(5),
+        statistic: "Sum",
+      }),
+      threshold: 1,
+      evaluationPeriods: 1,
+      comparisonOperator:
+        cloudwatch.ComparisonOperator.GREATER_THAN_OR_EQUAL_TO_THRESHOLD,
+      treatMissingData: cloudwatch.TreatMissingData.NOT_BREACHING,
+    }).addAlarmAction(new cw_actions.SnsAction(topic));
+    const resources = Template.fromStack(stack).toJSON().Resources;
+    expect(findAlarmTopicKeysMissingCloudWatchPublishGrant(resources)).toEqual(
+      [],
+    );
+  });
+
+  test("a key policy granting a DIFFERENT service (not cloudwatch.amazonaws.com) is still flagged", () => {
+    const app = new cdk.App();
+    const stack = new cdk.Stack(app, "BiteWrongServiceStack", {
+      env: { account: "123456789012", region: "us-east-1" },
+    });
+    const key = new kms.Key(stack, "WrongServiceKey", {
+      enableKeyRotation: true,
+    });
+    key.addToResourcePolicy(
+      new iam.PolicyStatement({
+        sid: "OnlySns",
+        effect: iam.Effect.ALLOW,
+        principals: [new iam.ServicePrincipal("sns.amazonaws.com")],
+        actions: ["kms:Decrypt", "kms:GenerateDataKey*"],
+        resources: ["*"],
+      }),
+    );
+    const topic = new sns.Topic(stack, "WrongServiceTopic", {
+      topicName: "citadel-bite-wrong-service-test",
+      masterKey: key,
+    });
+    new cloudwatch.Alarm(stack, "WrongServiceAlarm", {
+      alarmName: "citadel-bite-wrong-service-alarm-test",
+      metric: new cloudwatch.Metric({
+        namespace: "Citadel/Test",
+        metricName: "X",
+        period: cdk.Duration.minutes(5),
+        statistic: "Sum",
+      }),
+      threshold: 1,
+      evaluationPeriods: 1,
+      comparisonOperator:
+        cloudwatch.ComparisonOperator.GREATER_THAN_OR_EQUAL_TO_THRESHOLD,
+      treatMissingData: cloudwatch.TreatMissingData.NOT_BREACHING,
+    }).addAlarmAction(new cw_actions.SnsAction(topic));
+    const resources = Template.fromStack(stack).toJSON().Resources;
+    expect(
+      findAlarmTopicKeysMissingCloudWatchPublishGrant(resources).length,
+    ).toBe(1);
+  });
+});


### PR DESCRIPTION
## Summary

The off-frontier escalation alarm could never deliver. It targets a CMK-encrypted SNS topic, but nothing granted `cloudwatch.amazonaws.com` the `kms: GenerateDataKey*` and `kms:Decrypt` permissions Cloudwatch needs to publish to an encrypted topic - the live key policy contained only the account-root default.

Pre-existing, and it hid well: that alarm was one of the nine already carrying an action, so it looked correctly wired in every audit and dashboard while being structurally incapable of publishing anywhere. The publish is denied before delivery is even attempted, so adding a subscriber would not have fixed it.

## What changed

- The grant is added **unconditionally** - not gated on email mode, since publishing is required for any destination including Chatbot, and for the alarm to function at all. Scoped to that key only.
- **Structural guard**: for every alarm action targeting an SNS topic, if the topic is encrypted then the referenced key's policy must grant the publisher.

It walks alarm → action → topic → key from the synthesized template rather than a maintained list, and includes a non-vacuousness assertion so it cannot pass by matching nothing.

## Testing

Grant verified verbatim in the synthesized template in **both** destination modes (`AllowCloudWatchAlarmPublish`) - the point being that it must not depend on configuration. `cloudwatch.amazonaws.com` appears exactly once per template, that key alone.

Bite proof re-derived in review: removing the grant fails the guard, naming the exact alarm, topic and key. Sibling sweep confirmed only one encrypted topic exists across all five stacks, and the worker and supervisor publishers already hold the permissions they need - so this was the sole instance.

jest 6,930 passing across 455 suites; `tsc` and both synth modes clean; 29 of 29 alarm actions and the environment-aware unconfigured behaviour intact.
## Deployment notes
Deploying this makes the escalation alarm capable of publishing. It still needs a destination to reach a person: `ALARM_DELIVERY` plus either `ALARM_EMAIL` or the Slack variables in the deploying clone. For email, the recipient must confirm the subscription - an unconfirmed one is silently equivalent to none.