### PR TITLE
feat(arbiter): event-id dedupe for supervisor and fabricator

### DIFF
--- a/arbiter/fabricator/__tests__/test_event_idempotency.py
+++ b/arbiter/fabricator/__tests__/test_event_idempotency.py
@@ -1,0 +1,208 @@
+"""Slice B (CIT-125): fabricator dedupe on message id (DEVIATION — see below).
+
+Design B.1 specifies dedupe keyed on the EventBridge envelope ``event["id"]``
+for both supervisor and fabricator. Verified against the real wiring
+(backend/lib/arbiter-stack.ts: fabricatorQueue has NO EventBridge Rule
+target — only ``new SqsEventSource(fabricatorQueue, ...)``; the two producers
+that enqueue to it, ``fabricator-request-resolver.ts`` and
+``agent-import-resolver.ts``, both call SQS ``SendMessageCommand`` directly
+with a hand-built JSON body that carries no EventBridge envelope and no
+``id``/``detail`` field at all). There is no ``event.id`` for the fabricator
+to dedupe on.
+
+DEVIATION (disclosed, see reply): dedupe is keyed on the SQS ``messageId``
+(``record["messageId"]``) instead. This preserves the design's core
+guarantee — the key is stable across at-least-once SQS redelivery AND across
+an SQS DLQ redrive (moving a message back to the source queue preserves its
+``messageId``) — via the substrate the fabricator is actually built on,
+rather than one it isn't.
+
+Two-phase semantics (design B.1): PENDING claimed before the fabrication
+body runs; promoted to DONE on success. A redelivery seeing an existing
+PENDING record routes to reconcile (does not re-enter fabrication); a
+redelivery seeing DONE is a no-op.
+"""
+
+import os
+import sys
+from unittest.mock import MagicMock, patch
+
+import pytest
+from botocore.exceptions import ClientError
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+
+os.environ.setdefault("TOOL_CONFIG_TABLE", "fake-tool-table")
+os.environ.setdefault("AGENT_CONFIG_TABLE", "fake-agent-table")
+os.environ.setdefault("AGENT_BUCKET_NAME", "fake-bucket")
+os.environ.setdefault("COMPLETION_BUS_NAME", "fake-bus")
+os.environ.setdefault("WORKER_QUEUE_URL", "https://sqs.fake/queue")
+os.environ.setdefault("IDEMPOTENCY_TABLE", "citadel-idempotency-test")
+os.environ.setdefault("AWS_DEFAULT_REGION", "us-west-2")
+
+import index  # noqa: E402
+
+
+def _conditional_check_failed():
+    return ClientError(
+        error_response={
+            "Error": {
+                "Code": "ConditionalCheckFailedException",
+                "Message": "The conditional request failed",
+            }
+        },
+        operation_name="PutItem",
+    )
+
+
+def _sqs_record(message_id: str, body: dict, request_type: str | None = None):
+    record = {
+        "messageId": message_id,
+        "body": __import__("json").dumps(body),
+    }
+    if request_type is not None:
+        record["messageAttributes"] = {
+            "requestType": {"stringValue": request_type}
+        }
+    return record
+
+
+class TestFabricatorLambdaHandlerDedupe:
+    def test_first_delivery_of_message_processes_once(self):
+        event = {
+            "Records": [
+                _sqs_record(
+                    "msg-first-111",
+                    {"agent_input": {"taskDetails": "build a thing"}, "orchestration_id": "0"},
+                )
+            ]
+        }
+        with patch("index._claim_message_id", return_value="CLAIMED") as claim, \
+                patch("index.process_event") as process_event:
+            index.lambda_handler(event, {})
+
+        claim.assert_called_once_with("msg-first-111")
+        process_event.assert_called_once()
+
+    def test_duplicate_delivery_same_message_id_while_pending_does_not_refabricate(self):
+        """RED: today lambda_handler has zero dedupe — every record in
+        event['Records'] unconditionally calls process_event, so a
+        redelivered SQS message (at-least-once, or a DLQ redrive of a
+        message still mid-flight) re-enters fabrication. A PENDING claim
+        state must route to reconcile instead."""
+        event = {
+            "Records": [
+                _sqs_record(
+                    "msg-dup-222",
+                    {"agent_input": {"taskDetails": "build a thing"}, "orchestration_id": "0"},
+                )
+            ]
+        }
+        with patch("index._claim_message_id", return_value="ALREADY_PENDING") as claim, \
+                patch("index.process_event") as process_event, \
+                patch("index._route_to_reconcile") as reconcile:
+            index.lambda_handler(event, {})
+
+        claim.assert_called_once_with("msg-dup-222")
+        process_event.assert_not_called()
+        reconcile.assert_called_once_with("msg-dup-222")
+
+    def test_redrive_of_done_message_is_a_noop(self):
+        """A later redrive of a message whose fabrication already
+        completed (DONE) must not re-fabricate and must not error."""
+        event = {
+            "Records": [
+                _sqs_record(
+                    "msg-done-333",
+                    {"agent_input": {"taskDetails": "build a thing"}, "orchestration_id": "0"},
+                )
+            ]
+        }
+        with patch("index._claim_message_id", return_value="ALREADY_DONE") as claim, \
+                patch("index.process_event") as process_event, \
+                patch("index._route_to_reconcile") as reconcile:
+            index.lambda_handler(event, {})
+
+        claim.assert_called_once_with("msg-done-333")
+        process_event.assert_not_called()
+        reconcile.assert_not_called()
+
+    def test_successful_fabrication_marks_message_done(self):
+        event = {
+            "Records": [
+                _sqs_record(
+                    "msg-success-444",
+                    {"agent_input": {"taskDetails": "build a thing"}, "orchestration_id": "0"},
+                )
+            ]
+        }
+        with patch("index._claim_message_id", return_value="CLAIMED"), \
+                patch("index.process_event") as process_event, \
+                patch("index._complete_message_id") as complete:
+            index.lambda_handler(event, {})
+
+        process_event.assert_called_once()
+        complete.assert_called_once_with("msg-success-444")
+
+    def test_failed_fabrication_does_not_mark_done(self):
+        """On a raised exception from process_event, the message must NOT
+        be marked DONE (so a redrive can legitimately retry), and the
+        exception must still propagate so SQS/DLQ semantics apply."""
+        event = {
+            "Records": [
+                _sqs_record(
+                    "msg-fail-555",
+                    {"agent_input": {"taskDetails": "build a thing"}, "orchestration_id": "0"},
+                )
+            ]
+        }
+        with patch("index._claim_message_id", return_value="CLAIMED"), \
+                patch("index.process_event", side_effect=RuntimeError("boom")), \
+                patch("index._complete_message_id") as complete:
+            with pytest.raises(RuntimeError):
+                index.lambda_handler(event, {})
+
+        complete.assert_not_called()
+
+
+class TestClaimMessageIdImplementation:
+    """Unit coverage of the two-phase claim helper itself."""
+
+    def test_claim_returns_claimed_on_first_put(self):
+        fake_table = MagicMock()
+        fake_table.put_item.return_value = {}
+        with patch("index._idempotency_table", return_value=fake_table):
+            result = index._claim_message_id("msg-unit-1")
+
+        assert result == "CLAIMED"
+        _, kwargs = fake_table.put_item.call_args
+        assert kwargs["Item"]["eventId"] == "msg-unit-1"
+        assert kwargs["Item"]["status"] == "PENDING"
+        assert "ttl" in kwargs["Item"]
+
+    def test_claim_returns_already_pending_when_existing_record_is_pending(self):
+        fake_table = MagicMock()
+        fake_table.put_item.side_effect = _conditional_check_failed()
+        fake_table.get_item.return_value = {"Item": {"eventId": "msg-unit-2", "status": "PENDING"}}
+        with patch("index._idempotency_table", return_value=fake_table):
+            result = index._claim_message_id("msg-unit-2")
+
+        assert result == "ALREADY_PENDING"
+
+    def test_claim_returns_already_done_when_existing_record_is_done(self):
+        fake_table = MagicMock()
+        fake_table.put_item.side_effect = _conditional_check_failed()
+        fake_table.get_item.return_value = {"Item": {"eventId": "msg-unit-3", "status": "DONE"}}
+        with patch("index._idempotency_table", return_value=fake_table):
+            result = index._claim_message_id("msg-unit-3")
+
+        assert result == "ALREADY_DONE"
+
+    def test_complete_message_id_updates_status_to_done(self):
+        fake_table = MagicMock()
+        with patch("index._idempotency_table", return_value=fake_table):
+            index._complete_message_id("msg-unit-4")
+
+        fake_table.update_item.assert_called_once()
+        _, kwargs = fake_table.update_item.call_args
+        assert kwargs["Key"]["eventId"] == "msg-unit-4"

