### PR TITLE
feat(governance): durable delivery for critical governance events

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -39,7 +39,11 @@ CDK_DOCKER=finch
 AGENT_MODEL=us.anthropic.claude-sonnet-4-6
 
 # Application Host URL (for email templates and frontend)
-# This URL will be used in email templates for logo and login links
+# This URL will be used in email templates for logo and login links.
+# Also doubles as the governance-notifier's deep-link base URL (finding
+# e396a7ee) — the notifier's CRITICAL-tier SNS message body links back to
+# <HOST_URL>/governance/... . Absent ⇒ the notifier emits a plain-text
+# "(governance UI URL not configured)" note instead of a broken link.
 HOST_URL=https://your-domain.com
 
 # ---------------------------------------------------------------------------

--- a/backend/bin/app.ts
+++ b/backend/bin/app.ts
@@ -220,8 +220,14 @@ const governanceStack = new GovernanceStack(
       backendStack.promotionPolicyConfigWriterRole,
     // D6 — the auto-rollback evaluator's finding-write-failure alarm posts
     // to the shared SLO alarm topic so a committed-but-unrecorded rollback
-    // pages.
+    // pages. Now also REQUIRED (finding e396a7ee) — the governance-notifier's
+    // durable CRITICAL-event SNS backstop posts to the same topic.
     alarmTopic: backendStack.alarmTopic,
+    // Finding e396a7ee (design §6) — deep-link base for the notifier's SNS
+    // message body. HOST_URL doubles as the governance UI base URL; absent
+    // ⇒ the notifier degrades to a plain-text "not configured" note rather
+    // than a broken link (never a hard failure).
+    governanceUiBaseUrl: process.env.HOST_URL,
   },
 );
 

