### PR TITLE
chore(deps): resolve browserslist advisories via override floor

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -6918,9 +6918,9 @@
                   "license": "MIT"
             },
             "node_modules/baseline-browser-mapping": {
-                  "version": "2.10.33",
-                  "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.10.33.tgz",
-                  "integrity": "sha512-bA6+tcSLpz2tIEdDXZPpPTIuxBcC4+w6SieaYyfigIa4h8GlFxbA17v22Vx3JUtuZQj9SgOsnbK+aTBzyDyEuw==",
+                  "version": "2.11.20",
+                  "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.11.20.tgz",
+                  "integrity": "sha512-H0ulySigv6icDJ1F7SjtdCD6PrhTpdYCmP0CactWy1+ekh0AFd0o1Wn5T8b+hnTmdBx19u9yhL6wvCylXMY7zw==",
                   "dev": true,
                   "license": "Apache-2.0",
                   "bin": {
@@ -6950,9 +6950,9 @@
                   }
             },
             "node_modules/browserslist": {
-                  "version": "4.28.2",
-                  "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.28.2.tgz",
-                  "integrity": "sha512-48xSriZYYg+8qXna9kwqjIVzuQxi+KYWp2+5nCYnYKPTr0LvD89Jqk2Or5ogxz0NUMfIjhh2lIUX/LyX9B4oIg==",
+                  "version": "4.28.8",
+                  "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.28.8.tgz",
+                  "integrity": "sha512-V2NpofLblG64mfOtSgDhOJESZEGogzDMBv/q+W6oc4LXWP/q75eOXoOaaOu1EOadB9U4Bwx/e0yzbvwKH8zalA==",
                   "dev": true,
                   "funding": [
                         {
@@ -6970,11 +6970,11 @@
                   ],
                   "license": "MIT",
                   "dependencies": {
-                        "baseline-browser-mapping": "^2.10.12",
-                        "caniuse-lite": "^1.0.30001782",
-                        "electron-to-chromium": "^1.5.328",
-                        "node-releases": "^2.0.36",
-                        "update-browserslist-db": "^1.2.3"
+                        "baseline-browser-mapping": "^2.11.12",
+                        "caniuse-lite": "^1.0.30001809",
+                        "electron-to-chromium": "^1.5.402",
+                        "node-releases": "^2.0.53",
+                        "update-browserslist-db": "^1.3.0"
                   },
                   "bin": {
                         "browserslist": "cli.js"
@@ -7044,9 +7044,9 @@
                   }
             },
             "node_modules/caniuse-lite": {
-                  "version": "1.0.30001793",
-                  "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001793.tgz",
-                  "integrity": "sha512-iwSsYWaCOoh26cV8NwNRViHlrfUvYsHDfRVcbtmw0Kg6PJIZZXwMkj1442FYLBGkeUf1juAsU3DTfxW579mrPA==",
+                  "version": "1.0.30001810",
+                  "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001810.tgz",
+                  "integrity": "sha512-TITQPUkaz+aVk5GL6NhOdwk1aEaNTSDPsGFWrTuhKGtjTF70jL/Oht2W4c6rXUe5fu7Ie19VIahAXHIIiWWNeg==",
                   "dev": true,
                   "funding": [
                         {
@@ -7815,9 +7815,9 @@
                   "license": "MIT"
             },
             "node_modules/electron-to-chromium": {
-                  "version": "1.5.367",
-                  "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.367.tgz",
-                  "integrity": "sha512-4Mk/mrynCNQ+atY40D3UpmhLWB6AHMbYMlIrPhHcMF6x0L7O0b052FCAsxw1LlaR++UFuNg3D/A6XCuGDa0guQ==",
+                  "version": "1.5.419",
+                  "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.419.tgz",
+                  "integrity": "sha512-nHMPn8x4yCxCI0iSnL+LlHL5sUoUfjLXkcRIagZ4GBdrfFLFaiLNvzJWbJqZhFT9IAhw5tUSNlhggWN+otvp/A==",
                   "dev": true,
                   "license": "ISC"
             },
@@ -11236,9 +11236,9 @@
                   "license": "MIT"
             },
             "node_modules/node-releases": {
-                  "version": "2.0.47",
-                  "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.47.tgz",
-                  "integrity": "sha512-Uzmd6LXpouKo8EUK68IjH4+E01w/hXyV3R3g/geCJo+rXLNfh1xucB+LOzYEOQPSiUK3h/xZf0cQGcSsmyL2Og==",
+                  "version": "2.0.54",
+                  "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.54.tgz",
+                  "integrity": "sha512-YHs7BmmcsdAI5Ozuf8JZo6PT0mv2GIWC9vMfvUC3dp65M8hn7Ux8CPL+2oBI7juNuj9d0ndhTcznq2ODBps9cQ==",
                   "dev": true,
                   "license": "MIT",
                   "engines": {
@@ -13105,9 +13105,9 @@
                   }
             },
             "node_modules/update-browserslist-db": {
-                  "version": "1.2.3",
-                  "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.2.3.tgz",
-                  "integrity": "sha512-Js0m9cx+qOgDxo0eMiFGEueWztz+d4+M3rGlmKPT+T4IS/jP4ylw3Nwpu6cpTTP8R1MAC1kF4VbdLt3ARf209w==",
+                  "version": "1.3.2",
+                  "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.3.2.tgz",
+                  "integrity": "sha512-UQ+MSxlhRm1bzjhU+DcuXfjFO1FzNtqhK5+9Yvlp90ItDLk5vT932A0rFu619nf7RVS+Y/VeaUW1jaRDqZ8VJw==",
                   "dev": true,
                   "funding": [
                         {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -94,6 +94,7 @@
             "generate-aws-exports": "node scripts/generate-aws-exports.js"
       },
       "overrides": {
+            "browserslist": ">=4.28.8 <5",
             "dompurify": "^3.4.13",
             "form-data": "^4.0.6",
             "js-yaml": "^4.3.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -6258,9 +6258,9 @@
       "license": "MIT"
     },
     "node_modules/baseline-browser-mapping": {
-      "version": "2.10.38",
-      "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.10.38.tgz",
-      "integrity": "sha512-31/02mVB4yuQU6adKk5SlY6m+mxDwUq5KZkyYgnLrrKl7TEm1+3PyDtDBz2kOv/wxZz41GHsvV1A/u6RmiyBvw==",
+      "version": "2.11.20",
+      "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.11.20.tgz",
+      "integrity": "sha512-H0ulySigv6icDJ1F7SjtdCD6PrhTpdYCmP0CactWy1+ekh0AFd0o1Wn5T8b+hnTmdBx19u9yhL6wvCylXMY7zw==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {
@@ -6339,9 +6339,9 @@
       "license": "MIT"
     },
     "node_modules/browserslist": {
-      "version": "4.28.2",
-      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.28.2.tgz",
-      "integrity": "sha512-48xSriZYYg+8qXna9kwqjIVzuQxi+KYWp2+5nCYnYKPTr0LvD89Jqk2Or5ogxz0NUMfIjhh2lIUX/LyX9B4oIg==",
+      "version": "4.28.8",
+      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.28.8.tgz",
+      "integrity": "sha512-V2NpofLblG64mfOtSgDhOJESZEGogzDMBv/q+W6oc4LXWP/q75eOXoOaaOu1EOadB9U4Bwx/e0yzbvwKH8zalA==",
       "dev": true,
       "funding": [
         {
@@ -6359,11 +6359,11 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "baseline-browser-mapping": "^2.10.12",
-        "caniuse-lite": "^1.0.30001782",
-        "electron-to-chromium": "^1.5.328",
-        "node-releases": "^2.0.36",
-        "update-browserslist-db": "^1.2.3"
+        "baseline-browser-mapping": "^2.11.12",
+        "caniuse-lite": "^1.0.30001809",
+        "electron-to-chromium": "^1.5.402",
+        "node-releases": "^2.0.53",
+        "update-browserslist-db": "^1.3.0"
       },
       "bin": {
         "browserslist": "cli.js"
@@ -6456,9 +6456,9 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001799",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001799.tgz",
-      "integrity": "sha512-hG1bReV+OUU+MOqK4t/ZWI0tZOyz3rqS9XuhOUz1cIcbwBKjOyJEJuw9ER5JuNyqxNk8u/JUVbGibBOL1yrjFw==",
+      "version": "1.0.30001810",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001810.tgz",
+      "integrity": "sha512-TITQPUkaz+aVk5GL6NhOdwk1aEaNTSDPsGFWrTuhKGtjTF70jL/Oht2W4c6rXUe5fu7Ie19VIahAXHIIiWWNeg==",
       "dev": true,
       "funding": [
         {
@@ -7126,9 +7126,9 @@
       }
     },
     "node_modules/electron-to-chromium": {
-      "version": "1.5.375",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.375.tgz",
-      "integrity": "sha512-ZWP5eB4BVPW/ZYo9252hQZHZ5XavtsTgpbhcmMmRwymavC5AsLWQWBPaKMeNd2LW0KGby5HPXvj7+sr4ta5j/Q==",
+      "version": "1.5.419",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.419.tgz",
+      "integrity": "sha512-nHMPn8x4yCxCI0iSnL+LlHL5sUoUfjLXkcRIagZ4GBdrfFLFaiLNvzJWbJqZhFT9IAhw5tUSNlhggWN+otvp/A==",
       "dev": true,
       "license": "ISC"
     },
@@ -10049,9 +10049,9 @@
       "license": "MIT"
     },
     "node_modules/node-releases": {
-      "version": "2.0.48",
-      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.48.tgz",
-      "integrity": "sha512-1uz8041X6LoI6ZSdZacM9lVY28vuzDlSKitnpbSNK0RfKoIJkX29NBPVEFXhnuSuEOA9Ww0xnPJ+ILWbGAv8DA==",
+      "version": "2.0.54",
+      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.54.tgz",
+      "integrity": "sha512-YHs7BmmcsdAI5Ozuf8JZo6PT0mv2GIWC9vMfvUC3dp65M8hn7Ux8CPL+2oBI7juNuj9d0ndhTcznq2ODBps9cQ==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -11980,9 +11980,9 @@
       }
     },
     "node_modules/update-browserslist-db": {
-      "version": "1.2.3",
-      "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.2.3.tgz",
-      "integrity": "sha512-Js0m9cx+qOgDxo0eMiFGEueWztz+d4+M3rGlmKPT+T4IS/jP4ylw3Nwpu6cpTTP8R1MAC1kF4VbdLt3ARf209w==",
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.3.2.tgz",
+      "integrity": "sha512-UQ+MSxlhRm1bzjhU+DcuXfjFO1FzNtqhK5+9Yvlp90ItDLk5vT932A0rFu619nf7RVS+Y/VeaUW1jaRDqZ8VJw==",
       "dev": true,
       "funding": [
         {

--- a/package.json
+++ b/package.json
@@ -46,6 +46,7 @@
   "overrides": {
     "dompurify": "^3.4.12",
     "js-yaml": "^4.3.0",
+    "browserslist": ">=4.28.8 <5",
     "fast-uri": ">=3.1.5 <4",
     "shell-quote": "^1.9.0",
     "brace-expansion": ">=5.0.9 <6",


### PR DESCRIPTION
## Summary

Two HIGH advisories published against browserslist ≤4.28.6 (GHSA-C83g-rgw3-j3cx unbounded memory growth, GHSA-73wf-9998-2v4g crash/prototype write) began failing the blocking Security Scan gate on every PR. Both lockfiles resolved 4.28.2, transitive dev-only via the ts-jest → @babel/core chain.

- override floor `browserslist: ">=4.28.8 ‹5"` (registry latest) in root and frontend package. json; both lockfiles regenerated with npm
- No allowlist changes - the advisories are fixable, so allowlisting would be wrong

## Testing

- Root `audit-ci` exit 0 (residual: allowlisted aws-cdk-lib bundled brace-expansion only); frontend audit 0 vulnerabilities
- Backend jest 6942 passed, frontend jest 2041 passed, tsc clean both trees
- 'npm Is browserslist': single 4.28.8 resolution in each tree, no invalid edges