### PR TITLE
fix(gates): reconcile split-gates baseline drift with allowlists

### DIFF
--- a/backend/scripts/__tests__/split-gates-rail3.test.ts
+++ b/backend/scripts/__tests__/split-gates-rail3.test.ts
@@ -129,4 +129,93 @@ describe("rail 3 — resolver parity (negative: doctored templates must FAIL cor
       result.violations.some((v) => v.logicalId === "Query.unexpectedField"),
     ).toBe(true);
   });
+
+  it("FAILS on double-attach even for a field listed in expectedNewFields (the exemption only covers the missing/extra checks, never double-attach)", () => {
+    const baseline = makeBaseline(["Query.getProject"]);
+    const expectedNewFields = [
+      {
+        logicalId: "Mutation.resumeExecution",
+        justification: "test fixture — mirrors EXPECTED_NEW_FIELDS shape",
+      },
+    ];
+    const result = runResolverParity(
+      baseline,
+      [
+        {
+          stackName: "citadel-backend-dev",
+          template: templateWithFields([
+            "Query.getProject",
+            "Mutation.resumeExecution",
+          ]),
+        },
+        {
+          stackName: "citadel-projects-dev",
+          template: templateWithFields(["Mutation.resumeExecution"]),
+        },
+      ],
+      expectedNewFields,
+    );
+    expect(result.passed).toBe(false);
+    expect(
+      result.violations.some(
+        (v) =>
+          v.logicalId === "Mutation.resumeExecution" &&
+          /more than one place/.test(v.message),
+      ),
+    ).toBe(true);
+  });
+
+  it("passes when a field listed in expectedNewFields is present exactly once and not in baseline (the intended, non-vacuous use case)", () => {
+    const baseline = makeBaseline(["Query.getProject"]);
+    const expectedNewFields = [
+      {
+        logicalId: "Mutation.resumeExecution",
+        justification: "test fixture — mirrors EXPECTED_NEW_FIELDS shape",
+      },
+    ];
+    const result = runResolverParity(
+      baseline,
+      [
+        {
+          stackName: "citadel-backend-dev",
+          template: templateWithFields([
+            "Query.getProject",
+            "Mutation.resumeExecution",
+          ]),
+        },
+      ],
+      expectedNewFields,
+    );
+    expect(result.passed).toBe(true);
+  });
+
+  it("STILL FAILS for a MISSING baseline field even though an unrelated field is listed in expectedNewFields (the manifest never weakens the missing-field check)", () => {
+    const baseline = makeBaseline([
+      "Query.getProject",
+      "Mutation.createProject",
+    ]);
+    const expectedNewFields = [
+      {
+        logicalId: "Mutation.resumeExecution",
+        justification: "test fixture — mirrors EXPECTED_NEW_FIELDS shape",
+      },
+    ];
+    const result = runResolverParity(
+      baseline,
+      [
+        {
+          stackName: "citadel-backend-dev",
+          template: templateWithFields([
+            "Query.getProject",
+            "Mutation.resumeExecution",
+          ]),
+        },
+      ],
+      expectedNewFields,
+    );
+    expect(result.passed).toBe(false);
+    expect(
+      result.violations.some((v) => v.logicalId === "Mutation.createProject"),
+    ).toBe(true);
+  });
 });

--- a/backend/scripts/split-gates/move-manifest.ts
+++ b/backend/scripts/split-gates/move-manifest.ts
@@ -642,6 +642,22 @@ export const REMOVAL_ALLOWLIST: AllowlistEntry[] = [
       "Alarm on ProjectResolverFunction; recreated in CitadelProjectsStack as ProjectResolverThrottleAlarm.",
   },
 
+  // --- AppSync 5xx alarm relocation (decision ab73ae1b) ---
+  {
+    logicalId: "AppSync5xxAlarm67B161CE",
+    justification:
+      "Decision ab73ae1b: moved to TelemetryStack (telemetry-stack.ts:2213, " +
+      "platform-health SLO suite) as a strict superset alarm (SNS action, " +
+      "tighter threshold) owning the physical name " +
+      "citadel-appsync-5xx-<env>. Both stacks declaring the identical " +
+      "alarmName broke deploys (AWS::EarlyValidation::ResourceExistenceCheck " +
+      "on second deploy); no monitoring loss, since TelemetryStack's " +
+      "definition is a superset. Guarded by " +
+      "backend/test/duplicate-alarm-name-guard.test.ts. Not a stateful " +
+      "type (CloudWatch::Alarm), so allowlisting fully satisfies rail 1. " +
+      "See backend-stack.ts:3151 for the removal comment.",
+  },
+
   // ═══════════════════════════════════════════════════════════════════════
   // Phase 2 (decision 30e6d067, this stage): the registry / agent-import /
   // fabricator-request / fabricator-queue / fabrication-event / app-CRUD-