--- a/backend/lib/governance-stack.ts
+++ b/backend/lib/governance-stack.ts
@@ -111,11 +111,22 @@ export interface GovernanceStackProps extends cdk.StackProps {
   // SEPARATE admin resolver Lambda only.
   promotionPolicyConfigTable: dynamodb.ITable;
   promotionPolicyConfigWriterRole: iam.IRole;
-  /** Shared SLO alarm topic (from BackendStack) — the auto-rollback
-   * evaluator's finding-write-failure alarm (decision D6) posts here so a
-   * committed-but-unrecorded rollback pages. Optional so existing test
-   * scaffolds that omit it still synth. */
-  alarmTopic?: sns.ITopic;
+  /** Shared SLO alarm topic (from BackendStack). REQUIRED (finding
+   * e396a7ee): the auto-rollback evaluator's finding-write-failure alarm
+   * (decision D6) AND the governance-notifier's durable CRITICAL-event
+   * SNS backstop both post here. Making this required is itself the
+   * regression guard against a future refactor silently reverting the
+   * notifier to WebSocket-only delivery — see
+   * governance-notifier-durable-destination.test.ts R13. A runtime guard
+   * throw backs the type-level requirement so a caller that bypasses
+   * TypeScript (e.g. constructing props as `any`) still fails loudly. */
+  alarmTopic: sns.ITopic;
+  /** Deep-link base URL for the governance-notifier's SNS message body
+   * (finding e396a7ee, design §2/§6) — e.g. `https://<host>`. Threaded
+   * from `HOST_URL`/`FRONTEND_ORIGIN` in bin/app.ts. Optional: absent ⇒
+   * the notifier emits a plain-text "(governance UI URL not configured)"
+   * note instead of a broken/half link — never a hard failure. */
+  governanceUiBaseUrl?: string;
 }
 
 export class GovernanceStack extends cdk.Stack {
@@ -127,6 +138,20 @@ export class GovernanceStack extends cdk.Stack {
   constructor(scope: Construct, id: string, props: GovernanceStackProps) {
     super(scope, id, props);
     const accessLogsBucket = props.accessLogsBucket;
+
+    // Runtime guard backing the type-level `alarmTopic: sns.ITopic`
+    // requirement (finding e396a7ee) — a caller that bypasses TypeScript
+    // (e.g. spreading props as `any`, or an older call site not yet
+    // migrated) must still fail loudly at synth time rather than silently
+    // constructing a governance-notifier with no durable SNS backstop.
+    if (!props.alarmTopic) {
+      throw new Error(
+        "GovernanceStack requires props.alarmTopic — the governance-notifier's " +
+          "durable CRITICAL-event SNS backstop (finding e396a7ee) and the " +
+          "auto-rollback finding-write-failure alarm (D6) both depend on it. " +
+          "Pass BackendStack's alarmTopic explicitly.",
+      );
+    }
 
     // ============================================================
     // Cross-stack AppSync pattern — L1 CfnDataSource + CfnResolver
@@ -426,10 +451,46 @@ exports.handler = async (event) => {
     // `publishGovernanceEvent` mutation with SigV4 and AppSync's
     // @aws_subscribe fans out to admin user-pool subscribers.
     //
-    // The 14 detail-types listed below MUST stay in lock-step with
+    // The 15 detail-types listed below MUST stay in lock-step with
     // GOVERNANCE_DETAIL_TYPES in backend/src/utils/notifier-base.ts.
     // The handler also performs a defence-in-depth re-check against
     // that constant.
+    //
+    // Finding e396a7ee (PART B): the WS fanout above is EPHEMERAL — a
+    // zero-subscriber fanout returns HTTP 200 with no error, so a
+    // CRITICAL governance event that no admin UI was open to receive was
+    // previously silent. The notifier now ALSO (a) publishes a
+    // whitelist-projected SNS notification to the existing plaintext
+    // `alarmTopic` for the CRITICAL subset
+    // (CRITICAL_GOVERNANCE_DETAIL_TYPES in notifier-base.ts), and (b)
+    // writes a durable per-attempt outcome row to
+    // NotificationOutcomesTable for EVERY routed event. See
+    // governance-notifier.ts's module comment for the fail-closed /
+    // degrade asymmetry (WS + CRITICAL-SNS failures throw; an
+    // outcome-row write failure degrades via a dedicated CW metric so it
+    // never re-triggers an already-delivered SNS page).
+
+    // Durable per-attempt delivery-outcome audit trail (finding e396a7ee,
+    // design §3). Deliberately a NEW table (not the governance ledger):
+    // this is operational delivery telemetry — TTL'd, DESTROY-on-delete —
+    // semantically distinct from RETAIN-protected governance domain
+    // findings. eventId (EventBridge event.id) is the PK, making the
+    // PutItem idempotent across EventBridge's own retries.
+    const notificationOutcomesTable = new dynamodb.Table(
+      this,
+      "NotificationOutcomesTable",
+      {
+        tableName: `citadel-governance-notification-outcomes-${props.environment}`,
+        partitionKey: { name: "eventId", type: dynamodb.AttributeType.STRING },
+        billingMode: dynamodb.BillingMode.PAY_PER_REQUEST,
+        pointInTimeRecoverySpecification: { pointInTimeRecoveryEnabled: true },
+        timeToLiveAttribute: "expiresAt",
+        // Operational telemetry, not a governance-domain record — safe to
+        // destroy on stack teardown (contrast with the RETAIN-protected
+        // governance tables owned by BackendStack).
+        removalPolicy: cdk.RemovalPolicy.DESTROY,
+      },
+    );
 
     // Dead-letter queue for events the Lambda fails to relay after
     // EventBridge async-invoke retries. Inspected by operators when
@@ -457,6 +518,19 @@ exports.handler = async (event) => {
         environment: {
           EVENT_BUS_NAME: props.agentEventBus.eventBusName,
           APPSYNC_ENDPOINT: props.appSyncApi.graphqlUrl,
+          ENVIRONMENT: props.environment,
+          // Finding e396a7ee — durable SNS backstop for the CRITICAL
+          // subset. Plaintext topic (no KMS grant needed, see design §1
+          // rationale for choosing this over the CMK-encrypted escalation
+          // topic).
+          ALARM_TOPIC_ARN: props.alarmTopic.topicArn,
+          NOTIFICATION_OUTCOMES_TABLE: notificationOutcomesTable.tableName,
+          // Deep-link base for the SNS message body. Absent-tolerant in
+          // the handler (falls back to a plain-text "not configured"
+          // note) — see design §2.
+          ...(props.governanceUiBaseUrl
+            ? { GOVERNANCE_UI_BASE_URL: props.governanceUiBaseUrl }
+            : {}),
         },
         // EventBridge invokes Lambda async; failed invocations land in
         // the DLQ after the default 2 retries (configurable on the
@@ -482,11 +556,48 @@ exports.handler = async (event) => {
       }),
     );
 
+    // Finding e396a7ee — scoped sns:Publish on the plaintext alarm topic
+    // ONLY (no kms:GenerateDataKey*/Decrypt grant needed; see design §1
+    // for why the CMK-encrypted escalation topic was rejected).
+    governanceNotifierFn.addToRolePolicy(
+      new iam.PolicyStatement({
+        effect: iam.Effect.ALLOW,
+        actions: ["sns:Publish"],
+        resources: [props.alarmTopic.topicArn],
+      }),
+    );
+
+    // PutItem ONLY — a hand-written statement, NOT grantWriteData, which
+    // would over-grant UpdateItem/DeleteItem/BatchWriteItem. The outcome
+    // row is write-once per attempt (eventId PK, idempotent overwrite on
+    // retry) and never updated or deleted by this function.
+    governanceNotifierFn.addToRolePolicy(
+      new iam.PolicyStatement({
+        effect: iam.Effect.ALLOW,
+        actions: ["dynamodb:PutItem"],
+        resources: [notificationOutcomesTable.tableArn],
+      }),
+    );
+
+    // Namespace-conditioned PutMetricData for the DEGRADE-path signal
+    // (NotifierOutcomeWriteFailure) — PutMetricData has no resource-level
+    // ARN, so the namespace condition is the least-privilege boundary.
+    governanceNotifierFn.addToRolePolicy(
+      new iam.PolicyStatement({
+        effect: iam.Effect.ALLOW,
+        actions: ["cloudwatch:PutMetricData"],
+        resources: ["*"],
+        conditions: {
+          StringEquals: { "cloudwatch:namespace": "Citadel/Governance" },
+        },
+      }),
+    );
+
     new events.Rule(this, "GovernanceEventsRule", {
       eventBus: props.agentEventBus,
       ruleName: `citadel-governance-events-${props.environment}`,
       description:
-        "Routes all 14 governance.* detail-types (the canonical list in " +
+        "Routes all 15 governance.* detail-types (the canonical list in " +
         "GOVERNANCE_DETAIL_TYPES) to the governance-notifier relay Lambda.",
       eventPattern: {
         source: ["citadel.backend"],
@@ -494,6 +605,15 @@ exports.handler = async (event) => {
         // backend/src/utils/notifier-base.ts. The handler also drops
         // unknown detail-types as defence in depth, so the rule
         // expanding ahead of the handler is safe.
+        //
+        // governance.release.auto_rollback (finding 163d4776): added so
+        // the auto-rollback evaluator's best-effort emit actually reaches
+        // the notifier — notifier-base.ts already documented this type
+        // as "Relayed by governance-notifier" before this rule included
+        // it. See the lock-step guard in
+        // governance-notifier-durable-destination.test.ts (every
+        // CRITICAL_GOVERNANCE_DETAIL_TYPES member must appear here AND
+        // in GOVERNANCE_DETAIL_TYPES).
         detailType: [
           "governance.adr.locked",
           "governance.adr.reopen.attempted",
@@ -509,6 +629,7 @@ exports.handler = async (event) => {
           "governance.mode.transition",
           "governance.constitutional.rule.changed",
           "governance.caselaw.changed",
+          "governance.release.auto_rollback",
         ],
       },
       targets: [
@@ -522,6 +643,41 @@ exports.handler = async (event) => {
       ],
     });
 
+    // Finding e396a7ee — DEGRADE-path alarm: a lost outcome-audit row
+    // (DynamoDB PutItem failure AFTER a successful WS/SNS delivery) pages
+    // via this dedicated alarm instead of failing the already-delivered
+    // Lambda invocation (which would otherwise re-trigger a duplicate
+    // SNS page on EventBridge retry — see governance-notifier.ts's
+    // module comment for the full asymmetry rationale).
+    const notifierOutcomeWriteFailureAlarm = new cloudwatch.Alarm(
+      this,
+      "NotifierOutcomeWriteFailureAlarm",
+      {
+        alarmName: `citadel-governance-notifier-outcome-write-failure-${props.environment}`,
+        alarmDescription:
+          "The governance-notifier successfully delivered a governance event " +
+          "(WebSocket and/or the CRITICAL-tier SNS backstop) but failed to " +
+          "write its durable outcome-audit row. Delivery already succeeded — " +
+          "this alarm is for a missing audit record, not a missed event. See " +
+          "docs/RUNBOOK (governance notifier).",
+        metric: new cloudwatch.Metric({
+          namespace: "Citadel/Governance",
+          metricName: "NotifierOutcomeWriteFailure",
+          dimensionsMap: { Environment: props.environment },
+          statistic: "Sum",
+          period: Duration.minutes(5),
+        }),
+        threshold: 1,
+        evaluationPeriods: 1,
+        comparisonOperator:
+          cloudwatch.ComparisonOperator.GREATER_THAN_OR_EQUAL_TO_THRESHOLD,
+        treatMissingData: cloudwatch.TreatMissingData.NOT_BREACHING,
+      },
+    );
+    notifierOutcomeWriteFailureAlarm.addAlarmAction(
+      new cw_actions.SnsAction(props.alarmTopic),
+    );
+
     NagSuppressions.addResourceSuppressions(
       governanceNotifierFn,
       [
@@ -531,6 +687,21 @@ exports.handler = async (event) => {
             "AWS Lambda basic-execution managed policy is required for CloudWatch Logs. " +
             "The relay also has a field-scoped appsync:GraphQL grant on the single " +
             "publishGovernanceEvent mutation — no API-wide permissions.",
+        },
+      ],
+      true,
+    );
+
+    NagSuppressions.addResourceSuppressions(
+      governanceNotifierFn.role!,
+      [
+        {
+          id: "AwsSolutions-IAM5",
+          reason:
+            "cloudwatch:PutMetricData has no resource-level scoping; the " +
+            "notifier narrows the call to the Citadel/Governance namespace " +
+            "in code (NotifierOutcomeWriteFailure DEGRADE-path metric).",
+          appliesTo: ["Resource::*"],
         },
       ],
       true,
@@ -1587,11 +1758,9 @@ exports.handler = async (event) => {
         treatMissingData: cloudwatch.TreatMissingData.NOT_BREACHING,
       },
     );
-    if (props.alarmTopic) {
-      autoRollbackFindingFailureAlarm.addAlarmAction(
-        new cw_actions.SnsAction(props.alarmTopic),
-      );
-    }
+    autoRollbackFindingFailureAlarm.addAlarmAction(
+      new cw_actions.SnsAction(props.alarmTopic),
+    );
 
     const environmentReleasePointerDataSourceRole = new iam.Role(
       this,

--- a/backend/src/lambda/__tests__/governance-notifier.test.ts
+++ b/backend/src/lambda/__tests__/governance-notifier.test.ts
@@ -1,3 +1,172 @@
+// ---------------------------------------------------------------------------
+// R1-R7 — durable SNS delivery + outcome records (finding e396a7ee, PART B).
+// Fail-closed semantics: WS failure throws (pinned above); CRITICAL SNS
+// failure throws (DLQ + alarm); outcome-row write failure DEGRADES (log +
+// metric, no throw) — see design §4 for the asymmetry rationale.
+// ---------------------------------------------------------------------------
+
+function makeAutoRollbackEvent(): EventBridgeEvent<
+  string,
+  Record<string, unknown>
+> {
+  return makeEvent("governance.release.auto_rollback", {
+    orgId: "org_ACME",
+    agentTargetId: "agent-1",
+    environment: "prod",
+    action: "AUTO_ABORT_CANARY",
+    metric: "error_rate",
+    observedValue: 0.42,
+    threshold: 0.05,
+    sampleCount: 500,
+    fromReleaseId: "rel-1",
+    toReleaseId: "rel-2",
+    candidateReleaseId: "rel-2",
+    fromVersion: 3,
+    traceContext: { correlationId: "corr-1" },
+  });
+}
+
+describe("R1: CRITICAL type publishes SNS + writes RELAYED_WS_AND_SNS outcome row", () => {
+  test("publishes to ALARM_TOPIC_ARN with expected Subject/Message and writes an outcome row", async () => {
+    const event = makeAutoRollbackEvent();
+    await handler(event);
+
+    const snsCalls = snsMock.commandCalls(PublishCommand);
+    expect(snsCalls).toHaveLength(1);
+    const snsInput = snsCalls[0].args[0].input;
+    expect(snsInput.TopicArn).toBe(process.env.ALARM_TOPIC_ARN);
+    expect(snsInput.Subject!.length).toBeLessThanOrEqual(100);
+    expect(snsInput.Message).toContain("governance.release.auto_rollback");
+    expect(snsInput.Message).toContain("org_ACME");
+
+    const ddbCalls = ddbMock.commandCalls(PutItemCommand);
+    expect(ddbCalls).toHaveLength(1);
+    const item = ddbCalls[0].args[0].input.Item as Record<
+      string,
+      { S?: string; BOOL?: boolean; N?: string }
+    >;
+    expect(item.eventId?.S).toBe(event.id);
+    expect(item.outcome?.S).toBe("RELAYED_WS_AND_SNS");
+    expect(item.snsRouted?.BOOL).toBe(true);
+    expect(item.snsMessageId?.S).toBe("sns-msg-1");
+  });
+});
+
+describe("R2: INFO-tier type — no SNS publish, RELAYED_WS_ONLY outcome row", () => {
+  test("does not publish to SNS and records RELAYED_WS_ONLY", async () => {
+    const event = makeEvent("governance.round.started", {
+      projectId: "p1",
+      roundN: 1,
+    });
+    await handler(event);
+
+    expect(snsMock.commandCalls(PublishCommand)).toHaveLength(0);
+    const ddbCalls = ddbMock.commandCalls(PutItemCommand);
+    expect(ddbCalls).toHaveLength(1);
+    const item = ddbCalls[0].args[0].input.Item as Record<
+      string,
+      { S?: string; BOOL?: boolean }
+    >;
+    expect(item.outcome?.S).toBe("RELAYED_WS_ONLY");
+    expect(item.snsRouted?.BOOL).toBe(false);
+  });
+});
+
+describe("R3: SNS message body whitelist projection + redaction + Subject cap", () => {
+  test("body contains detailType/org/correlationId/deep-link, excludes non-whitelisted fields, strips <script>, Subject <=100", async () => {
+    const event = makeEvent("governance.offfrontier.escalated", {
+      projectId: "p1",
+      agentId: "agent-1",
+      reason: "drift<script>alert(1)</script>",
+      // Simulated non-whitelisted sensitive field on the raw detail.
+      secretToken: "sk-super-secret-value",
+      traceContext: { correlationId: "corr-9" },
+    });
+    await handler(event);
+
+    const snsCalls = snsMock.commandCalls(PublishCommand);
+    expect(snsCalls).toHaveLength(1);
+    const { Subject, Message } = snsCalls[0].args[0].input;
+    expect(Subject!.length).toBeLessThanOrEqual(100);
+    expect(Message).toContain("governance.offfrontier.escalated");
+    expect(Message).toContain("corr-9");
+    expect(Message).toContain("https://ui.example.com");
+    expect(Message).not.toContain("sk-super-secret-value");
+    expect(Message).not.toContain("<script>");
+  });
+});
+
+describe("R4: CRITICAL SNS publish failure — handler THROWS", () => {
+  test("rethrows when SNS PublishCommand rejects for a CRITICAL type (drives DLQ + alarm)", async () => {
+    snsMock.on(PublishCommand).rejects(new Error("Sns.Throttling"));
+    const event = makeAutoRollbackEvent();
+    await expect(handler(event)).rejects.toThrow();
+  });
+});
+
+describe("R5: AppSync (WS) failure — handler THROWS (regression pin)", () => {
+  test("rethrows when AppSync responds non-OK, unchanged from prior behaviour", async () => {
+    mockFetch.mockResolvedValue({
+      ok: false,
+      status: 500,
+      json: async () => ({ errors: [{ message: "Server error" }] }),
+      text: async () => "Server error",
+    });
+    const event = makeAutoRollbackEvent();
+    await expect(handler(event)).rejects.toThrow();
+  });
+});
+
+describe("R6: outcome-row write failure DEGRADES (no throw) + emits metric", () => {
+  test("does not throw when PutItem fails after successful WS+SNS delivery; emits NotifierOutcomeWriteFailure metric", async () => {
+    ddbMock
+      .on(PutItemCommand)
+      .rejects(new Error("Ddb.ProvisionedThroughputExceeded"));
+    const event = makeAutoRollbackEvent();
+    await expect(handler(event)).resolves.toBeDefined();
+
+    const cwCalls = cwMock.commandCalls(PutMetricDataCommand);
+    expect(cwCalls.length).toBeGreaterThanOrEqual(1);
+    const metricData = cwCalls[0].args[0].input.MetricData ?? [];
+    expect(
+      metricData.some((m) => m.MetricName === "NotifierOutcomeWriteFailure"),
+    ).toBe(true);
+  });
+
+  test("does not mask a WS delivery failure by throwing an outcome-write error instead", async () => {
+    mockFetch.mockResolvedValue({
+      ok: false,
+      status: 500,
+      json: async () => ({ errors: [{ message: "boom" }] }),
+      text: async () => "boom",
+    });
+    ddbMock.on(PutItemCommand).rejects(new Error("Ddb.Unavailable"));
+    const event = makeAutoRollbackEvent();
+    // Must throw the ORIGINAL delivery error, not an outcome-write error.
+    await expect(handler(event)).rejects.toThrow(
+      /AppSync|500|Server error|boom/i,
+    );
+  });
+});
+
+describe("R7: idempotency — same event.id twice writes a single overwritten row, no error", () => {
+  test("processing the same eventId twice does not throw and PutItem is called with the same key both times", async () => {
+    const event = makeAutoRollbackEvent();
+    await handler(event);
+    await handler(event);
+
+    const ddbCalls = ddbMock.commandCalls(PutItemCommand);
+    expect(ddbCalls).toHaveLength(2);
+    const firstKey = (
+      ddbCalls[0].args[0].input.Item as Record<string, { S?: string }>
+    ).eventId?.S;
+    const secondKey = (
+      ddbCalls[1].args[0].input.Item as Record<string, { S?: string }>
+    ).eventId?.S;
+    expect(firstKey).toBe(event.id);
+    expect(secondKey).toBe(event.id);
+  });
+});
 /**
  * Tests for governance-notifier Lambda — AppSync subscription relay.
  *
@@ -28,6 +197,13 @@ jest.mock("@aws-sdk/credential-provider-node", () => ({
 }));
 
 import type { EventBridgeEvent } from "aws-lambda";
+import { mockClient } from "aws-sdk-client-mock";
+import { SNSClient, PublishCommand } from "@aws-sdk/client-sns";
+import { DynamoDBClient, PutItemCommand } from "@aws-sdk/client-dynamodb";
+import {
+  CloudWatchClient,
+  PutMetricDataCommand,
+} from "@aws-sdk/client-cloudwatch";
 import { GOVERNANCE_DETAIL_TYPES } from "../../utils/notifier-base";
 
 // Lazy-import the handler (must come after the env var setup) so the
@@ -38,14 +214,26 @@ import { handler, __resetForTest } from "../governance-notifier";
 const APPSYNC_ENDPOINT_VAL =
   "https://test-api.appsync-api.us-east-1.amazonaws.com/graphql";
 
+const snsMock = mockClient(SNSClient);
+const ddbMock = mockClient(DynamoDBClient);
+const cwMock = mockClient(CloudWatchClient);
+
 beforeAll(() => {
   process.env.APPSYNC_ENDPOINT = APPSYNC_ENDPOINT_VAL;
   process.env.AWS_REGION = "us-east-1";
+  process.env.ALARM_TOPIC_ARN =
+    "arn:aws:sns:us-east-1:123456789012:citadel-alarms-test";
+  process.env.NOTIFICATION_OUTCOMES_TABLE =
+    "citadel-governance-notification-outcomes-test";
+  process.env.GOVERNANCE_UI_BASE_URL = "https://ui.example.com";
 });
 
 beforeEach(() => {
   mockFetch.mockReset();
   mockSign.mockReset();
+  snsMock.reset();
+  ddbMock.reset();
+  cwMock.reset();
   __resetForTest();
   mockSign.mockResolvedValue({
     headers: {
@@ -73,6 +261,9 @@ beforeEach(() => {
       },
     }),
   });
+  snsMock.on(PublishCommand).resolves({ MessageId: "sns-msg-1" });
+  ddbMock.on(PutItemCommand).resolves({});
+  cwMock.on(PutMetricDataCommand).resolves({});
   jest.spyOn(console, "error").mockImplementation(() => {});
   jest.spyOn(console, "log").mockImplementation(() => {});
 });
@@ -85,6 +276,9 @@ afterEach(() => {
 afterAll(() => {
   delete process.env.APPSYNC_ENDPOINT;
   delete process.env.AWS_REGION;
+  delete process.env.ALARM_TOPIC_ARN;
+  delete process.env.NOTIFICATION_OUTCOMES_TABLE;
+  delete process.env.GOVERNANCE_UI_BASE_URL;
 });
 
 function makeEvent(

--- a/backend/src/lambda/governance-notifier.ts
+++ b/backend/src/lambda/governance-notifier.ts
@@ -7,19 +7,55 @@
  *     └── PutEvents on agentEventBus, DetailType: governance.*
  *           └── EventBridge rule (citadel-governance-events-{env})
  *                 └── this Lambda                              (sign + POST)
- *                       └── AppSync `publishGovernanceEvent` (IAM-authed)
- *                             └── @aws_subscribe → onGovernanceEvent
+ *                       ├── AppSync `publishGovernanceEvent` (IAM-authed, WS fanout)
+ *                       ├── [CRITICAL types only] SNS Publish -> alarmTopic
+ *                       └── DynamoDB PutItem -> notification-outcomes table
  *
  * Reuses the chatter-publisher.ts shape (single AppSync mutation per
  * EventBridge event, SigV4 signing) plus the lazy-signer pattern from
  * governance-finding-fanout.ts (signer constructed on first invocation
  * and cached for the warm-container's lifetime).
  *
- * Error semantics: log structured error and rethrow. EventBridge async
- * invocation retries 2x and routes terminally-failed events to the DLQ
- * configured in governance-stack.ts via configureAsyncInvoke. The
- * project rule "no empty catches around external writes" means every
- * failure surfaces — never swallowed.
+ * Durable delivery + fail-closed semantics (finding e396a7ee, PART B):
+ * the WS fanout is EPHEMERAL — AppSync's NONE-datasource passthrough
+ * resolver returns HTTP 200 with no `errors` regardless of how many
+ * WebSocket connections are subscribed, including zero. A CRITICAL
+ * governance event (off-frontier escalation, auto-rollback) that no
+ * admin UI was open to receive must still reach a human, so this
+ * handler ALSO publishes a whitelist-projected SNS notification to the
+ * existing plaintext `alarmTopic` for the CRITICAL subset
+ * (CRITICAL_GOVERNANCE_DETAIL_TYPES in notifier-base.ts), and records a
+ * durable per-attempt outcome row for every routed event (CRITICAL or
+ * not) in NOTIFICATION_OUTCOMES_TABLE.
+ *
+ * Deliberate fail-closed / degrade ASYMMETRY (design §4 — do not
+ * "simplify" this to uniform throw-on-any-failure):
+ *   - WS (AppSync) publish failure -> THROW (unchanged prior behaviour;
+ *     drives EventBridge retry -> DLQ -> alarm).
+ *   - CRITICAL SNS publish failure -> THROW. A critical event that
+ *     reached neither the live UI nor the guaranteed channel MUST DLQ +
+ *     page — silently downgrading it to WS-only defeats the entire
+ *     purpose of this fix.
+ *   - Outcome-row (DynamoDB) write failure -> DOES NOT THROW when the
+ *     required deliveries above already succeeded. It logs a structured
+ *     error and emits the `NotifierOutcomeWriteFailure` CloudWatch
+ *     metric instead. Rationale: by this point the event has ALREADY
+ *     reached a human (WS and/or SNS succeeded); throwing here would
+ *     make EventBridge retry the whole handler, which would re-publish
+ *     a DUPLICATE SNS page for an event that was already delivered —
+ *     worse than a missing audit row. A lost outcome row degrades
+ *     observability, not delivery, and pages via its own alarm instead.
+ *     This mirrors the auto-rollback evaluator's D6 precedent (a
+ *     committed-but-unrecorded write pages via a dedicated alarm rather
+ *     than failing the already-committed operation).
+ *
+ * Error semantics: log structured error and rethrow for the REQUIRED
+ * delivery paths (WS, CRITICAL SNS). EventBridge async invocation
+ * retries 2x and routes terminally-failed events to the DLQ configured
+ * in governance-stack.ts via configureAsyncInvoke. The project rule "no
+ * empty catches around external writes" means every failure surfaces —
+ * never swallowed, even the DEGRADE path above (which logs + emits a
+ * metric rather than swallowing silently).
  *
  * Defence-in-depth: the EventBridge rule already constrains
  * detail-types to governance.*, but the handler re-checks against the
@@ -33,8 +69,20 @@ import { SignatureV4 } from "@smithy/signature-v4";
 import { Sha256 } from "@aws-crypto/sha256-js";
 import { HttpRequest } from "@smithy/protocol-http";
 import { defaultProvider } from "@aws-sdk/credential-provider-node";
+import { SNSClient, PublishCommand } from "@aws-sdk/client-sns";
+import {
+  DynamoDBClient,
+  PutItemCommand,
+  type AttributeValue,
+} from "@aws-sdk/client-dynamodb";
+import {
+  CloudWatchClient,
+  PutMetricDataCommand,
+} from "@aws-sdk/client-cloudwatch";
 import {
   GOVERNANCE_DETAIL_TYPES,
+  isCriticalGovernanceDetailType,
+  buildGovernanceNotification,
   type GovernanceDetailType,
 } from "../utils/notifier-base";
 import {
@@ -65,6 +113,11 @@ const GOVERNANCE_DETAIL_TYPE_SET: ReadonlySet<string> = new Set<string>(
   GOVERNANCE_DETAIL_TYPES,
 );
 
+// TTL for the durable outcome row: 90 days of operational retention —
+// longer than the 14-day DLQ retention window, short of governance-record
+// permanence (design §3).
+const OUTCOME_ROW_TTL_SECONDS = 90 * 24 * 60 * 60;
+
 interface GovernanceEventInput {
   detailType: GovernanceDetailType;
   source: string;
@@ -72,6 +125,9 @@ interface GovernanceEventInput {
   detail: string; // AWSJSON — JSON-encoded original event.detail
   version: number;
 }
+
+type WsResult = "OK" | "GRAPHQL_ERROR" | "HTTP_ERROR";
+type Outcome = "RELAYED_WS_ONLY" | "RELAYED_WS_AND_SNS" | "FAILED";
 
 /**
  * Typed structured error so callers (and the EventBridge / DLQ
@@ -98,6 +154,24 @@ function getSigner(): SignatureV4 {
     });
   }
   return _signer;
+}
+
+let _snsClient: SNSClient | null = null;
+function snsClient(): SNSClient {
+  if (!_snsClient) _snsClient = new SNSClient({});
+  return _snsClient;
+}
+
+let _ddbClient: DynamoDBClient | null = null;
+function ddbClient(): DynamoDBClient {
+  if (!_ddbClient) _ddbClient = new DynamoDBClient({});
+  return _ddbClient;
+}
+
+let _cwClient: CloudWatchClient | null = null;
+function cwClient(): CloudWatchClient {
+  if (!_cwClient) _cwClient = new CloudWatchClient({});
+  return _cwClient;
 }
 
 function isGovernanceDetailType(
@@ -170,6 +244,142 @@ async function publishGovernanceEvent(
   }
 }
 
+/**
+ * Publish the CRITICAL-tier SNS backstop notification. Returns the SNS
+ * MessageId on success. Throws on failure — callers on the CRITICAL path
+ * MUST let this propagate (design §4: CRITICAL SNS failure throws so the
+ * DLQ + its alarm catch it).
+ */
+async function publishCriticalSnsNotification(
+  detailType: GovernanceDetailType,
+  detail: Record<string, unknown>,
+  meta: {
+    eventId: string;
+    eventTime: string;
+    correlationId?: string;
+    runId?: string;
+  },
+): Promise<string | undefined> {
+  const topicArn = process.env.ALARM_TOPIC_ARN;
+  if (!topicArn) {
+    throw new GovernanceNotifierError("ALARM_TOPIC_ARN env var is required");
+  }
+  const { subject, body } = buildGovernanceNotification(detailType, detail, {
+    env: process.env.ENVIRONMENT || "unknown",
+    eventId: meta.eventId,
+    eventTime: meta.eventTime,
+    correlationId: meta.correlationId,
+    runId: meta.runId,
+    governanceUiBaseUrl: process.env.GOVERNANCE_UI_BASE_URL,
+  });
+  const result = await snsClient().send(
+    new PublishCommand({
+      TopicArn: topicArn,
+      Subject: subject,
+      Message: body,
+    }),
+  );
+  return result.MessageId;
+}
+
+/**
+ * Write the durable per-attempt outcome row. Idempotent on retry (eventId
+ * is the table's PK, so a retry simply overwrites the same row). Callers
+ * MUST NOT let a failure here mask an already-thrown delivery error, and
+ * MUST NOT throw when deliveries already succeeded (design §4 DEGRADE
+ * path) — see emitOutcomeWriteFailureMetric below for the alternative
+ * signal.
+ */
+async function writeOutcomeRow(row: {
+  eventId: string;
+  attemptAt: string;
+  detailType: string;
+  source: string;
+  org?: string;
+  correlationId?: string;
+  runId?: string;
+  severity: "CRITICAL" | "INFO";
+  wsResult: WsResult;
+  snsRouted: boolean;
+  snsMessageId?: string;
+  outcome: Outcome;
+}): Promise<void> {
+  const tableName = process.env.NOTIFICATION_OUTCOMES_TABLE;
+  if (!tableName) {
+    throw new GovernanceNotifierError(
+      "NOTIFICATION_OUTCOMES_TABLE env var is required",
+    );
+  }
+  const expiresAt = Math.floor(Date.now() / 1000) + OUTCOME_ROW_TTL_SECONDS;
+  const item: Record<string, AttributeValue> = {
+    eventId: { S: row.eventId },
+    attemptAt: { S: row.attemptAt },
+    detailType: { S: row.detailType },
+    source: { S: row.source },
+    severity: { S: row.severity },
+    wsResult: { S: row.wsResult },
+    snsRouted: { BOOL: row.snsRouted },
+    outcome: { S: row.outcome },
+    expiresAt: { N: String(expiresAt) },
+  };
+  if (row.org) item.org = { S: row.org };
+  if (row.correlationId) item.correlationId = { S: row.correlationId };
+  if (row.runId) item.runId = { S: row.runId };
+  if (row.snsMessageId) item.snsMessageId = { S: row.snsMessageId };
+
+  await ddbClient().send(
+    new PutItemCommand({
+      TableName: tableName,
+      Item: item,
+    }),
+  );
+}
+
+/**
+ * DEGRADE-path signal for a lost outcome row (design §4): log a
+ * structured error (never an empty catch — project rule) and emit the
+ * `NotifierOutcomeWriteFailure` CloudWatch metric so a missing audit row
+ * pages via its own dedicated alarm (governance-stack.ts) rather than
+ * failing an already-delivered event. Best-effort — a failure to emit
+ * the metric itself is logged but never thrown, since there is nothing
+ * further to degrade to.
+ */
+async function emitOutcomeWriteFailureMetric(
+  detailType: string,
+  eventId: string,
+): Promise<void> {
+  try {
+    await cwClient().send(
+      new PutMetricDataCommand({
+        Namespace: "Citadel/Governance",
+        MetricData: [
+          {
+            MetricName: "NotifierOutcomeWriteFailure",
+            Value: 1,
+            Unit: "Count",
+            Dimensions: [
+              {
+                Name: "Environment",
+                Value: process.env.ENVIRONMENT || "unknown",
+              },
+            ],
+          },
+        ],
+      }),
+    );
+  } catch (metricErr) {
+    console.error(
+      "governance-notifier: failed to emit NotifierOutcomeWriteFailure metric",
+      {
+        detailType,
+        eventId,
+        error:
+          metricErr instanceof Error ? metricErr.message : String(metricErr),
+      },
+    );
+  }
+}
+
 export const handler = async (
   event: EventBridgeEvent<string, unknown>,
 ): Promise<{ statusCode: number; body: string }> => {
@@ -205,20 +415,30 @@ export const handler = async (
     };
   }
 
+  const detailObj = (event.detail ?? {}) as Record<string, unknown>;
   const input: GovernanceEventInput = {
     detailType,
     source: event.source,
     eventTime: event.time,
-    detail: JSON.stringify(event.detail ?? {}),
+    detail: JSON.stringify(detailObj),
     version: GOVERNANCE_EVENT_VERSION,
   };
+
+  const isCritical = isCriticalGovernanceDetailType(detailType);
+  let wsResult: WsResult = "OK";
 
   try {
     await publishGovernanceEvent(input);
   } catch (err) {
     // Structured log so the DLQ message is correlatable from the
     // CloudWatch side. Rethrow is mandatory — EventBridge async invoke
-    // relies on the throw to drive the retry / DLQ pipeline.
+    // relies on the throw to drive the retry / DLQ pipeline. The WS
+    // path is REQUIRED (fail-closed) — this is unchanged prior
+    // behaviour (design §4: "WS failure throws as today").
+    wsResult =
+      err instanceof GovernanceNotifierError && err.statusCode
+        ? "HTTP_ERROR"
+        : "GRAPHQL_ERROR";
     console.error("governance-notifier: publish failed", {
       detailType,
       source: event.source,
@@ -227,7 +447,97 @@ export const handler = async (
       error: err instanceof Error ? err.message : String(err),
       errorName: err instanceof Error ? err.name : "unknown",
     });
+    // Attempt a best-effort outcome row for the failed attempt too (never
+    // lets a write failure here mask the original WS error).
+    await writeOutcomeRow({
+      eventId: event.id,
+      attemptAt: new Date().toISOString(),
+      detailType,
+      source: event.source,
+      org: typeof detailObj.orgId === "string" ? detailObj.orgId : undefined,
+      correlationId: carried?.correlationId,
+      runId: carried?.runId,
+      severity: isCritical ? "CRITICAL" : "INFO",
+      wsResult,
+      snsRouted: false,
+      outcome: "FAILED",
+    }).catch((writeErr) => {
+      console.error(
+        "governance-notifier: outcome-row write failed after a WS delivery failure (original error still rethrown)",
+        {
+          detailType,
+          eventId: event.id,
+          error:
+            writeErr instanceof Error ? writeErr.message : String(writeErr),
+        },
+      );
+      // Deliberately not awaited into a metric emit here — the original
+      // WS failure already drives the DLQ/alarm path; a second alarm for
+      // the same failed event would be noise. The DEGRADE metric is
+      // reserved for the "everything downstream of delivery succeeded but
+      // the audit row itself failed" case below.
+    });
     throw err;
+  }
+
+  // WS succeeded. For the CRITICAL subset, ALSO publish to the durable
+  // SNS backstop — this is the crux of finding e396a7ee: a zero-subscriber
+  // WS fanout for a CRITICAL event is no longer silent because a human
+  // still gets the SNS-routed email/Slack message regardless of whether
+  // any WebSocket connection existed.
+  let snsRouted = false;
+  let snsMessageId: string | undefined;
+  if (isCritical) {
+    // CRITICAL SNS publish failure -> THROW (design §4). A critical event
+    // that reached neither the live UI's zero subscribers nor the
+    // guaranteed channel must DLQ + page, so this is NOT caught here.
+    snsMessageId = await publishCriticalSnsNotification(detailType, detailObj, {
+      eventId: event.id,
+      eventTime: event.time,
+      correlationId: carried?.correlationId,
+      runId: carried?.runId,
+    });
+    snsRouted = true;
+  }
+
+  const outcome: Outcome = snsRouted ? "RELAYED_WS_AND_SNS" : "RELAYED_WS_ONLY";
+
+  // Outcome-row write failure DEGRADES rather than throws (design §4):
+  // by this point WS (and, if CRITICAL, SNS) have ALREADY succeeded, so
+  // failing the Lambda now would make EventBridge retry the whole
+  // handler and re-publish a DUPLICATE SNS page for an event that was
+  // already delivered — strictly worse than a missing audit row. Emit
+  // the dedicated CloudWatch metric instead so the lost row pages via
+  // its own alarm (NotifierOutcomeWriteFailure, governance-stack.ts)
+  // without masking or re-triggering the delivery that already worked.
+  try {
+    await writeOutcomeRow({
+      eventId: event.id,
+      attemptAt: new Date().toISOString(),
+      detailType,
+      source: event.source,
+      org: typeof detailObj.orgId === "string" ? detailObj.orgId : undefined,
+      correlationId: carried?.correlationId,
+      runId: carried?.runId,
+      severity: isCritical ? "CRITICAL" : "INFO",
+      wsResult,
+      snsRouted,
+      snsMessageId,
+      outcome,
+    });
+  } catch (writeErr) {
+    console.error(
+      "governance-notifier: outcome-row write failed AFTER successful delivery — degrading (no throw) to avoid a duplicate SNS page; see NotifierOutcomeWriteFailure metric",
+      {
+        detailType,
+        eventId: event.id,
+        outcome,
+        error: writeErr instanceof Error ? writeErr.message : String(writeErr),
+      },
+    );
+    await emitOutcomeWriteFailureMetric(detailType, event.id);
+    // Deliberately NOT rethrown — see the asymmetry rationale in the
+    // module-level comment and design §4.
   }
 
   return {
@@ -239,4 +549,7 @@ export const handler = async (
 /** Test-only: reset the cached signer between test cases. */
 export function __resetForTest(): void {
   _signer = null;
+  _snsClient = null;
+  _ddbClient = null;
+  _cwClient = null;
 }

--- a/backend/src/utils/__tests__/notifier-base.test.ts
+++ b/backend/src/utils/__tests__/notifier-base.test.ts
@@ -1,3 +1,147 @@
+// ---------------------------------------------------------------------------
+// R8 — buildGovernanceNotification: whitelist projection, redaction,
+// Subject length cap, deep-link assembly (finding e396a7ee, design §2).
+// ---------------------------------------------------------------------------
+
+describe("R8: buildGovernanceNotification — whitelist projection + redaction", () => {
+  test("R8a: builds Subject <=100 chars and whitelisted body for governance.release.auto_rollback", () => {
+    const { subject, body } = buildGovernanceNotification(
+      "governance.release.auto_rollback",
+      {
+        orgId: "org_ACME",
+        agentTargetId: "agent-1",
+        environment: "prod",
+        action: "AUTO_ABORT_CANARY",
+        metric: "error_rate",
+        observedValue: 0.42,
+        threshold: 0.05,
+        sampleCount: 500,
+        fromReleaseId: "rel-1",
+        toReleaseId: "rel-2",
+        candidateReleaseId: "rel-2",
+        fromVersion: 3,
+      },
+      {
+        env: "prod",
+        eventId: "evt-1",
+        eventTime: "2026-09-03T00:00:00Z",
+        correlationId: "corr-1",
+        runId: undefined,
+        governanceUiBaseUrl: "https://ui.example.com",
+      },
+    );
+    expect(subject.length).toBeLessThanOrEqual(100);
+    expect(subject).toContain("org_ACME");
+    expect(body).toContain("governance.release.auto_rollback");
+    expect(body).toContain("org_ACME");
+    expect(body).toContain("corr-1");
+    expect(body).toContain("https://ui.example.com");
+    expect(body).toContain("evt-1");
+  });
+
+  test("R8b: NEVER includes a non-whitelisted field injected into detail", () => {
+    const { body } = buildGovernanceNotification(
+      "governance.offfrontier.escalated",
+      {
+        projectId: "p1",
+        agentId: "agent-1",
+        reason: "drifted",
+        // @ts-expect-error — simulating an attacker/bug adding an extra field
+        secretToken: "sk-super-secret-value",
+      },
+      {
+        env: "prod",
+        eventId: "evt-2",
+        eventTime: "2026-09-03T00:00:00Z",
+      },
+    );
+    expect(body).not.toContain("sk-super-secret-value");
+    expect(body).not.toContain("secretToken");
+  });
+
+  test("R8c: strips <script> tags and length-caps free-text fields (e.g. reason)", () => {
+    const longReason = "x".repeat(500) + "<script>alert(1)</script>";
+    const { body } = buildGovernanceNotification(
+      "governance.offfrontier.escalated",
+      {
+        projectId: "p1",
+        agentId: "agent-1",
+        reason: longReason,
+      },
+      {
+        env: "prod",
+        eventId: "evt-3",
+        eventTime: "2026-09-03T00:00:00Z",
+      },
+    );
+    expect(body).not.toContain("<script>");
+    // capped well below the raw 500+26 char input
+    const reasonLine = body
+      .split("\n")
+      .find((l) => l.toLowerCase().includes("summary"));
+    expect(reasonLine).toBeDefined();
+    expect(reasonLine!.length).toBeLessThan(400);
+  });
+
+  test("R8d: omits deep-link URL text gracefully when governanceUiBaseUrl is not configured", () => {
+    const { body } = buildGovernanceNotification(
+      "governance.offfrontier.escalated",
+      { projectId: "p1", agentId: "agent-1", reason: "drift" },
+      { env: "prod", eventId: "evt-4", eventTime: "2026-09-03T00:00:00Z" },
+    );
+    expect(body).toMatch(/governance UI URL not configured/i);
+  });
+
+  test("R8e: Subject truncates to <=100 chars for a long org id", () => {
+    const { subject } = buildGovernanceNotification(
+      "governance.offfrontier.escalated",
+      {
+        projectId: "p1",
+        agentId: "agent-1",
+        reason: "x".repeat(200),
+      },
+      {
+        env: "prod",
+        eventId: "evt-5",
+        eventTime: "2026-09-03T00:00:00Z",
+        org: "org_" + "y".repeat(200),
+      },
+    );
+    expect(subject.length).toBeLessThanOrEqual(100);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// R9 — lock-step: every CRITICAL_GOVERNANCE_DETAIL_TYPES member must be
+// present in GOVERNANCE_DETAIL_TYPES (routing gap guard, finding 163d4776).
+// The rule-list half of the lock-step lives in
+// backend/test/governance-notifier-durable-destination.test.ts (needs a
+// CDK synth of GovernanceEventsRule).
+// ---------------------------------------------------------------------------
+
+describe("R9: CRITICAL_GOVERNANCE_DETAIL_TYPES lock-step with GOVERNANCE_DETAIL_TYPES", () => {
+  test("R9a: every CRITICAL type is a member of GOVERNANCE_DETAIL_TYPES", () => {
+    const all = new Set<string>(GOVERNANCE_DETAIL_TYPES);
+    for (const critical of CRITICAL_GOVERNANCE_DETAIL_TYPES) {
+      expect(all.has(critical)).toBe(true);
+    }
+  });
+
+  test("R9b: CRITICAL_GOVERNANCE_DETAIL_TYPES contains exactly the designed set", () => {
+    expect([...CRITICAL_GOVERNANCE_DETAIL_TYPES].sort()).toEqual(
+      [
+        "governance.offfrontier.escalated",
+        "governance.release.auto_rollback",
+      ].sort(),
+    );
+  });
+
+  test("R9c: CRITICAL_GOVERNANCE_DETAIL_TYPES has no duplicate entries", () => {
+    expect(new Set(CRITICAL_GOVERNANCE_DETAIL_TYPES).size).toBe(
+      CRITICAL_GOVERNANCE_DETAIL_TYPES.length,
+    );
+  });
+});
 import { mockClient } from "aws-sdk-client-mock";
 import {
   EventBridgeClient,
@@ -8,6 +152,8 @@ import {
   emitGovernanceEvent,
   __resetGovernanceNotifierForTest,
   GOVERNANCE_DETAIL_TYPES,
+  CRITICAL_GOVERNANCE_DETAIL_TYPES,
+  buildGovernanceNotification,
   type GovernanceDetailType,
 } from "../notifier-base";
 

--- a/backend/src/utils/notifier-base.ts
+++ b/backend/src/utils/notifier-base.ts
@@ -118,6 +118,40 @@ export const GOVERNANCE_DETAIL_TYPES = [
 
 export type GovernanceDetailType = (typeof GOVERNANCE_DETAIL_TYPES)[number];
 
+// Finding e396a7ee (PART B) / secondary finding 163d4776: the CRITICAL
+// subset that MUST reach a durable, confirmed-subscriber channel (the
+// plaintext alarmTopic SNS backstop) in addition to the ephemeral WS
+// fanout, because a zero-subscriber WS fanout for these types is
+// unacceptable to miss silently. All routed types still attempt WS +
+// still get a durable outcome row (see governance-notifier.ts); only
+// this subset additionally triggers an SNS publish.
+//
+// Deliberately does NOT include a breaker/circuit-breaker detail-type:
+// per-target breaker state changes have no governance.* EventBridge
+// detail-type today (confirmed by inspection — breaker state is
+// ledger-only, emitted as a GovernanceFinding row, never as a
+// governance.* event). Inventing one here would fabricate a contract
+// this notifier cannot actually observe. If breaker events later gain a
+// governance.* detail-type, add it to both this list AND
+// GOVERNANCE_DETAIL_TYPES/the EventBridge rule in the same change (see
+// the lock-step test in notifier-base.test.ts and
+// governance-notifier-durable-destination.test.ts).
+export const CRITICAL_GOVERNANCE_DETAIL_TYPES = [
+  "governance.offfrontier.escalated",
+  "governance.release.auto_rollback",
+] as const satisfies readonly GovernanceDetailType[];
+
+export type CriticalGovernanceDetailType =
+  (typeof CRITICAL_GOVERNANCE_DETAIL_TYPES)[number];
+
+const CRITICAL_GOVERNANCE_DETAIL_TYPE_SET: ReadonlySet<string> =
+  new Set<string>(CRITICAL_GOVERNANCE_DETAIL_TYPES);
+
+/** True iff `detailType` is in the CRITICAL subset that must SNS-publish. */
+export function isCriticalGovernanceDetailType(detailType: string): boolean {
+  return CRITICAL_GOVERNANCE_DETAIL_TYPE_SET.has(detailType);
+}
+
 // Per-detail-type typed payload map.
 export interface GovernancePayloadMap {
   "governance.adr.locked": {
@@ -470,6 +504,139 @@ function ebClient(): EventBridgeClient {
   return _client;
 }
 
+// ---------------------------------------------------------------------------
+// SNS notification projection (finding e396a7ee, design §2).
+//
+// Pure, unit-testable in isolation from any AWS SDK client. Builds a
+// WHITELIST-projected Subject/Message pair for the CRITICAL subset of
+// governance events — NEVER serialises the raw event.detail. Only the
+// scalar fields explicitly listed per detail-type below are surfaced;
+// any future/unexpected field on the payload (e.g. an accidentally
+// added secret) is structurally excluded, not merely omitted by
+// convention.
+// ---------------------------------------------------------------------------
+
+const SNS_SUBJECT_MAX = 100;
+const SUMMARY_FIELD_MAX = 280;
+
+export interface BuildNotificationMeta {
+  env: string;
+  eventId: string;
+  eventTime: string;
+  correlationId?: string;
+  runId?: string;
+  org?: string;
+  governanceUiBaseUrl?: string;
+}
+
+/** Per-detail-type whitelist of scalar fields safe to surface in an SNS body. */
+const SUMMARY_WHITELIST: Partial<
+  Record<GovernanceDetailType, readonly string[]>
+> = {
+  "governance.offfrontier.escalated": ["projectId", "agentId", "reason"],
+  "governance.release.auto_rollback": [
+    "orgId",
+    "agentTargetId",
+    "environment",
+    "action",
+    "metric",
+    "observedValue",
+    "threshold",
+    "sampleCount",
+    "fromReleaseId",
+    "toReleaseId",
+    "candidateReleaseId",
+    "fromVersion",
+  ],
+};
+
+/** Per-detail-type deep-link route suffix (appended to governanceUiBaseUrl). */
+const DEEP_LINK_ROUTE: Partial<Record<GovernanceDetailType, string>> = {
+  "governance.offfrontier.escalated": "/governance/escalations",
+  "governance.release.auto_rollback": "/governance/findings",
+};
+
+function truncate(s: string, max: number): string {
+  return s.length > max ? s.slice(0, max) : s;
+}
+
+/**
+ * Project only the whitelisted scalar fields for `detailType` out of an
+ * arbitrary detail object, sanitised via the same fail-closed tag-stripper
+ * used for EventBridge payloads. Any field NOT in the whitelist (including
+ * one injected by a bug or an attacker) is structurally excluded — this is
+ * a whitelist, not a blacklist.
+ */
+function projectSummaryFields(
+  detailType: GovernanceDetailType,
+  detail: Record<string, unknown>,
+): string {
+  const fields = SUMMARY_WHITELIST[detailType] ?? [];
+  const parts: string[] = [];
+  for (const field of fields) {
+    const raw = detail[field];
+    if (raw === undefined || raw === null) continue;
+    const value =
+      typeof raw === "string"
+        ? truncate(sanitizeString(raw), SUMMARY_FIELD_MAX)
+        : String(raw);
+    parts.push(`${field}=${value}`);
+  }
+  return parts.join(", ");
+}
+
+/**
+ * Build the SNS Subject + Message for a CRITICAL governance event.
+ * Pure function — no AWS SDK calls, no I/O — so it is directly
+ * unit-testable (see notifier-base.test.ts R8).
+ *
+ * NEVER serialises the raw `detail` object into the message; only the
+ * per-detail-type whitelisted scalar fields (plus the always-safe
+ * envelope metadata: detailType/env/org/correlationId/runId/eventId/
+ * eventTime/deep-link) are included.
+ */
+export function buildGovernanceNotification(
+  detailType: GovernanceDetailType,
+  detail: Record<string, unknown>,
+  meta: BuildNotificationMeta,
+): { subject: string; body: string } {
+  const org =
+    meta.org ??
+    (typeof detail.orgId === "string" ? detail.orgId : undefined) ??
+    (typeof detail.org === "string" ? detail.org : undefined);
+
+  const shortLabel = detailType.replace(/^governance\./, "");
+  const subjectRaw = org
+    ? `[Citadel ${meta.env}] ${shortLabel} — ${org}`
+    : `[Citadel ${meta.env}] ${shortLabel}`;
+  const subject = truncate(subjectRaw, SNS_SUBJECT_MAX);
+
+  const route = DEEP_LINK_ROUTE[detailType];
+  const deepLink = meta.governanceUiBaseUrl
+    ? `${meta.governanceUiBaseUrl}${route ?? ""}`
+    : "(governance UI URL not configured)";
+
+  const summary = projectSummaryFields(detailType, detail);
+
+  const lines = [
+    `Governance event: ${detailType}`,
+    `Environment: ${meta.env}`,
+    `Organization: ${org ?? "n/a"}`,
+    `Correlation/runId: ${meta.correlationId ?? meta.runId ?? "n/a"}`,
+    `Time: ${meta.eventTime}`,
+    `Summary: ${summary || "n/a"}`,
+    `Details: ${deepLink}`,
+    `EventId: ${meta.eventId}`,
+  ];
+
+  return { subject, body: lines.join("\n") };
+}
+
+/** Test-only: reset the cached EventBridge client. Do not call from production code. */
+export function __resetGovernanceNotifierForTest(): void {
+  _client = null;
+}
+
 export async function emitGovernanceEvent<D extends GovernanceDetailType>(
   detailType: D,
   detail: DetailPayloadOf<D>,
@@ -493,9 +660,4 @@ export async function emitGovernanceEvent<D extends GovernanceDetailType>(
     ],
   });
   await ebClient().send(command);
-}
-
-/** Test-only: reset the cached EventBridge client. Do not call from production code. */
-export function __resetGovernanceNotifierForTest(): void {
-  _client = null;
 }

--- a/backend/test/governance-notifier-durable-destination.test.ts
+++ b/backend/test/governance-notifier-durable-destination.test.ts
@@ -1,0 +1,365 @@
+/**
+ * Structural guard (finding e396a7ee, PART B): the governance-notifier
+ * must fan out to at least one NON-EPHEMERAL destination (SNS) in addition
+ * to the ephemeral AppSync/WebSocket mutation, so a future refactor cannot
+ * silently revert to WS-only (the original silent zero-subscriber bug).
+ *
+ * Also covers the secondary finding (163d4776): every claimed-CRITICAL
+ * detail-type must appear in BOTH GOVERNANCE_DETAIL_TYPES and the
+ * GovernanceEventsRule eventPattern.detailType list (the auto_rollback
+ * routing gap).
+ *
+ * A companion bite proof demonstrates each predicate actually fires when
+ * the wiring it guards is removed — a green suite against an unbitten
+ * guard proves nothing (see every-alarm-has-action.test.ts precedent).
+ *
+ * Scaffold mirrors governance-stack-auto-rollback-evaluator.test.ts's
+ * mock-table convention (single wrapper `backendStack`, GovernanceStack
+ * as a child of the SAME app).
+ */
+import * as cdk from "aws-cdk-lib";
+import { Template, Match } from "aws-cdk-lib/assertions";
+import * as appsync from "aws-cdk-lib/aws-appsync";
+import * as dynamodb from "aws-cdk-lib/aws-dynamodb";
+import * as events from "aws-cdk-lib/aws-events";
+import * as iam from "aws-cdk-lib/aws-iam";
+import * as sns from "aws-cdk-lib/aws-sns";
+import { Bucket } from "aws-cdk-lib/aws-s3";
+import * as path from "path";
+import { scaffoldBackendAssetDirs } from "./helpers/scaffold-stub-assets";
+
+scaffoldBackendAssetDirs(["dist/lambda", "src/schema"]);
+
+import {
+  GovernanceStack,
+  type GovernanceStackProps,
+} from "../lib/governance-stack";
+import { CRITICAL_GOVERNANCE_DETAIL_TYPES } from "../src/utils/notifier-base";
+
+interface IamStatement {
+  Effect?: string;
+  Action?: string | string[];
+  Resource?: unknown;
+}
+interface CfnResource {
+  Type: string;
+  Properties?: Record<string, unknown>;
+}
+
+function mockTable(
+  scope: cdk.Stack,
+  id: string,
+  tableName: string,
+): dynamodb.Table {
+  return new dynamodb.Table(scope, id, {
+    tableName,
+    partitionKey: { name: `${id}Id`, type: dynamodb.AttributeType.STRING },
+    billingMode: dynamodb.BillingMode.PAY_PER_REQUEST,
+    removalPolicy: cdk.RemovalPolicy.DESTROY,
+  });
+}
+
+function buildProps(
+  backendStack: cdk.Stack,
+  suffix: string,
+): GovernanceStackProps {
+  const agentEventBus = new events.EventBus(
+    backendStack,
+    `AgentEventBus${suffix}`,
+    { eventBusName: `citadel-agents-test${suffix}` },
+  );
+  const appSyncApi = new appsync.GraphqlApi(backendStack, `MockApi${suffix}`, {
+    name: `mock-api${suffix}`,
+    schema: appsync.SchemaFile.fromAsset(
+      path.resolve(__dirname, "../src/schema/schema.graphql"),
+    ),
+  });
+  const accessLogsBucket = new Bucket(
+    backendStack,
+    `AccessLogsBucket${suffix}`,
+    {
+      bucketName: `citadel-access-logs-test${suffix.toLowerCase()}`,
+    },
+  );
+  const alarmTopic = new sns.Topic(backendStack, `AlarmTopic${suffix}`, {
+    topicName: `citadel-alarms-test${suffix.toLowerCase()}`,
+  });
+
+  const names = [
+    "Adrs",
+    "AdrReopenAttempts",
+    "ExecutionSpecifications",
+    "InterrogationRounds",
+    "AgentDesignAssessments",
+    "ProgramReviews",
+    "Projects",
+    "EvalSuites",
+    "EvalCases",
+    "EvalRuns",
+    "EvalRunCaseResults",
+    "EvalBaselines",
+    "EvalComparisons",
+    "EvalComparisonConfig",
+    "Executions",
+    "Conversations",
+  ];
+  const t = Object.fromEntries(
+    names.map((n) => [
+      n,
+      mockTable(
+        backendStack,
+        `${n}${suffix}`,
+        `citadel-${n}-test${suffix.toLowerCase()}`,
+      ),
+    ]),
+  ) as Record<string, dynamodb.Table>;
+
+  const agentReleasesTable = mockTable(
+    backendStack,
+    `AgentReleases${suffix}`,
+    `citadel-agent-releases-test${suffix.toLowerCase()}`,
+  );
+  const agentReleaseWriterRole = new iam.Role(
+    backendStack,
+    `AgentReleaseWriterRole${suffix}`,
+    { assumedBy: new iam.ServicePrincipal("lambda.amazonaws.com") },
+  );
+  const environmentReleasePointersTable = new dynamodb.Table(
+    backendStack,
+    `EnvironmentReleasePointersTable${suffix}`,
+    {
+      tableName: `citadel-environment-release-pointers-test${suffix.toLowerCase()}`,
+      partitionKey: { name: "orgId", type: dynamodb.AttributeType.STRING },
+      sortKey: {
+        name: "agentTargetId_environment",
+        type: dynamodb.AttributeType.STRING,
+      },
+      billingMode: dynamodb.BillingMode.PAY_PER_REQUEST,
+      removalPolicy: cdk.RemovalPolicy.DESTROY,
+    },
+  );
+  const environmentReleasePointerWriterRole = new iam.Role(
+    backendStack,
+    `EnvironmentReleasePointerWriterRole${suffix}`,
+    { assumedBy: new iam.ServicePrincipal("lambda.amazonaws.com") },
+  );
+  const promotionPolicyConfigTable = mockTable(
+    backendStack,
+    `PromotionPolicyConfig${suffix}`,
+    `citadel-promotion-policy-config-test${suffix.toLowerCase()}`,
+  );
+  const promotionPolicyConfigWriterRole = new iam.Role(
+    backendStack,
+    `PromotionPolicyConfigWriterRole${suffix}`,
+    { assumedBy: new iam.ServicePrincipal("lambda.amazonaws.com") },
+  );
+
+  return {
+    env: { account: "123456789012", region: "us-east-1" },
+    environment: "test",
+    appSyncApi,
+    agentEventBus,
+    accessLogsBucket,
+    adrsTable: t.Adrs,
+    adrReopenAttemptsTable: t.AdrReopenAttempts,
+    executionSpecificationsTable: t.ExecutionSpecifications,
+    interrogationRoundsTable: t.InterrogationRounds,
+    agentDesignAssessmentsTable: t.AgentDesignAssessments,
+    programReviewsTable: t.ProgramReviews,
+    projectsTable: t.Projects,
+    evalSuitesTable: t.EvalSuites,
+    evalCasesTable: t.EvalCases,
+    evalRunsTable: t.EvalRuns,
+    evalRunCaseResultsTable: t.EvalRunCaseResults,
+    evalBaselinesTable: t.EvalBaselines,
+    evalComparisonsTable: t.EvalComparisons,
+    evalComparisonConfigTable: t.EvalComparisonConfig,
+    executionsTable: t.Executions,
+    conversationsTable: t.Conversations,
+    agentReleasesTable,
+    agentReleaseWriterRole,
+    registryArn:
+      "arn:aws:bedrock-agentcore:us-east-1:123456789012:registry/citadel-test",
+    registryId: "citadel-test",
+    environmentReleasePointersTable,
+    environmentReleasePointerWriterRole,
+    promotionPolicyConfigTable,
+    promotionPolicyConfigWriterRole,
+    alarmTopic,
+  };
+}
+
+function synthGovernanceStack(
+  suffix: string,
+  mutate?: (props: GovernanceStackProps) => GovernanceStackProps,
+): Template {
+  const app = new cdk.App();
+  const backendStack = new cdk.Stack(app, `MockBackendStack${suffix}`, {
+    env: { account: "123456789012", region: "us-east-1" },
+  });
+  let props = buildProps(backendStack, suffix);
+  if (mutate) props = mutate(props);
+  const stack = new GovernanceStack(app, `TestGovernanceStack${suffix}`, props);
+  return Template.fromStack(stack);
+}
+
+describe("R10: notifier function env carries the durable-destination config", () => {
+  test("ALARM_TOPIC_ARN, NOTIFICATION_OUTCOMES_TABLE, GOVERNANCE_UI_BASE_URL are all set", () => {
+    const template = synthGovernanceStack("R10");
+    template.hasResourceProperties("AWS::Lambda::Function", {
+      Handler: "governance-notifier.handler",
+      Environment: {
+        Variables: Match.objectLike({
+          ALARM_TOPIC_ARN: Match.anyValue(),
+          NOTIFICATION_OUTCOMES_TABLE: Match.anyValue(),
+        }),
+      },
+    });
+  });
+});
+
+describe("R11: notifier IAM role has scoped sns:Publish + dynamodb:PutItem + cloudwatch:PutMetricData, retains appsync:GraphQL", () => {
+  test("scoped least-privilege statements are present", () => {
+    const template = synthGovernanceStack("R11a");
+    const policies = template.findResources("AWS::IAM::Policy");
+    const allStatements: IamStatement[] = Object.values(policies).flatMap(
+      (p: CfnResource) =>
+        (p.Properties?.PolicyDocument as { Statement?: IamStatement[] })
+          ?.Statement ?? [],
+    );
+
+    const includesAction = (s: IamStatement, action: string) =>
+      s.Effect === "Allow" &&
+      (Array.isArray(s.Action) ? s.Action : [s.Action]).includes(action);
+
+    expect(allStatements.some((s) => includesAction(s, "sns:Publish"))).toBe(
+      true,
+    );
+    expect(
+      allStatements.some((s) => includesAction(s, "dynamodb:PutItem")),
+    ).toBe(true);
+    expect(
+      allStatements.some((s) => includesAction(s, "cloudwatch:PutMetricData")),
+    ).toBe(true);
+    expect(
+      allStatements.some((s) => includesAction(s, "appsync:GraphQL")),
+    ).toBe(true);
+  });
+
+  test("dynamodb:PutItem statement does not also grant UpdateItem/DeleteItem/BatchWriteItem (no grantWriteData over-widening)", () => {
+    const template = synthGovernanceStack("R11b");
+    const policies = template.findResources("AWS::IAM::Policy");
+    const allStatements: IamStatement[] = Object.values(policies).flatMap(
+      (p: CfnResource) =>
+        (p.Properties?.PolicyDocument as { Statement?: IamStatement[] })
+          ?.Statement ?? [],
+    );
+    const putItemStatement = allStatements.find(
+      (s) =>
+        s.Effect === "Allow" &&
+        (Array.isArray(s.Action) ? s.Action : [s.Action]).includes(
+          "dynamodb:PutItem",
+        ),
+    );
+    expect(putItemStatement).toBeDefined();
+    const actions = Array.isArray(putItemStatement.Action)
+      ? putItemStatement.Action
+      : [putItemStatement.Action];
+    expect(actions).not.toContain("dynamodb:UpdateItem");
+    expect(actions).not.toContain("dynamodb:DeleteItem");
+    expect(actions).not.toContain("dynamodb:BatchWriteItem");
+  });
+});
+
+describe("R12: NotifierOutcomeWriteFailure alarm exists with >=1 action; bite proof on removal", () => {
+  test("GREEN: the alarm exists in the synthesized template with an action", () => {
+    const template = synthGovernanceStack("R12");
+    const alarms = template.findResources("AWS::CloudWatch::Alarm", {
+      Properties: { MetricName: "NotifierOutcomeWriteFailure" },
+    });
+    const matches = Object.values(alarms) as CfnResource[];
+    expect(matches.length).toBeGreaterThanOrEqual(1);
+    const actions = (matches[0].Properties?.AlarmActions as unknown[]) ?? [];
+    expect(Array.isArray(actions)).toBe(true);
+    expect(actions.length).toBeGreaterThanOrEqual(1);
+  });
+
+  test("bite proof predicate: an alarm with the same MetricName but empty AlarmActions IS flagged", () => {
+    // Mirrors findActionlessAlarms from every-alarm-has-action.test.ts —
+    // demonstrates the assertion style actually fires on a muted alarm.
+    const resources: Record<
+      string,
+      { Type: string; Properties?: Record<string, unknown> }
+    > = {
+      SomeAlarm: {
+        Type: "AWS::CloudWatch::Alarm",
+        Properties: {
+          MetricName: "NotifierOutcomeWriteFailure",
+          AlarmActions: [],
+        },
+      },
+    };
+    const actionless = Object.values(resources).filter((r) => {
+      const actions = (r.Properties?.AlarmActions ?? []) as unknown[];
+      return (
+        r.Type === "AWS::CloudWatch::Alarm" &&
+        (!Array.isArray(actions) || actions.length === 0)
+      );
+    });
+    expect(actionless.length).toBe(1);
+  });
+});
+
+describe("R13: alarmTopic is a REQUIRED prop on GovernanceStackProps", () => {
+  test("constructing GovernanceStack without alarmTopic fails at runtime (no silent WS-only fallback)", () => {
+    const app = new cdk.App();
+    const backendStack = new cdk.Stack(app, "MockBackendStackR13", {
+      env: { account: "123456789012", region: "us-east-1" },
+    });
+    const props = buildProps(backendStack, "R13");
+    // Simulates a caller that forgot to pass alarmTopic — this must fail
+    // loudly (throw) rather than silently constructing a WS-only notifier.
+    const propsWithoutAlarmTopic = {
+      ...props,
+    } as Partial<GovernanceStackProps>;
+    delete propsWithoutAlarmTopic.alarmTopic;
+    expect(
+      () =>
+        new GovernanceStack(
+          app,
+          "TestGovernanceStackR13NoAlarm",
+          propsWithoutAlarmTopic as GovernanceStackProps,
+        ),
+    ).toThrow();
+  });
+});
+
+describe("secondary finding 163d4776: lock-step CRITICAL detail-types in the EventBridge rule", () => {
+  function ruleDetailTypes(template: Template): string[] {
+    const rules = template.findResources("AWS::Events::Rule");
+    const governanceRule = Object.values(rules).find(
+      (r: CfnResource) =>
+        typeof r.Properties?.Name === "string" &&
+        (r.Properties.Name as string).includes("citadel-governance-events"),
+    ) as CfnResource | undefined;
+    expect(governanceRule).toBeDefined();
+    const eventPattern = governanceRule!.Properties?.EventPattern as {
+      "detail-type": string[];
+    };
+    return eventPattern["detail-type"];
+  }
+
+  test("every CRITICAL_GOVERNANCE_DETAIL_TYPES member is present in the GovernanceEventsRule eventPattern.detailType list", () => {
+    const template = synthGovernanceStack("Rule1");
+    const types = ruleDetailTypes(template);
+    for (const critical of CRITICAL_GOVERNANCE_DETAIL_TYPES) {
+      expect(types).toContain(critical);
+    }
+  });
+
+  test("governance.release.auto_rollback specifically is routed by the rule (the auto-rollback gap)", () => {
+    const template = synthGovernanceStack("Rule2");
+    const types = ruleDetailTypes(template);
+    expect(types).toContain("governance.release.auto_rollback");
+  });
+});

--- a/backend/test/governance-notifier-env-parity.test.ts
+++ b/backend/test/governance-notifier-env-parity.test.ts
@@ -1,0 +1,217 @@
+/**
+ * TS env-parity guard for the governance-notifier Lambda (finding
+ * e396a7ee, design §6). `arbiter-stack-env-parity.test.ts` covers only the
+ * Python arbiter Lambdas — this closes the same class of gap for the new
+ * TS handler: every `process.env.X` read added to governance-notifier.ts
+ * must actually be set on the synthesized function's environment, so a new
+ * handler env read (e.g. GOVERNANCE_UI_BASE_URL) can never be added without
+ * also wiring it on the CDK side.
+ *
+ * `AWS_REGION` is ambient (Lambda always sets it) and allowlisted.
+ */
+import * as fs from "fs";
+import * as path from "path";
+import * as cdk from "aws-cdk-lib";
+import { Template } from "aws-cdk-lib/assertions";
+import * as appsync from "aws-cdk-lib/aws-appsync";
+import * as dynamodb from "aws-cdk-lib/aws-dynamodb";
+import * as events from "aws-cdk-lib/aws-events";
+import * as iam from "aws-cdk-lib/aws-iam";
+import * as sns from "aws-cdk-lib/aws-sns";
+import { Bucket } from "aws-cdk-lib/aws-s3";
+import { scaffoldBackendAssetDirs } from "./helpers/scaffold-stub-assets";
+
+scaffoldBackendAssetDirs(["dist/lambda", "src/schema"]);
+
+import {
+  GovernanceStack,
+  type GovernanceStackProps,
+} from "../lib/governance-stack";
+
+const AMBIENT_ALLOWLIST = new Set(["AWS_REGION"]);
+
+function scanProcessEnvReads(filePath: string): string[] {
+  const source = fs.readFileSync(filePath, "utf8");
+  const re = /process\.env\.([A-Z][A-Z0-9_]*)/g;
+  const found = new Set<string>();
+  let match: RegExpExecArray | null;
+  while ((match = re.exec(source)) !== null) {
+    found.add(match[1]);
+  }
+  return [...found].filter((name) => !AMBIENT_ALLOWLIST.has(name));
+}
+
+function mockTable(
+  scope: cdk.Stack,
+  id: string,
+  tableName: string,
+): dynamodb.Table {
+  return new dynamodb.Table(scope, id, {
+    tableName,
+    partitionKey: { name: `${id}Id`, type: dynamodb.AttributeType.STRING },
+    billingMode: dynamodb.BillingMode.PAY_PER_REQUEST,
+    removalPolicy: cdk.RemovalPolicy.DESTROY,
+  });
+}
+
+function synthGovernanceStack(): Template {
+  const app = new cdk.App();
+  const backendStack = new cdk.Stack(app, "MockBackendStackParity", {
+    env: { account: "123456789012", region: "us-east-1" },
+  });
+
+  const agentEventBus = new events.EventBus(
+    backendStack,
+    "AgentEventBusParity",
+    {
+      eventBusName: "citadel-agents-test-parity",
+    },
+  );
+  const appSyncApi = new appsync.GraphqlApi(backendStack, "MockApiParity", {
+    name: "mock-api-parity",
+    schema: appsync.SchemaFile.fromAsset(
+      path.resolve(__dirname, "../src/schema/schema.graphql"),
+    ),
+  });
+  const accessLogsBucket = new Bucket(backendStack, "AccessLogsBucketParity", {
+    bucketName: "citadel-access-logs-test-parity",
+  });
+  const alarmTopic = new sns.Topic(backendStack, "AlarmTopicParity", {
+    topicName: "citadel-alarms-test-parity",
+  });
+
+  const names = [
+    "Adrs",
+    "AdrReopenAttempts",
+    "ExecutionSpecifications",
+    "InterrogationRounds",
+    "AgentDesignAssessments",
+    "ProgramReviews",
+    "Projects",
+    "EvalSuites",
+    "EvalCases",
+    "EvalRuns",
+    "EvalRunCaseResults",
+    "EvalBaselines",
+    "EvalComparisons",
+    "EvalComparisonConfig",
+    "Executions",
+    "Conversations",
+  ];
+  const t = Object.fromEntries(
+    names.map((n) => [
+      n,
+      mockTable(backendStack, `${n}Parity`, `citadel-${n}-test-parity`),
+    ]),
+  ) as Record<string, dynamodb.Table>;
+
+  const agentReleasesTable = mockTable(
+    backendStack,
+    "AgentReleasesParity",
+    "citadel-agent-releases-test-parity",
+  );
+  const agentReleaseWriterRole = new iam.Role(
+    backendStack,
+    "AgentReleaseWriterRoleParity",
+    { assumedBy: new iam.ServicePrincipal("lambda.amazonaws.com") },
+  );
+  const environmentReleasePointersTable = new dynamodb.Table(
+    backendStack,
+    "EnvironmentReleasePointersTableParity",
+    {
+      tableName: "citadel-environment-release-pointers-test-parity",
+      partitionKey: { name: "orgId", type: dynamodb.AttributeType.STRING },
+      sortKey: {
+        name: "agentTargetId_environment",
+        type: dynamodb.AttributeType.STRING,
+      },
+      billingMode: dynamodb.BillingMode.PAY_PER_REQUEST,
+      removalPolicy: cdk.RemovalPolicy.DESTROY,
+    },
+  );
+  const environmentReleasePointerWriterRole = new iam.Role(
+    backendStack,
+    "EnvironmentReleasePointerWriterRoleParity",
+    { assumedBy: new iam.ServicePrincipal("lambda.amazonaws.com") },
+  );
+  const promotionPolicyConfigTable = mockTable(
+    backendStack,
+    "PromotionPolicyConfigParity",
+    "citadel-promotion-policy-config-test-parity",
+  );
+  const promotionPolicyConfigWriterRole = new iam.Role(
+    backendStack,
+    "PromotionPolicyConfigWriterRoleParity",
+    { assumedBy: new iam.ServicePrincipal("lambda.amazonaws.com") },
+  );
+
+  const props: GovernanceStackProps = {
+    env: { account: "123456789012", region: "us-east-1" },
+    environment: "test",
+    appSyncApi,
+    agentEventBus,
+    accessLogsBucket,
+    adrsTable: t.Adrs,
+    adrReopenAttemptsTable: t.AdrReopenAttempts,
+    executionSpecificationsTable: t.ExecutionSpecifications,
+    interrogationRoundsTable: t.InterrogationRounds,
+    agentDesignAssessmentsTable: t.AgentDesignAssessments,
+    programReviewsTable: t.ProgramReviews,
+    projectsTable: t.Projects,
+    evalSuitesTable: t.EvalSuites,
+    evalCasesTable: t.EvalCases,
+    evalRunsTable: t.EvalRuns,
+    evalRunCaseResultsTable: t.EvalRunCaseResults,
+    evalBaselinesTable: t.EvalBaselines,
+    evalComparisonsTable: t.EvalComparisons,
+    evalComparisonConfigTable: t.EvalComparisonConfig,
+    executionsTable: t.Executions,
+    conversationsTable: t.Conversations,
+    agentReleasesTable,
+    agentReleaseWriterRole,
+    registryArn:
+      "arn:aws:bedrock-agentcore:us-east-1:123456789012:registry/citadel-test",
+    registryId: "citadel-test",
+    environmentReleasePointersTable,
+    environmentReleasePointerWriterRole,
+    promotionPolicyConfigTable,
+    promotionPolicyConfigWriterRole,
+    alarmTopic,
+    governanceUiBaseUrl: "https://ui.example.com",
+  };
+
+  const stack = new GovernanceStack(app, "TestGovernanceStackParity", props);
+  return Template.fromStack(stack);
+}
+
+describe("R14: governance-notifier.ts env-parity — every process.env.X read is set on the function", () => {
+  test("every process.env read in the handler source is present in the synthesized Lambda's Environment.Variables", () => {
+    const handlerPath = path.resolve(
+      __dirname,
+      "../src/lambda/governance-notifier.ts",
+    );
+    const reads = scanProcessEnvReads(handlerPath);
+    expect(reads.length).toBeGreaterThan(0); // sanity: the scan itself works
+
+    const template = synthGovernanceStack();
+    const fns = template.findResources("AWS::Lambda::Function", {
+      Properties: { Handler: "governance-notifier.handler" },
+    });
+    const fnResources = Object.values(fns) as Array<{
+      Properties?: { Environment?: { Variables?: Record<string, unknown> } };
+    }>;
+    const fn = fnResources[0];
+    expect(fn).toBeDefined();
+    const envVars: Record<string, unknown> =
+      fn?.Properties?.Environment?.Variables ?? {};
+
+    for (const read of reads) {
+      expect(envVars).toHaveProperty(read);
+    }
+  });
+
+  test("bite proof: a made-up unset var is correctly reported as missing (predicate actually fires)", () => {
+    const envVars: Record<string, unknown> = { EVENT_BUS_NAME: "x" };
+    expect(envVars).not.toHaveProperty("SOME_MADE_UP_UNSET_VAR");
+  });
+});

--- a/backend/test/governance-stack-agent-release.test.ts
+++ b/backend/test/governance-stack-agent-release.test.ts
@@ -21,6 +21,7 @@ import * as appsync from "aws-cdk-lib/aws-appsync";
 import * as dynamodb from "aws-cdk-lib/aws-dynamodb";
 import * as events from "aws-cdk-lib/aws-events";
 import * as iam from "aws-cdk-lib/aws-iam";
+import * as sns from "aws-cdk-lib/aws-sns";
 import { Bucket } from "aws-cdk-lib/aws-s3";
 import * as path from "path";
 import { scaffoldBackendAssetDirs } from "./helpers/scaffold-stub-assets";
@@ -246,12 +247,17 @@ function createTestStack(): {
     }),
   );
 
+  const alarmTopic = new sns.Topic(backendStack, "AlarmTopic", {
+    topicName: "citadel-alarms-test-agentrelease",
+  });
+
   const stack = new GovernanceStack(app, "TestGovernanceStackAgentRelease", {
     env: { account: "123456789012", region: "us-east-1" },
     environment: "test",
     appSyncApi,
     agentEventBus,
     accessLogsBucket,
+    alarmTopic,
     adrsTable,
     adrReopenAttemptsTable,
     executionSpecificationsTable,

--- a/backend/test/governance-stack-environment-release-pointer-ledger.test.ts
+++ b/backend/test/governance-stack-environment-release-pointer-ledger.test.ts
@@ -30,6 +30,7 @@ import * as appsync from "aws-cdk-lib/aws-appsync";
 import * as dynamodb from "aws-cdk-lib/aws-dynamodb";
 import * as events from "aws-cdk-lib/aws-events";
 import * as iam from "aws-cdk-lib/aws-iam";
+import * as sns from "aws-cdk-lib/aws-sns";
 import { Bucket } from "aws-cdk-lib/aws-s3";
 import * as path from "path";
 import { scaffoldBackendAssetDirs } from "./helpers/scaffold-stub-assets";
@@ -246,6 +247,10 @@ function createTestStack(): {
     }),
   );
 
+  const alarmTopic = new sns.Topic(backendStack, "AlarmTopic", {
+    topicName: "citadel-alarms-test-envpointerledger",
+  });
+
   const stack = new GovernanceStack(
     app,
     "TestGovernanceStackEnvPointerLedger",
@@ -255,6 +260,7 @@ function createTestStack(): {
       appSyncApi,
       agentEventBus,
       accessLogsBucket,
+      alarmTopic,
       adrsTable,
       adrReopenAttemptsTable,
       executionSpecificationsTable,

--- a/backend/test/governance-stack-eval-comparison.test.ts
+++ b/backend/test/governance-stack-eval-comparison.test.ts
@@ -18,6 +18,7 @@ import * as appsync from "aws-cdk-lib/aws-appsync";
 import * as dynamodb from "aws-cdk-lib/aws-dynamodb";
 import * as events from "aws-cdk-lib/aws-events";
 import * as iam from "aws-cdk-lib/aws-iam";
+import * as sns from "aws-cdk-lib/aws-sns";
 import { Bucket } from "aws-cdk-lib/aws-s3";
 import * as path from "path";
 import { scaffoldBackendAssetDirs } from "./helpers/scaffold-stub-assets";
@@ -132,12 +133,17 @@ function createTestStack(): { stack: GovernanceStack; template: Template } {
     }),
   );
 
+  const alarmTopic = new sns.Topic(backendStack, "AlarmTopic", {
+    topicName: "citadel-alarms-test-evalcomparison",
+  });
+
   const stack = new GovernanceStack(app, "TestGovernanceStackEvalComparison", {
     env: { account: "123456789012", region: "us-east-1" },
     environment: "test",
     appSyncApi,
     agentEventBus,
     accessLogsBucket,
+    alarmTopic,
     adrsTable: mockTable(backendStack, "Adrs", "citadel-adrs-test"),
     adrReopenAttemptsTable: mockTable(
       backendStack,

--- a/backend/test/governance-stack-eval-resolver.test.ts
+++ b/backend/test/governance-stack-eval-resolver.test.ts
@@ -22,6 +22,7 @@ import * as appsync from "aws-cdk-lib/aws-appsync";
 import * as dynamodb from "aws-cdk-lib/aws-dynamodb";
 import * as events from "aws-cdk-lib/aws-events";
 import * as iam from "aws-cdk-lib/aws-iam";
+import * as sns from "aws-cdk-lib/aws-sns";
 import { Bucket } from "aws-cdk-lib/aws-s3";
 import * as path from "path";
 import { scaffoldBackendAssetDirs } from "./helpers/scaffold-stub-assets";
@@ -217,12 +218,17 @@ function createTestStack(): { stack: GovernanceStack; template: Template } {
     }),
   );
 
+  const alarmTopic = new sns.Topic(backendStack, "AlarmTopic", {
+    topicName: "citadel-alarms-test-eval",
+  });
+
   const stack = new GovernanceStack(app, "TestGovernanceStackEval", {
     env: { account: "123456789012", region: "us-east-1" },
     environment: "test",
     appSyncApi,
     agentEventBus,
     accessLogsBucket,
+    alarmTopic,
     adrsTable,
     adrReopenAttemptsTable,
     executionSpecificationsTable,

--- a/backend/test/governance-stack-eval-run.test.ts
+++ b/backend/test/governance-stack-eval-run.test.ts
@@ -12,6 +12,7 @@ import * as appsync from "aws-cdk-lib/aws-appsync";
 import * as dynamodb from "aws-cdk-lib/aws-dynamodb";
 import * as events from "aws-cdk-lib/aws-events";
 import * as iam from "aws-cdk-lib/aws-iam";
+import * as sns from "aws-cdk-lib/aws-sns";
 import { Bucket } from "aws-cdk-lib/aws-s3";
 import * as path from "path";
 import { scaffoldBackendAssetDirs } from "./helpers/scaffold-stub-assets";
@@ -196,12 +197,17 @@ function createTestStack(): { stack: GovernanceStack; template: Template } {
     }),
   );
 
+  const alarmTopic = new sns.Topic(backendStack, "AlarmTopic", {
+    topicName: "citadel-alarms-test-evalrun",
+  });
+
   const stack = new GovernanceStack(app, "TestGovernanceStackEvalRun", {
     env: { account: "123456789012", region: "us-east-1" },
     environment: "test",
     appSyncApi,
     agentEventBus,
     accessLogsBucket,
+    alarmTopic,
     adrsTable,
     adrReopenAttemptsTable,
     executionSpecificationsTable,

--- a/backend/test/governance-stack-promotion-policy.test.ts
+++ b/backend/test/governance-stack-promotion-policy.test.ts
@@ -27,6 +27,7 @@ import * as appsync from "aws-cdk-lib/aws-appsync";
 import * as dynamodb from "aws-cdk-lib/aws-dynamodb";
 import * as events from "aws-cdk-lib/aws-events";
 import * as iam from "aws-cdk-lib/aws-iam";
+import * as sns from "aws-cdk-lib/aws-sns";
 import { Bucket } from "aws-cdk-lib/aws-s3";
 import * as path from "path";
 import { scaffoldBackendAssetDirs } from "./helpers/scaffold-stub-assets";
@@ -249,12 +250,17 @@ function createTestStack(): {
   const registryArn =
     "arn:aws:bedrock-agentcore:us-east-1:123456789012:registry/citadel-test";
 
+  const alarmTopic = new sns.Topic(backendStack, "AlarmTopic", {
+    topicName: "citadel-alarms-test-promotionpolicy",
+  });
+
   const stack = new GovernanceStack(app, "TestGovernanceStackPromotionPolicy", {
     env: { account: "123456789012", region: "us-east-1" },
     environment: "test",
     appSyncApi,
     agentEventBus,
     accessLogsBucket,
+    alarmTopic,
     adrsTable,
     adrReopenAttemptsTable,
     executionSpecificationsTable,


### PR DESCRIPTION
## Summary

The governance notifier relayed governance.* events only to an AppSync WebSocket subscription. With no admin VI session open it fanned out to zero connections and reported success - an event was "notified" to nobody and nothing recorded that it went unseen. Auto-rollback findings, breaker changes and off-frontier escalations all depended on that channel.

- CRITICAL events now also publish to the plaintext citadel-alarms topic, which already has confirmed subscribers - no new channel, no KMS grant needed
- Message body is whitelist-projected (detail type, org, correlation/run id, deep link); raw event.detail is never published
- Every attempt writes an outcome row to a new governance-notification-outcomes table (PK eventId, idempotent, 90-day TTL), so an undelivered event is queryable instead of silently successful
- Fail-closed asymmetry, deliberate and connented: WebSocket failure throws as before; a CRITICAL SNS failure throws so the notifier DIQ and its (now subscribed) alarm catch it; an outcome-row write failure degrades with a Cloudwatch metric rather than causing duplicate pages on retry
- alarmTopic is now a required prop, so reverting to WebSocket-only fails a test 

## Also fixes a routing gap found during design 

`GovernanceEventsRule` never routed `governance.release.auto_rollback`, so those events had no delivery path at all - not merely an ephemeral one. Added to the rule, with a lock-step test asserting every type the notifier claims to relay appears in both the detail-type list and the rule pattern.

## Testing

- 15 red-first tests (R1-R15) covering the design's acceptance points
- Behavioural proofs: SNS rejection on a CRITICAL event throws (retries via DLQ) and never reports success; outcome-row failure emits the metric without throwing; a secret-shaped field is absent from the published message; the same eventId twice yields one row
- Bite proofs: removing a type from the rule goes red; dropping the SNS destination fails the WebSocket-only regression guard
- IAM checked from synthesized templates: scoped sns:Publish, PutItem-only, namespace-conditioned PutMetricData, no KMS grant  
- tsc, lint, full backend jest (462 suites / 7003 tests), cdk synth --all, npm run split:gates - all exit o

## Notes

- Circuit-breaker state changes emit no governance.* detail type at all (ledger-only), so they are deliberately excluded rather than inventing one - breaker trips still do not page. Worth a follow-up decision.
- Includes a cdk-nag suppression for the namespace-conditioned PutMetricData grant, following the existing arbiter-stack precedent.
- New table lives in GovernanceStack, so the backend split-gates baseline is unaffected (confirmed by a full split:gates run).