### PR TITLE
test(reliability): DLQ coverage, retry-policy and dedupe guards

### DIFF
--- a/arbiter/fabricator/__tests__/test_event_idempotency_moto.py
+++ b/arbiter/fabricator/__tests__/test_event_idempotency_moto.py
@@ -50,6 +50,16 @@ try:
 except ImportError:  # pragma: no cover
     pytest.skip("moto not installed", allow_module_level=True)
 
+# The fabricator's index.py imports `strands` at module level, so the
+# `import index` below errors at collection time in environments without
+# the strands SDK. Skip (don't error) there; the suite still EXECUTES
+# wherever strands is installed — CI's arbiter jobs `pip install
+# strands-agents` (see .github/workflows/ci.yml), and local runs use the
+# pinned .venv-check.
+pytest.importorskip(
+    "strands", reason="CI installs strands-agents; local runs use .venv-check"
+)
+
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
 
 os.environ.setdefault("TOOL_CONFIG_TABLE", "fake-tool-table")

--- a/arbiter/fabricator/__tests__/test_event_idempotency_moto.py
+++ b/arbiter/fabricator/__tests__/test_event_idempotency_moto.py
@@ -1,0 +1,200 @@
+"""Slice B (CIT-125) COMPOSED dedupe proof — fabricator, real DDB engine.
+
+The sibling ``test_event_idempotency.py`` proves the two-phase claim logic
+and the handler wiring SEPARATELY with ``unittest.mock``. This suite locks
+in the COMPOSED path — the REAL ``lambda_handler`` driving the REAL
+``_claim_message_id`` / ``_complete_message_id`` whose conditional PutItem
+and UpdateItem are evaluated by a REAL DynamoDB engine (moto) — as a
+permanent regression suite (the slice-B verification's F1–F6 proof set;
+pattern per ``workerWrapper/__tests__/test_tool_call_write_paths_e2e_moto.py``).
+
+Dedupe key: the SQS ``messageId`` (disclosed deviation from design B.1's
+``event.id`` — the fabricator queue's producers send hand-built JSON bodies
+with no EventBridge envelope; see the sibling suite's module docstring for
+the full verification). ``messageId`` is stable across at-least-once SQS
+redelivery AND across a DLQ redrive, so the composed proofs below model a
+redrive as re-delivering the SAME record.
+
+REAL vs STUBBED (explicit)
+--------------------------
+* REAL, against moto: ``lambda_handler``'s two-phase guard,
+  ``_claim_message_id`` (conditional PutItem + get_item fallback),
+  ``_complete_message_id`` (UpdateExpression with the reserved-word-safe
+  ``#status`` alias — exactly the class of wire defect moto catches and a
+  dict-backed fake cannot), the claim rows, and the idempotency table
+  (schema verbatim from backend/lib/backend-stack.ts IdempotencyTable:
+  PK ``eventId`` (S), PAY_PER_REQUEST).
+* STUBBED: ``process_event`` ONLY — a counting MagicMock so fabrication
+  multiplicity is observable without running the fabrication body.
+
+conftest note: ``arbiter/conftest.py`` swaps ``boto3.client`` /
+``boto3.resource`` for MagicMock factories. The fabricator's
+``_idempotency_table()`` lazily does ``import boto3; boto3.resource(...)``
+per call, so inside ``mock_aws`` the fixture restores ``boto3.resource`` to
+a real ``boto3.Session``-backed callable (``boto3.Session`` is NOT stubbed)
+— the real helper body then reaches moto, not a mock.
+"""
+
+import json
+import os
+import sys
+import time
+from unittest.mock import MagicMock
+
+import boto3
+import pytest
+from botocore.exceptions import ClientError
+
+try:
+    from moto import mock_aws
+except ImportError:  # pragma: no cover
+    pytest.skip("moto not installed", allow_module_level=True)
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+
+os.environ.setdefault("TOOL_CONFIG_TABLE", "fake-tool-table")
+os.environ.setdefault("AGENT_CONFIG_TABLE", "fake-agent-table")
+os.environ.setdefault("AGENT_BUCKET_NAME", "fake-bucket")
+os.environ.setdefault("COMPLETION_BUS_NAME", "fake-bus")
+os.environ.setdefault("WORKER_QUEUE_URL", "https://sqs.fake/queue")
+os.environ.setdefault("IDEMPOTENCY_TABLE", "citadel-idempotency-test")
+os.environ.setdefault("AWS_DEFAULT_REGION", "us-east-1")
+
+import index  # noqa: E402
+
+REGION = "us-east-1"
+TABLE = "citadel-idempotency-moto"
+SEVEN_DAYS = 7 * 24 * 60 * 60  # design B.1 TTL
+
+
+def _sqs_event(*message_ids: str) -> dict:
+    """An SQS batch event with one record per message id."""
+    return {
+        "Records": [
+            {
+                "messageId": mid,
+                "body": json.dumps(
+                    {"agent_input": {"taskDetails": f"fabricate {mid}"}}
+                ),
+                "messageAttributes": {},
+            }
+            for mid in message_ids
+        ]
+    }
+
+
+@pytest.fixture
+def composed(monkeypatch):
+    """Real idempotency table in moto + real two-phase claim path;
+    process_event counted."""
+    with mock_aws():
+        # Restore the REAL boto3.resource factory (conftest stubbed it) so
+        # the fabricator's lazy per-call `boto3.resource('dynamodb')` in
+        # _idempotency_table() reaches moto.
+        monkeypatch.setattr(
+            boto3,
+            "resource",
+            lambda *a, **k: boto3.Session(region_name=REGION).resource(*a, **k),
+        )
+        resource = boto3.Session(region_name=REGION).resource("dynamodb")
+        # Schema verbatim from backend/lib/backend-stack.ts IdempotencyTable.
+        resource.create_table(
+            TableName=TABLE,
+            KeySchema=[{"AttributeName": "eventId", "KeyType": "HASH"}],
+            AttributeDefinitions=[{"AttributeName": "eventId", "AttributeType": "S"}],
+            BillingMode="PAY_PER_REQUEST",
+        )
+        monkeypatch.setattr(index, "IDEMPOTENCY_TABLE", TABLE)
+        process_event = MagicMock(name="process_event")
+        monkeypatch.setattr(index, "process_event", process_event)
+        yield resource.Table(TABLE), process_event
+
+
+def test_f1_first_delivery_fabricates_once_and_promotes_pending_to_done(composed):
+    """First sight: process_event runs once; row lands as DONE (the PENDING
+    claim written before the body is promoted after it succeeds)."""
+    table, process_event = composed
+    index.lambda_handler(_sqs_event("msg-F1"), {})
+    assert process_event.call_count == 1
+    item = table.get_item(Key={"eventId": "msg-F1"}).get("Item")
+    assert item is not None
+    assert item["status"] == "DONE"
+
+
+def test_f2_redrive_of_done_message_is_a_noop(composed):
+    """A DLQ redrive re-delivering a completed messageId must NOT
+    re-fabricate — the documented historical duplicate-fabrication failure."""
+    table, process_event = composed
+    index.lambda_handler(_sqs_event("msg-F2"), {})
+    assert table.get_item(Key={"eventId": "msg-F2"})["Item"]["status"] == "DONE"
+    process_event.reset_mock()
+    index.lambda_handler(_sqs_event("msg-F2"), {})
+    assert process_event.call_count == 0
+
+
+def test_f3_claim_row_keyed_on_literal_message_id_with_design_ttl(composed):
+    """Row uses the LITERAL SQS messageId, consumer tag, 7d TTL."""
+    table, _process_event = composed
+    before = int(time.time())
+    index.lambda_handler(_sqs_event("msg-F3"), {})
+    item = table.get_item(Key={"eventId": "msg-F3"}).get("Item")
+    assert item is not None, "claim row must exist under the literal messageId"
+    assert item["consumer"] == "fabricator"
+    assert int(item["ttl"]) - int(item["claimedAt"]) == SEVEN_DAYS
+    assert before <= int(item["claimedAt"]) <= int(time.time())
+
+
+def test_f4_poison_pending_reconcile_lifecycle(composed, caplog):
+    """(a) poison raises and the row stays PENDING (never falsely DONE);
+    (b) a redrive while PENDING routes to reconcile WITHOUT re-entering the
+    fabrication body; (c) after an operator row-clean the redrive
+    fabricates exactly once and promotes to DONE (runbook path)."""
+    table, process_event = composed
+    # (a) poison AFTER the claim: propagate (SQS retry/DLQ semantics),
+    # row must remain PENDING — a failed fabrication is never marked DONE.
+    process_event.side_effect = RuntimeError("poison: fabrication blew up")
+    with pytest.raises(RuntimeError):
+        index.lambda_handler(_sqs_event("msg-F4"), {})
+    assert table.get_item(Key={"eventId": "msg-F4"})["Item"]["status"] == "PENDING"
+    # (b) fixed handler; redrive of the SAME messageId sees PENDING ->
+    # reconcile route, fabrication body NOT re-entered.
+    process_event.side_effect = None
+    process_event.reset_mock()
+    with caplog.at_level("WARNING"):
+        index.lambda_handler(_sqs_event("msg-F4"), {})
+    assert process_event.call_count == 0
+    assert any(
+        "PENDING" in rec.getMessage() and "msg-F4" in rec.getMessage()
+        for rec in caplog.records
+    ), "reconcile routing must be observable in the WARNING log"
+    assert table.get_item(Key={"eventId": "msg-F4"})["Item"]["status"] == "PENDING"
+    # (c) operator clears the row (DLQ_REDRIVE runbook reconcile step) ->
+    # redrive fabricates exactly once and completes.
+    table.delete_item(Key={"eventId": "msg-F4"})
+    index.lambda_handler(_sqs_event("msg-F4"), {})
+    assert process_event.call_count == 1
+    assert table.get_item(Key={"eventId": "msg-F4"})["Item"]["status"] == "DONE"
+
+
+def test_f5_distinct_message_ids_in_one_batch_each_fabricate(composed):
+    """No false dedupe across a batch: two distinct messageIds -> two
+    fabrications, both promoted to DONE."""
+    table, process_event = composed
+    index.lambda_handler(_sqs_event("msg-F5-a", "msg-F5-b"), {})
+    assert process_event.call_count == 2
+    for mid in ("msg-F5-a", "msg-F5-b"):
+        assert table.get_item(Key={"eventId": mid})["Item"]["status"] == "DONE"
+
+
+def test_f6_fail_closed_on_dedupe_store_error(composed, monkeypatch):
+    """A REAL non-conditional ClientError (table missing ->
+    ResourceNotFoundException) propagates and blocks fabrication: the
+    message redelivers/DLQs rather than being silently acked."""
+    _table, process_event = composed
+    monkeypatch.setattr(index, "IDEMPOTENCY_TABLE", "citadel-idempotency-absent")
+    with pytest.raises(ClientError) as excinfo:
+        index.lambda_handler(_sqs_event("msg-F6"), {})
+    assert (
+        excinfo.value.response["Error"]["Code"] != "ConditionalCheckFailedException"
+    )
+    assert process_event.call_count == 0