@@ -1508,6 +1524,44 @@ export const SATELLITE_STACK_NAMES: string[] = [
 ];
 
 /**
+ * Rail 3 has no addition-allowlist mechanism of its own (unlike rail 1's
+ * `ADDITION_ALLOWLIST`) — resolver-parity baseline drift for legitimate new
+ * fields must be expected explicitly here, mirroring rail 1's allowlist
+ * shape and justification-comment convention. Every field below corresponds
+ * 1:1 to an `ADDITION_ALLOWLIST` resolver entry above (decision 453d1acc:
+ * allowlist route, do not regenerate the baseline). Adding an entry here
+ * does NOT weaken rail 3's other checks — MISSING baseline fields and
+ * DOUBLE-ATTACH still violate; this only exempts the exact field keys
+ * listed from the "extra"/unexpected-new-field check.
+ */
+export const EXPECTED_NEW_FIELDS: AllowlistEntry[] = [
+  {
+    logicalId: "Mutation.resumeExecution",
+    justification:
+      "StepRunner resume resolver — see ADDITION_ALLOWLIST entry " +
+      "AgenticAIApiResumeExecutionResolver38379257.",
+  },
+  {
+    logicalId: "Mutation.setEvalSamplingConfig",
+    justification:
+      "Decision d36fbbf7: eval-sampling AppSync wiring — see " +
+      "ADDITION_ALLOWLIST entry AgenticAIApiSetEvalSamplingConfigResolver7000B62F.",
+  },
+  {
+    logicalId: "Query.getEvalSamplingConfig",
+    justification:
+      "Decision d36fbbf7: eval-sampling AppSync wiring — see " +
+      "ADDITION_ALLOWLIST entry AgenticAIApiGetEvalSamplingConfigResolver9D568E32.",
+  },
+  {
+    logicalId: "Query.listEvalProdSamples",
+    justification:
+      "Decision d36fbbf7: eval-sampling AppSync wiring — see " +
+      "ADDITION_ALLOWLIST entry AgenticAIApiListEvalProdSamplesResolverFF0E4413.",
+  },
+];
+
+/**
  * CIT-125 slice A — the one deliberate, justified addition to the backend
  * template this stage allows: the shared per-stack async DLQ
  * (`BackendAsyncDlq`) and its auto-generated `QueuePolicy`. Every other new
@@ -1533,6 +1587,181 @@ export const ADDITION_ALLOWLIST: AllowlistEntry[] = [
     justification:
       "Auto-generated SQS QueuePolicy for BackendAsyncDlq (enforceSSL); " +
       "moves with the queue. Logical ID confirmed via the same synth.",
+  },
+
+  // ═══════════════════════════════════════════════════════════════════════
+  // CIT-101 — Eval/Release/Promotion platform. 23 legitimate additions
+  // landed on main between the Jul-25 baseline capture and this
+  // reconciliation stage (decision 453d1acc: allowlist route, do not
+  // regenerate the baseline). Construct block backend-stack.ts:3283–3812;
+  // source comments there tag these tables "release evidence, governed
+  // like ExecutionSpecifications: RETAIN + deletionProtection + PITR".
+  // Logical IDs confirmed via a live `cdk synth citadel-backend-dev` +
+  // `npm run split:gates` run, not hand-typed.
+  // ═══════════════════════════════════════════════════════════════════════
+  {
+    logicalId: "EvalSuitesTableCD7FA97A",
+    justification: "CIT-101: eval/release platform — EvalSuites table.",
+  },
+  {
+    logicalId: "EvalCasesTable5ACF1009",
+    justification: "CIT-101: eval/release platform — EvalCases table.",
+  },
+  {
+    logicalId: "EvalRunsTable1462273E",
+    justification: "CIT-101: eval/release platform — EvalRuns table.",
+  },
+  {
+    logicalId: "EvalRunCaseResultsTable961B302A",
+    justification:
+      "CIT-101: eval/release platform — EvalRunCaseResults table.",
+  },
+  {
+    logicalId: "EvalBaselinesTable1E81E088",
+    justification: "CIT-101: eval/release platform — EvalBaselines table.",
+  },
+  {
+    logicalId: "EvalComparisonsTableBB147DA7",
+    justification: "CIT-101: eval/release platform — EvalComparisons table.",
+  },
+  {
+    logicalId: "EvalComparisonConfigTable5E04F05F",
+    justification:
+      "CIT-101: eval/release platform — EvalComparisonConfig table.",
+  },
+  {
+    logicalId: "EvalSamplingConfigTable853B8B52",
+    justification:
+      "CIT-101: eval/release platform — EvalSamplingConfig table.",
+  },
+  {
+    logicalId: "EvalProdSamplesTable2B37B8C9",
+    justification: "CIT-101: eval/release platform — EvalProdSamples table.",
+  },
+  {
+    logicalId: "AgentReleasesTable4E094171",
+    justification: "CIT-101: eval/release platform — AgentReleases table.",
+  },
+  {
+    logicalId: "EnvironmentReleasePointersTableFC230B29",
+    justification:
+      "CIT-101: eval/release platform — EnvironmentReleasePointers table.",
+  },
+  {
+    logicalId: "PromotionPolicyConfigTable47D26109",
+    justification:
+      "CIT-101: eval/release platform — PromotionPolicyConfig table.",
+  },
+  {
+    logicalId: "AgentReleaseWriterRole02E9922B",
+    justification:
+      "CIT-101: eval/release platform — writer role for AgentReleasesTable.",
+  },
+  {
+    logicalId: "AgentReleaseWriterRoleDefaultPolicy750604C6",
+    justification: "DefaultPolicy of AgentReleaseWriterRole; added with it.",
+  },
+  {
+    logicalId: "EnvironmentReleasePointerWriterRoleBAD849A2",
+    justification:
+      "CIT-101: eval/release platform — writer role for " +
+      "EnvironmentReleasePointersTable.",
+  },
+  {
+    logicalId: "EnvironmentReleasePointerWriterRoleDefaultPolicy054A5C1E",
+    justification:
+      "DefaultPolicy of EnvironmentReleasePointerWriterRole; added with it.",
+  },
+  {
+    logicalId: "PromotionPolicyConfigWriterRole8A02956B",
+    justification:
+      "CIT-101: eval/release platform — writer role for " +
+      "PromotionPolicyConfigTable.",
+  },
+  {
+    logicalId: "PromotionPolicyConfigWriterRoleDefaultPolicy507FE4A7",
+    justification:
+      "DefaultPolicy of PromotionPolicyConfigWriterRole; added with it.",
+  },
+  {
+    logicalId: "SeedEvalSuitesFunctionEEE6C7BC",
+    justification:
+      "CIT-101: eval/release platform — custom-resource seed Lambda for " +
+      "EvalSuitesTable.",
+  },
+  {
+    logicalId: "SeedEvalSuitesFunctionLogs5595E734",
+    justification: "LogGroup of SeedEvalSuitesFunction; added with it.",
+  },
+  {
+    logicalId: "SeedEvalSuitesFunctionServiceRole8B365008",
+    justification: "Execution role of SeedEvalSuitesFunction; added with it.",
+  },
+  {
+    logicalId: "SeedEvalSuitesFunctionServiceRoleDefaultPolicy7F26E48E",
+    justification:
+      "DefaultPolicy of SeedEvalSuitesFunction's role; added with it.",
+  },
+  {
+    logicalId: "SeedEvalSuitesResource",
+    justification:
+      "CustomResource invoking SeedEvalSuitesFunction on deploy; added with it.",
+  },
+
+  // ═══════════════════════════════════════════════════════════════════════
+  // Eval-sampling AppSync wiring (decision d36fbbf7, "Phase 2 production
+  // sampling"). 6 additions from
+  // `BackendStack.addEvalSamplingConfigResolvers()` (backend-stack.ts:
+  // 3901–3936), called from bin/app.ts:406 with a deterministic ARN of the
+  // TelemetryStack-owned `citadel-eval-sampling-config-resolver-<env>`
+  // Lambda — a cross-stack pattern used to avoid a cyclic stack dependency.
+  // ═══════════════════════════════════════════════════════════════════════
+  {
+    logicalId: "AgenticAIApiEvalSamplingConfigLambdaDataSourceD4E6867C",
+    justification:
+      "Decision d36fbbf7: eval-sampling AppSync wiring — Lambda " +
+      "DataSource pointing at TelemetryStack's eval-sampling-config " +
+      "resolver Lambda.",
+  },
+  {
+    logicalId: "AgenticAIApiEvalSamplingConfigLambdaDataSourceServiceRoleFC35DA0E",
+    justification:
+      "Service role of EvalSamplingConfigLambdaDataSource; added with it.",
+  },
+  {
+    logicalId:
+      "AgenticAIApiEvalSamplingConfigLambdaDataSourceServiceRoleDefaultPolicyA14B3695",
+    justification:
+      "DefaultPolicy of EvalSamplingConfigLambdaDataSource's role; added with it.",
+  },
+  {
+    logicalId: "AgenticAIApiSetEvalSamplingConfigResolver7000B62F",
+    justification:
+      "Decision d36fbbf7: eval-sampling AppSync wiring — " +
+      "Mutation.setEvalSamplingConfig resolver.",
+  },
+  {
+    logicalId: "AgenticAIApiGetEvalSamplingConfigResolver9D568E32",
+    justification:
+      "Decision d36fbbf7: eval-sampling AppSync wiring — " +
+      "Query.getEvalSamplingConfig resolver.",
+  },
+  {
+    logicalId: "AgenticAIApiListEvalProdSamplesResolverFF0E4413",
+    justification:
+      "Decision d36fbbf7: eval-sampling AppSync wiring — " +
+      "Query.listEvalProdSamples resolver.",
+  },
+
+  // ═══════════════════════════════════════════════════════════════════════
+  // StepRunner resume resolver (1 addition).
+  // ═══════════════════════════════════════════════════════════════════════
+  {
+    logicalId: "AgenticAIApiResumeExecutionResolver38379257",
+    justification:
+      "StepRunner resume resolver — Mutation.resumeExecution on the " +
+      "existing ExecutionLambdaDataSource (backend-stack.ts:3011); adds " +
+      "workflow-resume capability, no existing resource changes.",
   },
 ];
 

--- a/backend/scripts/split-gates/rails/rail3-resolver-parity.ts
+++ b/backend/scripts/split-gates/rails/rail3-resolver-parity.ts
@@ -5,13 +5,23 @@
  * (backend + every satellite, though in this no-move stage the satellite
  * list is empty) and asserts:
  *   - the merged typeName.fieldName set equals the baseline's set exactly
- *     (no field lost, no field gained).
+ *     (no field lost, no field gained) — except fields explicitly listed in
+ *     `expectedNewFields` (mirrors rail 1's `ADDITION_ALLOWLIST` shape and
+ *     justification convention; rail 3 otherwise has no allowlist
+ *     mechanism). This exemption ONLY affects the "extra"/unexpected-new-
+ *     field check below — MISSING baseline fields and DOUBLE-ATTACH are
+ *     evaluated unconditionally and always violate.
  *   - no typeName.fieldName is attached in more than one stack (CFN forbids
  *     double-attaching a resolver to the same field).
  */
 import { CfnTemplate, StackBaseline } from "../types";
 import { extractResolverKeys } from "../template-utils";
 import { RailResult, RailViolation } from "../types";