--- a/arbiter/fabricator/index.py
+++ b/arbiter/fabricator/index.py
@@ -34,6 +34,7 @@ from registry_recovery import (
 )
 import boto3
 from botocore.config import Config
+from botocore.exceptions import ClientError
 from common.region import cross_region_prefix
 from model_config_loader import load_model_id
 
@@ -46,6 +47,18 @@ FABRICATOR_MODEL_ID = load_model_id(
     region=_REGION,
     fallback_model_id=f"{_MODEL_PREFIX}.anthropic.claude-sonnet-4-6",
 )
+
+# CIT-125 slice B: shared idempotency table (backend-stack.ts:178-ish,
+# `citadel-idempotency-${env}`, PK `eventId`, TTL attr `ttl`), referenced by
+# NAME (Table.fromTableName in arbiter-stack.ts) — no new table. DEVIATION
+# from the design's literal "event.id" framing: the fabricator queue has no
+# EventBridge envelope (fabricator-request-resolver.ts / agent-import-
+# resolver.ts both SendMessageCommand directly with a hand-built JSON body,
+# no `id`/`detail` field). The dedupe key used here is the SQS `messageId`
+# instead — stable across at-least-once SQS redelivery and across a DLQ
+# redrive, which is the same guarantee the design relies on for the EB id.
+IDEMPOTENCY_TABLE = os.environ.get('IDEMPOTENCY_TABLE')
+IDEMPOTENCY_TTL_SECONDS = 7 * 24 * 60 * 60
 
 logger = logging.getLogger(__name__)
 