--- a/arbiter/supervisor/__tests__/test_event_idempotency_moto.py
+++ b/arbiter/supervisor/__tests__/test_event_idempotency_moto.py
@@ -1,0 +1,174 @@
+"""Slice B (CIT-125) COMPOSED dedupe proof — supervisor, real DDB engine.
+
+The sibling ``test_event_idempotency.py`` proves the handler wiring and the
+claim helper SEPARATELY, with ``unittest.mock`` standing in for DynamoDB.
+That leaves the composed path — the REAL ``handler`` calling the REAL
+``_claim_event_id`` whose ``put_item``/``ConditionExpression`` is evaluated
+by a REAL DynamoDB engine — unlocked-in. This suite closes that gap using
+moto (the slice-B verification's P1–P5 proof set, re-derived here as a
+permanent regression suite; pattern per
+``workerWrapper/__tests__/test_tool_call_write_paths_e2e_moto.py``).
+
+REAL vs STUBBED (explicit)
+--------------------------
+* REAL, against moto: ``handler``'s dedupe guard, ``_claim_event_id``'s
+  conditional PutItem (moto enforces ``attribute_not_exists`` semantics,
+  attribute typing, and raises genuine ``ConditionalCheckFailedException``
+  / ``ResourceNotFoundException`` ClientErrors), the claim-row contents,
+  and the idempotency table itself (schema verbatim from
+  backend/lib/backend-stack.ts IdempotencyTable: PK ``eventId`` (S),
+  PAY_PER_REQUEST, TTL attribute ``ttl``).
+* STUBBED: ``orchestrate`` ONLY — replaced with a counting MagicMock so
+  dispatch multiplicity is observable without running the LLM
+  orchestration loop. Nothing between the handler entry and the
+  ``orchestrate(...)`` call site is faked.
+
+conftest note: ``arbiter/conftest.py`` swaps ``boto3.client`` /
+``boto3.resource`` for MagicMock factories for the whole suite, so this
+module's import-time ``dynamodb = boto3.resource('dynamodb')`` global is a
+mock. Inside ``mock_aws`` the fixture rebinds ``index.dynamodb`` to a real
+``boto3.Session``-backed resource (``boto3.Session`` is NOT stubbed), so
+``_idempotency_table()`` reaches moto.
+"""
+
+import os
+import sys
+import time
+from unittest.mock import MagicMock
+
+import boto3
+import pytest
+from botocore.exceptions import ClientError
+
+try:
+    from moto import mock_aws
+except ImportError:  # pragma: no cover
+    pytest.skip("moto not installed", allow_module_level=True)
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+
+os.environ.setdefault("ORCHESTRATION_TABLE", "fake-orchestration-table")
+os.environ.setdefault("WORKER_STATE_TABLE", "fake-worker-state-table")
+os.environ.setdefault("AGENT_CONFIG_TABLE", "fake-agent-config-table")
+os.environ.setdefault("EVENT_BUS_NAME", "fake-bus")
+os.environ.setdefault("COMPLETION_BUS_NAME", "fake-bus")
+os.environ.setdefault("IDEMPOTENCY_TABLE", "citadel-idempotency-test")
+os.environ.setdefault("AWS_DEFAULT_REGION", "us-east-1")
+
+import index  # noqa: E402
+
+REGION = "us-east-1"
+TABLE = "citadel-idempotency-moto"
+SEVEN_DAYS = 7 * 24 * 60 * 60  # design B.1 TTL
+
+
+def _task_request(event_id: str | None) -> dict:
+    """A minimal EventBridge task.request envelope (id optional)."""
+    event = {
+        "source": "task.request",
+        "detail-type": "System-Task",
+        "detail": {"task": "compose a plan", "appId": "app-1"},
+    }
+    if event_id is not None:
+        event["id"] = event_id
+    return event
+
+
+@pytest.fixture
+def composed(monkeypatch):
+    """Real idempotency table in moto + real claim path; orchestrate counted."""
+    with mock_aws():
+        resource = boto3.Session(region_name=REGION).resource("dynamodb")
+        # Schema verbatim from backend/lib/backend-stack.ts IdempotencyTable
+        # (PK eventId (S); TTL attr `ttl` is data, not schema).
+        resource.create_table(
+            TableName=TABLE,
+            KeySchema=[{"AttributeName": "eventId", "KeyType": "HASH"}],
+            AttributeDefinitions=[{"AttributeName": "eventId", "AttributeType": "S"}],
+            BillingMode="PAY_PER_REQUEST",
+        )
+        # Rebind the module's import-time globals: the conftest-mocked
+        # `dynamodb` resource -> real moto-backed resource; table name ->
+        # the moto table. monkeypatch restores both after the test.
+        monkeypatch.setattr(index, "dynamodb", resource)
+        monkeypatch.setattr(index, "IDEMPOTENCY_TABLE", TABLE)
+        orchestrate = MagicMock(name="orchestrate")
+        monkeypatch.setattr(index, "orchestrate", orchestrate)
+        yield resource.Table(TABLE), orchestrate
+
+
+def test_p1_duplicate_event_id_dispatches_exactly_once(composed):
+    """Same event.id delivered twice -> orchestrate() called EXACTLY once."""
+    _table, orchestrate = composed
+    index.handler(_task_request("evt-P1"), {})
+    index.handler(_task_request("evt-P1"), {})
+    assert orchestrate.call_count == 1
+
+
+def test_p2_distinct_event_ids_are_each_processed(composed):
+    """No false dedupe: two distinct ids -> two dispatches."""
+    _table, orchestrate = composed
+    index.handler(_task_request("evt-P2-a"), {})
+    index.handler(_task_request("evt-P2-b"), {})
+    assert orchestrate.call_count == 2
+
+
+def test_p3_claim_row_keyed_on_literal_event_id_with_design_ttl(composed):
+    """Row uses the LITERAL event.id (not a hash), consumer tag, 7d TTL."""
+    table, _orchestrate = composed
+    before = int(time.time())
+    index.handler(_task_request("evt-P3"), {})
+    item = table.get_item(Key={"eventId": "evt-P3"}).get("Item")
+    assert item is not None, "claim row must exist under the literal event.id"
+    assert item["consumer"] == "supervisor"
+    assert int(item["ttl"]) - int(item["claimedAt"]) == SEVEN_DAYS
+    assert before <= int(item["claimedAt"]) <= int(time.time())
+
+
+def test_p4_poison_redrive_lifecycle(composed):
+    """Poison propagates; a same-id redrive stays a no-op (claim survives,
+    NEEDS-RECONCILE-FIRST per design B.1); after an operator row-clean the
+    redrive processes exactly once (the DLQ_REDRIVE runbook path)."""
+    table, orchestrate = composed
+    # (a) poison AFTER the claim: error must propagate (EB retry/DLQ
+    # semantics preserved — never silently acked)...
+    orchestrate.side_effect = RuntimeError("poison: downstream blew up")
+    with pytest.raises(RuntimeError):
+        index.handler(_task_request("evt-P4"), {})
+    # ...and the claim row survives the failure.
+    assert table.get_item(Key={"eventId": "evt-P4"}).get("Item") is not None
+    # (b) handler fixed; a redrive of the SAME envelope is still a no-op —
+    # the claim outlives the failure, so supervisor redrive is
+    # reconcile-first, exactly as the runbook documents.
+    orchestrate.side_effect = None
+    orchestrate.reset_mock()
+    index.handler(_task_request("evt-P4"), {})
+    assert orchestrate.call_count == 0
+    # (c) operator clears the row (runbook reconcile step) -> redrive
+    # processes exactly once.
+    table.delete_item(Key={"eventId": "evt-P4"})
+    index.handler(_task_request("evt-P4"), {})
+    assert orchestrate.call_count == 1
+
+
+def test_p5_fail_closed_on_dedupe_store_error(composed, monkeypatch):
+    """A REAL non-conditional ClientError from the engine (table missing ->
+    ResourceNotFoundException) must propagate and block dispatch: the event
+    redelivers/DLQs rather than being silently acked or double-run."""
+    _table, orchestrate = composed
+    monkeypatch.setattr(index, "IDEMPOTENCY_TABLE", "citadel-idempotency-absent")
+    with pytest.raises(ClientError) as excinfo:
+        index.handler(_task_request("evt-P5"), {})
+    assert (
+        excinfo.value.response["Error"]["Code"] != "ConditionalCheckFailedException"
+    )
+    assert orchestrate.call_count == 0
+
+
+def test_fail_open_without_event_id_writes_no_claim_row(composed):
+    """Documented fail-open: an envelope with no `id` is processed WITHOUT
+    dedupe and leaves no claim row (never silently drop work)."""
+    table, orchestrate = composed
+    index.handler(_task_request(None), {})
+    assert orchestrate.call_count == 1
+    assert table.scan()["Count"] == 0

