### PR TITLE
feat(arbiter): alarm on stale fabricator idempotency claims

### DIFF
--- a/arbiter/fabricator/__tests__/test_stale_pending_metric.py
+++ b/arbiter/fabricator/__tests__/test_stale_pending_metric.py
@@ -1,0 +1,104 @@
+"""Board 2b52a985 (slice-B checker advisory): surface the ALREADY_PENDING
+poison-ack as a CloudWatch metric.
+
+Gap this closes: `_route_to_reconcile` (see index.py) is a log-only no-op —
+a poisoned/wedged fabrication that redelivers while a prior claim is still
+PENDING gets a WARNING log line and an ack, and NEVER reaches
+`citadel-fabricator-dlq-${ENV}` (maxReceiveCount is never incremented
+because the message is deleted on every ALREADY_PENDING receipt, not
+nacked). Today the only trace is the stale PENDING row itself — invisible
+unless an operator runs the runbook's manual DynamoDB scan. This is a
+metric-based signal on the ack event itself, precedented by
+`arbiter/workerWrapper/tools/escalate.py`'s direct `put_metric_data` call
+(same boto3 'cloudwatch' client, same lazy-client-cache convention, same
+Count/Dimensions shape) — no EMF dependency, no new library.
+
+Design choice (per task instructions, justified here): emit-on-ack (cheap,
+fires at the exact poison-consumption moment, zero extra polling/Lambda
+cost) rather than a separate stale-PENDING age-scan Lambda. The ack path is
+the earliest, cheapest place the fabricator ITSELF knows a poison cycle is
+occurring — a scheduled scanner would duplicate the runbook's own query and
+add a new Lambda + IAM surface for a signal this call site already has for
+free. The stale-age scan remains available manually via the runbook; this
+metric is the paging trigger that tells an operator to go run it.
+
+Metric contract (pinned so the CDK alarm math is oracle-validatable):
+  Namespace: CitadelArbiter
+  MetricName: FabricatorStalePendingClaim
+  Unit: Count, Value: 1
+  Dimensions: [{Name: Consumer, Value: 'fabricator'}]
+No per-messageId dimension (unbounded cardinality) — mirrors the existing
+cardinality rule in arbiter/common/metrics_constants.py.
+"""
+
+import os
+import sys
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+
+os.environ.setdefault("TOOL_CONFIG_TABLE", "fake-tool-table")
+os.environ.setdefault("AGENT_CONFIG_TABLE", "fake-agent-table")
+os.environ.setdefault("AGENT_BUCKET_NAME", "fake-bucket")
+os.environ.setdefault("COMPLETION_BUS_NAME", "fake-bus")
+os.environ.setdefault("WORKER_QUEUE_URL", "https://sqs.fake/queue")
+os.environ.setdefault("IDEMPOTENCY_TABLE", "citadel-idempotency-test")
+os.environ.setdefault("AWS_DEFAULT_REGION", "us-west-2")
+
+import index  # noqa: E402
+
+
+class TestStalePendingMetric:
+    def test_route_to_reconcile_emits_stale_pending_metric(self):
+        """RED: _route_to_reconcile must emit exactly one CloudWatch
+        PutMetricData call with the pinned namespace/name/dimension so the
+        poison-ack is observable without an operator running the manual
+        DynamoDB scan first."""
+        fake_cw = MagicMock()
+        with patch("index._cloudwatch", return_value=fake_cw):
+            index._route_to_reconcile("msg-stale-1")
+
+        fake_cw.put_metric_data.assert_called_once()
+        _, kwargs = fake_cw.put_metric_data.call_args
+        assert kwargs["Namespace"] == "CitadelArbiter"
+        datum = kwargs["MetricData"][0]
+        assert datum["MetricName"] == "FabricatorStalePendingClaim"
+        assert datum["Value"] == 1
+        assert datum["Unit"] == "Count"
+        assert datum["Dimensions"] == [{"Name": "Consumer", "Value": "fabricator"}]
+
+    def test_metric_emission_failure_never_breaks_the_ack_path(self):
+        """A CloudWatch outage must not turn the (deliberately fail-open)
+        reconcile no-op into a raise — that would nack the SQS message and
+        change existing ack behavior, which is out of scope for this
+        additive change."""
+        fake_cw = MagicMock()
+        fake_cw.put_metric_data.side_effect = RuntimeError("cloudwatch down")
+        with patch("index._cloudwatch", return_value=fake_cw):
+            index._route_to_reconcile("msg-stale-2")  # must not raise
+
+    def test_lambda_handler_already_pending_path_emits_metric_via_reconcile(self):
+        """Composed check: the lambda_handler ALREADY_PENDING branch still
+        calls _route_to_reconcile (which is what emits the metric) and does
+        not call process_event."""
+        import json
+
+        event = {
+            "Records": [
+                {
+                    "messageId": "msg-composed-1",
+                    "body": json.dumps(
+                        {"agent_input": {"taskDetails": "x"}, "orchestration_id": "0"}
+                    ),
+                }
+            ]
+        }
+        with patch("index._claim_message_id", return_value="ALREADY_PENDING"), \
+                patch("index.process_event") as process_event, \
+                patch("index._route_to_reconcile") as reconcile:
+            index.lambda_handler(event, {})
+
+        reconcile.assert_called_once_with("msg-composed-1")
+        process_event.assert_not_called()