+
+export interface ExpectedNewFieldEntry {
+  logicalId: string;
+  justification: string;
+}
 
 export interface NamedTemplate {
   stackName: string;
@@ -21,9 +31,13 @@ export interface NamedTemplate {
 export function runResolverParity(
   baseline: StackBaseline,
   stacks: NamedTemplate[],
+  expectedNewFields: ExpectedNewFieldEntry[] = [],
 ): RailResult {
   const violations: RailViolation[] = [];
   const baselineKeys = new Set(Object.keys(baseline.resolvers));
+  const expectedNewFieldKeys = new Set(
+    expectedNewFields.map((e) => e.logicalId),
+  );
 
   // key -> list of stack names that define it (any list of length > 1 = double-attach)
   const mergedOwners = new Map<string, string[]>();
@@ -42,8 +56,12 @@ export function runResolverParity(
 
   const mergedKeys = new Set(mergedOwners.keys());
 
+  // MISSING check is unconditional — never weakened by expectedNewFields.
   const missing = [...baselineKeys].filter((k) => !mergedKeys.has(k));
-  const extra = [...mergedKeys].filter((k) => !baselineKeys.has(k));
+  // "extra" check exempts only the fields explicitly listed as expected.
+  const extra = [...mergedKeys].filter(
+    (k) => !baselineKeys.has(k) && !expectedNewFieldKeys.has(k),
+  );
 
   for (const key of missing) {
     violations.push({
@@ -59,6 +77,8 @@ export function runResolverParity(
       message: `Resolver field "${key}" appears in the merged stack set but was not in the baseline. Unexpected new field.`,
     });
   }
+  // DOUBLE-ATTACH check is unconditional — never weakened by
+  // expectedNewFields, including for fields listed there.
   for (const [key, owners] of mergedOwners) {
     if (owners.length > 1) {
       violations.push({

--- a/backend/scripts/split-gates/run-rails.ts
+++ b/backend/scripts/split-gates/run-rails.ts
@@ -34,6 +34,7 @@ import {
   MOVED_RESOLVERS,
   MOVED_LAMBDA_ROLES,
   SATELLITE_STACK_NAMES,
+  EXPECTED_NEW_FIELDS,
 } from "./move-manifest";
 import { RailResult, StackBaseline } from "./types";
 
@@ -153,10 +154,11 @@ function main(): void {
       ),
     }),
   );
-  const rail3 = runResolverParity(baseline, [
-    { stackName, template: freshTemplate },
-    ...satelliteTemplates,
-  ]);
+  const rail3 = runResolverParity(
+    baseline,
+    [{ stackName, template: freshTemplate }, ...satelliteTemplates],
+    EXPECTED_NEW_FIELDS,
+  );
 
   // Rails 6/7 need per-satellite Lambda-policy / resolver snapshots — built
   // the same way the baseline was, from each satellite's own template.


### PR DESCRIPTION
## Summary

`npm run split:gates` has failed on main since the dev baseline was captured on 2026-07-25: rail 1 reported 31 violations and rail 3 reported 4. None was a real regression - the baseline simply predates 5.5 weeks of legitimate feature work. This allowlists the known-good drift so the gate is green on truth, without touching the baseline.

- rail 1, 30 additions allowlisted with justification comments: the eval/release platform (12 tables, 3 writer roles † policies, seed cluster), the eval-sampling AppSync wiring (decision d36fbbf7), and the StepRunner resume resolver
- rail 1, one removal allowlisted: `AppSync5xxAlarm67B161CE`, deliberately moved to TelemetryStack (decision abl3aelb) because duplicate physical alarm names broke deploys; telemetry's alarm is a strict superset, and the duplicate-alarm-name guard already protects the invariant
- rail 3 had no allowlist mechanism at all: adds a minimal EXPECTED NEW FIELDS manifest covering exactly 4 fields, exempting only the "extra field" check
- Baselines under backend/split-baseline/ are untouched, as are rails 6/7 and CI

## Why not regenerate the baseline?

Regenerating would make rails 1 and 3 pass trivially but destroys the pre-split resolver and IAM history that rails 3, 6 and 7 compare satellites against - historically 62/22/62 violations - and `split-gates sh` explicitly warns against casual regeneration. A post-split baseline reset remains available later as a deliberate governance act owned by decision 30e6d067. Route recorded as decision 453dlacc.

## Testing

- `npm run split:gates`: ALL RAILS PASSED (first green since 2026-07-25); the live run reproduced the prior violation counts exactly before the fix
- Gate still bites, each proven and byte-identically reverted: an unlisted resource fails rail l; removing a stateful resource fails rail l even when given an allowlist-shaped entry; rail 3 still fails on a missing baseline field; two new unit tests prove double-attach and missing-field detection survive the manifest
- Every allowlist entry cross-checked against the live synth (no dead entries); EXPECTED_NEW_FIELDS has no wildcard or prefix matching
- tsc, lint, rail-2 jest suite, full backend jest: all clean 

## Notes

- These rails are local-only today (not wired into CI, and the dev baseline embeds the capture host's account/region). Making them CI-viable needs env-parameterised satellite names and a decision on which baseline is canonical - deliberately out of scope here.