@@ -2469,9 +2482,95 @@ def process_event(event, context, request_type=None):
     publish_intake_progress(orchestration_id, agent_index, total_agents, agent_use_id)
 
 
+def _idempotency_table():
+    """Return the shared idempotency table resource (CIT-125 slice B).
+
+    Lazily resolved on each call so tests can patch it without needing
+    IDEMPOTENCY_TABLE bound at import time — mirrors the existing lazy
+    `boto3.resource('dynamodb')` call sites already in this module (e.g.
+    store_agent_config_dynamo).
+    """
+    import boto3 as _boto3
+    return _boto3.resource('dynamodb').Table(IDEMPOTENCY_TABLE)
+
+
+def _claim_message_id(message_id: str) -> str:
+    """Two-phase claim on the SQS `messageId` (design B.1, fabricator side).
+
+    A bare single-claim guard (like the supervisor's) is not enough here:
+    fabrication is long-running and partially side-effecting (registers
+    agents/tools, creates roles), so a redelivery arriving WHILE the first
+    attempt is still in flight must be distinguished from a redelivery
+    AFTER it already completed.
+
+    Returns one of:
+      - "CLAIMED": first sight — PENDING record written, proceed with
+        fabrication.
+      - "ALREADY_PENDING": an earlier attempt's PENDING record still
+        exists — do NOT re-enter the fabrication body; route to reconcile
+        (a poisoned-then-fixed message may have partially fabricated).
+      - "ALREADY_DONE": a prior attempt already completed — no-op.
+
+    Any ClientError other than the conditional-check failure on the initial
+    claim PutItem is rethrown so the message is redelivered/DLQ'd rather
+    than silently swallowed.
+    """
+    import time as _time
+    now = int(_time.time())
+    table = _idempotency_table()
+    try:
+        table.put_item(
+            Item={
+                "eventId": message_id,
+                "ttl": now + IDEMPOTENCY_TTL_SECONDS,
+                "consumer": "fabricator",
+                "status": "PENDING",
+                "claimedAt": now,
+            },
+            ConditionExpression="attribute_not_exists(eventId)",
+        )
+        return "CLAIMED"
+    except ClientError as e:
+        if e.response.get("Error", {}).get("Code") != "ConditionalCheckFailedException":
+            raise
+        existing = table.get_item(Key={"eventId": message_id}).get("Item") or {}
+        if existing.get("status") == "DONE":
+            return "ALREADY_DONE"
+        # PENDING (or a legacy/unknown status) — treat as in-flight/for-
+        # reconcile rather than assuming DONE, per design B.1.
+        return "ALREADY_PENDING"
+
+
+def _complete_message_id(message_id: str) -> None:
+    """Promote a claimed message id to DONE after successful fabrication."""
+    _idempotency_table().update_item(
+        Key={"eventId": message_id},
+        UpdateExpression="SET #status = :done",
+        ExpressionAttributeNames={"#status": "status"},
+        ExpressionAttributeValues={":done": "DONE"},
+    )
+
+
+def _route_to_reconcile(message_id: str) -> None:
+    """Log-and-route hook for a redelivery seen while PENDING (design B.1 /
+    docs/runbooks/DLQ_REDRIVE.md slice C): the runbook, not this handler,
+    owns the manual reconcile procedure. This is deliberately a no-op
+    beyond logging — it exists as a named seam so a future automated
+    reconcile step has a single call site to extend, and so tests can
+    assert the routing decision independently of that future behavior.
+    """
+    logger.warning(
+        "Fabricator message id=%s redelivered while a prior attempt is "
+        "still PENDING; skipping re-fabrication and routing to manual "
+        "reconcile (see docs/runbooks/DLQ_REDRIVE.md)",
+        message_id,
+    )
+
+
 def lambda_handler(event, context):
     print(f"processing event {event}")
     for record in event['Records']:
+        message_id = record.get('messageId')
         message_body = json.loads(record['body'])
         # print(f"Parsed message body: {json.dumps(message_body, indent=2)}")
         
@@ -2480,8 +2579,25 @@ def lambda_handler(event, context):
         if 'messageAttributes' in record and 'requestType' in record['messageAttributes']:
             request_type = record['messageAttributes']['requestType'].get('stringValue')
             print(f"Request type from messageAttributes: {request_type}")
-        
+
+        # CIT-125 slice B: two-phase dedupe on the SQS messageId (see
+        # IDEMPOTENCY_TABLE comment above for why messageId, not event.id).
+        # Records without a messageId (defensive: should not occur on the
+        # real SQS path) are NOT deduped — fail open rather than silently
+        # dropping work.
+        if message_id:
+            claim = _claim_message_id(message_id)
+            if claim == "ALREADY_PENDING":
+                _route_to_reconcile(message_id)
+                continue
+            if claim == "ALREADY_DONE":
+                print(f"Message id={message_id} already fabricated (DONE); skipping")
+                continue
+
         process_event(message_body, context, request_type=request_type)
+
+        if message_id:
+            _complete_message_id(message_id)
 
 if __name__ == "__main__":
     # Grab a record from your lambda and invoke, configuration will vary drastically