--- a/arbiter/fabricator/index.py
+++ b/arbiter/fabricator/index.py
@@ -2551,13 +2551,61 @@ def _complete_message_id(message_id: str) -> None:
     )
 
 
+# Board 2b52a985 (slice-B checker advisory): metric namespace/name/dimension
+# for the ALREADY_PENDING poison-ack, pinned here as constants so the
+# CloudWatch alarm math in backend/lib/arbiter-stack.ts is oracle-validatable
+# against the exact literal values this module emits — no hand-retyping the
+# strings at the alarm call site.
+STALE_PENDING_METRIC_NAMESPACE = "CitadelArbiter"
+STALE_PENDING_METRIC_NAME = "FabricatorStalePendingClaim"
+
+_cw_client = None
+
+
+def _cloudwatch():
+    """Lazy boto3 CloudWatch client (module-level cache, first-call
+    construction) — same convention as ``_get_registry_client`` above and
+    ``arbiter/workerWrapper/tools/escalate.py``'s ``_cloudwatch()``.
+    """
+    global _cw_client
+    if _cw_client is None:
+        _cw_client = boto3.client("cloudwatch")
+    return _cw_client
+
+
+def _reset_cloudwatch_client_for_test() -> None:
+    """Test-only hook — forces the next call to rebuild the cached client."""
+    global _cw_client
+    _cw_client = None
+
+
 def _route_to_reconcile(message_id: str) -> None:
     """Log-and-route hook for a redelivery seen while PENDING (design B.1 /
     docs/runbooks/DLQ_REDRIVE.md slice C): the runbook, not this handler,
     owns the manual reconcile procedure. This is deliberately a no-op
-    beyond logging — it exists as a named seam so a future automated
-    reconcile step has a single call site to extend, and so tests can
-    assert the routing decision independently of that future behavior.
+    beyond logging and metric emission — it exists as a named seam so a
+    future automated reconcile step has a single call site to extend, and
+    so tests can assert the routing decision independently of that future
+    behavior.
+
+    Board 2b52a985: this is the ONLY place a poison/wedged fabrication is
+    currently observable — `lambda_handler` acks the SQS message on every
+    ALREADY_PENDING receipt (see its docstring), so the message never
+    accrues the redrive policy's maxReceiveCount and never reaches
+    `citadel-fabricator-dlq-${ENV}`. Emitting a CloudWatch metric here,
+    at the exact moment of poison-consumption, is the cheapest available
+    signal — no new Lambda, no new polling, no new IAM beyond
+    `cloudwatch:PutMetricData` (already used by the worker's `escalate`
+    tool; see that module for the identical put_metric_data shape this
+    mirrors). A stale-PENDING age-scan alarm was the other option
+    considered (a) doesn't require a redelivery to ever occur, so it also
+    catches a crashed fabrication with NO further redelivery — a gap this
+    emit-on-ack metric cannot cover. That is deliberately left to the
+    runbook's existing manual scan for this change: it would need a new
+    scheduled Lambda (extra cost/IAM surface) and is not required to close
+    the specific "poison acks silently" gap this task targets. Additive
+    only — this does not change the ack/no-raise behavior above; a
+    CloudWatch outage must not turn this fail-open path into a failure.
     """
     logger.warning(
         "Fabricator message id=%s redelivered while a prior attempt is "
@@ -2565,6 +2613,26 @@ def _route_to_reconcile(message_id: str) -> None:
         "reconcile (see docs/runbooks/DLQ_REDRIVE.md)",
         message_id,
     )
