### PR TITLE
feat(workflow): optional per-node compensation block in the contract

### DIFF
--- a/arbiter/common/__tests__/test_workflow_contract.py
+++ b/arbiter/common/__tests__/test_workflow_contract.py
@@ -727,3 +727,363 @@ class TestNodeResultDetailQueueWaitTimestampsAdditive:
         parsed = parse_node_result_detail(detail)
         assert parsed.dispatched_at is None
         assert parsed.worker_started_at is None
+
+
+# --- Compensation block (CIT-123 slice 1: data only, no executor behaviour) --
+#
+# An optional, additive per-node ``compensation`` block: ``{tool, args,
+# sideEffecting?}``. Validated via ``normalize_compensation_block``. A node
+# with no ``compensation`` key must behave and serialize byte-identically to
+# today. See ``COMPENSATION_TRIGGER_DEFAULTS`` / ``COMPENSATION_ON_FAILURE_DEFAULT``
+# below for the workflow-level policy defaults (owner call, provisional).
+
+
+class TestNormalizeCompensationBlock:
+    """Red-first unit tests for the pure per-node compensation validator."""
+
+    def test_absent_block_returns_none(self):
+        from common.workflow_contract import normalize_compensation_block
+
+        assert normalize_compensation_block({'id': 'n1', 'agentId': 'a1'}) is None
+
+    def test_none_block_returns_none(self):
+        from common.workflow_contract import normalize_compensation_block
+
+        assert normalize_compensation_block({'id': 'n1', 'compensation': None}) is None
+
+    def test_valid_block_roundtrips_with_defaults(self):
+        from common.workflow_contract import normalize_compensation_block
+
+        node = {
+            'id': 'n1',
+            'compensation': {
+                'tool': 'close_ticket',
+                'args': {'ticketId': '${output.ticketId}'},
+            },
+        }
+        result = normalize_compensation_block(node)
+        assert result == {
+            'tool': 'close_ticket',
+            'args': {'ticketId': '${output.ticketId}'},
+            'sideEffecting': True,
+        }
+
+    def test_valid_block_preserves_explicit_side_effecting_false(self):
+        from common.workflow_contract import normalize_compensation_block
+
+        node = {
+            'compensation': {
+                'tool': 'noop',
+                'args': {},
+                'sideEffecting': False,
+            }
+        }
+        result = normalize_compensation_block(node)
+        assert result == {'tool': 'noop', 'args': {}, 'sideEffecting': False}
+
+    def test_missing_tool_raises(self):
+        from common.workflow_contract import normalize_compensation_block
+
+        with pytest.raises(ValueError, match="'tool'"):
+            normalize_compensation_block({'compensation': {'args': {}}})
+
+    def test_empty_tool_raises(self):
+        from common.workflow_contract import normalize_compensation_block
+
+        with pytest.raises(ValueError, match="'tool'"):
+            normalize_compensation_block({'compensation': {'tool': '', 'args': {}}})
+
+    def test_non_string_tool_raises(self):
+        from common.workflow_contract import normalize_compensation_block
+
+        with pytest.raises(ValueError, match="'tool'"):
+            normalize_compensation_block({'compensation': {'tool': 123, 'args': {}}})
+
+    def test_missing_args_raises(self):
+        from common.workflow_contract import normalize_compensation_block
+
+        with pytest.raises(ValueError, match="'args'"):
+            normalize_compensation_block({'compensation': {'tool': 'close_ticket'}})
+
+    def test_non_object_args_raises(self):
+        from common.workflow_contract import normalize_compensation_block
+
+        with pytest.raises(ValueError, match="'args'"):
+            normalize_compensation_block(
+                {'compensation': {'tool': 'close_ticket', 'args': 'not-a-dict'}}
+            )
+
+    def test_non_object_compensation_block_raises(self):
+        from common.workflow_contract import normalize_compensation_block
+
+        with pytest.raises(ValueError, match='compensation'):
+            normalize_compensation_block({'compensation': 'not-a-dict'})
+
+    def test_unknown_key_raises(self):
+        from common.workflow_contract import normalize_compensation_block
+
+        with pytest.raises(ValueError, match='unknown'):
+            normalize_compensation_block(
+                {
+                    'compensation': {
+                        'tool': 'close_ticket',
+                        'args': {},
+                        'bogusKey': True,
+                    }
+                }
+            )
+
+    def test_non_bool_side_effecting_raises(self):
+        from common.workflow_contract import normalize_compensation_block
+
+        with pytest.raises(ValueError, match="'sideEffecting'"):
+            normalize_compensation_block(
+                {'compensation': {'tool': 'close_ticket', 'args': {}, 'sideEffecting': 'yes'}}
+            )
+
+    def test_node_not_a_dict_raises(self):
+        from common.workflow_contract import normalize_compensation_block
+
+        with pytest.raises(ValueError):
+            normalize_compensation_block('not-a-dict')  # type: ignore[arg-type]
+
+    # --- template-syntax validation at parse time (renderer is slice 2) -----
+    # Only syntactic well-formedness of ``${output....}`` tokens is checked
+    # here: balanced ``${`` / ``}``, and (when present) the token body must
+    # start with ``output`` followed only by ``.<identifier>`` or
+    # ``[<int>]`` segments. Resolving the reference against a recorded
+    # output is explicitly out of scope (slice 2).
+
+    def test_template_syntax_valid_nested_path_accepted(self):
+        from common.workflow_contract import normalize_compensation_block
+
+        node = {
+            'compensation': {
+                'tool': 'close_ticket',
+                'args': {'id': '${output.ticket.id}'},
+            }
+        }
+        result = normalize_compensation_block(node)
+        assert result['args'] == {'id': '${output.ticket.id}'}
+
+    def test_template_syntax_valid_array_index_accepted(self):
+        from common.workflow_contract import normalize_compensation_block
+
+        node = {
+            'compensation': {
+                'tool': 'close_ticket',
+                'args': {'id': '${output.tickets[0].id}'},
+            }
+        }
+        normalize_compensation_block(node)  # must not raise
+
+    def test_template_syntax_plain_string_without_tokens_accepted(self):
+        from common.workflow_contract import normalize_compensation_block
+
+        node = {
+            'compensation': {
+                'tool': 'close_ticket',
+                'args': {'reason': 'manual rollback, no template here'},
+            }
+        }
+        normalize_compensation_block(node)  # must not raise
+
+    def test_template_syntax_unbalanced_brace_raises(self):
+        from common.workflow_contract import normalize_compensation_block
+
+        node = {
+            'compensation': {
+                'tool': 'close_ticket',
+                'args': {'id': '${output.ticketId'},
+            }
+        }
+        with pytest.raises(ValueError, match='template'):
+            normalize_compensation_block(node)
+
+    def test_template_syntax_wrong_root_raises(self):
+        from common.workflow_contract import normalize_compensation_block
+
+        node = {
+            'compensation': {
+                'tool': 'close_ticket',
+                'args': {'id': '${input.ticketId}'},
+            }
+        }
+        with pytest.raises(ValueError, match='template'):
+            normalize_compensation_block(node)
+
+    def test_template_syntax_empty_token_raises(self):
+        from common.workflow_contract import normalize_compensation_block
+
+        node = {
+            'compensation': {
+                'tool': 'close_ticket',
+                'args': {'id': '${}'},
+            }
+        }
+        with pytest.raises(ValueError, match='template'):
+            normalize_compensation_block(node)
+
+    def test_template_syntax_checked_recursively_in_nested_args(self):
+        from common.workflow_contract import normalize_compensation_block
+
+        node = {
+            'compensation': {
+                'tool': 'close_ticket',
+                'args': {'nested': {'deep': ['${output.foo}', '${bad syntax']}},
+            }
+        }
+        with pytest.raises(ValueError, match='template'):
+            normalize_compensation_block(node)
+
+    def test_template_syntax_eval_gadget_string_is_inert_literal_not_rejected(self):
+        # Per D4: no eval/format; a gadget-shaped literal that isn't a
+        # well-formed ${output...} token is just an ordinary string value —
+        # NOT a template reference — so it is accepted, not executed.
+        from common.workflow_contract import normalize_compensation_block
+
+        node = {
+            'compensation': {
+                'tool': 'close_ticket',
+                'args': {'payload': '{0.__class__.__mro__}'},
+            }
+        }
+        normalize_compensation_block(node)  # must not raise
+
+
+# --- Absent-block equivalence (byte-identical when no compensation block) ---
+
+
+class TestCompensationAbsentEquivalence:
+    """A workflow/node with no ``compensation`` key must be byte-identical
+    (dispatch message + serialization) to pre-feature behaviour."""
+
+    def test_build_node_dispatch_message_unaffected_by_compensation_feature(self):
+        # No compensation kwarg exists on the dispatch builder (slice 1 keeps
+        # the wire dispatch message untouched per the design note) — this
+        # pins that the dispatch message shape is unchanged.
+        message = build_node_dispatch_message(
+            execution_id='exec-1',
+            node_id='node-1',
+            workflow_id='wf-1',
+            agent_id='agent-1',
+        )
+        assert message == {
+            'message_type': MESSAGE_TYPE_WORKFLOW_NODE,
+            'execution_id': 'exec-1',
+            'node_id': 'node-1',
+            'workflow_id': 'wf-1',
+            'agent_id': 'agent-1',
+            'input': {},
+            'configuration': {},
+        }
+
+    @given(
+        node_dict=st.fixed_dictionaries(
+            {
+                'id': _ids,
+                'agentId': _ids,
+            }
+        )
+    )
+    def test_normalize_compensation_block_is_none_for_any_node_without_the_key(
+        self, node_dict: dict
+    ):
+        from common.workflow_contract import normalize_compensation_block
+
+        # Property: for any node dict that does not carry a 'compensation'
+        # key, the normalizer is a no-op (returns None) regardless of what
+        # other keys/values the node carries.
+        before = json.dumps(node_dict, sort_keys=True)
+        assert normalize_compensation_block(node_dict) is None
+        after = json.dumps(node_dict, sort_keys=True)
+        assert before == after  # normalizer must not mutate its input
+
+
+# --- Workflow-level compensation policy defaults (owner call, provisional) --
+
+
+class TestCompensationPolicyDefaults:
+    """The workflow-level opt-in/policy surface: conservative defaults,
+    declared in one place so the (still-open) owner decision is a one-line
+    change. See the module-level comment above the constants for rationale.
+    """
+
+    def test_defaults_module_constants_exist_and_are_conservative(self):
+        from common.workflow_contract import (
+            COMPENSATION_ON_FAILURE_DEFAULT,
+            COMPENSATION_TRIGGER_MIN_COMPLETED_NODES_DEFAULT,
+            COMPENSATION_TRIGGER_MODE_DEFAULT,
+        )
+
+        # Conservative: disabled unless explicitly opted in.
+        assert COMPENSATION_TRIGGER_MODE_DEFAULT == 'off'
+        assert COMPENSATION_TRIGGER_MIN_COMPLETED_NODES_DEFAULT == 0
+        # Conservative: stop rather than best-effort continue on failure.
+        assert COMPENSATION_ON_FAILURE_DEFAULT == 'stop'
+
+    def test_normalize_compensation_policy_applies_defaults_when_absent(self):
+        from common.workflow_contract import normalize_compensation_policy
+
+        assert normalize_compensation_policy(None) == {
+            'enabled': False,
+            'trigger': {'mode': 'off', 'minCompletedNodes': 0},
+            'onFailure': 'stop',
+        }
+        assert normalize_compensation_policy({}) == {
+            'enabled': False,
+            'trigger': {'mode': 'off', 'minCompletedNodes': 0},
+            'onFailure': 'stop',
+        }
+
+    def test_normalize_compensation_policy_roundtrips_explicit_values(self):
+        from common.workflow_contract import normalize_compensation_policy
+
+        policy = {
+            'enabled': True,
+            'trigger': {'mode': 'on_terminal_failure', 'minCompletedNodes': 2},
+            'onFailure': 'continue',
+        }
+        assert normalize_compensation_policy(policy) == policy
+
+    def test_normalize_compensation_policy_rejects_unknown_top_level_key(self):
+        from common.workflow_contract import normalize_compensation_policy
+
+        with pytest.raises(ValueError, match='unknown'):
+            normalize_compensation_policy({'enabled': True, 'bogus': 1})
+
+    def test_normalize_compensation_policy_rejects_unknown_trigger_key(self):
+        from common.workflow_contract import normalize_compensation_policy
+
+        with pytest.raises(ValueError, match='unknown'):
+            normalize_compensation_policy({'trigger': {'mode': 'off', 'bogus': 1}})
+
+    def test_normalize_compensation_policy_rejects_bad_trigger_mode(self):
+        from common.workflow_contract import normalize_compensation_policy
+
+        with pytest.raises(ValueError, match='mode'):
+            normalize_compensation_policy({'trigger': {'mode': 'sometimes'}})
+
+    def test_normalize_compensation_policy_rejects_negative_min_completed_nodes(self):
+        from common.workflow_contract import normalize_compensation_policy
+
+        with pytest.raises(ValueError, match='minCompletedNodes'):
+            normalize_compensation_policy({'trigger': {'minCompletedNodes': -1}})
+
+    def test_normalize_compensation_policy_rejects_bad_on_failure(self):
+        from common.workflow_contract import normalize_compensation_policy
+
+        with pytest.raises(ValueError, match='onFailure'):
+            normalize_compensation_policy({'onFailure': 'retry'})
+
+    def test_normalize_compensation_policy_rejects_non_bool_enabled(self):
+        from common.workflow_contract import normalize_compensation_policy
+
+        with pytest.raises(ValueError, match='enabled'):
+            normalize_compensation_policy({'enabled': 'yes'})
+
+    def test_normalize_compensation_policy_rejects_non_object_policy(self):
+        from common.workflow_contract import normalize_compensation_policy
+
+        with pytest.raises(ValueError, match='compensation'):
+            normalize_compensation_policy('not-a-dict')  # type: ignore[arg-type]

