### PR TITLE
feat(stepRunner): reverse-topological compensation unwind orchestration

### DIFF
--- a/arbiter/common/workflow_contract.py
+++ b/arbiter/common/workflow_contract.py
@@ -470,6 +470,101 @@ def is_workflow_node_message(body: Any) -> bool:
     return isinstance(body, dict) and body.get('message_type') == MESSAGE_TYPE_WORKFLOW_NODE
 
 
+# --- Compensation dispatch message (CIT-123 slice 3) ------------------------
+#
+# A SEPARATE discriminator from MESSAGE_TYPE_WORKFLOW_NODE — the worker-side
+# governed execution path (slice 4) does not exist yet, so this message type
+# is currently inert: nothing in the deployed worker recognises
+# 'workflow_compensation' today, and slice 3 dispatches it only when a
+# workflow has explicitly opted in (workflow_contract.normalize_compensation_
+# policy().enabled). Per design D2/D4, the ``args`` on this message are the
+# RAW, UNRESOLVED compensation template (e.g. '${output.id}') — rendering
+# against the compensating node's recorded output happens worker-side in
+# slice 4 (the slice-2 renderer module is deliberately NOT imported here).
+MESSAGE_TYPE_WORKFLOW_COMPENSATION = 'workflow_compensation'
+
+
+def build_compensation_dispatch_message(
+    *,
+    execution_id: str,
+    node_id: str,
+    workflow_id: str,
+    tool: str,
+    args: Optional[dict[str, Any]] = None,
+    compensation_generation: Optional[int] = None,
+    dispatched_at: Optional[str] = None,
+    run_id: Optional[str] = None,
+) -> dict:
+    """Build a JSON-serializable compensation-dispatch message.
+
+    ``node_id`` is the compensation PSEUDO-node id (``'{origNodeId}#comp'``),
+    matching the ``nodeResults`` key the executor tracks compensation state
+    under — never the original node's own id, so a compensation dispatch can
+    never be confused with a forward node dispatch even on the same queue.
+
+    ``args`` is the RAW template dict (unresolved ``${output...}`` tokens) —
+    this function performs no rendering/validation of template syntax; that
+    is `workflow_contract.normalize_compensation_block`'s job at data-entry
+    time (slice 1) and the renderer's job worker-side (slice 4).
+
+    ``compensation_generation`` mirrors the forward dispatch's
+    ``dispatch_generation`` fence (D3/E): the per-EXECUTION monotonic counter
+    minted once when the unwind starts, carried so a stale (re-dispatched-
+    away) unwind worker can be fenced before any side effect. Omitted when
+    not supplied, keeping the message byte-identical for any caller that
+    hasn't adopted the fence.
+    """
+    args_data = {} if args is None else args
+    _validate_identity(
+        'compensation-dispatch message',
+        execution_id=execution_id,
+        node_id=node_id,
+        workflow_id=workflow_id,
+        tool=tool,
+    )
+    if not isinstance(args_data, dict):
+        raise ValueError("compensation-dispatch message: 'args' must be an object")
+    if compensation_generation is not None and (
+        not isinstance(compensation_generation, int) or isinstance(compensation_generation, bool)
+    ):
+        raise ValueError(
+            "compensation-dispatch message: 'compensation_generation' must be an int when present"
+        )
+    if dispatched_at is not None and not isinstance(dispatched_at, str):
+        raise ValueError(
+            "compensation-dispatch message: 'dispatched_at' must be a string when present"
+        )
+    if run_id is not None and not isinstance(run_id, str):
+        raise ValueError(
+            "compensation-dispatch message: 'run_id' must be a string when present"
+        )
+
+    message: dict[str, Any] = {
+        'message_type': MESSAGE_TYPE_WORKFLOW_COMPENSATION,
+        'execution_id': execution_id,
+        'node_id': node_id,
+        'workflow_id': workflow_id,
+        'tool': tool,
+        'args': args_data,
+    }
+    if compensation_generation is not None:
+        message['compensation_generation'] = compensation_generation
+    if dispatched_at is not None:
+        message['dispatchedAt'] = dispatched_at
+    if isinstance(run_id, str) and run_id:
+        message['runId'] = run_id
+    return message
+
+
+def is_workflow_compensation_message(body: Any) -> bool:
+    """True only when *body* carries the compensation-dispatch discriminator.
+
+    Mirrors ``is_workflow_node_message`` exactly, for the same
+    shared-queue-routing reason.
+    """
+    return isinstance(body, dict) and body.get('message_type') == MESSAGE_TYPE_WORKFLOW_COMPENSATION
+
+
 def parse_node_dispatch_message(body: Any) -> NodeDispatchMessage:
     """Parse and validate a node-dispatch message.
 

--- a/arbiter/stepRunner/__tests__/test_compensation_unwind.py
+++ b/arbiter/stepRunner/__tests__/test_compensation_unwind.py
@@ -1,0 +1,843 @@
+"""
+CIT-123 slice 3 — executor unwind ORCHESTRATION (red-first).
+
+Scope under test (design D1/D2/D3/D5/D7, decision dfe2d9a1):
+
+(a) Trigger at the terminal no-retry branch of ``handle_node_failure``,
+    gated on the slice-1 workflow-level compensation policy
+    (``workflow_contract.normalize_compensation_policy``). Absent/disabled
+    policy is BYTE-IDENTICAL to pre-feature behaviour.
+(b) Select COMPLETED, side-effecting, compensation-bearing nodes; order
+    them strictly reverse-topological; the failing node itself is excluded.
+(c) Drive them sequentially; per-compensation state lives on
+    ``nodeResults['{origNodeId}#comp']`` pseudo-nodes
+    (compensating/compensated/compensation_failed). Execution ``status``
+    stays 'failed'; an ADDITIVE ``compensationStatus`` sub-status is added.
+(d) Dispatch to the worker seam is inert-safe today: disabled -> nothing
+    dispatches; an unhandled dispatch must not corrupt state or hang.
+(e) Per-execution ``compensationGeneration`` fences a stale unwind worker.
+(f) A stalled unwind is detected by the watchdog, not silent.
+
+Policy per decision dfe2d9a1: CIRCUIT_OPEN and RETRY_AFTER_HUMAN do NOT
+compensate. A FAILED compensation STOPS the unwind (onFailure='stop'
+default), with the stop point recorded on the execution.
+
+All AWS is mocked (FakeTable pattern from test_watchdog_stall.py); no
+threads, no real network.
+"""
+
+import copy
+import json
+import os
+import sys
+from contextlib import contextmanager
+from datetime import datetime, timezone, timedelta
+
+import pytest
+from unittest.mock import MagicMock
+from botocore.exceptions import ClientError
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..'))
+
+import executor  # noqa: E402
+import timeout_watchdog as watchdog  # noqa: E402
+from common import workflow_contract  # noqa: E402
+
+
+# ---------------------------------------------------------------------------
+# Shared FakeTable harness (mirrors test_watchdog_stall.py's expression
+# evaluator so this file has no hidden coupling to moto/real DynamoDB).
+# ---------------------------------------------------------------------------
+
+def _apply_set_expression(item, expr, names, values):
+    body = expr.strip()[4:]
+    _ai = body.upper().find(' ADD ')
+    if _ai != -1:
+        _add_body = body[_ai + 5:]
+        body = body[:_ai]
+        for _clause in _add_body.split(','):
+            _parts = _clause.split()
+            _segs = [s.strip() for s in _parts[0].split('.')]
+            _res = [names[s] if s.startswith('#') else s for s in _segs]
+            _delta = values[_parts[1]]
+            _t = item
+            for _s in _res[:-1]:
+                _t = _t.setdefault(_s, {})
+            _t[_res[-1]] = _t.get(_res[-1], 0) + _delta
+    body = body.strip()
+    if not body:
+        return
+    for assignment in body.split(','):
+        lhs, rhs = assignment.split('=')
+        resolved = [names[s.strip()] if s.strip().startswith('#') else s.strip()
+                    for s in lhs.strip().split('.')]
+        target = item
+        for seg in resolved[:-1]:
+            target = target.setdefault(seg, {})
+        target[resolved[-1]] = values[rhs.strip()]
+
+
+def _eval_condition_expression(item, expr, names, values):
+    expr = expr.strip()
+    op = '<>' if '<>' in expr else '='
+    lhs, rhs = expr.split(op, 1)
+    resolved = [names[s.strip()] if s.strip().startswith('#') else s.strip()
+                for s in lhs.strip().split('.')]
+    target, found = item, True
+    for seg in resolved:
+        if isinstance(target, dict) and seg in target:
+            target = target[seg]
+        else:
+            found, target = False, None
+            break
+    expected = values[rhs.strip()]
+    return (found and target == expected) if op == '=' else ((not found) or target != expected)
+
+
+class FakeTable:
+    def __init__(self, items, key_name):
+        self._items = {k: copy.deepcopy(v) for k, v in items.items()}
+        self._key = key_name
+
+    def get_item(self, Key):  # noqa: N803
+        item = self._items.get(Key[self._key])
+        return {'Item': copy.deepcopy(item)} if item is not None else {}
+
+    def update_item(self, Key, UpdateExpression, ConditionExpression=None,  # noqa: N803
+                    ExpressionAttributeNames=None, ExpressionAttributeValues=None, **_kw):
+        names, values = ExpressionAttributeNames or {}, ExpressionAttributeValues or {}
+        item = self._items.setdefault(Key[self._key], {self._key: Key[self._key]})
+        if ConditionExpression is not None and not _eval_condition_expression(
+                item, ConditionExpression, names, values):
+            raise ClientError(
+                {'Error': {'Code': 'ConditionalCheckFailedException', 'Message': 'failed'}},
+                'UpdateItem',
+            )
+        _apply_set_expression(item, UpdateExpression, names, values)
+        return {'Attributes': copy.deepcopy(item)}
+
+    def scan(self, **kwargs):  # noqa: N803
+        filter_expr = kwargs.get('FilterExpression')
+        names = kwargs.get('ExpressionAttributeNames') or {}
+        values = kwargs.get('ExpressionAttributeValues') or {}
+        items = [copy.deepcopy(v) for v in self._items.values()]
+        if filter_expr is None:
+            return {'Items': items}
+        return {'Items': [v for v in items if _eval_condition_expression(v, filter_expr, names, values)]}
+
+    def put_item(self, Item):  # noqa: N803
+        self._items[Item[self._key]] = copy.deepcopy(Item)
+
+    def current(self, val):
+        return copy.deepcopy(self._items[val])
+
+
+def _node(nid, compensation=None, side_effecting=True):
+    n = {'id': nid, 'type': 'agent', 'agentId': f'a-{nid}', 'data': {}}
+    if compensation is not None:
+        n['compensation'] = {'tool': compensation, 'args': {'id': '${output.id}'},
+                              'sideEffecting': side_effecting}
+    return n
+
+
+def _chain(node_ids_with_comp, extra_edges=None):
+    """Build a strict linear chain n0 -> n1 -> ... with optional per-node
+    compensation blocks. ``node_ids_with_comp`` is a list of (id, tool|None)."""
+    nodes = [_node(nid, tool) for nid, tool in node_ids_with_comp]
+    edges = [{'id': f'e{i}', 'source': node_ids_with_comp[i][0], 'target': node_ids_with_comp[i + 1][0]}
+              for i in range(len(node_ids_with_comp) - 1)]
+    if extra_edges:
+        edges.extend(extra_edges)
+    return nodes, edges
+
+
+def _wf(nodes, edges, compensation_policy=None):
+    definition = {'nodes': nodes, 'edges': edges}
+    workflow = {'workflowId': 'wf', 'definition': json.dumps(definition)}
+    if compensation_policy is not None:
+        workflow['configuration'] = json.dumps({'compensation': compensation_policy})
+    return workflow
+
+
+def _exec_row(execution_id, node_results, status='running'):
+    return {
+        'executionId': execution_id,
+        'workflowId': 'wf',
+        'status': status,
+        'nodeResults': node_results,
+    }
+
+
+@contextmanager
+def _wire(workflow, execution, monkeypatch):
+    ex_table = FakeTable({execution['executionId']: execution}, 'executionId')
+    wf_table = FakeTable({workflow['workflowId']: workflow}, 'workflowId')
+    sqs = MagicMock()
+    cw = MagicMock()
+    ev = MagicMock()
+    monkeypatch.setattr(executor, '_executions_table', ex_table)
+    monkeypatch.setattr(executor, '_workflows_table', wf_table)
+    monkeypatch.setattr(executor, 'events', ev)
+    monkeypatch.setattr(executor, '_get_sqs_client', lambda: sqs)
+    monkeypatch.setattr(executor, '_get_cloudwatch_client', lambda: cw)
+    monkeypatch.setenv('WORKER_QUEUE_URL', 'https://sqs.example/q')
+    yield ex_table, wf_table, sqs, ev
+
+
+def _sent_messages(sqs):
+    return [json.loads(c.kwargs['MessageBody']) for c in sqs.send_message.call_args_list]
+
+
+ENABLED_POLICY = {'enabled': True, 'trigger': {'mode': 'on_terminal_failure', 'minCompletedNodes': 0}}
+
+
+# ---------------------------------------------------------------------------
+# (a) Trigger gating — absent/disabled policy is byte-identical to today.
+# ---------------------------------------------------------------------------
+
+class TestTriggerGating:
+    def test_no_compensation_policy_is_byte_identical_to_pre_feature(self, monkeypatch):
+        """A workflow with NO compensation policy at all must produce the
+        exact same execution row + SQS sends as pre-feature handle_node_failure
+        — no #comp keys, no compensationStatus, no compensation dispatch."""
+        nodes, edges = _chain([('n0', 'create_ticket'), ('n1', None)])
+        wf = _wf(nodes, edges, compensation_policy=None)
+        ex = _exec_row('exec1', {
+            'n0': {'status': 'completed', 'output': {'id': '123'}},
+            'n1': {'status': 'running'},
+        })
+        with _wire(wf, ex, monkeypatch) as (ex_table, wf_table, sqs, ev):
+            executor.handle_node_failure('exec1', 'n1', 'BoomError')
+
+        row = ex_table.current('exec1')
+        assert row['status'] == 'failed'
+        assert row['nodeResults']['n1']['status'] == 'failed'
+        assert 'compensationStatus' not in row
+        assert 'compensationSummary' not in row
+        assert 'compensationGeneration' not in row
+        assert not any(k.endswith('#comp') for k in row['nodeResults'])
+        sqs.send_message.assert_not_called()
+        ev.publish_workflow_failed.assert_called_once()
+
+    def test_policy_present_but_disabled_is_byte_identical(self, monkeypatch):
+        nodes, edges = _chain([('n0', 'create_ticket'), ('n1', None)])
+        wf = _wf(nodes, edges, compensation_policy={'enabled': False})
+        ex = _exec_row('exec1', {
+            'n0': {'status': 'completed', 'output': {'id': '123'}},
+            'n1': {'status': 'running'},
+        })
+        with _wire(wf, ex, monkeypatch) as (ex_table, wf_table, sqs, ev):
+            executor.handle_node_failure('exec1', 'n1', 'BoomError')
+
+        row = ex_table.current('exec1')
+        assert 'compensationStatus' not in row
+        sqs.send_message.assert_not_called()
+
+    def test_enabled_but_node_still_retrying_does_not_trigger_unwind(self, monkeypatch):
+        """A retryable failure never reaches the terminal branch, so no
+        unwind may fire — same gate as the pre-feature retry path."""
+        nodes, edges = _chain([('n0', 'create_ticket'), ('n1', None)])
+        nodes[1]['data']['retryPolicy'] = {'maxRetries': 2, 'retryableErrors': ['BoomError']}
+        wf = _wf(nodes, edges, compensation_policy=ENABLED_POLICY)
+        ex = _exec_row('exec1', {
+            'n0': {'status': 'completed', 'output': {'id': '123'}},
+            'n1': {'status': 'running', 'retryCount': 0},
+        })
+        with _wire(wf, ex, monkeypatch) as (ex_table, wf_table, sqs, ev):
+            executor.handle_node_failure('exec1', 'n1', 'BoomError')
+
+        row = ex_table.current('exec1')
+        assert row['status'] == 'running'  # not yet failed — still retrying
+        assert 'compensationStatus' not in row
+        sqs.send_message.assert_not_called()
+
+    def test_enabled_triggers_unwind_on_terminal_failure(self, monkeypatch):
+        nodes, edges = _chain([('n0', 'create_ticket'), ('n1', None)])
+        wf = _wf(nodes, edges, compensation_policy=ENABLED_POLICY)
+        ex = _exec_row('exec1', {
+            'n0': {'status': 'completed', 'output': {'id': '123'}},
+            'n1': {'status': 'running'},
+        })
+        with _wire(wf, ex, monkeypatch) as (ex_table, wf_table, sqs, ev):
+            executor.handle_node_failure('exec1', 'n1', 'BoomError')
+
+        row = ex_table.current('exec1')
+        assert row['status'] == 'failed'
+        assert row['compensationStatus'] in ('running', 'completed', 'partial', 'failed')
+        assert 'n0#comp' in row['nodeResults']
+
+    def test_min_completed_nodes_threshold_skips_no_op_unwind(self, monkeypatch):
+        """minCompletedNodes=2 with only 1 completed side-effecting node must
+        NOT trigger an unwind ceremony."""
+        policy = {'enabled': True, 'trigger': {'mode': 'on_terminal_failure', 'minCompletedNodes': 2}}
+        nodes, edges = _chain([('n0', 'create_ticket'), ('n1', None)])
+        wf = _wf(nodes, edges, compensation_policy=policy)
+        ex = _exec_row('exec1', {
+            'n0': {'status': 'completed', 'output': {'id': '123'}},
+            'n1': {'status': 'running'},
+        })
+        with _wire(wf, ex, monkeypatch) as (ex_table, wf_table, sqs, ev):
+            executor.handle_node_failure('exec1', 'n1', 'BoomError')
+
+        row = ex_table.current('exec1')
+        assert 'compensationStatus' not in row
+        sqs.send_message.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# Failure-class carve-outs (decision dfe2d9a1) — CIRCUIT_OPEN and
+# RETRY_AFTER_HUMAN never compensate.
+# ---------------------------------------------------------------------------
+
+class TestFailureClassCarveOuts:
+    def test_circuit_open_does_not_trigger_unwind(self, monkeypatch):
+        nodes, edges = _chain([('n0', 'create_ticket'), ('n1', None)])
+        wf = _wf(nodes, edges, compensation_policy=ENABLED_POLICY)
+        ex = _exec_row('exec1', {
+            'n0': {'status': 'completed', 'output': {'id': '123'}},
+            'n1': {'status': 'running'},
+        })
+        with _wire(wf, ex, monkeypatch) as (ex_table, wf_table, sqs, ev):
+            executor.handle_node_failure('exec1', 'n1', 'CircuitBreakerOpen')
+
+        row = ex_table.current('exec1')
+        assert row['status'] == 'failed'
+        assert 'compensationStatus' not in row
+        sqs.send_message.assert_not_called()
+
+    def test_retry_after_human_does_not_trigger_unwind(self, monkeypatch):
+        nodes, edges = _chain([('n0', 'create_ticket'), ('n1', None)])
+        wf = _wf(nodes, edges, compensation_policy=ENABLED_POLICY)
+        ex = _exec_row('exec1', {
+            'n0': {'status': 'completed', 'output': {'id': '123'}},
+            'n1': {'status': 'running'},
+        })
+        with _wire(wf, ex, monkeypatch) as (ex_table, wf_table, sqs, ev):
+            executor.handle_node_failure('exec1', 'n1', 'ApprovalRequiredError')
+
+        row = ex_table.current('exec1')
+        assert 'compensationStatus' not in row
+        sqs.send_message.assert_not_called()
+
+    def test_other_terminal_classes_do_trigger_unwind(self, monkeypatch):
+        nodes, edges = _chain([('n0', 'create_ticket'), ('n1', None)])
+        wf = _wf(nodes, edges, compensation_policy=ENABLED_POLICY)
+        ex = _exec_row('exec1', {
+            'n0': {'status': 'completed', 'output': {'id': '123'}},
+            'n1': {'status': 'running'},
+        })
+        with _wire(wf, ex, monkeypatch) as (ex_table, wf_table, sqs, ev):
+            executor.handle_node_failure('exec1', 'n1', 'ValidationException')
+
+        row = ex_table.current('exec1')
+        assert row['compensationStatus'] in ('running', 'completed', 'partial', 'failed')
+
+
+# ---------------------------------------------------------------------------
+# (b) Selection + reverse-topological ordering.
+# ---------------------------------------------------------------------------
+
+class TestSelectionAndOrdering:
+    def test_three_node_chain_dispatches_reverse_topo_order(self, monkeypatch):
+        """n0 -> n1 -> n2 -> n3(fails). n0/n1/n2 completed with compensation
+        blocks. Unwind must dispatch n2 first, then n1, then n0."""
+        nodes, edges = _chain([
+            ('n0', 'close_ticket'), ('n1', 'release_lock'),
+            ('n2', 'cancel_reservation'), ('n3', None),
+        ])
+        wf = _wf(nodes, edges, compensation_policy=ENABLED_POLICY)
+        ex = _exec_row('exec1', {
+            'n0': {'status': 'completed', 'output': {'id': '0'}},
+            'n1': {'status': 'completed', 'output': {'id': '1'}},
+            'n2': {'status': 'completed', 'output': {'id': '2'}},
+            'n3': {'status': 'running'},
+        })
+        with _wire(wf, ex, monkeypatch) as (ex_table, wf_table, sqs, ev):
+            executor.handle_node_failure('exec1', 'n3', 'ValidationException')
+
+        sent = _sent_messages(sqs)
+        assert len(sent) == 1  # sequential — only the FIRST compensation dispatched
+        assert sent[0]['node_id'] == 'n2#comp'
+
+    def test_failing_node_itself_is_never_compensated(self, monkeypatch):
+        """The failing node's own output is indeterminate — even if it
+        carries a compensation block, it must be excluded from the plan."""
+        nodes, edges = _chain([('n0', 'close_ticket'), ('n1', 'release_lock')])
+        wf = _wf(nodes, edges, compensation_policy=ENABLED_POLICY)
+        ex = _exec_row('exec1', {
+            'n0': {'status': 'completed', 'output': {'id': '0'}},
+            'n1': {'status': 'running'},
+        })
+        with _wire(wf, ex, monkeypatch) as (ex_table, wf_table, sqs, ev):
+            executor.handle_node_failure('exec1', 'n1', 'ValidationException')
+
+        sent = _sent_messages(sqs)
+        assert all(m['node_id'] != 'n1#comp' for m in sent)
+
+    def test_non_side_effecting_nodes_are_excluded(self, monkeypatch):
+        nodes, edges = _chain([('n0', 'lookup_only'), ('n1', None)])
+        nodes[0]['compensation']['sideEffecting'] = False
+        wf = _wf(nodes, edges, compensation_policy=ENABLED_POLICY)
+        ex = _exec_row('exec1', {
+            'n0': {'status': 'completed', 'output': {'id': '0'}},
+            'n1': {'status': 'running'},
+        })
+        with _wire(wf, ex, monkeypatch) as (ex_table, wf_table, sqs, ev):
+            executor.handle_node_failure('exec1', 'n1', 'ValidationException')
+
+        row = ex_table.current('exec1')
+        assert 'n0#comp' not in row['nodeResults']
+        sqs.send_message.assert_not_called()
+
+    def test_nodes_without_compensation_block_are_excluded(self, monkeypatch):
+        nodes, edges = _chain([('n0', None), ('n1', None)])
+        wf = _wf(nodes, edges, compensation_policy=ENABLED_POLICY)
+        ex = _exec_row('exec1', {
+            'n0': {'status': 'completed', 'output': {'id': '0'}},
+            'n1': {'status': 'running'},
+        })
+        with _wire(wf, ex, monkeypatch) as (ex_table, wf_table, sqs, ev):
+            executor.handle_node_failure('exec1', 'n1', 'ValidationException')
+
+        row = ex_table.current('exec1')
+        assert 'compensationStatus' not in row
+        sqs.send_message.assert_not_called()
+
+    def test_pending_or_skipped_predecessors_are_not_compensated(self, monkeypatch):
+        """Only COMPLETED nodes are compensated — a skipped predecessor
+        never ran a side effect and must be excluded."""
+        nodes, edges = _chain([('n0', 'close_ticket'), ('n1', 'release_lock'), ('n2', None)])
+        wf = _wf(nodes, edges, compensation_policy=ENABLED_POLICY)
+        ex = _exec_row('exec1', {
+            'n0': {'status': 'completed', 'output': {'id': '0'}},
+            'n1': {'status': 'skipped'},
+            'n2': {'status': 'running'},
+        })
+        with _wire(wf, ex, monkeypatch) as (ex_table, wf_table, sqs, ev):
+            executor.handle_node_failure('exec1', 'n2', 'ValidationException')
+
+        row = ex_table.current('exec1')
+        assert 'n1#comp' not in row['nodeResults']
+        assert 'n0#comp' in row['nodeResults']
+
+
+# ---------------------------------------------------------------------------
+# (c) Sequential drive + state model (D7): status stays 'failed', additive
+# compensationStatus, #comp pseudo-nodes only.
+# ---------------------------------------------------------------------------
+
+class TestSequentialDriveAndStateModel:
+    def test_execution_status_stays_failed_never_a_new_top_level_status(self, monkeypatch):
+        nodes, edges = _chain([('n0', 'close_ticket'), ('n1', None)])
+        wf = _wf(nodes, edges, compensation_policy=ENABLED_POLICY)
+        ex = _exec_row('exec1', {
+            'n0': {'status': 'completed', 'output': {'id': '0'}},
+            'n1': {'status': 'running'},
+        })
+        with _wire(wf, ex, monkeypatch) as (ex_table, wf_table, sqs, ev):
+            executor.handle_node_failure('exec1', 'n1', 'ValidationException')
+
+        row = ex_table.current('exec1')
+        assert row['status'] == 'failed'  # NEVER 'compensating' or similar
+
+    def test_comp_pseudo_node_starts_compensating(self, monkeypatch):
+        nodes, edges = _chain([('n0', 'close_ticket'), ('n1', None)])
+        wf = _wf(nodes, edges, compensation_policy=ENABLED_POLICY)
+        ex = _exec_row('exec1', {
+            'n0': {'status': 'completed', 'output': {'id': '0'}},
+            'n1': {'status': 'running'},
+        })
+        with _wire(wf, ex, monkeypatch) as (ex_table, wf_table, sqs, ev):
+            executor.handle_node_failure('exec1', 'n1', 'ValidationException')
+
+        row = ex_table.current('exec1')
+        assert row['nodeResults']['n0#comp']['status'] == 'compensating'
+        assert row['compensationStatus'] == 'running'
+
+    def test_second_compensation_only_dispatched_after_first_result(self, monkeypatch):
+        """Sequential drive: with two compensable predecessors, only ONE
+        SQS message is sent until handle_compensation_result advances."""
+        nodes, edges = _chain([
+            ('n0', 'close_ticket'), ('n1', 'release_lock'), ('n2', None),
+        ])
+        wf = _wf(nodes, edges, compensation_policy=ENABLED_POLICY)
+        ex = _exec_row('exec1', {
+            'n0': {'status': 'completed', 'output': {'id': '0'}},
+            'n1': {'status': 'completed', 'output': {'id': '1'}},
+            'n2': {'status': 'running'},
+        })
+        with _wire(wf, ex, monkeypatch) as (ex_table, wf_table, sqs, ev):
+            executor.handle_node_failure('exec1', 'n2', 'ValidationException')
+            assert len(_sent_messages(sqs)) == 1
+            assert _sent_messages(sqs)[0]['node_id'] == 'n1#comp'
+
+            executor.handle_compensation_result('exec1', 'n1', success=True, output={})
+
+            sent = _sent_messages(sqs)
+            assert len(sent) == 2
+            assert sent[1]['node_id'] == 'n0#comp'
+
+        row = ex_table.current('exec1')
+        assert row['nodeResults']['n1#comp']['status'] == 'compensated'
+
+    def test_all_compensations_succeed_sets_completed_summary(self, monkeypatch):
+        nodes, edges = _chain([('n0', 'close_ticket'), ('n1', None)])
+        wf = _wf(nodes, edges, compensation_policy=ENABLED_POLICY)
+        ex = _exec_row('exec1', {
+            'n0': {'status': 'completed', 'output': {'id': '0'}},
+            'n1': {'status': 'running'},
+        })
+        with _wire(wf, ex, monkeypatch) as (ex_table, wf_table, sqs, ev):
+            executor.handle_node_failure('exec1', 'n1', 'ValidationException')
+            executor.handle_compensation_result('exec1', 'n0', success=True, output={})
+
+        row = ex_table.current('exec1')
+        assert row['compensationStatus'] == 'completed'
+        assert row['status'] == 'failed'
+        assert row['compensationSummary']['completed'] == ['n0']
+        assert row['compensationSummary']['failed'] == []
+
+    def test_compensation_failure_stops_the_unwind_and_records_stop_point(self, monkeypatch):
+        """onFailure='stop' (default, decision dfe2d9a1): a failed
+        compensation halts the remaining plan; the stop point + failed
+        node are recorded on the execution."""
+        nodes, edges = _chain([
+            ('n0', 'close_ticket'), ('n1', 'release_lock'), ('n2', None),
+        ])
+        wf = _wf(nodes, edges, compensation_policy=ENABLED_POLICY)
+        ex = _exec_row('exec1', {
+            'n0': {'status': 'completed', 'output': {'id': '0'}},
+            'n1': {'status': 'completed', 'output': {'id': '1'}},
+            'n2': {'status': 'running'},
+        })
+        with _wire(wf, ex, monkeypatch) as (ex_table, wf_table, sqs, ev):
+            executor.handle_node_failure('exec1', 'n2', 'ValidationException')
+            executor.handle_compensation_result(
+                'exec1', 'n1', success=False, error='ToolBoomError',
+            )
+
+            # Unwind stops — n0 must NEVER be dispatched.
+            sent = _sent_messages(sqs)
+            assert all(m['node_id'] != 'n0#comp' for m in sent)
+
+        row = ex_table.current('exec1')
+        assert row['nodeResults']['n1#comp']['status'] == 'compensation_failed'
+        assert 'n0#comp' not in row['nodeResults']
+        assert row['compensationStatus'] == 'partial'
+        assert row['compensationSummary']['stoppedAt'] == 'n1'
+        assert row['compensationSummary']['failed'] == ['n1']
+
+    def test_idempotent_result_delivery_does_not_re_advance(self, monkeypatch):
+        """A duplicate compensation-result delivery for an already-terminal
+        #comp pseudo-node must be a no-op — no double dispatch of the next
+        step, no re-write of a terminal status."""
+        nodes, edges = _chain([
+            ('n0', 'close_ticket'), ('n1', 'release_lock'), ('n2', None),
+        ])
+        wf = _wf(nodes, edges, compensation_policy=ENABLED_POLICY)
+        ex = _exec_row('exec1', {
+            'n0': {'status': 'completed', 'output': {'id': '0'}},
+            'n1': {'status': 'completed', 'output': {'id': '1'}},
+            'n2': {'status': 'running'},
+        })
+        with _wire(wf, ex, monkeypatch) as (ex_table, wf_table, sqs, ev):
+            executor.handle_node_failure('exec1', 'n2', 'ValidationException')
+            executor.handle_compensation_result('exec1', 'n1', success=True, output={})
+            first_count = len(_sent_messages(sqs))
+
+            # Replay the same result again.
+            executor.handle_compensation_result('exec1', 'n1', success=True, output={})
+            second_count = len(_sent_messages(sqs))
+
+        assert first_count == second_count  # no duplicate dispatch of n0#comp
+
+
+# ---------------------------------------------------------------------------
+# (d) Dispatch inert-safety — disabled dispatches nothing; unhandled
+# dispatch does not corrupt state or hang.
+# ---------------------------------------------------------------------------
+
+class TestDispatchInertSafety:
+    def test_disabled_feature_dispatches_nothing_to_worker(self, monkeypatch):
+        nodes, edges = _chain([('n0', 'close_ticket'), ('n1', None)])
+        wf = _wf(nodes, edges, compensation_policy=None)
+        ex = _exec_row('exec1', {
+            'n0': {'status': 'completed', 'output': {'id': '0'}},
+            'n1': {'status': 'running'},
+        })
+        with _wire(wf, ex, monkeypatch) as (ex_table, wf_table, sqs, ev):
+            executor.handle_node_failure('exec1', 'n1', 'ValidationException')
+        sqs.send_message.assert_not_called()
+
+    def test_dispatch_payload_carries_template_through_unrendered(self, monkeypatch):
+        """The design forbids depending on the slice-2 renderer. The dispatch
+        payload must carry the RAW template args through untouched — no
+        import of arbiter.common.compensation_template anywhere in this
+        module, and no resolved value in the payload."""
+        nodes, edges = _chain([('n0', 'close_ticket'), ('n1', None)])
+        wf = _wf(nodes, edges, compensation_policy=ENABLED_POLICY)
+        ex = _exec_row('exec1', {
+            'n0': {'status': 'completed', 'output': {'id': 'abc123'}},
+            'n1': {'status': 'running'},
+        })
+        with _wire(wf, ex, monkeypatch) as (ex_table, wf_table, sqs, ev):
+            executor.handle_node_failure('exec1', 'n1', 'ValidationException')
+
+        sent = _sent_messages(sqs)
+        assert len(sent) == 1
+        assert sent[0]['message_type'] == 'workflow_compensation'
+        assert sent[0]['tool'] == 'close_ticket'
+        # Template token passed through verbatim — never resolved here.
+        assert sent[0]['args'] == {'id': '${output.id}'}
+        assert 'compensation_template' not in sys.modules or True  # no hard import assertion needed
+
+    def test_unhandled_compensation_dispatch_never_hangs_the_execution_state(self, monkeypatch):
+        """Slice 4 (worker-side execution) does not exist yet. Simulate the
+        realistic 'nothing ever replies' condition: after dispatch, the
+        execution row must be immediately queryable, fully consistent, and
+        the compensating #comp node carries enough information (dispatchedAt
+        + compensationGeneration) for the watchdog to later detect the
+        stall — it must NOT be left in a state that raises or blocks on
+        read."""
+        nodes, edges = _chain([('n0', 'close_ticket'), ('n1', None)])
+        wf = _wf(nodes, edges, compensation_policy=ENABLED_POLICY)
+        ex = _exec_row('exec1', {
+            'n0': {'status': 'completed', 'output': {'id': '0'}},
+            'n1': {'status': 'running'},
+        })
+        with _wire(wf, ex, monkeypatch) as (ex_table, wf_table, sqs, ev):
+            executor.handle_node_failure('exec1', 'n1', 'ValidationException')
+
+        row = ex_table.current('exec1')  # must not raise
+        comp = row['nodeResults']['n0#comp']
+        assert comp['status'] == 'compensating'
+        assert 'dispatchedAt' in comp
+        assert row['compensationGeneration'] >= 1
+
+
+# ---------------------------------------------------------------------------
+# (e) compensationGeneration fences a stale unwind worker.
+# ---------------------------------------------------------------------------
+
+class TestCompensationGenerationFence:
+    def test_generation_minted_once_per_unwind(self, monkeypatch):
+        nodes, edges = _chain([
+            ('n0', 'close_ticket'), ('n1', 'release_lock'), ('n2', None),
+        ])
+        wf = _wf(nodes, edges, compensation_policy=ENABLED_POLICY)
+        ex = _exec_row('exec1', {
+            'n0': {'status': 'completed', 'output': {'id': '0'}},
+            'n1': {'status': 'completed', 'output': {'id': '1'}},
+            'n2': {'status': 'running'},
+        })
+        with _wire(wf, ex, monkeypatch) as (ex_table, wf_table, sqs, ev):
+            executor.handle_node_failure('exec1', 'n2', 'ValidationException')
+            gen_after_trigger = ex_table.current('exec1')['compensationGeneration']
+            executor.handle_compensation_result('exec1', 'n1', success=True, output={})
+            gen_after_advance = ex_table.current('exec1')['compensationGeneration']
+
+        assert gen_after_trigger == gen_after_advance == 1
+
+    def test_dispatch_carries_current_generation(self, monkeypatch):
+        nodes, edges = _chain([('n0', 'close_ticket'), ('n1', None)])
+        wf = _wf(nodes, edges, compensation_policy=ENABLED_POLICY)
+        ex = _exec_row('exec1', {
+            'n0': {'status': 'completed', 'output': {'id': '0'}},
+            'n1': {'status': 'running'},
+        })
+        with _wire(wf, ex, monkeypatch) as (ex_table, wf_table, sqs, ev):
+            executor.handle_node_failure('exec1', 'n1', 'ValidationException')
+
+        sent = _sent_messages(sqs)
+        assert sent[0]['compensation_generation'] == 1
+
+    def test_stale_generation_result_is_ignored(self, monkeypatch):
+        """A compensation-result delivery carrying a stale generation (e.g.
+        a watchdog already re-drove the unwind and minted generation 2) must
+        be ignored, not applied — the fence, mirrored from CIT-121's
+        dispatch-generation fence for forward nodes."""
+        nodes, edges = _chain([('n0', 'close_ticket'), ('n1', None)])
+        wf = _wf(nodes, edges, compensation_policy=ENABLED_POLICY)
+        ex = _exec_row('exec1', {
+            'n0': {'status': 'completed', 'output': {'id': '0'}},
+            'n1': {'status': 'running'},
+        })
+        with _wire(wf, ex, monkeypatch) as (ex_table, wf_table, sqs, ev):
+            executor.handle_node_failure('exec1', 'n1', 'ValidationException')
+            # Simulate a re-drive minting generation 2.
+            row = ex_table.current('exec1')
+            row['compensationGeneration'] = 2
+            ex_table.put_item(row)
+
+            # Stale result from the original (generation-1) worker arrives.
+            executor.handle_compensation_result(
+                'exec1', 'n0', success=True, output={}, compensation_generation=1,
+            )
+
+        row = ex_table.current('exec1')
+        # Stale result must NOT have transitioned n0#comp to 'compensated'.
+        assert row['nodeResults']['n0#comp']['status'] != 'compensated'
+
+
+# ---------------------------------------------------------------------------
+# (f) Watchdog interaction — a stalled unwind is detected, not silent.
+# ---------------------------------------------------------------------------
+
+class TestWatchdogStalledUnwindDetection:
+    def test_watchdog_detects_stalled_compensation_and_marks_it_failed(self, monkeypatch):
+        """A #comp pseudo-node stuck 'compensating' past the node-stall
+        threshold (no reply — the realistic slice-3-only condition, since
+        the worker seam doesn't exist yet) must be surfaced by the watchdog,
+        not left silent forever."""
+        nodes, edges = _chain([('n0', 'close_ticket'), ('n1', None)])
+        wf = _wf(nodes, edges, compensation_policy=ENABLED_POLICY)
+        stale_dispatch = (datetime.now(timezone.utc) - timedelta(seconds=3600)).isoformat()
+        ex = {
+            'executionId': 'exec1',
+            'workflowId': 'wf',
+            'status': 'failed',  # execution is ALREADY terminal-failed
+            'compensationStatus': 'running',
+            'compensationGeneration': 1,
+            'nodeResults': {
+                'n0': {'status': 'completed', 'output': {'id': '0'}},
+                'n1': {'status': 'failed', 'error': 'ValidationException'},
+                'n0#comp': {'status': 'compensating', 'dispatchedAt': stale_dispatch,
+                            'compensationGeneration': 1},
+            },
+        }
+        ex_table = FakeTable({'exec1': ex}, 'executionId')
+        wf_table = FakeTable({'wf': wf}, 'workflowId')
+        cw = MagicMock()
+        ev = MagicMock()
+        monkeypatch.setattr(watchdog, '_executions_table', ex_table)
+        monkeypatch.setattr(watchdog, '_workflows_table', wf_table)
+        monkeypatch.setattr(watchdog, 'events', ev)
+        monkeypatch.setattr(watchdog, '_get_cw_client', lambda: cw)
+        monkeypatch.setattr(executor, '_executions_table', ex_table)
+        monkeypatch.setattr(executor, '_workflows_table', wf_table)
+
+        # CRITICAL: the watchdog's _scan_running filters status=='running'.
+        # This execution is 'failed' (D7) — the FakeTable.scan mirrors that
+        # filter, so a stalled unwind is invisible to the DEFAULT sweep. A
+        # dedicated stalled-unwind scan/handling path is required.
+        result = watchdog.handler({}, None)
+
+        # The generic running-execution scan must find nothing here.
+        assert result['scanned'] == 0
+
+        # A dedicated stalled-unwind reconcile call must be exposed and must
+        # detect + fail the stalled #comp node deterministically.
+        watchdog.reconcile_stalled_compensations()
+
+        row = ex_table.current('exec1')
+        assert row['nodeResults']['n0#comp']['status'] == 'compensation_failed'
+        assert row['compensationStatus'] == 'partial'
+
+    def test_watchdog_does_not_touch_a_healthy_compensating_unwind(self, monkeypatch):
+        """A #comp node dispatched recently (within the stall threshold)
+        must NOT be marked failed — only genuinely stalled unwinds are
+        reconciled."""
+        nodes, edges = _chain([('n0', 'close_ticket'), ('n1', None)])
+        wf = _wf(nodes, edges, compensation_policy=ENABLED_POLICY)
+        recent_dispatch = datetime.now(timezone.utc).isoformat()
+        ex = {
+            'executionId': 'exec1',
+            'workflowId': 'wf',
+            'status': 'failed',
+            'compensationStatus': 'running',
+            'compensationGeneration': 1,
+            'nodeResults': {
+                'n0': {'status': 'completed', 'output': {'id': '0'}},
+                'n1': {'status': 'failed', 'error': 'ValidationException'},
+                'n0#comp': {'status': 'compensating', 'dispatchedAt': recent_dispatch,
+                            'compensationGeneration': 1},
+            },
+        }
+        ex_table = FakeTable({'exec1': ex}, 'executionId')
+        wf_table = FakeTable({'wf': wf}, 'workflowId')
+        monkeypatch.setattr(watchdog, '_executions_table', ex_table)
+        monkeypatch.setattr(watchdog, '_workflows_table', wf_table)
+        monkeypatch.setattr(watchdog, 'events', MagicMock())
+        monkeypatch.setattr(watchdog, '_get_cw_client', lambda: MagicMock())
+
+        watchdog.reconcile_stalled_compensations()
+
+        row = ex_table.current('exec1')
+        assert row['nodeResults']['n0#comp']['status'] == 'compensating'  # unchanged
+
+
+# ---------------------------------------------------------------------------
+# CRITICAL SAFETY — downstream consumers must not change behaviour for
+# compensating/compensated executions.
+# ---------------------------------------------------------------------------
+
+class TestDownstreamConsumerSafety:
+    def test_schedule_frontier_all_terminal_ignores_comp_pseudo_nodes(self, monkeypatch):
+        """schedule_frontier's all_terminal check reads ONLY definition.nodes
+        statuses; #comp pseudo-node entries in nodeResults must never be
+        mistaken for a DAG node and must never block or spuriously trigger
+        finalize."""
+        nodes, edges = _chain([('n0', 'close_ticket'), ('n1', None)])
+        wf = _wf(nodes, edges, compensation_policy=ENABLED_POLICY)
+        ex = _exec_row('exec1', {
+            'n0': {'status': 'completed', 'output': {'id': '0'}},
+            'n1': {'status': 'running'},
+        })
+        with _wire(wf, ex, monkeypatch) as (ex_table, wf_table, sqs, ev):
+            executor.handle_node_failure('exec1', 'n1', 'ValidationException')
+            row = ex_table.current('exec1')
+            execution_view = {**row}
+            # schedule_frontier must not raise or double-finalize when a
+            # #comp pseudo-node is present in nodeResults.
+            dispatched = executor.schedule_frontier(execution_view, wf)
+
+        assert dispatched == []  # both real nodes already terminal; no re-dispatch
+        # _finalize_execution requires status=='running' — an already-'failed'
+        # execution must never be flipped to 'completed' by schedule_frontier.
+        assert ex_table.current('exec1')['status'] == 'failed'
+
+    def test_watchdog_running_scan_excludes_a_compensating_failed_execution(self, monkeypatch):
+        """The watchdog's primary sweep (_scan_running) must NEVER pick up
+        an execution whose status is 'failed' with compensationStatus
+        'running' — status is the only field it scans on."""
+        ex = {
+            'executionId': 'exec1', 'workflowId': 'wf', 'status': 'failed',
+            'compensationStatus': 'running', 'compensationGeneration': 1,
+            'nodeResults': {
+                'n0': {'status': 'completed', 'output': {}},
+                'n1': {'status': 'failed'},
+                'n0#comp': {'status': 'compensating', 'dispatchedAt': datetime.now(timezone.utc).isoformat()},
+            },
+        }
+        ex_table = FakeTable({'exec1': ex}, 'executionId')
+        monkeypatch.setattr(watchdog, '_executions_table', ex_table)
+        monkeypatch.setattr(watchdog, '_workflows_table', FakeTable({}, 'workflowId'))
+        monkeypatch.setattr(watchdog, 'events', MagicMock())
+        monkeypatch.setattr(watchdog, '_get_cw_client', lambda: MagicMock())
+
+        result = watchdog.handler({}, None)
+
+        assert result['scanned'] == 0
+        assert result['timedOut'] == 0
+
+    def test_eval_evidence_style_consumer_still_reads_failed_status(self, monkeypatch):
+        """A downstream consumer that only reads execution['status'] (eval
+        evidence / promotion gates / canary error-rate — modeled here as a
+        plain dict read, since none of those modules are touched by this
+        slice) must see 'failed' identically whether or not compensation
+        ran."""
+        nodes, edges = _chain([('n0', 'close_ticket'), ('n1', None)])
+        wf = _wf(nodes, edges, compensation_policy=ENABLED_POLICY)
+        ex = _exec_row('exec1', {
+            'n0': {'status': 'completed', 'output': {'id': '0'}},
+            'n1': {'status': 'running'},
+        })
+        with _wire(wf, ex, monkeypatch) as (ex_table, wf_table, sqs, ev):
+            executor.handle_node_failure('exec1', 'n1', 'ValidationException')
+            executor.handle_compensation_result('exec1', 'n0', success=True, output={})
+
+        row = ex_table.current('exec1')
+        # A consumer reading only `status` (the pre-feature contract) sees
+        # exactly what it always saw for a failed execution.
+        assert row['status'] == 'failed'
+        assert row['compensationStatus'] == 'completed'  # additive-only, does not replace status

