### PR TITLE
test(reliability): raise alarm-delivery timeout for synth contention

### DIFF
--- a/backend/test/alarm-delivery-stacks.test.ts
+++ b/backend/test/alarm-delivery-stacks.test.ts
@@ -34,6 +34,16 @@ scaffoldArbiterStubs();
 import { ArbiterStack } from "../lib/arbiter-stack";
 import { BackendStack } from "../lib/backend-stack";
 
+// This suite performs 4 full CDK synths (ArbiterStack x3, BackendStack x1).
+// Standalone it runs in ~1-2s per test, but under CI/full-suite CPU
+// contention (16+ other CDK-synth suites scheduled concurrently by Jest's
+// slowest-first heuristic under maxWorkers: "50%") a single synth has been
+// measured taking 22.7s vs 849ms standalone — within 1.3x of the global
+// 30s testTimeout in jest.config.js. Raise this suite's own timeout well
+// above that measured worst case rather than the global default, since the
+// slowdown is contention-driven, not a hang (finding 0fe3b82f).
+jest.setTimeout(120000);
+
 function buildArbiter(alarmDelivery: AlarmDeliveryConfig): Template {
   const app = new cdk.App({ context: { "aws:cdk:bundling-stacks": [] } });
   const backend = new cdk.Stack(app, "MockBackend", {


### PR DESCRIPTION
## Summary

backend/test/alarm-delivery-stacks.test.ts fails intermittently in full-suite runs and passes standalone (reproduced on main with no local changes). Investigation disproved the filed hypothesis and found a timing headroom problem instead.

- The suspected env-var leak does not exist: the suite never touches process.env, and alarmDelivery is passed as an explicit prop
- Actual risk factor: the suite performs 4 full CDK synths, measured at 22.7s under full-suite CPU contention versus 849ms standalone - within 1.3x of the 30s global testTimeout
- Fix: `jest.setTimeout(120000)` for this suite only, with a comment recording the measured numbers so a future reader can re-evaluate

## Preventive, not proven-causal

Neither the localization pass nor the fix could force the timeout to trip: 20 combined attempts (10 full-suite runs, 10 core-pinned contention runs against the heaviest co-suspects) all passed. The mechanism is well-supported by the timing measurements but was never directly reproduced. If the flake recurs despite the 120s ceiling, the timeout theory is falsified and CDK synth nondeterminism is the next suspect - noted in the resolved finding.

## Testing

- 10 consecutive full backend jest runs, all green (460 suites, 6974 tests), plus the checker's own independent 10 runs
- Non-vacuity proven: removing the unconfigured-prod-env throw from the resolver turns 4 tests red, restored byte-identically to green - the suite still enforces the production-safety contract
- No skipped tests, no removed assertions, no loosened matchers; diff is one test file; tsc and lint clean

## Notes

- This raises a ceiling rather than making the suite faster. When suite runtime becomes a concern, the durable fix is reducing the 4 synths (e.g. sharing a synthesized template across cases), which is a larger refactor.