--- a/arbiter/common/workflow_contract.py
+++ b/arbiter/common/workflow_contract.py
@@ -32,6 +32,7 @@ timestamp, which callers may supply explicitly for full determinism.
 """
 from __future__ import annotations
 
+import re
 from dataclasses import dataclass, field
 from datetime import datetime, timezone
 from typing import Any, Optional
@@ -61,6 +62,221 @@ MESSAGE_TYPE_WORKFLOW_NODE = 'workflow_node'
 STATUS_COMPLETED = 'completed'
 STATUS_FAILED = 'failed'
 _VALID_STATUSES = (STATUS_COMPLETED, STATUS_FAILED)
+
+
+# --- Compensation contract (CIT-123 slice 1: data only) ----------------------
+#
+# DATA ONLY. This section declares the optional per-node ``compensation``
+# block and the workflow-level compensation policy shape. It intentionally
+# contains NO executor/worker/dispatch behaviour — see the CIT-123 design
+# (slices 2-5) for the template renderer, unwind orchestration, governed
+# execution, and sink/UI. A node or workflow with no compensation data is
+# byte-identical to pre-feature behaviour: nothing in this module is read by
+# any existing code path yet, and none of the existing dispatch/result
+# builders above are touched.
+#
+# ---------------------------------------------------------------------------
+# OWNER-DECISION DEFAULTS (still open — see CIT-123 design ยง4 "Owner-call
+# summary"). Every default below is deliberately conservative (opt-in / stop
+# on failure) and is declared ONCE, here, so changing an owner's ruling later
+# is a one-line edit in this block rather than a search across call sites.
+# Do not duplicate these literals elsewhere; import the constants.
+# ---------------------------------------------------------------------------
+
+# Workflow-level trigger mode: 'off' (compensation never fires) or
+# 'on_terminal_failure' (fires once, at the no-retry terminal-fail branch).
+# PROVISIONAL DEFAULT: 'off' — compensation is inert until a workflow opts in.
+COMPENSATION_TRIGGER_MODE_DEFAULT = 'off'
+_VALID_COMPENSATION_TRIGGER_MODES = ('off', 'on_terminal_failure')
+
+# Minimum number of completed, side-effecting, compensation-bearing nodes
+# required before an unwind is worth running at all.
+# PROVISIONAL DEFAULT: 0 (always unwind when enabled) — some owners may
+# prefer 1 to skip a no-op unwind ceremony on an early failure.
+COMPENSATION_TRIGGER_MIN_COMPLETED_NODES_DEFAULT = 0
+
+# Behaviour when a single compensation step itself fails mid-unwind:
+# 'stop' (halt the remaining unwind) or 'continue' (best-effort, keep going).
+# PROVISIONAL DEFAULT: 'stop' — later compensations may depend on earlier
+# ones having rolled back; continuing blindly risks a worse inconsistent
+# state. See CIT-123 design D5.
+COMPENSATION_ON_FAILURE_DEFAULT = 'stop'
+_VALID_COMPENSATION_ON_FAILURE = ('stop', 'continue')
+
+# --- Template syntax (D4): restricted ${output.<path>} grammar --------------
+#
+# Slice 1 validates SYNTAX ONLY at parse/normalize time — no resolution
+# against a recorded output (that is the slice-2 renderer). The grammar is a
+# root token ``output`` followed by zero or more ``.<identifier>`` or
+# ``[<int>]`` segments. No function calls, arithmetic, or arbitrary attribute
+# access — this is intentionally NOT eval/format/jinja-compatible so
+# injection-gadget shapes (e.g. ``{0.__class__.__mro__}``) are just inert
+# non-matching literals, never executed.
+_TEMPLATE_TOKEN_RE = re.compile(r'\$\{([^{}]*)\}')
+_TEMPLATE_PATH_RE = re.compile(r'^output(?:\.[A-Za-z_][A-Za-z0-9_]*|\[\d+\])*$')
+
+
+def _validate_template_syntax(value: Any, *, path: str) -> None:
+    """Recursively validate ``${output...}`` token syntax in *value*.
+
+    Only string leaves are inspected; a string is scanned for every
+    ``${...}`` token and each token body must match the restricted
+    ``output`` path grammar. Raises ``ValueError`` (mentioning 'template')
+    on any malformed token. Non-token text (including gadget-shaped
+    literals that are not well-formed ``${...}`` tokens) is left untouched.
+    """
+    if isinstance(value, str):
+        for match in _TEMPLATE_TOKEN_RE.finditer(value):
+            token_body = match.group(1)
+            if not _TEMPLATE_PATH_RE.match(token_body):
+                raise ValueError(
+                    "compensation args: malformed template reference "
+                    f"'${{{token_body}}}' at {path} — expected "
+                    "'output', 'output.<key>', or 'output[<index>]' segments"
+                )
+        # An unmatched literal '${' or stray '}' with no balanced pair is
+        # also malformed template syntax.
+        if value.count('${') != len(list(_TEMPLATE_TOKEN_RE.finditer(value))):
+            raise ValueError(
+                f"compensation args: unbalanced template braces in value at {path}"
+            )
+    elif isinstance(value, dict):
+        for key, nested in value.items():
+            _validate_template_syntax(nested, path=f'{path}.{key}')
+    elif isinstance(value, list):
+        for index, nested in enumerate(value):
+            _validate_template_syntax(nested, path=f'{path}[{index}]')
+    # Other scalar types (int, float, bool, None) carry no template syntax.
+
+
+_COMPENSATION_BLOCK_KEYS = ('tool', 'args', 'sideEffecting')
+
+
+def normalize_compensation_block(node: dict) -> Optional[dict]:
+    """Validate and normalize a node definition's optional ``compensation``
+    block.
+
+    Returns ``None`` when *node* carries no (or a ``None``) ``compensation``
+    key — this is the byte-identical-when-absent path. Returns
+    ``{'tool': str, 'args': dict, 'sideEffecting': bool}`` (defaulting
+    ``sideEffecting`` to ``True``) when a well-formed block is present.
+
+    Raises ``ValueError`` — loudly, never silently coerced — when the block
+    is present but malformed: not an object, an unknown key, a missing/empty
+    ``tool``, a non-object ``args``, a non-bool ``sideEffecting``, or a
+    template-syntax error inside ``args`` (see ``_validate_template_syntax``).
+
+    DATA ONLY: this function performs no I/O, no template resolution, and is
+    not called from any executor/worker/dispatch path in this slice.
+    """
+    if not isinstance(node, dict):
+        raise ValueError("compensation block: node definition must be an object")
+
+    block = node.get('compensation')
+    if block is None:
+        return None
+
+    if not isinstance(block, dict):
+        raise ValueError("compensation block: 'compensation' must be an object when present")
+
+    unknown_keys = set(block.keys()) - set(_COMPENSATION_BLOCK_KEYS)
+    if unknown_keys:
+        raise ValueError(
+            f"compensation block: unknown key(s) {sorted(unknown_keys)}; "
+            f"allowed keys are {_COMPENSATION_BLOCK_KEYS}"
+        )
+
+    tool = block.get('tool')
+    if not isinstance(tool, str) or tool == '':
+        raise ValueError("compensation block: field 'tool' is required and must be a non-empty string")
+
+    args = block.get('args')
+    if not isinstance(args, dict):
+        raise ValueError("compensation block: field 'args' is required and must be an object")
+    _validate_template_syntax(args, path='args')
+
+    side_effecting = block.get('sideEffecting', True)
+    if not isinstance(side_effecting, bool):
+        raise ValueError("compensation block: field 'sideEffecting' must be a boolean when present")
+
+    return {'tool': tool, 'args': args, 'sideEffecting': side_effecting}
+
+
+_COMPENSATION_POLICY_KEYS = ('enabled', 'trigger', 'onFailure')
+_COMPENSATION_TRIGGER_KEYS = ('mode', 'minCompletedNodes')
+
+
+def normalize_compensation_policy(policy: Optional[dict]) -> dict:
+    """Validate and normalize a workflow-level compensation policy block.
+
+    Applies the conservative provisional defaults declared above for any
+    absent field. Accepts ``None`` (workflow carries no compensation policy
+    at all) and returns the fully-defaulted, all-disabled shape — this is
+    the byte-identical-when-absent path for the workflow-level policy.
+
+    Raises ``ValueError`` — loudly — on an unknown top-level or nested
+    ``trigger`` key, a non-bool ``enabled``, an invalid ``trigger.mode``, a
+    negative ``trigger.minCompletedNodes``, or an invalid ``onFailure``.
+
+    DATA ONLY: no trigger evaluation, no executor wiring in this slice.
+    """
+    if policy is None:
+        policy = {}
+    if not isinstance(policy, dict):
+        raise ValueError("compensation policy: 'compensation' policy must be an object")
+
+    unknown_keys = set(policy.keys()) - set(_COMPENSATION_POLICY_KEYS)
+    if unknown_keys:
+        raise ValueError(
+            f"compensation policy: unknown key(s) {sorted(unknown_keys)}; "
+            f"allowed keys are {_COMPENSATION_POLICY_KEYS}"
+        )
+
+    enabled = policy.get('enabled', False)
+    if not isinstance(enabled, bool):
+        raise ValueError("compensation policy: field 'enabled' must be a boolean")
+
+    trigger = policy.get('trigger', {})
+    if not isinstance(trigger, dict):
+        raise ValueError("compensation policy: field 'trigger' must be an object")
+    unknown_trigger_keys = set(trigger.keys()) - set(_COMPENSATION_TRIGGER_KEYS)
+    if unknown_trigger_keys:
+        raise ValueError(
+            f"compensation policy: unknown trigger key(s) {sorted(unknown_trigger_keys)}; "
+            f"allowed keys are {_COMPENSATION_TRIGGER_KEYS}"
+        )
+
+    mode = trigger.get('mode', COMPENSATION_TRIGGER_MODE_DEFAULT)
+    if mode not in _VALID_COMPENSATION_TRIGGER_MODES:
+        raise ValueError(
+            f"compensation policy: trigger 'mode' must be one of "
+            f"{_VALID_COMPENSATION_TRIGGER_MODES}, got {mode!r}"
+        )
+
+    min_completed_nodes = trigger.get(
+        'minCompletedNodes', COMPENSATION_TRIGGER_MIN_COMPLETED_NODES_DEFAULT
+    )
+    if (
+        not isinstance(min_completed_nodes, int)
+        or isinstance(min_completed_nodes, bool)
+        or min_completed_nodes < 0
+    ):
+        raise ValueError(
+            "compensation policy: trigger 'minCompletedNodes' must be a non-negative int"
+        )
+
+    on_failure = policy.get('onFailure', COMPENSATION_ON_FAILURE_DEFAULT)
+    if on_failure not in _VALID_COMPENSATION_ON_FAILURE:
+        raise ValueError(
+            f"compensation policy: 'onFailure' must be one of "
+            f"{_VALID_COMPENSATION_ON_FAILURE}, got {on_failure!r}"
+        )
+
+    return {
+        'enabled': enabled,
+        'trigger': {'mode': mode, 'minCompletedNodes': min_completed_nodes},
+        'onFailure': on_failure,
+    }
 
 
 # --- Typed structures --------------------------------------------------------

--- a/frontend/src/types/__tests__/workflow.compensation.test.ts
+++ b/frontend/src/types/__tests__/workflow.compensation.test.ts
@@ -1,0 +1,92 @@
+/**
+ * CIT-123 slice 1 (data/type only): optional per-node `compensation` block.
+ *
+ * Covers the TS type guard `isCompensationBlock` and the extension of
+ * `isWorkflowNodeDefinition` to accept an optional, well-formed
+ * `compensation` block and reject a malformed one. No renderer/executor
+ * behaviour — template syntax validation lives on the Python side
+ * (`normalize_compensation_block` in arbiter/common/workflow_contract.py).
+ */
+import {
+  isCompensationBlock,
+  isWorkflowNodeDefinition,
+  type WorkflowNodeDefinition,
+} from '../workflow';
+
+const baseNode = {
+  id: 'node-1',
+  agentId: 'agent-1',
+  position: { x: 0, y: 0 },
+  configuration: {},
+};
+
+describe('isCompensationBlock', () => {
+  it('accepts a well-formed block with tool + args', () => {
+    expect(
+      isCompensationBlock({ tool: 'close_ticket', args: { ticketId: '${output.ticketId}' } })
+    ).toBe(true);
+  });
+
+  it('accepts an explicit sideEffecting boolean', () => {
+    expect(isCompensationBlock({ tool: 'noop', args: {}, sideEffecting: false })).toBe(true);
+  });
+
+  it('rejects a missing tool', () => {
+    expect(isCompensationBlock({ args: {} })).toBe(false);
+  });
+
+  it('rejects an empty-string tool', () => {
+    expect(isCompensationBlock({ tool: '', args: {} })).toBe(false);
+  });
+
+  it('rejects a non-string tool', () => {
+    expect(isCompensationBlock({ tool: 123, args: {} })).toBe(false);
+  });
+
+  it('rejects a missing args', () => {
+    expect(isCompensationBlock({ tool: 'close_ticket' })).toBe(false);
+  });
+
+  it('rejects a non-object args', () => {
+    expect(isCompensationBlock({ tool: 'close_ticket', args: 'nope' })).toBe(false);
+  });
+
+  it('rejects an array args', () => {
+    expect(isCompensationBlock({ tool: 'close_ticket', args: [] })).toBe(false);
+  });
+
+  it('rejects a non-boolean sideEffecting', () => {
+    expect(isCompensationBlock({ tool: 'close_ticket', args: {}, sideEffecting: 'yes' })).toBe(
+      false
+    );
+  });
+
+  it('rejects null and non-objects', () => {
+    expect(isCompensationBlock(null)).toBe(false);
+    expect(isCompensationBlock('not-an-object')).toBe(false);
+  });
+});
+
+describe('isWorkflowNodeDefinition with optional compensation', () => {
+  it('accepts a node with no compensation key (absent-block equivalence)', () => {
+    expect(isWorkflowNodeDefinition(baseNode)).toBe(true);
+  });
+
+  it('accepts a node with a well-formed compensation block', () => {
+    const node: WorkflowNodeDefinition = {
+      ...baseNode,
+      compensation: { tool: 'close_ticket', args: { ticketId: '${output.ticketId}' } },
+    };
+    expect(isWorkflowNodeDefinition(node)).toBe(true);
+  });
+
+  it('rejects a node whose compensation block is malformed', () => {
+    const node = { ...baseNode, compensation: { args: {} } };
+    expect(isWorkflowNodeDefinition(node)).toBe(false);
+  });
+
+  it('rejects a node whose compensation block is not an object', () => {
+    const node = { ...baseNode, compensation: 'not-a-block' };
+    expect(isWorkflowNodeDefinition(node)).toBe(false);
+  });
+});

--- a/frontend/src/types/workflow.ts
+++ b/frontend/src/types/workflow.ts
@@ -93,6 +93,21 @@ export interface NodeResult {
 }
 
 /**
+ * Optional per-node compensation action (CIT-123 slice 1: data/type only).
+ *
+ * DATA ONLY — no renderer/executor behaviour is implied by this type. `args`
+ * may contain `${output.<path>}` template references; syntax (not
+ * resolution) is validated on the Python side by
+ * `normalize_compensation_block` in `arbiter/common/workflow_contract.py`.
+ * `sideEffecting` defaults to `true` when omitted.
+ */
+export interface CompensationBlock {
+  tool: string;
+  args: Record<string, unknown>;
+  sideEffecting?: boolean;
+}
+
+/**
  * Simplified node definition for serialization
  */
 export interface WorkflowNodeDefinition {
@@ -107,6 +122,8 @@ export interface WorkflowNodeDefinition {
   position: { x: number; y: number };
   configuration: Record<string, any>;
   retryPolicy?: RetryPolicy;
+  /** Optional per-node compensation action. See `CompensationBlock`. */
+  compensation?: CompensationBlock;
 }
 
 /**
@@ -222,6 +239,23 @@ export function isWorkflowEdge(edge: any): edge is WorkflowEdge {
 }
 
 /**
+ * Type guard to check if a value is a CompensationBlock.
+ * Slice 1 (data/type only): validates shape, not template resolution.
+ */
+export function isCompensationBlock(value: any): value is CompensationBlock {
+  return (
+    value !== null &&
+    typeof value === 'object' &&
+    typeof value.tool === 'string' &&
+    value.tool !== '' &&
+    value.args !== null &&
+    typeof value.args === 'object' &&
+    !Array.isArray(value.args) &&
+    (value.sideEffecting === undefined || typeof value.sideEffecting === 'boolean')
+  );
+}
+
+/**
  * Type guard to check if a value is a WorkflowNodeDefinition
  */
 export function isWorkflowNodeDefinition(node: any): node is WorkflowNodeDefinition {
@@ -234,7 +268,8 @@ export function isWorkflowNodeDefinition(node: any): node is WorkflowNodeDefinit
     typeof node.position === 'object' &&
     typeof node.position.x === 'number' &&
     typeof node.position.y === 'number' &&
-    typeof node.configuration === 'object'
+    typeof node.configuration === 'object' &&
+    (node.compensation === undefined || isCompensationBlock(node.compensation))
   );
 }
 


### PR DESCRIPTION
## Summary

First slice of compensation actions for partial workflows. Data and schema only: declares the shape, validates it strictly, and changes no runtime behaviour. No executor, worker, CDK or UI changes.
- Optional per-node `compensation` block: `{ tool, args, sideEffecting? }` I, where
args may reference the node's recorded output via a restricted `$ (output. <path>}` template syntax
- Workflow-level policy: `{enabled, trigger: { mode, minCompletediodes, onFailure }`
- Validation fails loudly and names the offending field: unknown keys, missing or empty tool, non-object args, non-boolean sideEffecting, malformed templates
- Template handling is syntax validation only - regex, no eval, no format, no jinja, no substitution. Gadget-shaped strings such as `${output._class_}` are inert literals and rejected as malformed tokens, not evaluated
- TypeScript mirror is a type plus guards; no resolver or serialization behaviour

## Behaviour is unchanged for existing workflows

A workflow with no compensation block validates and serializes byte-identically to before, asserted by a property test. The node dispatch wire shape is deliberately untouched - forwarding compensation over the wire belongs to a later slice.

## Provisional defaults

`trigger mode='off'`, `minCompletedNodes=0`, `onFailure='stop'` - conservative (opt-in, halt on failure) and isolated in one named-constant block marked PROVISIONAL, because the trigger point and failure policy are still open owner decisions. Changing them later is a one-place edit.

## Testing

- 33 red-first pytest cases (round-trip, absent-block equivalence, every rejection path, template accept/reject) plus 14 frontend guard tests
- Scoped pytest 121 passed; full arbiter pytest 1692 passed with pre-existing failures proven identical on main via a clean worktree; tsc clean

## Notes

- Deliberately no renderer: evaluating templates against recorded output is the next slice, so nothing here can dereference an output yet
- Remaining slices: args renderer, executor unwind orchestration, worker governed execution, then interim failure sink plus UI, docs and end-to-end acceptance