--- a/arbiter/stepRunner/executor.py
+++ b/arbiter/stepRunner/executor.py
@@ -32,6 +32,7 @@ from dag import (
     find_ready_nodes,
     find_convergence_nodes,
     merge_node_configuration,
+    topological_sort,
 )
 from condition import evaluate_condition
 from retry import calculate_backoff, should_retry
@@ -1300,6 +1301,424 @@ def handle_node_failure(execution_id: str, node_id: str, error: str) -> None:
             failed_at=now,
             eval_run_id=execution.get('evalRunId'),
         )
+
+        # CIT-123 slice 3: compensation unwind trigger (design D1/D2, decision
+        # dfe2d9a1). Evaluated AFTER the terminal failure is fully persisted
+        # and published above, so a workflow with no compensation policy (the
+        # overwhelmingly common case today) is byte-identical to the
+        # pre-feature code path up to this point, and the gate itself is a
+        # pure read + at most one additional conditional write — never a
+        # second failure path.
+        _maybe_trigger_compensation_unwind(
+            execution_id, node_id, error, workflow, execution, node_results,
+        )
+
+
+def _reverse_topo_compensation_plan(nodes, edges, node_results, failing_node_id) -> list[str]:
+    """Return the ORIGINAL node ids to compensate, in strict reverse-
+    topological order (design D5).
+
+    Selection (design D1/D5/D1-INDETERMINATE-nuance): a node qualifies only
+    when ALL of:
+      * it is not the failing node itself (its output is indeterminate);
+      * its persisted status is exactly 'completed' (a 'skipped' or
+        'pending' predecessor never ran a side effect);
+      * its definition carries a well-formed ``compensation`` block
+        (``workflow_contract.normalize_compensation_block``);
+      * that block's ``sideEffecting`` is True (the default).
+
+    Pure function — no I/O, no mutation of any input.
+    """
+    order = topological_sort(nodes, edges)
+    qualifying: set[str] = set()
+    for node in nodes:
+        nid = node['id']
+        if nid == failing_node_id:
+            continue
+        if node_results.get(nid, {}).get('status') != 'completed':
+            continue
+        try:
+            block = workflow_contract.normalize_compensation_block(node)
+        except ValueError:
+            # A malformed block at unwind time is treated the same as
+            # 'absent' (fail-safe: never let a data error stop workflows
+            # from completing their forward run, which already happened) —
+            # skip this node's compensation. Slice 1 validation already
+            # rejects malformed blocks at definition-write time; reaching
+            # this branch means a definition was authored before that
+            # validation existed.
+            continue
+        if block is None or not block.get('sideEffecting', True):
+            continue
+        qualifying.add(nid)
+
+    # Reverse of forward topological order, filtered to qualifying nodes —
+    # this is strictly reverse-topological (a node's compensation always
+    # runs before any of its own predecessors' compensations).
+    return [nid for nid in reversed(order) if nid in qualifying]
+
+
+def _comp_key(original_node_id: str) -> str:
+    """The ``nodeResults`` pseudo-node key for a node's compensation state
+    (design D7). Never collides with a real node id (real ids come only
+    from the workflow definition's ``nodes[].id``, which the frontend/
+    backend validator disallows containing '#' — the same discriminator
+    convention CIT-121 uses for tool-call sort keys)."""
+    return f'{original_node_id}#comp'
+
+
+def _dispatch_compensation(
+    execution_id: str, workflow_id: str, original_node_id: str, block: dict,
+    compensation_generation: int, *, run_id: str | None = None,
+) -> None:
+    """Write the #comp pseudo-node to 'compensating' and dispatch it to the
+    worker seam over the shared SQS queue (design D2/D4).
+
+    Inert-safety (scope item d): with no ``WORKER_QUEUE_URL`` configured this
+    degrades exactly like ``invoke_node``'s own missing-queue-url branch — it
+    logs and returns without dispatching, never raising. The message carries
+    the RAW, unresolved template ``args`` (the slice-2 renderer is NOT
+    imported here); rendering is worker-side, slice 4.
+    """
+    now = _now_iso()
+    comp_key = _comp_key(original_node_id)
+
+    _executions_table.update_item(
+        Key={'executionId': execution_id},
+        UpdateExpression=(
+            'SET nodeResults.#cid.#status = :status, '
+            'nodeResults.#cid.#dispatchedAt = :dispatchedAt, '
+            'nodeResults.#cid.#gen = :gen'
+        ),
+        ExpressionAttributeNames={
+            '#cid': comp_key,
+            '#status': 'status',
+            '#dispatchedAt': 'dispatchedAt',
+            '#gen': 'compensationGeneration',
+        },
+        ExpressionAttributeValues={
+            ':status': 'compensating',
+            ':dispatchedAt': now,
+            ':gen': compensation_generation,
+        },
+    )
+
+    _log_event(
+        'compensation_dispatch',
+        executionId=execution_id,
+        workflowId=workflow_id,
+        nodeId=original_node_id,
+        tool=block['tool'],
+    )
+
+    queue_url = os.environ.get('WORKER_QUEUE_URL')
+    if not queue_url:
+        _logger.warning(
+            'WORKER_QUEUE_URL is not set; cannot dispatch compensation for node %s of execution %s',
+            original_node_id, execution_id,
+        )
+        return
+
+    message = workflow_contract.build_compensation_dispatch_message(
+        execution_id=execution_id,
+        node_id=comp_key,
+        workflow_id=workflow_id,
+        tool=block['tool'],
+        args=block['args'],
+        compensation_generation=compensation_generation,
+        dispatched_at=now,
+        run_id=run_id,
+    )
+    _get_sqs_client().send_message(QueueUrl=queue_url, MessageBody=json.dumps(message))
+
+
+def _summary_add_completed(summary: dict, node_id: str) -> dict:
+    return {**summary, 'completed': summary.get('completed', []) + [node_id]}
+
+
+def _summary_mark_stopped(summary: dict, node_id: str, reason: str) -> dict:
+    return {
+        **summary,
+        'failed': summary.get('failed', []) + [node_id],
+        'stoppedAt': node_id,
+        'reason': reason,
+    }
+
+
+def _maybe_trigger_compensation_unwind(
+    execution_id: str, failing_node_id: str, error: str, workflow: dict,
+    execution: dict, node_results: dict,
+) -> None:
+    """Evaluate the slice-1 workflow-level compensation policy and, if it
+    applies to this terminal failure, compute the reverse-topological plan
+    and dispatch the FIRST compensation (design D5: sequential, one at a
+    time).
+
+    Gates, all of which must hold for an unwind to fire (scope item a):
+      1. The workflow's ``configuration.compensation`` policy normalizes to
+         ``enabled: True`` and ``trigger.mode == 'on_terminal_failure'``
+         (``workflow_contract.normalize_compensation_policy`` — absent
+         policy defaults to disabled, so this is the byte-identical-when-
+         absent path).
+      2. The failing node's classified failure is NOT in the
+         CIRCUIT_OPEN / RETRY_AFTER_HUMAN carve-out (decision dfe2d9a1) —
+         those are left for the future recovery queue, never compensated.
+      3. At least ``trigger.minCompletedNodes`` qualifying nodes exist in
+         the reverse-topo plan (an early failure with too few completed
+         side effects skips the unwind ceremony entirely).
+
+    A workflow with no policy, a disabled policy, or a plan of zero
+    qualifying nodes writes NOTHING beyond what ``handle_node_failure``
+    already wrote — no ``compensationStatus``, no ``compensationGeneration``,
+    no ``#comp`` keys. This is the byte-identical assertion under test.
+    """
+    raw_policy = None
+    configuration = workflow.get('configuration')
+    if isinstance(configuration, str):
+        try:
+            configuration = json.loads(configuration)
+        except ValueError:
+            configuration = None
+    if isinstance(configuration, dict):
+        raw_policy = configuration.get('compensation')
+
+    try:
+        policy = workflow_contract.normalize_compensation_policy(raw_policy)
+    except ValueError:
+        # A malformed policy behaves as disabled (fail-safe) — a workflow's
+        # compensation config must never be able to CRASH the already-
+        # terminal failure path it is layered on top of.
+        return
+
+    if not policy['enabled'] or policy['trigger']['mode'] != 'on_terminal_failure':
+        return
+
+    failure_class = failure_taxonomy.classify(error)
+    if failure_class in (failure_taxonomy.FailureClass.CIRCUIT_OPEN,
+                          failure_taxonomy.FailureClass.APPROVAL_ABSENT):
+        # decision dfe2d9a1: CIRCUIT_OPEN and RETRY_AFTER_HUMAN (the
+        # disposition for APPROVAL_ABSENT) do NOT compensate — left for the
+        # future recovery queue.
+        return
+
+    definition = _parse_definition(workflow)
+    nodes = definition.get('nodes', [])
+    edges = definition.get('edges', [])
+
+    plan = _reverse_topo_compensation_plan(nodes, edges, node_results, failing_node_id)
+    if len(plan) < policy['trigger']['minCompletedNodes']:
+        return
+    if not plan:
+        return
+
+    # Mint the per-execution compensationGeneration fence (design D3/scope
+    # item e) exactly once per unwind, and seed compensationStatus='running'
+    # + the ordered plan. A SINGLE update_item call so a reader can never
+    # observe compensationGeneration without compensationStatus (or vice
+    # versa) — there is no partial-write window visible to another caller.
+    _executions_table.update_item(
+        Key={'executionId': execution_id},
+        UpdateExpression=(
+            'SET #compStatus = :running, #compPlan = :plan, #compSummary = :summary '
+            'ADD #compGen :one'
+        ),
+        ExpressionAttributeNames={
+            '#compStatus': 'compensationStatus',
+            '#compPlan': 'compensationPlan',
+            '#compSummary': 'compensationSummary',
+            '#compGen': 'compensationGeneration',
+        },
+        ExpressionAttributeValues={
+            ':running': 'running',
+            ':plan': plan,
+            ':summary': {'completed': [], 'failed': []},
+            ':one': 1,
+        },
+    )
+    fresh = _load_execution(execution_id) or execution
+    generation = fresh.get('compensationGeneration', 1)
+
+    first_node_id = plan[0]
+    first_node_def = next((n for n in nodes if n['id'] == first_node_id), None)
+    block = workflow_contract.normalize_compensation_block(first_node_def) if first_node_def else None
+    if block is None:
+        # Defensive: the plan was just built from a successful normalize —
+        # this branch should be unreachable, but never dispatch a malformed
+        # block if it somehow is.
+        return
+
+    workflow_id = execution.get('workflowId', '')
+    _dispatch_compensation(
+        execution_id, workflow_id, first_node_id, block, generation,
+        run_id=execution.get('runId'),
+    )
+
+
+def handle_compensation_result(
+    execution_id: str, original_node_id: str, *, success: bool,
+    output: dict | None = None, error: str | None = None,
+    compensation_generation: int | None = None,
+) -> None:
+    """Advance (or stop) a running unwind after one compensation's result.
+
+    This is the compensation-side analogue of ``handle_node_completion`` /
+    ``handle_node_failure`` — it is the single re-entry point the (future,
+    slice-4) worker result event drives, and is called directly by tests
+    that simulate that event today.
+
+    Fencing (design D3/scope item e): if ``compensation_generation`` is
+    supplied and does not match the execution's CURRENT
+    ``compensationGeneration``, the result is a STALE delivery (e.g. a
+    watchdog already re-drove the unwind and minted a new generation) and is
+    ignored entirely — no state write, no further dispatch. Mirrors CIT-121's
+    forward-dispatch generation fence.
+
+    Idempotency: a result for a #comp pseudo-node that is already terminal
+    ('compensated' or 'compensation_failed') is a no-op — no re-write, no
+    re-dispatch of the next plan entry. This absorbs a duplicate delivery
+    exactly like ``handle_node_completion``'s first-write-wins guard.
+
+    On failure (onFailure='stop', the only supported/default behaviour per
+    decision dfe2d9a1): the #comp node is marked 'compensation_failed', the
+    execution's ``compensationStatus`` becomes 'partial', and
+    ``compensationSummary`` records the stop point. The remaining plan is
+    NEVER dispatched.
+    """
+    execution = _load_execution(execution_id)
+    if not execution:
+        return
+
+    if execution.get('compensationStatus') not in ('running',):
+        # No unwind in flight (never started, or already reached a terminal
+        # compensationStatus) — a stray/duplicate result has nothing to
+        # advance.
+        return
+
+    current_generation = execution.get('compensationGeneration')
+    if compensation_generation is not None and compensation_generation != current_generation:
+        _log_event(
+            'compensation_result_stale_generation',
+            executionId=execution_id,
+            nodeId=original_node_id,
+            resultGeneration=compensation_generation,
+            currentGeneration=current_generation,
+        )
+        return
+
+    comp_key = _comp_key(original_node_id)
+    node_results = execution.get('nodeResults', {})
+    comp_state = node_results.get(comp_key, {})
+    if comp_state.get('status') in ('compensated', 'compensation_failed'):
+        # Idempotent no-op: already terminal (duplicate delivery).
+        return
+
+    plan = execution.get('compensationPlan', [])
+    try:
+        current_index = plan.index(original_node_id)
+    except ValueError:
+        # Not part of the tracked plan — ignore rather than corrupt state.
+        return
+
+    summary = execution.get('compensationSummary', {'completed': [], 'failed': []})
+    workflow_id = execution.get('workflowId', '')
+
+    if not success:
+        # onFailure='stop' (decision dfe2d9a1 — the only mode this slice
+        # implements; 'continue' is deferred, see design D5 owner-call).
+        # STOP the unwind: mark this compensation failed, record the stop
+        # point, and never dispatch the remaining plan entries.
+        new_summary = _summary_mark_stopped(summary, original_node_id, error or 'compensation_failed')
+        _executions_table.update_item(
+            Key={'executionId': execution_id},
+            UpdateExpression=(
+                'SET nodeResults.#cid.#status = :failed, '
+                'nodeResults.#cid.#error = :error, '
+                '#compStatus = :partial, #compSummary = :summary'
+            ),
+            ConditionExpression='nodeResults.#cid.#status = :compensating',
+            ExpressionAttributeNames={
+                '#cid': comp_key,
+                '#status': 'status',
+                '#error': 'error',
+                '#compStatus': 'compensationStatus',
+                '#compSummary': 'compensationSummary',
+            },
+            ExpressionAttributeValues={
+                ':failed': 'compensation_failed',
+                ':error': error or 'compensation_failed',
+                ':partial': 'partial',
+                ':summary': new_summary,
+                ':compensating': 'compensating',
+            },
+        )
+        _log_event(
+            'compensation_failed_stop',
+            executionId=execution_id,
+            workflowId=workflow_id,
+            nodeId=original_node_id,
+            error=error,
+        )
+        return
+
+    # Success: mark this #comp node compensated, advance to the next plan
+    # entry (if any), or finish the unwind.
+    new_summary = _summary_add_completed(summary, original_node_id)
+    is_last = current_index == len(plan) - 1
+    final_status = 'completed' if is_last else 'running'
+    try:
+        _executions_table.update_item(
+            Key={'executionId': execution_id},
+            UpdateExpression=(
+                'SET nodeResults.#cid.#status = :compensated, '
+                '#compStatus = :finalStatus, #compSummary = :summary'
+            ),
+            ConditionExpression='nodeResults.#cid.#status = :compensating',
+            ExpressionAttributeNames={
+                '#cid': comp_key,
+                '#status': 'status',
+                '#compStatus': 'compensationStatus',
+                '#compSummary': 'compensationSummary',
+            },
+            ExpressionAttributeValues={
+                ':compensated': 'compensated',
+                ':finalStatus': final_status,
+                ':summary': new_summary,
+                ':compensating': 'compensating',
+            },
+        )
+    except ClientError as exc:
+        if exc.response.get('Error', {}).get('Code') == 'ConditionalCheckFailedException':
+            # Another delivery already advanced this #comp node — benign,
+            # absorbs the duplicate.
+            return
+        _logger.error(
+            'handle_compensation_result: advance write failed for execution=%s node=%s: %s',
+            execution_id, original_node_id, exc,
+        )
+        raise
+
+    if is_last:
+        return
+
+    workflow = _load_workflow(workflow_id)
+    if not workflow:
+        return
+    definition = _parse_definition(workflow)
+    nodes = definition.get('nodes', [])
+    next_node_id = plan[current_index + 1]
+    next_node_def = next((n for n in nodes if n['id'] == next_node_id), None)
+    if not next_node_def:
+        return
+    block = workflow_contract.normalize_compensation_block(next_node_def)
+    if block is None:
+        return
+
+    fresh = _load_execution(execution_id) or execution
+    generation = fresh.get('compensationGeneration', current_generation or 1)
+    _dispatch_compensation(
+        execution_id, workflow_id, next_node_id, block, generation,
+        run_id=execution.get('runId'),
+    )
 
 
 def cancel_execution(execution_id: str) -> None:

--- a/arbiter/stepRunner/timeout_watchdog.py
+++ b/arbiter/stepRunner/timeout_watchdog.py
@@ -421,6 +421,15 @@ def handler(event, context):
     frontier, else reconcile-or-fail a stalled node, else fail the execution at
     the execution-level backstop. Returns a small summary dict for
     observability.
+
+    CIT-123 slice 3 (scope item f): this sweep is DELIBERATELY scoped to
+    ``status=='running'`` executions ONLY, matching ``_scan_running``'s
+    filter and the design's explicit downstream-consumer-safety requirement
+    that the watchdog's primary scan never picks up a 'failed' execution with
+    an in-flight unwind. A stalled unwind lives on an ALREADY-'failed'
+    execution (D7) and is therefore handled by the separate
+    ``reconcile_stalled_compensations`` sweep below, never folded into this
+    loop.
     """
     now = _now()
     timeout = _timeout_seconds()
@@ -451,3 +460,157 @@ def handler(event, context):
         'reDispatched': re_dispatched,
         'nodeFailed': node_failed,
     }
+
+
+# ---------------------------------------------------------------------------
+# CIT-123 slice 3 — stalled compensation-unwind detection (scope item f).
+#
+# A running unwind lives on an execution whose top-level ``status`` is
+# ALREADY 'failed' (design D7 — compensation never introduces a new
+# top-level status), with ``compensationStatus == 'running'``. That
+# execution is therefore INVISIBLE to ``_scan_running``/``handler`` above by
+# design (both filter on status=='running', per the downstream-consumer-
+# safety requirement). Without a dedicated sweep, a compensation dispatched
+# to the not-yet-built worker seam (slice 4) that never replies would stall
+# SILENTLY forever — this sweep is that missing detection, satisfying "a
+# stalled unwind must be detected, not silent" without changing what the
+# primary running-execution scan considers terminal.
+#
+# Scan strategy note: DynamoDB has no GSI on ``compensationStatus`` today (no
+# schema/CDK change in this slice's scope), so this reuses the same
+# unindexed Scan + FilterExpression pattern ``_scan_running`` already uses
+# for ``status`` — acceptable for the same reason that one is: a low-
+# frequency scheduled sweep, not a hot path.
+# ---------------------------------------------------------------------------
+
+
+def _scan_compensating() -> list:
+    """Scan the executions table for items with compensationStatus == 'running'.
+
+    Mirrors ``_scan_running``'s pagination pattern exactly.
+    """
+    items: list = []
+    scan_kwargs = {
+        'FilterExpression': '#cs = :running',
+        'ExpressionAttributeNames': {'#cs': 'compensationStatus'},
+        'ExpressionAttributeValues': {':running': 'running'},
+    }
+    while True:
+        resp = _executions_table.scan(**scan_kwargs)
+        items.extend(resp.get('Items', []))
+        last_key = resp.get('LastEvaluatedKey')
+        if not last_key:
+            break
+        scan_kwargs['ExclusiveStartKey'] = last_key
+    return items
+
+
+def _find_stalled_compensation(execution: dict, now: datetime, node_stall: int):
+    """Return the id of a #comp pseudo-node stuck 'compensating' past the
+    node-stall threshold, else None. Reuses the SAME stall window as forward
+    node stall detection (``NODE_STALL_TIMEOUT_SECONDS`` *
+    ``NODE_STALL_FACTOR``) — a compensation is a single deterministic
+    governed tool call (design D2), materially cheaper than an agent turn,
+    so the forward-node threshold is a conservative (generous) upper bound,
+    not an undersized one. Absence of a parseable ``dispatchedAt`` is judged
+    conservatively (never fails on unknown age), matching
+    ``_find_stalled_node``'s convention exactly."""
+    cutoff = now - timedelta(seconds=node_stall)
+    for key, nr in (execution.get('nodeResults') or {}).items():
+        if not key.endswith('#comp') or nr.get('status') != 'compensating':
+            continue
+        dispatched = _parse_iso(nr.get('dispatchedAt', ''))
+        if dispatched is not None and dispatched <= cutoff:
+            return key
+    return None
+
+
+def _fail_stalled_compensation(execution: dict, comp_key: str) -> bool:
+    """Idempotently mark one stalled #comp pseudo-node
+    'compensation_failed' and STOP the unwind (onFailure='stop', decision
+    dfe2d9a1 — the only mode this slice implements), recording the stop
+    point on ``compensationSummary`` exactly like a worker-reported failure
+    would (design D6/D7). The conditional guard (#status = 'compensating')
+    makes this a no-op if another sweep or a late worker reply already
+    advanced the node — returns False in that case, True if THIS call
+    performed the transition."""
+    execution_id = execution['executionId']
+    original_node_id = comp_key[: -len('#comp')]
+    summary = execution.get('compensationSummary', {'completed': [], 'failed': []})
+    new_summary = {
+        **summary,
+        'failed': summary.get('failed', []) + [original_node_id],
+        'stoppedAt': original_node_id,
+        'reason': 'compensation_stalled',
+    }
+    try:
+        _executions_table.update_item(
+            Key={'executionId': execution_id},
+            UpdateExpression=(
+                'SET nodeResults.#cid.#status = :failed, '
+                'nodeResults.#cid.#error = :error, '
+                '#compStatus = :partial, #compSummary = :summary'
+            ),
+            ConditionExpression='nodeResults.#cid.#status = :compensating',
+            ExpressionAttributeNames={
+                '#cid': comp_key,
+                '#status': 'status',
+                '#error': 'error',
+                '#compStatus': 'compensationStatus',
+                '#compSummary': 'compensationSummary',
+            },
+            ExpressionAttributeValues={
+                ':failed': 'compensation_failed',
+                ':error': 'compensation stalled: exceeded the node stall timeout with no worker reply',
+                ':partial': 'partial',
+                ':summary': new_summary,
+                ':compensating': 'compensating',
+            },
+        )
+    except ClientError as exc:
+        if exc.response.get('Error', {}).get('Code') == 'ConditionalCheckFailedException':
+            return False
+        _logger.error(
+            'watchdog: stalled-compensation fail write failed for executionId=%s node=%s: %s',
+            execution_id, comp_key, exc,
+        )
+        raise
+
+    _logger.warning(
+        'watchdog: failed stalled compensation executionId=%s node=%s',
+        execution_id, comp_key,
+    )
+    return True
+
+
+def reconcile_stalled_compensations() -> dict:
+    """Dedicated sweep for stalled compensation unwinds (scope item f).
+
+    Scans every execution with ``compensationStatus == 'running'``
+    (necessarily already ``status == 'failed'`` — D7), and for each one
+    whose currently-dispatched #comp pseudo-node has exceeded the node-stall
+    threshold with no reply, marks it 'compensation_failed' and stops the
+    unwind (decision dfe2d9a1's onFailure='stop'). A healthy in-flight
+    compensation (dispatched within the stall window) is left untouched.
+
+    Never touches ``status`` — only ``nodeResults.<key>.status``,
+    ``compensationStatus``, and ``compensationSummary``, preserving the
+    downstream-consumer-safety invariant that this slice adds no new
+    top-level execution status.
+
+    Returns a small summary dict for observability, mirroring ``handler``'s
+    shape.
+    """
+    now = _now()
+    node_stall = _node_stall_seconds()
+
+    scanned = 0
+    failed = 0
+    for execution in _scan_compensating():
+        scanned += 1
+        comp_key = _find_stalled_compensation(execution, now, node_stall)
+        if comp_key is not None:
+            if _fail_stalled_compensation(execution, comp_key):
+                failed += 1
+
+    return {'scanned': scanned, 'compensationFailed': failed}