--- a/backend/lib/__tests__/dlq-coverage-structural.test.ts
+++ b/backend/lib/__tests__/dlq-coverage-structural.test.ts
@@ -22,6 +22,18 @@
  * alarmed set. A new DLQ added anywhere is auto-discovered and MUST be
  * alarmed, or this test fails — no list to update.
  *
+ * PER-CONSUMER PIN (coverage-hardening follow-up): the queue-level guard
+ * above only trips when a queue loses ALL of its consumers (total-queue
+ * orphan). Removing ONE consumer's `deadLetterQueue` prop (say, dropping
+ * the supervisor's DeadLetterConfig while the other five arbiter consumers
+ * keep theirs) leaves the queue discovered and alarmed — silent coverage
+ * loss. The `PINNED_COVERED_CONSUMERS` baseline below pins, per stack, the
+ * exact set of consumer→DLQ edges derived from the synthesized templates,
+ * so removing (or silently gaining) a single consumer's dead-letter wiring
+ * fails the pin test. Updating the pin is a deliberate, reviewed act:
+ * re-run `npx cdk synth --all --quiet`, read the failing diff, and move
+ * the baseline only when the coverage change is intentional.
+ *
  * Requires `cdk synth --all` (or `npm run split:gates` / `npm run nag`,
  * which both synth first) to have populated `cdk.out/*.template.json`.
  * Skips (does not fail) when templates are absent, mirroring
@@ -90,6 +102,13 @@ interface DiscoveredDlq {
   stackName: string;
   queueLogicalId: string;
   queueName: string;
+  /**
+   * Logical ID of the resource whose failure path feeds the DLQ: the
+   * Lambda function (DeadLetterConfig), the event source mapping
+   * (OnFailure), the source queue (RedrivePolicy), or the EventBridge
+   * rule (RuleTarget). This is what the per-consumer pin keys on.
+   */
+  consumerLogicalId: string;
   discoveredVia:
     "RedrivePolicy" | "DeadLetterConfig" | "OnFailure" | "RuleTarget";
 }
@@ -112,7 +131,7 @@ function discoverDlqsInStack(
 ): DiscoveredDlq[] {
   const found: DiscoveredDlq[] = [];
 
-  for (const [, res] of Object.entries(template.Resources)) {
+  for (const [consumerLogicalId, res] of Object.entries(template.Resources)) {
     // 1) Work-queue DLQs: AWS::SQS::Queue.RedrivePolicy.deadLetterTargetArn
     if (res.Type === "AWS::SQS::Queue") {
       const redrive = (res.Properties ?? {})["RedrivePolicy"] as
@@ -126,6 +145,7 @@ function discoverDlqsInStack(
             stackName,
             queueLogicalId: targetLogicalId,
             queueName,
+            consumerLogicalId,
             discoveredVia: "RedrivePolicy",
           });
         }
@@ -145,6 +165,7 @@ function discoverDlqsInStack(
             stackName,
             queueLogicalId: targetLogicalId,
             queueName,
+            consumerLogicalId,
             discoveredVia: "DeadLetterConfig",
           });
         }
@@ -166,6 +187,7 @@ function discoverDlqsInStack(
             stackName,
             queueLogicalId: targetLogicalId,
             queueName,
+            consumerLogicalId,
             discoveredVia: "OnFailure",
           });
         }
@@ -194,6 +216,7 @@ function discoverDlqsInStack(
               stackName,
               queueLogicalId: targetLogicalId,
               queueName,
+              consumerLogicalId,
               discoveredVia: "RuleTarget",
             });
           }