--- a/arbiter/supervisor/__tests__/test_event_idempotency.py
+++ b/arbiter/supervisor/__tests__/test_event_idempotency.py
@@ -1,0 +1,201 @@
+"""Slice B (CIT-125): supervisor event.id dedupe.
+
+Guards against duplicate dispatch/continuation on at-least-once EventBridge
+delivery and DLQ redrive by claiming ``event["id"]`` in the shared
+``citadel-idempotency-<env>`` table (PK ``eventId``) before doing any work.
+
+Contract under test (design B.1):
+  - First delivery of a given event id: claim succeeds, handler proceeds
+    (``orchestrate`` / continuation called).
+  - Duplicate delivery of the SAME event id: claim raises
+    ``ConditionalCheckFailedException`` -> handler is a no-op (ACK, return).
+  - Distinct event ids are each processed once (no false-positive dedupe).
+  - A DDB error OTHER than the conditional-check failure on the claim write
+    must propagate (rethrown) so the message is redelivered / DLQ'd rather
+    than silently swallowed.
+"""
+
+import os
+import sys
+from unittest.mock import MagicMock, patch
+
+import pytest
+from botocore.exceptions import ClientError
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+
+os.environ.setdefault("ORCHESTRATION_TABLE", "fake-orchestration-table")
+os.environ.setdefault("WORKER_STATE_TABLE", "fake-worker-state-table")
+os.environ.setdefault("AGENT_CONFIG_TABLE", "fake-agent-config-table")
+os.environ.setdefault("EVENT_BUS_NAME", "fake-bus")
+os.environ.setdefault("COMPLETION_BUS_NAME", "fake-bus")
+os.environ.setdefault("IDEMPOTENCY_TABLE", "citadel-idempotency-test")
+os.environ.setdefault("AWS_DEFAULT_REGION", "us-west-2")
+
+import index  # noqa: E402
+
+
+def _conditional_check_failed():
+    return ClientError(
+        error_response={
+            "Error": {
+                "Code": "ConditionalCheckFailedException",
+                "Message": "The conditional request failed",
+            }
+        },
+        operation_name="PutItem",
+    )
+
+
+def _throttling_error():
+    return ClientError(
+        error_response={
+            "Error": {
+                "Code": "ProvisionedThroughputExceededException",
+                "Message": "throttled",
+            }
+        },
+        operation_name="PutItem",
+    )
+
+
+class TestSupervisorTaskRequestDedupe:
+    def test_first_delivery_dispatches_once(self):
+        event = {
+            "source": "task.request",
+            "detail": {"task": "do the thing", "appId": "app-1"},
+            "id": "evt-aaa-111",
+        }
+        with patch("index._claim_event_id", return_value=True) as claim, \
+                patch("index.orchestrate") as orchestrate:
+            index.handler(event, {})
+
+        claim.assert_called_once_with("evt-aaa-111")
+        orchestrate.assert_called_once()
+
+    def test_duplicate_task_request_same_event_id_dispatches_once(self):
+        """RED: today the handler has no dedupe guard at all, so a
+        duplicate delivery of the same event id calls orchestrate() a
+        second time. This must become a no-op."""
+        event = {
+            "source": "task.request",
+            "detail": {"task": "do the thing", "appId": "app-1"},
+            "id": "evt-dup-222",
+        }
+        with patch("index._claim_event_id", return_value=False) as claim, \
+                patch("index.orchestrate") as orchestrate:
+            index.handler(event, {})
+
+        claim.assert_called_once_with("evt-dup-222")
+        orchestrate.assert_not_called()
+
+    def test_distinct_event_ids_both_processed(self):
+        """No false-positive dedupe across genuinely distinct events."""
+        event_a = {
+            "source": "task.request",
+            "detail": {"task": "task A"},
+            "id": "evt-distinct-a",
+        }
+        event_b = {
+            "source": "task.request",
+            "detail": {"task": "task B"},
+            "id": "evt-distinct-b",
+        }
+        with patch("index._claim_event_id", return_value=True) as claim, \
+                patch("index.orchestrate") as orchestrate:
+            index.handler(event_a, {})
+            index.handler(event_b, {})
+
+        assert claim.call_count == 2
+        assert orchestrate.call_count == 2
+
+    def test_claim_ddb_transient_error_propagates_not_swallowed(self):
+        """A non-conditional-check DDB error on the claim write must
+        rethrow so EventBridge retries / eventually DLQs the message,
+        rather than being treated as either success or duplicate."""
+        event = {
+            "source": "task.request",
+            "detail": {"task": "do the thing"},
+            "id": "evt-transient-err",
+        }
+        with patch("index._claim_event_id", side_effect=_throttling_error()), \
+                patch("index.orchestrate") as orchestrate:
+            with pytest.raises(ClientError):
+                index.handler(event, {})
+
+        orchestrate.assert_not_called()
+
+
+class TestSupervisorTaskCompletionDedupe:
+    def test_first_completion_triggers_continuation_once(self):
+        event = {
+            "source": "task.completion",
+            "detail": {"orchestration_id": "orch-1", "node": "worker-a"},
+            "id": "evt-completion-first",
+        }
+        fake_orchestration = {"request_id": "req-1"}
+        with patch("index._claim_event_id", return_value=True) as claim, \
+                patch("index.load_orchestration", return_value=fake_orchestration), \
+                patch("index.update_workflow_tracking", return_value=(True, {"ok": True})), \
+                patch("index.update_orchestration_with_results") as update_results, \
+                patch("index.parse_decimals", side_effect=lambda x: x), \
+                patch("index.orchestrate") as orchestrate:
+            index.handler(event, {})
+
+        claim.assert_called_once_with("evt-completion-first")
+        update_results.assert_called_once()
+        orchestrate.assert_called_once()
+
+    def test_duplicate_completion_same_event_id_continues_once(self):
+        """RED: today a redelivered task.completion re-runs
+        update_orchestration_with_results + orchestrate() a second time.
+        Must become a no-op on the duplicate delivery."""
+        event = {
+            "source": "task.completion",
+            "detail": {"orchestration_id": "orch-1", "node": "worker-a"},
+            "id": "evt-completion-dup",
+        }
+        with patch("index._claim_event_id", return_value=False) as claim, \
+                patch("index.load_orchestration") as load_orch, \
+                patch("index.update_workflow_tracking") as update_tracking, \
+                patch("index.update_orchestration_with_results") as update_results, \
+                patch("index.orchestrate") as orchestrate:
+            index.handler(event, {})
+
+        claim.assert_called_once_with("evt-completion-dup")
+        load_orch.assert_not_called()
+        update_tracking.assert_not_called()
+        update_results.assert_not_called()
+        orchestrate.assert_not_called()
+
+
+class TestClaimEventIdImplementation:
+    """Unit-level coverage of the conditional-put claim helper itself,
+    independent of the handler wiring above."""
+
+    def test_claim_returns_true_on_first_put(self):
+        fake_table = MagicMock()
+        fake_table.put_item.return_value = {}
+        with patch("index._idempotency_table", return_value=fake_table):
+            result = index._claim_event_id("evt-unit-1", consumer="supervisor")
+
+        assert result is True
+        _, kwargs = fake_table.put_item.call_args
+        assert kwargs["Item"]["eventId"] == "evt-unit-1"
+        assert "ttl" in kwargs["Item"]
+        assert kwargs["ConditionExpression"] is not None
+
+    def test_claim_returns_false_on_conditional_check_failed(self):
+        fake_table = MagicMock()
+        fake_table.put_item.side_effect = _conditional_check_failed()
+        with patch("index._idempotency_table", return_value=fake_table):
+            result = index._claim_event_id("evt-unit-2", consumer="supervisor")
+
+        assert result is False
+
+    def test_claim_reraises_other_client_errors(self):
+        fake_table = MagicMock()
+        fake_table.put_item.side_effect = _throttling_error()
+        with patch("index._idempotency_table", return_value=fake_table):
+            with pytest.raises(ClientError):
+                index._claim_event_id("evt-unit-3", consumer="supervisor")