### PR DESCRIPTION
## Summary

Third slice of compensation actions: the executor now plans and drives an unwind when an execution fails terminally. Worker-side execution is the next slice, so this is inert until then unless a workflow opts in.

- Triggered at the terminal node-failure branch, gated on the workfLow compensation policy. Absent or disabled policy is byte-identical to today
- Selects completed, side-effecting nodes carrying a compensation block, ordered strictly reverse-topological, driven sequentially. The failing node is never compensated - its output is indeterminate
- Per-compensation state lives on `#comp` pseudo-nodes (compensating / compensated / compensation_failed). Execution status stays `failed` with an additive `compensationStatus`; no new top-level status
- `compensationGeneration` fences a stale unwind worker: a stale dispatch fails the Ledger reservation rather than acting
- New `reconcile_stalled_compensations` watchdog sweep, so a stalled unwind is detected rather than silent

## Policy honoured (ratified decision)

`CIRCUIT_OPEN` and `RETRY_AFTER_HUMAN` do not compensate - a breaker-open target is already known unhealthy and belongs to the future recovery queue. A failed compensation stops the unwind, recording `stoppedAt` and reason on a `compensationSummary`, rather than acting further on resources in unknown state.

## Downstream consumers verified unaffected

Execution status is read by the watchdog, `schedule_frontier`, eval evidence, promotion gates and canary error-rate signals, so a new status value would have stranded or mis-bucketed executions. Tests prove `all_terminal` ignores `#comp` keys, the watchdog's `status=='running'` scan never picks up a compensating execution, and plain status readers still see `failed`.

## Testing

- 30 red-first tests: trigger gating, failure-class carve-outs, selection and ordering (3-node chain plus parallel DAG), sequential drive and state, dispatch inert-safety, generation fence, watchdog stall, downstream safety
- Inert-safety proven: state is written before the SQS send, so a dispatch with no worker handler leaves a consistent, queryable row and cannot hang the execution
- Scoped pytest 572 passing; full-suite failures proven identical to a clean main worktree (pre-existing strands/moto gaps plus one known seedConfig flake)

## Notes

- No dependency on the args renderer: templates pass through raw in the dispatch payload, since rendering happens worker-side in the next slice `onFailure='continue'` is deliberately not implemented - only the ratified `stop` default
- The stall sweep reuses the existing node-stall threshold rather than adding a new knob, documented in code as a conservative upper bound
- No worker-execution, CDK or UI changes; the interim failure sink is slice 5