@@ -232,6 +255,101 @@ function collectAlarmedQueueNames(telemetryTemplate: CfnTemplate): Set<string> {
     }
   }
   return alarmed;
+}
+
+/**
+ * Canonical, env-independent form of one consumer→DLQ coverage edge:
+ * `<mechanism>:<consumerLogicalId>-><queueName minus the trailing -${ENV}>`.
+ * Logical IDs are env-independent (the CDK path hash does not include the
+ * environment), so the same pin validates dev/staging/prod synth output.
+ */
+function coverageEdge(d: DiscoveredDlq): string {
+  const envSuffix = `-${ENV}`;
+  const queueBase = d.queueName.endsWith(envSuffix)
+    ? d.queueName.slice(0, -envSuffix.length)
+    : d.queueName;
+  return `${d.discoveredVia}:${d.consumerLogicalId}->${queueBase}`;
+}
+
+/**
+ * PER-CONSUMER PINNED BASELINE — derived from `cdk synth --all` output
+ * (all four discovery mechanisms above), NOT hand-authored. 42 edges:
+ * the 32 shared-async-DLQ consumers from CIT-125 slice A plus the 10
+ * pre-existing work-queue / stream / notifier / rule-target edges.
+ *
+ * WHY: the queue-level assertions in this file only fail when a DLQ loses
+ * ALL consumers. This pin fails when ANY single consumer's dead-letter
+ * wiring is removed, renamed, or silently added.
+ *
+ * TO UPDATE (deliberate coverage change only): re-synth, then rebuild the
+ * failing stack's entries from the jest diff — each entry is
+ * `mechanism:consumerLogicalId->queueNameWithoutEnvSuffix`. A hash-suffix
+ * change caused by a construct-path refactor is expected to land here as
+ * a reviewed diff; that is the point of pinning.
+ */
+const PINNED_COVERED_CONSUMERS: Record<string, readonly string[]> = {
+  arbiter: [
+    "DeadLetterConfig:ActivatorAgent74A6D68E->citadel-arbiter-async-dlq",
+    "DeadLetterConfig:GovernanceGraphSnapshotFn8BC19523->citadel-arbiter-async-dlq",
+    "DeadLetterConfig:GovernanceModeRefresherFn8358D228->citadel-arbiter-async-dlq",
+    "DeadLetterConfig:StepRunnerFunctionBE4DB8E6->citadel-arbiter-async-dlq",
+    "DeadLetterConfig:SupervisorAgent7CBC906A->citadel-arbiter-async-dlq",
+    "DeadLetterConfig:WorkflowTimeoutWatchdogFunctionE2172B89->citadel-arbiter-async-dlq",
+    "OnFailure:GovernanceFindingFanoutEventSourceMapping1803FCF3->citadel-governance-finding-fanout-dlq",
+    "OnFailure:GovernanceGraphSnapshotOnChangeAuthorityUnitsESMD2494E8F->citadel-governance-graph-snapshot-on-change-dlq",
+    "OnFailure:GovernanceGraphSnapshotOnChangeCaseLawESM9C755D01->citadel-governance-graph-snapshot-on-change-dlq",
+    "OnFailure:GovernanceGraphSnapshotOnChangeCompositionContractsESM3FDE106E->citadel-governance-graph-snapshot-on-change-dlq",
+    "OnFailure:GovernanceGraphSnapshotOnChangeConstitutionalLayersESME463D395->citadel-governance-graph-snapshot-on-change-dlq",
+    "RedrivePolicy:fabricatorQueue414BE48B->citadel-fabricator-dlq",
+    "RedrivePolicy:workerAgentQueueA757937E->citadel-worker-agent-dlq",
+  ],
+  backend: [
+    "DeadLetterConfig:AgentMessageHandlerFunctionEF15B1DF->citadel-backend-async-dlq",
+    "DeadLetterConfig:AppComponentRegistrationHandlerCD7DC5A3->citadel-backend-async-dlq",
+    "DeadLetterConfig:AppInvokeHandlerFD7933F8->citadel-backend-async-dlq",
+    "DeadLetterConfig:GatewayRegistrationHandler00584901->citadel-backend-async-dlq",
+    "DeadLetterConfig:ModelCatalogSyncFunction25BE66F5->citadel-backend-async-dlq",
+    "DeadLetterConfig:ReconcileAppsMetaScheduledFunction4D0CB960->citadel-backend-async-dlq",
+    "DeadLetterConfig:WorkflowProgressFanoutFunctionB24A2000->citadel-backend-async-dlq",
+  ],
+  telemetry: [
+    "DeadLetterConfig:CostBudgetEvaluator39D4C8D1->citadel-telemetry-async-dlq",
+    "DeadLetterConfig:CostLedgerReconciler2D094117->citadel-telemetry-async-dlq",
+    "DeadLetterConfig:CostLedgerWriter9749D180->citadel-telemetry-async-dlq",
+    "DeadLetterConfig:EvalCaseScorerFunctionE7E10371->citadel-telemetry-async-dlq",
+    "DeadLetterConfig:EvalDriftDetectorFunctionFB431D89->citadel-telemetry-async-dlq",
+    "DeadLetterConfig:EvalDriftFindingWriterFunction99B43D60->citadel-telemetry-async-dlq",
+    "DeadLetterConfig:EvalRunAggregatorFunction0C2BA6F9->citadel-telemetry-async-dlq",
+    "DeadLetterConfig:EvalSampleScorerFunctionFCFB43C5->citadel-telemetry-async-dlq",
+    "DeadLetterConfig:EvalSamplingSelectorFunction221FE615->citadel-telemetry-async-dlq",
+  ],
+  governance: [
+    "DeadLetterConfig:AgentReleaseRollbackEvaluatorFunction1ABEF5A3->citadel-governance-async-dlq",
+    "DeadLetterConfig:EvalRunnerFunction338D3E59->citadel-governance-async-dlq",
+    "DeadLetterConfig:GovernanceNotifierFnAF80559D->citadel-governance-notifier-dlq",
+    "RedrivePolicy:EvalDispatchQueueFD99DE58->citadel-eval-dispatch-dlq",
+    "RuleTarget:GovernanceEventsRuleCAEA7CAA->citadel-governance-notifier-dlq",
+  ],
+  registry: [
+    "DeadLetterConfig:AgentImportManifestResultHandlerAC7A0B8E->citadel-registry-async-dlq",
+    "DeadLetterConfig:FabricationEventHandlerFunctionA425E3C0->citadel-registry-async-dlq",
+    "RuleTarget:RegistrySyncRuleE4DF9965->citadel-registry-sync-dlq",
+  ],
+  projects: [
+    "DeadLetterConfig:AssessmentCompletionNotifierF2243F8D->citadel-projects-async-dlq",
+    "DeadLetterConfig:ChatterPublisherFunction40B50CEA->citadel-projects-async-dlq",
+    "DeadLetterConfig:DesignProgressNotifier61A5E671->citadel-projects-async-dlq",
+    "DeadLetterConfig:ProjectProgressUpdater66E18062->citadel-projects-async-dlq",
+  ],
+  services: [
+    "DeadLetterConfig:DocumentIngestPollerFunction2ED9DA3B->citadel-services-async-dlq",
+    "DeadLetterConfig:HealthMonitorFunctionE81A641C->citadel-services-async-dlq",
+  ],
+};
+
+/** `citadel-arbiter-${ENV}` -> `arbiter` (keys of the pinned baseline). */
+function stackSlug(stackName: string): string {
+  return stackName.replace(/^citadel-/, "").replace(new RegExp(`-${ENV}$`), "");
 }
 
 const loadedTemplates = STACK_NAMES.map((name) => ({
@@ -288,5 +406,33 @@ describe("structural DLQ coverage guard (derived from synthesized templates)", (
       (name) => !discoveredNames.has(name),
     );
     expect(orphaned).toEqual([]);
+  });
+
+  describe("per-stack covered-consumer pin (single-consumer regressions trip here)", () => {
+    // One test per stack so a failure names the stack directly. Sorted
+    // string arrays give a readable jest diff: a MISSING entry means a
+    // consumer lost its dead-letter wiring; an EXTRA entry means new
+    // coverage that must be pinned (and, for shared-DLQ consumers, added
+    // to docs/runbooks/DLQ_REDRIVE.md — see the runbook-completeness
+    // guard in dlq-runbook-completeness.test.ts).
+    it.each(STACK_NAMES)(
+      "%s: covered-consumer set matches the synth-derived baseline",
+      (stackName) => {
+        const slug = stackSlug(stackName);
+        const pinned = PINNED_COVERED_CONSUMERS[slug];
+        expect(pinned).toBeDefined();
+        const discovered = allDiscoveredDlqs
+          .filter((d) => d.stackName === stackName)
+          .map(coverageEdge)
+          .sort();
+        expect(discovered).toEqual([...pinned].sort());
+      },
+    );
+
+    it("pinned baseline covers every synthesized stack (no stack silently dropped from the pin)", () => {
+      expect(Object.keys(PINNED_COVERED_CONSUMERS).sort()).toEqual(
+        STACK_NAMES.map(stackSlug).sort(),
+      );
+    });
   });
 });