--- a/arbiter/supervisor/index.py
+++ b/arbiter/supervisor/index.py
@@ -8,6 +8,7 @@ import logging
 import sys
 from typing import Any
 import boto3
+from botocore.exceptions import ClientError
 import os
 
 # Tracing foundation (architect task 5459301e-1e7b-4bfd-bccb-b106aba2748c):
@@ -211,6 +212,14 @@ MODEL_ID = load_model_id(
 EVENT_BUS_NAME = os.environ.get('EVENT_BUS_NAME')
 ORCHESTRATION_TABLE = os.environ.get('ORCHESTRATION_TABLE')
 WORKER_STATE_TABLE = os.environ.get('WORKER_STATE_TABLE')
+# CIT-125 slice B: shared idempotency table (backend-stack.ts:178-ish,
+# `citadel-idempotency-${env}`, PK `eventId`, TTL attr `ttl`). Referenced by
+# NAME (Table.fromTableName in arbiter-stack.ts) rather than a cross-stack
+# construct import, so this env var is the only coupling to it.
+IDEMPOTENCY_TABLE = os.environ.get('IDEMPOTENCY_TABLE')
+# Dedupe claims only need to outlive the realistic redrive/triage window,
+# not the full 14-day DLQ retention (design B.1 tradeoff).
+IDEMPOTENCY_TTL_SECONDS = 7 * 24 * 60 * 60
 
 sqs = boto3.client('sqs')
 dynamodb = boto3.resource('dynamodb')
@@ -1299,9 +1308,60 @@ def send_response(message, callback=None):
         print(f"Unknown callback type: {callback_type}")
 
 
+def _idempotency_table():
+    """Return the shared idempotency table resource (CIT-125 slice B).
+
+    Lazily resolved on each call (not module-level) so tests can patch it
+    without needing IDEMPOTENCY_TABLE bound at import time, mirroring the
+    existing lazy-lookup style used elsewhere in this module (e.g.
+    store_agent_config_dynamo's `boto3.resource('dynamodb')` call).
+    """
+    return dynamodb.Table(IDEMPOTENCY_TABLE)
+
+
+def _claim_event_id(event_id: str, consumer: str = "supervisor") -> bool:
+    """Conditionally claim `event_id` in the shared idempotency table.
+
+    Mirrors the cost-ledger-writer pattern (backend/src/lambda/
+    cost-ledger-writer.ts): a single conditional PutItem keyed on the
+    EventBridge envelope id, which is stable across EB delivery retries AND
+    a DLQ redrive (design B.1). Returns True on first sight (proceed),
+    False when the id was already claimed (duplicate — no-op). Any other
+    ClientError (e.g. throttling) is rethrown so the message is redelivered/
+    DLQ'd rather than silently treated as success or duplicate.
+    """
+    now = int(time.time())
+    try:
+        _idempotency_table().put_item(
+            Item={
+                "eventId": event_id,
+                "ttl": now + IDEMPOTENCY_TTL_SECONDS,
+                "consumer": consumer,
+                "claimedAt": now,
+            },
+            ConditionExpression="attribute_not_exists(eventId)",
+        )
+        return True
+    except ClientError as e:
+        if e.response.get("Error", {}).get("Code") == "ConditionalCheckFailedException":
+            return False
+        raise
+
+
 def handler(event, lambda_context):
     print(f"Received event: {json.dumps(event)}")
-    
+
+    # CIT-125 slice B: dedupe on the EventBridge envelope id before any
+    # side-effecting work. At-least-once EB delivery and a DLQ redrive both
+    # redeliver the SAME event id, so a duplicate delivery must not
+    # double-dispatch (task.request) or double-continue (task.completion).
+    # Events without an `id` (defensive: should not occur on the real EB
+    # path) are NOT deduped — fail open rather than silently dropping work.
+    event_id = event.get('id')
+    if event_id and not _claim_event_id(event_id):
+        print(f"Duplicate event id={event_id}; already claimed, skipping")
+        return
+
     # Check if this is a task completion event from a worker agent
     if 'source' in event and event['source'] == 'task.completion':
         orchestration_id = event['detail']['orchestration_id']

--- a/backend/lib/arbiter-stack.ts
+++ b/backend/lib/arbiter-stack.ts
@@ -380,6 +380,26 @@ export class ArbiterStack extends cdk.Stack {
     modelConfigTable.grantReadData(supervisorLambda);
     modelCatalogTable.grantReadData(supervisorLambda);
 
+    // CIT-125 slice B: event.id dedupe (at-least-once delivery + DLQ
+    // redrive safety). Reuses the existing shared idempotency table
+    // (BackendStack, `citadel-idempotency-${env}`, PK `eventId`, TTL attr
+    // `ttl`) — no new table. Referenced by NAME (fromTableName), same
+    // no-cross-stack-construct-dependency pattern as the model tables
+    // immediately above, since ArbiterStack already depends on ServicesStack
+    // which depends on BackendStack. Least privilege: RW only on this table
+    // (PutItem for the claim, GetItem/UpdateItem not needed by the
+    // supervisor's single-claim guard).
+    const supervisorIdempotencyTable = dynamodb.Table.fromTableName(
+      this,
+      "SupervisorIdempotencyTableRef",
+      `citadel-idempotency-${props.environment}`,
+    );
+    supervisorIdempotencyTable.grantReadWriteData(supervisorLambda);
+    supervisorLambda.addEnvironment(
+      "IDEMPOTENCY_TABLE",
+      `citadel-idempotency-${props.environment}`,
+    );
+
     // Grant Supervisor read-only access to Registry APIs so it can
     // resolve agent/app identifiers during orchestration. Full CRUD
     // stays on the Fabricator per least-privilege.
@@ -1140,6 +1160,25 @@ export class ArbiterStack extends cdk.Stack {
     );
     fabricatorModelConfigTable.grantReadData(fabricatorLambda);
     fabricatorModelCatalogTable.grantReadData(fabricatorLambda);
+
+    // CIT-125 slice B: dedupe on message id (at-least-once delivery + DLQ
+    // redrive safety). Reuses the same shared idempotency table as the
+    // supervisor (BackendStack, `citadel-idempotency-${env}`) — no new
+    // table. Referenced by NAME, construct id Fabricator-prefixed so it
+    // doesn't collide with SupervisorIdempotencyTableRef. Least privilege:
+    // RW only on this table — the fabricator's two-phase claim needs
+    // PutItem (claim), GetItem (resolve PENDING vs DONE on a duplicate),
+    // and UpdateItem (promote to DONE).
+    const fabricatorIdempotencyTable = dynamodb.Table.fromTableName(
+      this,
+      "FabricatorIdempotencyTableRef",
+      `citadel-idempotency-${props.environment}`,
+    );
+    fabricatorIdempotencyTable.grantReadWriteData(fabricatorLambda);
+    fabricatorLambda.addEnvironment(
+      "IDEMPOTENCY_TABLE",
+      `citadel-idempotency-${props.environment}`,
+    );
 
     // PutItem/UpdateItem on the durable fabrication-jobs table (owned by
     // BackendStack) so the consumer can upsert PROCESSING/COMPLETED/FAILED

--- a/backend/test/arbiter-stack-event-idempotency.test.ts
+++ b/backend/test/arbiter-stack-event-idempotency.test.ts
@@ -1,0 +1,190 @@
+import * as cdk from "aws-cdk-lib";
+import { Template } from "aws-cdk-lib/assertions";
+import * as dynamodb from "aws-cdk-lib/aws-dynamodb";
+import * as events from "aws-cdk-lib/aws-events";
+import * as lambda from "aws-cdk-lib/aws-lambda";
+import * as appsync from "aws-cdk-lib/aws-appsync";
+import { Bucket } from "aws-cdk-lib/aws-s3";
+import * as path from "path";
+import {
+  scaffoldBackendAssetDirs,
+  scaffoldArbiterStubs,
+} from "./helpers/scaffold-stub-assets";
+
+scaffoldBackendAssetDirs(["dist/lambda", "src/schema"]);
+scaffoldArbiterStubs();
+
+import { ArbiterStack } from "../lib/arbiter-stack";
+
+// CIT-125 slice B: supervisor + fabricator event-id dedupe. Verifies the
+// design's core wiring constraint — reuse of the EXISTING shared
+// `citadel-idempotency-${env}` table (owned by BackendStack) via
+// Table.fromTableName, with RW grants + IDEMPOTENCY_TABLE env on both
+// consumer Lambdas, and NO new DynamoDB table created for this feature.
+
+const ENVIRONMENT = "test";
+
+function buildTemplate(): Template {
+  const app = new cdk.App({ context: { "aws:cdk:bundling-stacks": [] } });
+  const backendStack = new cdk.Stack(app, "MockBackendStack", {
+    env: { account: "123456789012", region: "us-east-1" },
+  });
+
+  const agentEventBus = new events.EventBus(backendStack, "AgentEventBus", {
+    eventBusName: `citadel-agents-${ENVIRONMENT}`,
+  });
+  const mkTable = (id: string, name: string, pk: string) =>
+    new dynamodb.Table(backendStack, id, {
+      tableName: name,
+      partitionKey: { name: pk, type: dynamodb.AttributeType.STRING },
+      billingMode: dynamodb.BillingMode.PAY_PER_REQUEST,
+      removalPolicy: cdk.RemovalPolicy.DESTROY,
+    });
+  const agentConfigTable = mkTable(
+    "AgentConfigTable",
+    `citadel-agents-${ENVIRONMENT}`,
+    "agentId",
+  );
+  const workflowsTable = mkTable(
+    "WorkflowsTable",
+    `citadel-workflows-${ENVIRONMENT}`,
+    "workflowId",
+  );
+  const executionsTable = mkTable(
+    "ExecutionsTable",
+    `citadel-executions-${ENVIRONMENT}`,
+    "executionId",
+  );
+  const executionSpecificationsTable = mkTable(
+    "ExecutionSpecificationsTable",
+    `citadel-execution-specifications-${ENVIRONMENT}`,
+    "specId",
+  );
+  const codeBucket = new Bucket(backendStack, "CodeBucket", {
+    bucketName: `citadel-code-${ENVIRONMENT}`,
+  });
+  const fanoutFunction = new lambda.Function(backendStack, "FanoutFunction", {
+    runtime: lambda.Runtime.NODEJS_24_X,
+    handler: "workflow-progress-fanout.handler",
+    code: lambda.Code.fromAsset("dist/lambda"),
+    timeout: cdk.Duration.seconds(30),
+  });
+  const appSyncApi = new appsync.GraphqlApi(backendStack, "MockApi", {
+    name: "mock-api",
+    schema: appsync.SchemaFile.fromAsset(
+      path.resolve(__dirname, "../src/schema/schema.graphql"),
+    ),
+  });
+
+  const stack = new ArbiterStack(app, "TestArbiterStack", {
+    environment: ENVIRONMENT,
+    env: { account: "123456789012", region: "us-east-1" },
+    agentEventBus,
+    agentConfigTable,
+    codeBucket,
+    workflowsTable,
+    executionsTable,
+    fanoutFunction,
+    appSyncEndpoint: appSyncApi.graphqlUrl,
+    executionSpecificationsTable,
+  });
+  return Template.fromStack(stack);
+}
+
+describe("ArbiterStack — CIT-125 slice B event-id/message-id dedupe wiring", () => {
+  let template: Template;
+  beforeAll(() => {
+    template = buildTemplate();
+  });
+
+  test("no new DynamoDB table is created for idempotency (table count unchanged)", () => {
+    // The idempotency table is owned by BackendStack and referenced by
+    // name — ArbiterStack itself must synthesize zero AWS::DynamoDB::Table
+    // resources whose TableName is the idempotency table.
+    const tables = template.findResources("AWS::DynamoDB::Table", {
+      Properties: { TableName: `citadel-idempotency-${ENVIRONMENT}` },
+    });
+    expect(Object.keys(tables)).toHaveLength(0);
+  });
+
+  test("supervisor has IDEMPOTENCY_TABLE env pointing at the shared table", () => {
+    const fns = template.findResources("AWS::Lambda::Function");
+    const supervisorIds = Object.keys(fns).filter((id) =>
+      id.startsWith("SupervisorAgent"),
+    );
+    expect(supervisorIds).toHaveLength(1);
+    const vars = fns[supervisorIds[0]].Properties.Environment.Variables;
+    expect(vars.IDEMPOTENCY_TABLE).toBe(`citadel-idempotency-${ENVIRONMENT}`);
+  });
+
+  test("fabricator has IDEMPOTENCY_TABLE env pointing at the shared table", () => {
+    const fns = template.findResources("AWS::Lambda::Function");
+    const fabricatorIds = Object.keys(fns).filter((id) =>
+      id.startsWith("FabricatorAgent"),
+    );
+    expect(fabricatorIds).toHaveLength(1);
+    const vars = fns[fabricatorIds[0]].Properties.Environment.Variables;
+    expect(vars.IDEMPOTENCY_TABLE).toBe(`citadel-idempotency-${ENVIRONMENT}`);
+  });
+
+  test("supervisor and fabricator both hold a read+write grant on the idempotency table ARN", () => {
+    const expectedArn = {
+      "Fn::Join": [
+        "",
+        [
+          "arn:",
+          { Ref: "AWS::Partition" },
+          `:dynamodb:us-east-1:123456789012:table/citadel-idempotency-${ENVIRONMENT}`,
+        ],
+      ],
+    };
+    // Actual item-action set emitted by CDK's grantReadWriteData() for this
+    // table (grantReadWriteData additionally emits a SEPARATE statement
+    // with the stream-only actions GetRecords/GetShardIterator, harmlessly
+    // present even though this table has no DynamoDB Stream — asserting on
+    // the item-action statement here is sufficient to prove RW, not RO).
+    const rwActions = [
+      "dynamodb:BatchGetItem",
+      "dynamodb:GetItem",
+      "dynamodb:Scan",
+      "dynamodb:Query",
+      "dynamodb:ConditionCheckItem",
+      "dynamodb:BatchWriteItem",
+      "dynamodb:PutItem",
+      "dynamodb:UpdateItem",
+      "dynamodb:DeleteItem",
+      "dynamodb:DescribeTable",
+    ];
+
+    const policies = template.findResources("AWS::IAM::Policy");
+    let grantsFound = 0;
+    for (const policy of Object.values(policies) as Array<{
+      Properties: {
+        PolicyDocument: { Statement: Array<Record<string, unknown>> };
+      };
+    }>) {
+      for (const stmt of policy.Properties.PolicyDocument.Statement) {
+        const resources = Array.isArray(stmt.Resource)
+          ? stmt.Resource
+          : [stmt.Resource];
+        const matchesIdempotencyTable = resources.some(
+          (r: unknown) => JSON.stringify(r) === JSON.stringify(expectedArn),
+        );
+        if (!matchesIdempotencyTable) continue;
+        const actions = Array.isArray(stmt.Action)
+          ? stmt.Action
+          : [stmt.Action];
+        // Skip the separate stream-actions statement grantReadWriteData
+        // also emits (GetRecords/GetShardIterator) — only the item-action
+        // statement is asserted here.
+        if (actions.includes("dynamodb:GetRecords")) continue;
+        // grantReadWriteData's item-action statement carries exactly this
+        // set (order may vary) — not a superset, not a subset.
+        expect([...actions].sort()).toEqual([...rwActions].sort());
+        grantsFound += 1;
+      }
+    }
+    // One grant statement per consumer (supervisor + fabricator).
+    expect(grantsFound).toBe(2);
+  });
+});


### PR DESCRIPTION
## Summary
The DLQ audit classified the supervisor and fabricator consumers as redrive-unsafe: EventBridge delivers at-least-once, and a duplicate (or a DLQ redrive) re-ran orchestration and re-fabricated agents - the fabricator's duplicate-fabrication history is documented. This PR makes both consumers idempotent so the new shared DLQs can actually be redriven.

- Supervisor: a single conditional-put claim on the literal `event.id` in the existing 'citadel-idempotency-‹env› table (referenced by name, no new table); duplicate `task.request` /`task.completion` events become no-ops; claim rows carry a 7-day TTL
- Fabricator: two-phase PENDING-DONE claim keyed on the SQS `messageId` - its queue has no EventBridge envelope (both producers call SendMessage directly), so `messageld` is the stable identity across redeliveries and redrives
- Fail-closed: on dedupe-store errors the handler raises with no side effects, SO the message redelivers and eventually dead-letters - never a silent skip
- CDK: both Lambdas gain `IDEMPOTENCY_TABLE` env + read/write grants on the shared table; zero new DynamoDB tables synthesized

## Testing

- 18 new pytest cases (red-first) plus 4 CDK assertions; scoped suites all exit 0 (supervisor 183, fabricator 360, workerwrapper 379, common 268)
- Full arbiter suite delta vs main: +18 tests, 0 new failures; tse clean; all ArbiterStack jest suites green
- Independent moto proofs against real handlers + real DynamoDB engine: on main, a duplicate event. id runs orchestration twice and a redrive re-fabricates a DONE message; on this branch, side effects fire exactly once (supervisor 1/7, fabricator 8/8), including the poisoned-then-fixed redrive and operator row-clean paths

## Notes

- Poison fabricator messages ack on second receive (ALREADY_PENDING) and never reach 'citadel-fabricator-dlq' - triage anchors on stale PENDING rows; the redrive runbook PR documents this, and a stale-PENDING metric/alarm is tracked as a follow-up
- Branch was cut from pre-merge main (8685b93); both this and PR 102 touch arbiter-stack.ts, so expect a trivial rebase/merge if the hunks collide