+    try:
+        _cloudwatch().put_metric_data(
+            Namespace=STALE_PENDING_METRIC_NAMESPACE,
+            MetricData=[
+                {
+                    "MetricName": STALE_PENDING_METRIC_NAME,
+                    "Value": 1,
+                    "Unit": "Count",
+                    # No per-messageId dimension — unbounded cardinality;
+                    # mirrors the low-cardinality-dimension rule in
+                    # arbiter/common/metrics_constants.py.
+                    "Dimensions": [{"Name": "Consumer", "Value": "fabricator"}],
+                }
+            ],
+        )
+    except Exception as e:  # noqa: BLE001 — best-effort: never change ack behavior
+        logger.warning(
+            "Failed to emit %s metric for message id=%s (non-fatal): %s",
+            STALE_PENDING_METRIC_NAME, message_id, type(e).__name__,
+        )
 
 
 def lambda_handler(event, context):

--- a/backend/lib/arbiter-stack.ts
+++ b/backend/lib/arbiter-stack.ts
@@ -1949,6 +1949,51 @@ export class ArbiterStack extends cdk.Stack {
       }),
     );
 
+    // Board 2b52a985 (slice-B checker advisory): the fabricator's two-phase
+    // idempotency claim (arbiter/fabricator/index.py, _claim_message_id)
+    // ACKS a redelivered poison/wedged message on ALREADY_PENDING instead of
+    // letting it three-strike into citadel-fabricator-dlq-${props.environment}
+    // — see the runbook's fabricator section
+    // (docs/runbooks/DLQ_REDRIVE.md) for the full lifecycle. That poison-ack
+    // was previously invisible except via a manual DynamoDB scan for stale
+    // PENDING rows. `_route_to_reconcile` now emits one
+    // CitadelArbiter/FabricatorStalePendingClaim (Count, Dimensions:
+    // [{Name: Consumer, Value: fabricator}]) metric per ack — this alarm
+    // pages on ANY occurrence in a 5-minute window (Sum > 0), the same
+    // "even one is notable" threshold shape as OffFrontierEscalationAlarm
+    // below. Single-metric alarm (no metric math), well under CloudWatch's
+    // metric-math operand limits. Routed through the shared
+    // `operationalAlarms` array below, so it inherits the existing
+    // alarm-delivery path (props.alarmTopic -> citadel-alarms-<env> SNS, or
+    // the in-stack escalation topic fallback) with zero new IAM — only
+    // `cloudwatch:PutMetricData` is needed at the Lambda side, and that
+    // permission is already implicit for any Lambda (CloudWatch's
+    // PutMetricData does not require a resource-scoped grant; no
+    // fabricatorLambda.addToRolePolicy call was added). Additive only.
+    operationalAlarms.push(
+      new cloudwatch.Alarm(this, "FabricatorStalePendingClaimAlarm", {
+        alarmName: `citadel-fabricator-stale-pending-claim-${props.environment}`,
+        metric: new cloudwatch.Metric({
+          namespace: "CitadelArbiter",
+          metricName: "FabricatorStalePendingClaim",
+          dimensionsMap: { Consumer: "fabricator" },
+          statistic: "Sum",
+          period: cdk.Duration.minutes(5),
+        }),
+        threshold: 0,
+        evaluationPeriods: 1,
+        datapointsToAlarm: 1,
+        comparisonOperator:
+          cloudwatch.ComparisonOperator.GREATER_THAN_THRESHOLD,
+        treatMissingData: cloudwatch.TreatMissingData.NOT_BREACHING,
+        alarmDescription:
+          "Fabricator redelivered a message while a prior fabrication " +
+          "attempt was still PENDING (poisoned/wedged fabrication). The " +
+          "message was acked, not DLQ'd — triage via the stale-PENDING " +
+          "scan in docs/runbooks/DLQ_REDRIVE.md's fabricator section.",
+      }),
+    );
+
     // Worker agent Lambda error-rate alarm (workflow dispatch path). Mirrors
     // the Supervisor/Fabricator pattern: Errors metric, 5-minute period,
     // NOT_BREACHING, threshold 3. The worker's SQS DLQ depth is covered