--- a/backend/lib/__tests__/dlq-runbook-completeness.test.ts
+++ b/backend/lib/__tests__/dlq-runbook-completeness.test.ts
@@ -1,0 +1,200 @@
+/**
+ * Runbook completeness guard (CIT-125 slice C, design C.3 #2).
+ *
+ * Ties the DLQ_REDRIVE runbook back to the synthesized reality: every
+ * consumer Lambda that sets a shared per-stack async DLQ
+ * (`citadel-<stack>-async-dlq-<env>`) as its `DeadLetterConfig` must be
+ * mentioned in `docs/runbooks/DLQ_REDRIVE.md`. A new consumer wired to a
+ * shared DLQ without a runbook row fails here — the on-call procedure
+ * (§2 queue inventory + §3 redrive matrix) must never lag the deployed
+ * consumer set.
+ *
+ * Matching is deliberately tolerant of naming-style drift between CDK
+ * logical IDs and the runbook's prose/kebab-case: the consumer's logical
+ * ID is stripped of its trailing CDK path hash and generic
+ * Function/Handler/Fn/Agent/Scheduled suffixes, then both sides are
+ * normalized to lowercase alphanumerics before a substring check
+ * (`SupervisorAgent7CBC906A` → `supervisor`;
+ * `WorkflowTimeoutWatchdogFunctionE2172B89` → `workflowtimeoutwatchdog`,
+ * which matches the runbook's "workflow-timeout watchdog"). The negative
+ * control below proves the matcher is falsifiable.
+ *
+ * Discovery mirrors backend/lib/__tests__/dlq-coverage-structural.test.ts
+ * (same cdk.out templates, same skip-when-absent convention — run
+ * `cdk synth --all` first). The structural guard pins the consumer sets;
+ * this guard pins the runbook to them.
+ */
+import * as fs from "fs";
+import * as path from "path";
+
+const ENV = process.env.SPLIT_GATES_ENV ?? "dev";
+const CDK_OUT = path.resolve(__dirname, "..", "..", "cdk.out");
+const RUNBOOK_PATH = path.resolve(
+  __dirname,
+  "..",
+  "..",
+  "..",
+  "docs",
+  "runbooks",
+  "DLQ_REDRIVE.md",
+);
+
+// Every stack that can own a shared async DLQ consumer (mirror of the
+// structural guard's stack list).
+const STACK_NAMES = [
+  `citadel-arbiter-${ENV}`,
+  `citadel-backend-${ENV}`,
+  `citadel-telemetry-${ENV}`,
+  `citadel-governance-${ENV}`,
+  `citadel-registry-${ENV}`,
+  `citadel-projects-${ENV}`,
+  `citadel-services-${ENV}`,
+];
+
+const SHARED_ASYNC_DLQ_NAME = /^citadel-[a-z]+-async-dlq-/;
+
+interface CfnResource {
+  Type: string;
+  Properties?: Record<string, unknown>;
+}
+interface CfnTemplate {
+  Resources: Record<string, CfnResource>;
+}
+
+function loadTemplate(stackName: string): CfnTemplate | undefined {
+  const p = path.join(CDK_OUT, `${stackName}.template.json`);
+  if (!fs.existsSync(p)) return undefined;
+  return JSON.parse(fs.readFileSync(p, "utf-8")) as CfnTemplate;
+}
+
+function resolveLogicalIdFromRef(ref: unknown): string | undefined {
+  if (!ref || typeof ref !== "object") return undefined;
+  const asRecord = ref as Record<string, unknown>;
+  if (Array.isArray(asRecord["Fn::GetAtt"])) {
+    const [logicalId] = asRecord["Fn::GetAtt"] as unknown[];
+    return typeof logicalId === "string" ? logicalId : undefined;
+  }
+  if (typeof asRecord["Ref"] === "string") return asRecord["Ref"] as string;
+  return undefined;
+}
+
+interface SharedDlqConsumer {
+  stackName: string;
+  consumerLogicalId: string;
+  queueName: string;
+}
+
+/** Lambda functions whose DeadLetterConfig targets a shared async DLQ. */
+function discoverSharedDlqConsumers(
+  stackName: string,
+  template: CfnTemplate,
+): SharedDlqConsumer[] {
+  const found: SharedDlqConsumer[] = [];
+  for (const [logicalId, res] of Object.entries(template.Resources)) {
+    if (res.Type !== "AWS::Lambda::Function") continue;
+    const dlqConfig = (res.Properties ?? {})["DeadLetterConfig"] as
+      Record<string, unknown> | undefined;
+    const targetLogicalId = resolveLogicalIdFromRef(dlqConfig?.["TargetArn"]);
+    if (!targetLogicalId) continue;
+    const queue = template.Resources[targetLogicalId];
+    if (!queue || queue.Type !== "AWS::SQS::Queue") continue;
+    const queueName = (queue.Properties ?? {})["QueueName"];
+    if (typeof queueName !== "string") continue;
+    if (!SHARED_ASYNC_DLQ_NAME.test(queueName)) continue;
+    found.push({ stackName, consumerLogicalId: logicalId, queueName });
+  }
+  return found;
+}
+
+/** `SupervisorAgent7CBC906A` → `Supervisor` (hash + generic suffixes off). */
+function consumerBaseName(consumerLogicalId: string): string {
+  // CDK logical IDs end with an 8-hex-char path hash (uppercase).
+  let base = consumerLogicalId.replace(/[0-9A-F]{8}$/, "");
+  const GENERIC_SUFFIXES = ["Function", "Handler", "Agent", "Fn", "Scheduled"];
+  let stripped = true;
+  while (stripped) {
+    stripped = false;
+    for (const suffix of GENERIC_SUFFIXES) {
+      // Keep at least 6 chars of identity — never strip a name to mush.
+      if (base.endsWith(suffix) && base.length - suffix.length >= 6) {
+        base = base.slice(0, -suffix.length);
+        stripped = true;
+      }
+    }
+  }
+  return base;
+}
+
+/** Lowercase alphanumerics only — style-insensitive comparison space. */
+function normalize(s: string): string {
+  return s.toLowerCase().replace(/[^a-z0-9]/g, "");
+}
+
+const loadedTemplates = STACK_NAMES.map((name) => ({
+  name,
+  template: loadTemplate(name),
+}));
+const allTemplatesPresent = loadedTemplates.every((t) => t.template);
+
+describe("DLQ_REDRIVE runbook completeness (every synthesized shared-DLQ consumer documented)", () => {
+  if (!allTemplatesPresent) {
+    const missing = loadedTemplates
+      .filter((t) => !t.template)
+      .map((t) => t.name)
+      .join(", ");
+    it.skip(
+      `skipped: one or more synthesized templates missing under cdk.out/ ` +
+        `(run 'cdk synth --all' first). missing=[${missing}]`,
+      () => {},
+    );
+    return;
+  }
+
+  const consumers: SharedDlqConsumer[] = [];
+  for (const { name, template } of loadedTemplates) {
+    consumers.push(
+      ...discoverSharedDlqConsumers(name, template as CfnTemplate),
+    );
+  }
+  const runbook = fs.readFileSync(RUNBOOK_PATH, "utf-8");
+  const normalizedRunbook = normalize(runbook);
+
+  it("discovers shared-DLQ consumers in every synthesized stack (sanity check the discovery walk)", () => {
+    expect(consumers.length).toBeGreaterThan(0);
+    const stacksWithConsumers = new Set(consumers.map((c) => c.stackName));
+    expect([...stacksWithConsumers].sort()).toEqual([...STACK_NAMES].sort());
+  });
+
+  it("every synthesized shared-DLQ consumer appears in docs/runbooks/DLQ_REDRIVE.md", () => {
+    const undocumented = consumers.filter(
+      (c) =>
+        !normalizedRunbook.includes(
+          normalize(consumerBaseName(c.consumerLogicalId)),
+        ),
+    );
+    // A failure here means a consumer gained a shared-DLQ DeadLetterConfig
+    // without a runbook entry: add it to §2's queue-inventory table AND a
+    // §3 redrive-matrix row (SAFE / RECONCILE-FIRST / re-derive) before
+    // updating anything in this test.
+    expect(
+      undocumented.map(
+        (c) => `${c.stackName}:${c.consumerLogicalId} (${c.queueName})`,
+      ),
+    ).toEqual([]);
+  });
+
+  it("a consumer absent from the runbook would fail the guard (negative control on the matcher)", () => {
+    const synthetic = "SyntheticUnrunbookedConsumerFnAB12CD34";
+    expect(
+      normalizedRunbook.includes(normalize(consumerBaseName(synthetic))),
+    ).toBe(false);
+  });
+
+  it("normalization keeps enough identity to discriminate (no consumer collapses to a trivial token)", () => {
+    for (const c of consumers) {
+      expect(
+        normalize(consumerBaseName(c.consumerLogicalId)).length,
+      ).toBeGreaterThanOrEqual(6);
+    }
+  });
+});