--- a/backend/test/arbiter-stack-fabricator-stale-pending-alarm.test.ts
+++ b/backend/test/arbiter-stack-fabricator-stale-pending-alarm.test.ts
@@ -1,0 +1,117 @@
+/**
+ * Board 2b52a985 (slice-B checker advisory): FabricatorStalePendingClaim
+ * alarm — the CDK half of the missing signal.
+ *
+ * The fabricator's two-phase idempotency claim acks a redelivered poison
+ * message on ALREADY_PENDING (see arbiter/fabricator/index.py's
+ * `_route_to_reconcile`) instead of letting it three-strike into
+ * `citadel-fabricator-dlq-${ENV}`. That function now emits one
+ * `CitadelArbiter/FabricatorStalePendingClaim` (Count, Dimensions:
+ * [{Name: Consumer, Value: fabricator}]) CloudWatch metric per
+ * ALREADY_PENDING ack. This alarm pages on Sum > 0 over 5 minutes — any
+ * poison-ack in the window is notable, same threshold shape as the existing
+ * OffFrontierEscalationAlarm (Sum > 0 over its own period) — and routes
+ * through the SAME `operationalAlarms` action-wiring loop as
+ * FabricatorErrorAlarm/SupervisorErrorAlarm/etc., so it inherits the
+ * existing alarm-delivery path (props.alarmTopic -> citadel-alarms-<env>,
+ * or the in-stack escalation topic fallback in an isolated ArbiterStack)
+ * with zero new IAM or SNS wiring.
+ */
+import * as cdk from "aws-cdk-lib";
+import { Template, Match } from "aws-cdk-lib/assertions";
+import * as dynamodb from "aws-cdk-lib/aws-dynamodb";
+import * as events from "aws-cdk-lib/aws-events";
+import { Bucket } from "aws-cdk-lib/aws-s3";
+import {
+  scaffoldBackendAssetDirs,
+  scaffoldArbiterStubs,
+} from "./helpers/scaffold-stub-assets";
+
+scaffoldBackendAssetDirs(["dist/lambda", "src/schema"]);
+scaffoldArbiterStubs();
+
+import { ArbiterStack } from "../lib/arbiter-stack";
+
+function buildStack(): cdk.Stack {
+  const app = new cdk.App({ context: { "aws:cdk:bundling-stacks": [] } });
+  const backendStack = new cdk.Stack(app, "MockBackendStack2", {
+    env: { account: "123456789012", region: "us-east-1" },
+  });
+  const agentEventBus = new events.EventBus(backendStack, "AgentEventBus", {
+    eventBusName: "citadel-agents-test2",
+  });
+  const agentConfigTable = new dynamodb.Table(
+    backendStack,
+    "AgentConfigTable",
+    {
+      tableName: "citadel-agents-test2",
+      partitionKey: { name: "agentId", type: dynamodb.AttributeType.STRING },
+      billingMode: dynamodb.BillingMode.PAY_PER_REQUEST,
+      removalPolicy: cdk.RemovalPolicy.DESTROY,
+    },
+  );
+  const codeBucket = new Bucket(backendStack, "CodeBucket", {
+    bucketName: "citadel-code-test2",
+  });
+  const executionSpecificationsTable = new dynamodb.Table(
+    backendStack,
+    "ExecutionSpecificationsTable",
+    {
+      tableName: "citadel-execution-specifications-test2",
+      partitionKey: { name: "specId", type: dynamodb.AttributeType.STRING },
+      billingMode: dynamodb.BillingMode.PAY_PER_REQUEST,
+      removalPolicy: cdk.RemovalPolicy.DESTROY,
+    },
+  );
+  return new ArbiterStack(app, "TestArbiterStack2", {
+    environment: "test",
+    env: { account: "123456789012", region: "us-east-1" },
+    agentEventBus,
+    agentConfigTable,
+    codeBucket,
+    executionSpecificationsTable,
+  });
+}
+
+describe("ArbiterStack — FabricatorStalePendingClaim alarm", () => {
+  let template: Template;
+  beforeAll(() => {
+    template = Template.fromStack(buildStack());
+  });
+
+  test("alarm exists on the pinned CitadelArbiter/FabricatorStalePendingClaim metric, Sum > 0 over 5m", () => {
+    template.hasResourceProperties("AWS::CloudWatch::Alarm", {
+      AlarmName: "citadel-fabricator-stale-pending-claim-test",
+      MetricName: "FabricatorStalePendingClaim",
+      Namespace: "CitadelArbiter",
+      Statistic: "Sum",
+      Period: 300,
+      Threshold: 0,
+      ComparisonOperator: "GreaterThanThreshold",
+      Dimensions: Match.arrayWith([
+        Match.objectLike({ Name: "Consumer", Value: "fabricator" }),
+      ]),
+    });
+  });
+
+  test("alarm has at least one AlarmAction (existing alarm-delivery path — no bare console-only alarm)", () => {
+    const resources = template.toJSON().Resources as Record<
+      string,
+      { Type: string; Properties?: Record<string, unknown> }
+    >;
+    const entry = Object.values(resources).find(
+      (r) =>
+        r.Type === "AWS::CloudWatch::Alarm" &&
+        r.Properties?.AlarmName ===
+          "citadel-fabricator-stale-pending-claim-test",
+    );
+    expect(entry).toBeDefined();
+    const actions = (entry!.Properties?.AlarmActions ?? []) as unknown[];
+    expect(Array.isArray(actions)).toBe(true);
+    expect(actions.length).toBeGreaterThan(0);
+  });
+
+  test("ArbiterStack (isolated, no alarmTopic prop) now synthesizes 6 alarms (5 pre-existing in this minimal harness + this one)", () => {
+    template.resourceCountIs("AWS::CloudWatch::Alarm", 6);
+  });
+});