--- a/backend/test/arbiter-stack-event-idempotency.test.ts
+++ b/backend/test/arbiter-stack-event-idempotency.test.ts
@@ -10,6 +10,7 @@ import {
   scaffoldBackendAssetDirs,
   scaffoldArbiterStubs,
 } from "./helpers/scaffold-stub-assets";
+import { assertSharedAsyncDlqShape } from "./helpers/shared-dlq-shape";
 
 scaffoldBackendAssetDirs(["dist/lambda", "src/schema"]);
 scaffoldArbiterStubs();
@@ -186,5 +187,39 @@ describe("ArbiterStack — CIT-125 slice B event-id/message-id dedupe wiring", (
     }
     // One grant statement per consumer (supervisor + fabricator).
     expect(grantsFound).toBe(2);
+  });
+});
+
+// CIT-125 slice A follow-up (design A.6 #2 and #6, deferred from the
+// feature PR per the slice-A verification advisory): per-stack guards over
+// the supervisor rules' RetryPolicy and the shared async DLQ's queue shape,
+// asserted against the same in-process Template.fromStack harness as the
+// dedupe-wiring tests above.
+describe("ArbiterStack — CIT-125 slice A reliability guards (supervisor retry policy + shared DLQ shape)", () => {
+  let template: Template;
+  beforeAll(() => {
+    template = buildTemplate();
+  });
+
+  test.each(["TaskRequestRule", "TaskCompletionRule"])(
+    "%s target carries RetryPolicy {maxEventAge 7200s, retryAttempts 2} (kills the 24h default retry storm)",
+    (rulePrefix) => {
+      const rules = template.findResources("AWS::Events::Rule");
+      const ids = Object.keys(rules).filter((id) => id.startsWith(rulePrefix));
+      expect(ids).toHaveLength(1);
+      const targets = rules[ids[0]].Properties.Targets;
+      expect(targets).toHaveLength(1);
+      // Exact equality: a widened maxEventAge or extra retry attempts would
+      // silently reintroduce EventBridge's 24h/185-attempt default storm
+      // before events reach the arbiter async DLQ.
+      expect(targets[0].RetryPolicy).toEqual({
+        MaximumEventAgeInSeconds: 7200,
+        MaximumRetryAttempts: 2,
+      });
+    },
+  );
+
+  test("shared async DLQ carries the design queue shape (14d retention, SQS-managed SSE, enforceSSL policy)", () => {
+    assertSharedAsyncDlqShape(template, "arbiter");
   });
 });

--- a/backend/test/arbiter-stack-event-idempotency.test.ts
+++ b/backend/test/arbiter-stack-event-idempotency.test.ts
@@ -201,14 +201,26 @@ describe("ArbiterStack — CIT-125 slice A reliability guards (supervisor retry 
     template = buildTemplate();
   });
 