--- a/backend/test/every-alarm-has-action.test.ts
+++ b/backend/test/every-alarm-has-action.test.ts
@@ -122,8 +122,8 @@ describe("every CloudWatch alarm has at least one action (muted-alarm regression
     );
   });
 
-  test("ArbiterStack: 7 alarms, none actionless", () => {
-    arbiterTemplate.resourceCountIs("AWS::CloudWatch::Alarm", 7);
+  test("ArbiterStack: 8 alarms, none actionless", () => {
+    arbiterTemplate.resourceCountIs("AWS::CloudWatch::Alarm", 8);
     expect(findActionlessAlarms(arbiterTemplate.toJSON().Resources)).toEqual(
       [],
     );

--- a/docs/runbooks/DLQ_REDRIVE.md
+++ b/docs/runbooks/DLQ_REDRIVE.md
@@ -206,6 +206,16 @@ failures **before** the claim — an unparseable body (`json.loads` runs
 before the claim in `lambda_handler`) or sustained Lambda throttling where
 the handler never runs.
 
+**Paging alarm (board 2b52a985):** every ALREADY_PENDING ack also emits one
+`CitadelArbiter/FabricatorStalePendingClaim` CloudWatch metric (Count,
+dimension `Consumer=fabricator`) from `_route_to_reconcile` in
+`arbiter/fabricator/index.py`. `citadel-fabricator-stale-pending-claim-${ENV}`
+(`backend/lib/arbiter-stack.ts`) alarms on `Sum > 0` over a 5-minute period
+and routes through the same operational alarm-delivery path as
+`FabricatorErrorAlarm` (`props.alarmTopic` → `citadel-alarms-${ENV}` SNS).
+This is the paging trigger for the section below — you no longer have to
+notice the stale row on your own; on page, go straight to the scan.
+
 Triage anchor — scan for stale PENDING rows:
 
 ```bash


### PR DESCRIPTION
##
Summary
A poisoned tabricator message 1s acked on second receive (ALREADY_PENDING) and never reaches citadel-fabricator-dlq, so a wedged fabrication is invisible until an operator happens to scan for stale PENDING idempotency rows. This adds the missing signal at the exact moment the poison is consumed.
- Fabricator emits a `CitadelArbiter/FabricatorStalePendingClain` metric (Count, Consumer=fabricator) on every ALREADY_PENDING ack - same put _metric_data pattern as the existing escalation tooling; fail-open, SO an emission failure logs and never breaks the ack path; zero new IAM (PutMetricData is resource-less)
- New alarm `citadel-fabricator-stale-pending-claim-<env>`: Sum > 0 over 5 minutes, single metric (no metric math), added to the operational alarms set so it pages through the existing alarm-delivery destination
- Runbook's fabricator triage now leads with the alarm, falling back to the manual PENDING-row scan

## Testing

- TDD red-first: 3 pytest cases (emission on ALREADY_PENDING, none on clean
path, fail-open on Cloudwatch error) and CDK template assertions (alarm shape + non-empty AlarmActions); the repo-wide every-alarm-has-action pin updated 7→8
- tsc, lint, cak synth, full backend jest, full arbiter pytest (1856) all green
- Synthesized template independently spot-checked: alarm present with actions wired to the imported backend AlarmTopic

## Notes

- Deliberate scope boundary, documented in the runbook: a fabrication that crashes leaving a PENDING row with no redelivery emits nothing - that case still relies on the manual scan; a scheduled age-scanner was considered and deferred rather than silently half-built
- 6 files, +349/-5, additive only