-  test.each(["TaskRequestRule", "TaskCompletionRule"])(
-    "%s target carries RetryPolicy {maxEventAge 7200s, retryAttempts 2} (kills the 24h default retry storm)",
-    (rulePrefix) => {
+  test.each([
+    ["TaskRequestRule", "task.request"],
+    ["TaskCompletionRule", "task.completion"],
+  ])(
+    "%s (source %s) targets the supervisor with RetryPolicy {maxEventAge 7200s, retryAttempts 2} (kills the 24h default retry storm)",
+    (rulePrefix, source) => {
       const rules = template.findResources("AWS::Events::Rule");
       const ids = Object.keys(rules).filter((id) => id.startsWith(rulePrefix));
       expect(ids).toHaveLength(1);
-      const targets = rules[ids[0]].Properties.Targets;
+      const rule = rules[ids[0]];
+      // Rule identity: pin the rule to its slice-A event source so the
+      // guard tracks the task.request / task.completion rules themselves,
+      // not merely a construct-ID lookalike.
+      expect(rule.Properties.EventPattern).toEqual({ source: [source] });
+      const targets = rule.Properties.Targets;
       expect(targets).toHaveLength(1);
+      // Target identity: the supervisor Lambda (GetAtt on the
+      // SupervisorAgent* logical id) — the RetryPolicy pinned below is
+      // provably the SUPERVISOR's, not some other consumer's.
+      expect(JSON.stringify(targets[0].Arn)).toContain("SupervisorAgent");
       // Exact equality: a widened maxEventAge or extra retry attempts would
       // silently reintroduce EventBridge's 24h/185-attempt default storm
       // before events reach the arbiter async DLQ.

--- a/backend/test/arbiter-stack-seed-module-digest.test.ts
+++ b/backend/test/arbiter-stack-seed-module-digest.test.ts
@@ -9,10 +9,17 @@
  * property — CloudFormation reported the resource unchanged and never
  * re-invoked the handler, so the repository fix never reached S3.
  *
- * FIX: a content digest of the seed source (computeSeedModuleDigest, over the
- * whole seedConfig dir via cdk.FileSystem.fingerprint) is now a custom-resource
+ * FIX: a content digest of the seed source (computeSeedModuleDigest — a
+ * content-only sha256 folding each file's relative path + raw bytes over a
+ * sorted, exclusion-filtered walk of seedConfig/) is now a custom-resource
  * property (`ModuleDigest`). Any source edit changes the digest, forcing a
- * re-upload on the next deploy.
+ * re-upload on the next deploy. Deliberately NOT cdk.FileSystem.fingerprint
+ * (the original implementation, replaced under finding b9627d6f): that
+ * primitive memoizes per-file content hashes in an on-disk cache keyed by
+ * `${ino}|${mtimeMs}|${size}`, so a same-length rewrite within one mtime
+ * tick can be served a stale digest — the CI flake this suite's own
+ * mutate-and-recompute tests reproduced. See the IMPLEMENTATION NOTE above
+ * computeSeedModuleDigest in arbiter-stack.ts.
  *
  * WHAT THESE TESTS CATCH / DO NOT CATCH:
  *   - They prove the synthesized template carries a real, source-derived

--- a/backend/test/backend-stack-workflows.test.ts
+++ b/backend/test/backend-stack-workflows.test.ts
@@ -16,6 +16,7 @@ for (const dir of assetDirs) {
 }
 
 import { BackendStack } from "../lib/backend-stack";
+import { assertSharedAsyncDlqShape } from "./helpers/shared-dlq-shape";
 
 describe("BackendStack — Workflow/App/Execution Lambda functions and AppSync wiring (Task 1.5)", () => {
   let template: Template;
@@ -27,6 +28,11 @@ describe("BackendStack — Workflow/App/Execution Lambda functions and AppSync w
       env: { account: "123456789012", region: "us-east-1" },
     });
     template = Template.fromStack(stack);
+  });
+
+  // --- CIT-125 slice A follow-up (design A.6 #6): shared async DLQ shape ---
+  test("shared async DLQ carries the design queue shape (14d retention, SQS-managed SSE, enforceSSL policy)", () => {
+    assertSharedAsyncDlqShape(template, "backend");
   });
 
   // --- WorkflowResolverFunction ---

--- a/backend/test/governance-stack-auto-rollback-evaluator.test.ts
+++ b/backend/test/governance-stack-auto-rollback-evaluator.test.ts
@@ -20,6 +20,7 @@ import * as sns from "aws-cdk-lib/aws-sns";
 import { Bucket } from "aws-cdk-lib/aws-s3";
 import * as path from "path";
 import { scaffoldBackendAssetDirs } from "./helpers/scaffold-stub-assets";
+import { assertSharedAsyncDlqShape } from "./helpers/shared-dlq-shape";
 
 scaffoldBackendAssetDirs(["dist/lambda", "src/schema"]);
 
@@ -234,5 +235,19 @@ describe("GovernanceStack — auto-rollback evaluator", () => {
       }
     }
     expect(grantsCostLedgerQuery).toBe(true);
+  });
+});
+
+// CIT-125 slice A follow-up (design A.6 #6, deferred from the feature PR
+// per the slice-A verification advisory): shared async DLQ queue shape,
+// asserted against this file's existing Template.fromStack harness.
+describe("GovernanceStack — CIT-125 slice A shared async DLQ shape", () => {
+  let template: Template;
+  beforeAll(() => {
+    template = createTemplate();
+  });
+
+  test("shared async DLQ carries the design queue shape (14d retention, SQS-managed SSE, enforceSSL policy)", () => {
+    assertSharedAsyncDlqShape(template, "governance");
   });
 });

--- a/backend/test/helpers/shared-dlq-shape.ts
+++ b/backend/test/helpers/shared-dlq-shape.ts
@@ -1,0 +1,120 @@
+/**
+ * Shared-DLQ queue-shape assertion helper (CIT-125 slice A follow-up,
+ * design A.6 #6).
+ *
+ * Every per-stack shared async DLQ (`citadel-<stack>-async-dlq-<env>`)
+ * must carry the exact queue shape the design prescribes:
+ *   - MessageRetentionPeriod 1209600s (14 days) — the redrive window the
+ *     DLQ_REDRIVE runbook's procedures assume;
+ *   - SqsManagedSseEnabled true (SQS_MANAGED encryption);
+ *   - an enforceSSL QueuePolicy (Deny sqs:* to any principal when
+ *     aws:SecureTransport is false) attached to the queue.
+ *
+ * Called from each stack's EXISTING Template.fromStack harness so the
+ * assertion runs against in-process synth (no cdk.out dependency) — one
+ * call site per stack, one shape definition here.
+ *
+ * NOTE: files under test/helpers/ are compiled by the BUILD tsc (they
+ * match none of tsconfig.json's test-file excludes), where jest's ambient
+ * globals are not typed (`@types/jest` is not installed; jest injects its
+ * globals only at runtime via the ts-jest transform's `types` override).
+ * This helper therefore uses no `expect` — violations are collected and
+ * thrown as a single Error, which jest reports as the calling test's
+ * failure with the full violation list in the message.
+ */
+import { Template } from "aws-cdk-lib/assertions";
+
+/** 14 days, in seconds — the design's DLQ retention (A.0 queue shape). */
+export const SHARED_ASYNC_DLQ_RETENTION_SECONDS = 14 * 24 * 60 * 60;
+
+interface CfnResourceLike {
+  Type?: string;
+  Properties?: Record<string, unknown>;
+}
+
+/**
+ * Asserts the `citadel-<slug>-async-dlq-<environment>` queue in `template`
+ * has the design's retention + SSE shape and an enforceSSL QueuePolicy.
+ * Throws a single Error listing every violation found (empty = passes).
+ */
+export function assertSharedAsyncDlqShape(
+  template: Template,
+  slug: string,
+  environment = "test",
+): void {
+  const queueName = `citadel-${slug}-async-dlq-${environment}`;
+  const problems: string[] = [];
+
+  // --- Queue exists exactly once, with retention + SQS-managed SSE ---
+  const queues = template.findResources("AWS::SQS::Queue", {
+    Properties: { QueueName: queueName },
+  }) as Record<string, CfnResourceLike>;
+  const queueIds = Object.keys(queues);
+  if (queueIds.length !== 1) {
+    throw new Error(
+      `shared async DLQ shape (${queueName}): expected exactly 1 ` +
+        `AWS::SQS::Queue with that QueueName, found ${queueIds.length} ` +
+        `[${queueIds.join(", ")}]`,
+    );
+  }
+  const queueLogicalId = queueIds[0];
+  const queueProps = queues[queueLogicalId].Properties ?? {};
+  if (
+    queueProps.MessageRetentionPeriod !== SHARED_ASYNC_DLQ_RETENTION_SECONDS
+  ) {
+    problems.push(
+      `MessageRetentionPeriod: expected ${SHARED_ASYNC_DLQ_RETENTION_SECONDS} ` +
+        `(14d), got ${JSON.stringify(queueProps.MessageRetentionPeriod)}`,
+    );
+  }
+  if (queueProps.SqsManagedSseEnabled !== true) {
+    problems.push(
+      `SqsManagedSseEnabled: expected true, got ` +
+        `${JSON.stringify(queueProps.SqsManagedSseEnabled)}`,
+    );
+  }
+
+  // --- enforceSSL QueuePolicy: Deny sqs:* when aws:SecureTransport=false ---
+  const policies = template.findResources("AWS::SQS::QueuePolicy") as Record<
+    string,
+    CfnResourceLike
+  >;
+  let attachedDenyStatements = 0;
+  for (const policy of Object.values(policies)) {
+    const props = policy.Properties ?? {};
+    const queuesAttached = (props.Queues ?? []) as Array<unknown>;
+    const attachesToQueue = queuesAttached.some(
+      (q) =>
+        typeof q === "object" &&
+        q !== null &&
+        (q as Record<string, unknown>).Ref === queueLogicalId,
+    );
+    if (!attachesToQueue) continue;
+    const doc = (props.PolicyDocument ?? {}) as {
+      Statement?: Array<Record<string, unknown>>;
+    };
+    for (const stmt of doc.Statement ?? []) {
+      if (stmt.Effect !== "Deny") continue;
+      const actions = Array.isArray(stmt.Action) ? stmt.Action : [stmt.Action];
+      if (!actions.includes("sqs:*")) continue;
+      const condition = (stmt.Condition ?? {}) as {
+        Bool?: Record<string, unknown>;
+      };
+      if (condition.Bool?.["aws:SecureTransport"] !== "false") continue;
+      attachedDenyStatements += 1;
+    }
+  }
+  if (attachedDenyStatements !== 1) {
+    problems.push(
+      `enforceSSL QueuePolicy: expected exactly 1 Deny-sqs:*-when-insecure ` +
+        `statement attached to ${queueLogicalId}, found ${attachedDenyStatements}`,
+    );
+  }
+
+  if (problems.length > 0) {
+    throw new Error(
+      `shared async DLQ shape violation(s) for ${queueName} ` +
+        `(logical id ${queueLogicalId}):\n  - ${problems.join("\n  - ")}`,
+    );
+  }
+}

--- a/backend/test/projects-stack.test.ts
+++ b/backend/test/projects-stack.test.ts
@@ -22,6 +22,7 @@ import * as sns from "aws-cdk-lib/aws-sns";
 import { Bucket } from "aws-cdk-lib/aws-s3";
 import * as path from "path";
 import { scaffoldBackendAssetDirs } from "./helpers/scaffold-stub-assets";
+import { assertSharedAsyncDlqShape } from "./helpers/shared-dlq-shape";
 
 scaffoldBackendAssetDirs(["dist/lambda", "src/schema"]);
 
@@ -350,5 +351,19 @@ describe("ProjectsStack — backend-stack-split phase 1", () => {
     });
     // 10 Lambda data sources -> 10 appsync-assumable roles.
     expect(Object.keys(roles)).toHaveLength(10);
+  });
+});
+
+// CIT-125 slice A follow-up (design A.6 #6, deferred from the feature PR
+// per the slice-A verification advisory): shared async DLQ queue shape,
+// asserted against this file's existing Template.fromStack harness.
+describe("ProjectsStack — CIT-125 slice A shared async DLQ shape", () => {
+  let template: Template;
+  beforeAll(() => {
+    ({ template } = createTestStack());
+  });
+
+  test("shared async DLQ carries the design queue shape (14d retention, SQS-managed SSE, enforceSSL policy)", () => {
+    assertSharedAsyncDlqShape(template, "projects");
   });
 });

--- a/backend/test/registry-stack.test.ts
+++ b/backend/test/registry-stack.test.ts
@@ -23,6 +23,7 @@ import * as dynamodb from "aws-cdk-lib/aws-dynamodb";
 import * as events from "aws-cdk-lib/aws-events";
 import * as path from "path";
 import { scaffoldBackendAssetDirs } from "./helpers/scaffold-stub-assets";
+import { assertSharedAsyncDlqShape } from "./helpers/shared-dlq-shape";
 
 scaffoldBackendAssetDirs(["dist/lambda", "src/schema"]);
 
@@ -432,5 +433,19 @@ describe("RegistryStack — backend-stack-split phase 2", () => {
     });
     // 6 data sources => 6 appsync-assumable roles.
     expect(Object.keys(roles)).toHaveLength(6);
+  });
+});
+
+// CIT-125 slice A follow-up (design A.6 #6, deferred from the feature PR
+// per the slice-A verification advisory): shared async DLQ queue shape,
+// asserted against this file's existing Template.fromStack harness.
+describe("RegistryStack — CIT-125 slice A shared async DLQ shape", () => {
+  let template: Template;
+  beforeAll(() => {
+    ({ template } = createTestStack());
+  });
+
+  test("shared async DLQ carries the design queue shape (14d retention, SQS-managed SSE, enforceSSL policy)", () => {
+    assertSharedAsyncDlqShape(template, "registry");
   });
 });

--- a/backend/test/services-stack.test.ts
+++ b/backend/test/services-stack.test.ts
@@ -5,6 +5,7 @@ import {
   scaffoldBackendAssetDirs,
   scaffoldServiceDockerfiles,
 } from "./helpers/scaffold-stub-assets";
+import { assertSharedAsyncDlqShape } from "./helpers/shared-dlq-shape";
 
 // Ensure asset directories exist for CDK synthesis
 scaffoldBackendAssetDirs(["src/schema", "src/lambda/cognito-secret-handler"]);
@@ -46,6 +47,12 @@ describe("ServicesStack", () => {
 
   test("has no duplicate Construct imports (compiles successfully)", () => {
     expect(stack).toBeInstanceOf(ServicesStack);
+  });
+
+  // CIT-125 slice A follow-up (design A.6 #6, deferred from the feature PR
+  // per the slice-A verification advisory): shared async DLQ queue shape.
+  test("shared async DLQ carries the design queue shape (14d retention, SQS-managed SSE, enforceSSL policy)", () => {
+    assertSharedAsyncDlqShape(template, "services");
   });
 
   test("creates OpenSearch Serverless collection for KB", () => {

--- a/backend/test/telemetry-stack.test.ts
+++ b/backend/test/telemetry-stack.test.ts
@@ -205,6 +205,7 @@ for (const dir of assetDirs) {
 }
 
 import { TelemetryStack } from "../lib/telemetry-stack";
+import { assertSharedAsyncDlqShape } from "./helpers/shared-dlq-shape";
 
 function createTestStack(): { stack: TelemetryStack; template: Template } {
   const app = new cdk.App();
@@ -1152,5 +1153,19 @@ describe("TelemetryStack — Phase 2 governance.eval.case.judged dual-consumer r
       // citadel.backend, every judge-basis dimension stayed PENDING).
       expect(rule.Properties.EventPattern.source).toEqual(["citadel.backend"]);
     }
+  });
+});
+
+// CIT-125 slice A follow-up (design A.6 #6, deferred from the feature PR
+// per the slice-A verification advisory): shared async DLQ queue shape,
+// asserted against this file's existing Template.fromStack harness.
+describe("TelemetryStack — CIT-125 slice A shared async DLQ shape", () => {
+  let template: Template;
+  beforeAll(() => {
+    ({ template } = createTestStack());
+  });
+
+  test("shared async DLQ carries the design queue shape (14d retention, SQS-managed SSE, enforceSSL policy)", () => {
+    assertSharedAsyncDlqShape(template, "telemetry");
   });
 });


### PR DESCRIPTION
## Summary

Test-only follow-up closing the regression gaps the DLQ/idempotency reviews flagged: several shipped guarantees had no guard that would trip if quietly removed. Zero production changes.

- Per-consumer DLQ pins: the structural guard now holds a per-stack baseline of covered consumers, so removing a single consumer's dead-letter wiring fails a test naming the lost edge (previously only total-queue orphaning tripped)
- Shared queue-shape guard across all 7 stacks: 14-day retention, SQS-managed
SSE, enforce-SSL policy
- Supervisor rule assertions: task.request | task.completion rules pinned to the supervisor target with RetryPolicy {2 attempts, 2h max event age}
- Runbook completeness: every synthesized shared-DLQ consumer must appear in docs/runbooks/DLQ_REDRIVE.md, so
new consumers can't ship undocumented
- Moto-backed dedupe suites (12 tests): supervisor event. id and fabricator messageId claims driven through the real handlers against a real DynamoDB engine - regression-locks the exactly-once behavior shipped earlier
- Stale docblock in the seed-digest test corrected (fingerprint → content hash)

## Testing

- Every new guard is mutation-proven: DLQ removal, retry-attempts 2→5, retention 14d→7d, runbook mangle, and dedupe ConditionExpression removal each produce a named red, with byte-identical restore verified
- tsc, lint, cdk synth, full backend jest (6963+), scoped pytest all exit O 

## Notes

- The structural guards read synthesized templates and skip gracefully when cdk.out is absent - run `cdk synth --all` before jest locally; worth confirming the Backend Tests CI job's ordering does the same
- The fabricator moto suite uses `pytest.importorskip("strands")`: it skips in strands-less local runs and executes in CI (which installs strands-agents) and under .venv-check (12/12 there)