### PR TITLE
feat(worker): governed compensation execution through the tool seam

### DIFF
--- a/arbiter/common/__tests__/test_workflow_contract.py
+++ b/arbiter/common/__tests__/test_workflow_contract.py
@@ -44,6 +44,14 @@ _ids = st.text(
     min_size=1,
     max_size=40,
 )
+# Identity fields that flow through _validate_identity (execution_id,
+# node_id, workflow_id, agent_id on build_node_dispatch_message /
+# build_node_result_detail): same as _ids but excludes the reserved ledger
+# key delimiter '#', which those builders now reject (see
+# common.workflow_contract._validate_identity / LEDGER_KEY_DELIMITER, the
+# f9ceb38e ledger-key-collision fix). '#'-hygiene itself is covered by its
+# own dedicated rejection tests below.
+_identity_ids = _ids.filter(lambda s: '#' not in s)
 # Free text (may be empty) with no surrogates — safe for json round-trips.
 _text = st.text(st.characters(blacklist_categories=('Cs',)), max_size=60)
 # Non-empty free text (for error strings).
@@ -80,10 +88,10 @@ def test_discriminator_and_status_constants_have_expected_values():
 
 
 @given(
-    execution_id=_ids,
-    node_id=_ids,
-    workflow_id=_ids,
-    agent_id=_ids,
+    execution_id=_identity_ids,
+    node_id=_identity_ids,
+    workflow_id=_identity_ids,
+    agent_id=_identity_ids,
     input_data=_json_dicts,
     configuration=_json_dicts,
     correlation_id=st.none() | _ids,
@@ -112,10 +120,10 @@ def test_dispatch_message_round_trips_all_fields(
 
 
 @given(
-    execution_id=_ids,
-    node_id=_ids,
-    workflow_id=_ids,
-    agent_id=_ids,
+    execution_id=_identity_ids,
+    node_id=_identity_ids,
+    workflow_id=_identity_ids,
+    agent_id=_identity_ids,
     input_data=_json_dicts,
     configuration=_json_dicts,
 )
@@ -196,10 +204,10 @@ def test_build_dispatch_rejects_empty_identifier():
 
 
 @given(
-    execution_id=_ids,
-    node_id=_ids,
-    workflow_id=_ids,
-    agent_id=_ids,
+    execution_id=_identity_ids,
+    node_id=_identity_ids,
+    workflow_id=_identity_ids,
+    agent_id=_identity_ids,
     output=_json_dicts,
     timestamp=_ids,
 )
@@ -228,10 +236,10 @@ def test_result_detail_round_trips_when_completed(
 
 
 @given(
-    execution_id=_ids,
-    node_id=_ids,
-    workflow_id=_ids,
-    agent_id=_ids,
+    execution_id=_identity_ids,
+    node_id=_identity_ids,
+    workflow_id=_identity_ids,
+    agent_id=_identity_ids,
     error=_nonempty_text,
     timestamp=_ids,
 )

--- a/arbiter/common/workflow_contract.py
+++ b/arbiter/common/workflow_contract.py
@@ -357,11 +357,42 @@ def _require_non_empty_str(mapping: dict, key: str, kind: str) -> str:
     return value
 
 
+#: Delimiter used to join segments of the tool-execution ledger's sort key
+#: (``nodeId#callIndex#toolName#argsHash``, see
+#: ``workerWrapper.tool_idempotency.build_sort_key``). An identifier that
+#: itself contains this character can derive a ledger key indistinguishable
+#: from a DIFFERENT identifier's key (e.g. node id ``n1#comp`` collides with
+#: the compensation pseudo-node derived from node id ``n1``) — the colliding
+#: party then replays the other's recorded result via a ledger HIT_COMPLETED
+#: and skips its own real side effect. Rejected here, at message BUILD time
+#: (create/send), for every identifier that flows into a ledger key segment.
+#: This function is NOT called on the message PARSE/read path (see
+#: ``parse_node_dispatch_message`` / ``parse_node_result_detail``), so an
+#: already-stored message or workflow execution containing a legacy '#'
+#: identifier still parses; only NEW build calls are rejected.
+#:
+#: Scope note: this module has no workflow-DEFINITION (nodes[].id)
+#: create/update validator — that create/update path lives in the backend
+#: TypeScript layer (``backend/src/lambda/workflow-resolver.ts``), which
+#: currently applies NO character restriction to a node id either (confirmed
+#: by inspection: no ``valid``/regex/pattern check on any node id field in
+#: that resolver). No committed/seeded workflow definition or blueprint in
+#: this repository uses ``'#'`` in a node id (confirmed by search). Extending
+#: rejection to that TypeScript create/update path is out of scope for this
+#: Python-side ledger-key fix; flagged here rather than silently assumed.
+LEDGER_KEY_DELIMITER = '#'
+
+
 def _validate_identity(kind: str, **fields: Any) -> None:
     for key, value in fields.items():
         if not isinstance(value, str) or value == '':
             raise ValueError(
                 f"{kind}: field '{key}' is required and must be a non-empty string"
+            )
+        if LEDGER_KEY_DELIMITER in value:
+            raise ValueError(
+                f"{kind}: field '{key}' must not contain the reserved "
+                f"delimiter {LEDGER_KEY_DELIMITER!r} (got {value!r})"
             )
 
 

--- a/arbiter/workerWrapper/__tests__/test_compensation_executor.py
+++ b/arbiter/workerWrapper/__tests__/test_compensation_executor.py
@@ -123,6 +123,20 @@ def moto_tables(monkeypatch):
 
 
 def _seed_execution_row(resource, execution_id, node_id, generation=1):
+    """Seed the execution row's ``nodeResults[node_id].dispatchGeneration``
+    fence value.
+
+    ``node_id`` here MUST be the ORIGIN node id (e.g. ``"node-a"``), never
+    the ``"node-a#comp"`` wire pseudo-id ``_dispatch()`` below puts on the
+    dispatch's ``node_id`` field. ``execute_compensation`` strips the
+    ``'#comp'`` suffix (via ``_origin_node_id``) before building the
+    ``IdempotencyToolHook``/fenced reserve, so the fence lookup
+    (``nodeResults.<nodeId>.dispatchGeneration``) is keyed by the ORIGIN id —
+    seeding this row under the pseudo id would make every fenced-reserve
+    test below fail closed with a fence-condition mismatch, not the
+    behaviour under test. See ``compensation_executor._origin_node_id`` /
+    ``build_compensation_hook``'s docstring (f9ceb38e fix).
+    """
     resource.Table(EXEC_TABLE).put_item(Item={
         "executionId": execution_id,
         "nodeResults": {node_id: {"dispatchGeneration": generation}},
@@ -246,7 +260,7 @@ class TestGovernanceDeny:
         escalations = []
         monkeypatch.setattr(ce, "_escalate", lambda **kw: escalations.append(kw))
 
-        _seed_execution_row(moto_tables, "exec-1", "node-a#comp", generation=1)
+        _seed_execution_row(moto_tables, "exec-1", "node-a", generation=1)
 
         result = ce.execute_compensation(
             _dispatch(),
@@ -265,7 +279,7 @@ class TestGovernanceDeny:
         executed = []
         resolver = _resolver(executed, name="close_ticket")
         monkeypatch.setattr(ce, "_escalate", lambda **kw: None)
-        _seed_execution_row(moto_tables, "exec-1", "node-a#comp", generation=1)
+        _seed_execution_row(moto_tables, "exec-1", "node-a", generation=1)
 
         ce.execute_compensation(
             _dispatch(), recorded_output=_recorded_output(), org_id="org1",
@@ -288,7 +302,7 @@ class TestDoubleDelivery:
         executed = []
         resolver = _resolver(executed, name="close_ticket")
         monkeypatch.setattr(ce, "_escalate", lambda **kw: None)
-        _seed_execution_row(moto_tables, "exec-1", "node-a#comp", generation=1)
+        _seed_execution_row(moto_tables, "exec-1", "node-a", generation=1)
 
         first = ce.execute_compensation(
             _dispatch(), recorded_output=_recorded_output(), org_id="org1",
@@ -318,7 +332,7 @@ class TestStaleGeneration:
         resolver = _resolver(executed, name="close_ticket")
         monkeypatch.setattr(ce, "_escalate", lambda **kw: None)
         # Execution row fenced at generation 2; dispatch carries stale gen 1.
-        _seed_execution_row(moto_tables, "exec-1", "node-a#comp", generation=2)
+        _seed_execution_row(moto_tables, "exec-1", "node-a", generation=2)
 
         result = ce.execute_compensation(
             _dispatch(generation=1), recorded_output=_recorded_output(),
@@ -342,7 +356,7 @@ class TestBreakerOpen:
         executed = []
         resolver = _resolver(executed, name="close_ticket")
         monkeypatch.setattr(ce, "_escalate", lambda **kw: None)
-        _seed_execution_row(moto_tables, "exec-1", "node-a#comp", generation=1)
+        _seed_execution_row(moto_tables, "exec-1", "node-a", generation=1)
 
         target = BreakerTarget(kind="mcp_server", target_id="mcp-1")
         moto_tables.Table(BREAKER_TABLE).put_item(Item={
@@ -378,7 +392,7 @@ class TestOffloadedRehydration:
         executed = []
         resolver = _resolver(executed, name="close_ticket")
         monkeypatch.setattr(ce, "_escalate", lambda **kw: None)
-        _seed_execution_row(moto_tables, "exec-1", "node-a#comp", generation=1)
+        _seed_execution_row(moto_tables, "exec-1", "node-a", generation=1)
 
         rehydrate_calls = []
 
@@ -410,7 +424,7 @@ class TestFailClosedOutput:
         resolver = _resolver(executed, name="close_ticket")
         escalations = []
         monkeypatch.setattr(ce, "_escalate", lambda **kw: escalations.append(kw))
-        _seed_execution_row(moto_tables, "exec-1", "node-a#comp", generation=1)
+        _seed_execution_row(moto_tables, "exec-1", "node-a", generation=1)
 
         result = ce.execute_compensation(
             _dispatch(), recorded_output=None, org_id="org1",
@@ -425,7 +439,7 @@ class TestFailClosedOutput:
         executed = []
         resolver = _resolver(executed, name="close_ticket")
         monkeypatch.setattr(ce, "_escalate", lambda **kw: None)
-        _seed_execution_row(moto_tables, "exec-1", "node-a#comp", generation=1)
+        _seed_execution_row(moto_tables, "exec-1", "node-a", generation=1)
 
         result = ce.execute_compensation(
             _dispatch(), recorded_output={"resultTruncated": True, "ticketId": "T-1"},
@@ -448,7 +462,7 @@ class TestResultContract:
         executed = []
         resolver = _resolver(executed, name="close_ticket")
         monkeypatch.setattr(ce, "_escalate", lambda **kw: None)
-        _seed_execution_row(moto_tables, "exec-1", "node-a#comp", generation=1)
+        _seed_execution_row(moto_tables, "exec-1", "node-a", generation=1)
 
         result = ce.execute_compensation(
             _dispatch(), recorded_output=_recorded_output(), org_id="org1",
@@ -472,7 +486,7 @@ class TestKeyDerivation:
         executed = []
         resolver = _resolver(executed, name="close_ticket")
         monkeypatch.setattr(ce, "_escalate", lambda **kw: None)
-        _seed_execution_row(moto_tables, "exec-1", "node-a#comp", generation=1)
+        _seed_execution_row(moto_tables, "exec-1", "node-a", generation=1)
 
         ce.execute_compensation(
             _dispatch(), recorded_output=_recorded_output(), org_id="org1",
@@ -483,5 +497,10 @@ class TestKeyDerivation:
         assert len(rows) == 1
         row = rows[0]
         assert row["pk"] == "org1#exec-1"
-        # sk = origNodeId(#comp already embedded in node_id)#0#tool#argsHash
-        assert row["sk"].startswith("node-a#comp#0#close_ticket#")
+        # sk = originNodeId#callIndex#tool#argsHash#comp — the compensation
+        # marker is appended AFTER the argsHash field (never adjacent to
+        # node_id), so it is collision-free with any original call's key
+        # regardless of node_id's content. See tool_idempotency.
+        # build_sort_key / COMPENSATION_MARKER docstrings (f9ceb38e fix).
+        assert row["sk"].startswith("node-a#0#close_ticket#")
+        assert row["sk"].endswith("#comp")

--- a/arbiter/workerWrapper/__tests__/test_compensation_executor.py
+++ b/arbiter/workerWrapper/__tests__/test_compensation_executor.py
@@ -1,0 +1,487 @@
+"""CIT-123 slice 4 — worker-side GOVERNED compensation execution (red-first).
+
+Covers the load-bearing D2 decision: a compensation dispatch executes through
+the SAME ``ComposedToolHook`` seam as any agent tool call — deny-list →
+breaker → approval-consume → idempotency reservation — via an LLM-free direct
+governed tool invocation entry point. No second installer, no parallel path.
+
+strands is not installed in this env, so the strands seam is simulated with
+the SAME fake ``strands.types._events.ToolResultEvent`` / fake tool-object
+technique ``test_composed_tool_governance.py`` /
+``test_composed_tool_breaker_seam.py`` already use.
+"""
+from __future__ import annotations
+
+import asyncio
+import os
+import sys
+import types
+
+import boto3
+import pytest
+
+try:
+    from moto import mock_aws
+except ImportError:  # pragma: no cover
+    pytest.skip("moto not installed", allow_module_level=True)
+
+_PROJECT_ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "..", ".."))
+if _PROJECT_ROOT not in sys.path:
+    sys.path.insert(0, _PROJECT_ROOT)
+_HERE_WW = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
+if _HERE_WW not in sys.path:
+    sys.path.insert(0, _HERE_WW)
+
+import governed_tool_handler  # noqa: E402
+import tool_idempotency_hook  # noqa: E402
+from tool_idempotency_hook import ComposedToolHook, _IdempotentToolWrapper  # noqa: E402
+from governance_tool_hook import _GovernanceDeniedTool  # noqa: E402
+from tool_breaker_hook import ToolBreaker, _CircuitOpenTool  # noqa: E402
+from governance.tool_breaker_store import (  # noqa: E402
+    BreakerConfig, ToolBreakerStore, __reset_breaker_client_for_test,
+)
+from governance.tool_breaker_logic import BreakerTarget  # noqa: E402
+from governance.tool_execution_ledger import StaleWorkerFencedError  # noqa: E402
+
+ledger = tool_idempotency_hook.ledger
+
+LEDGER_TABLE = "citadel-tool-execution-ledger-comp-test"
+EXEC_TABLE = "citadel-executions-comp-test"
+BREAKER_TABLE = "citadel-tool-breaker-comp-test"
+
+import compensation_executor as ce  # noqa: E402
+
+
+@pytest.fixture(autouse=True)
+def _governance_writes_succeed(monkeypatch):
+    monkeypatch.setattr(governed_tool_handler, "write_finding", lambda *a, **k: None)
+    tool_idempotency_hook.drain_governance_refusals()
+    yield
+    tool_idempotency_hook.drain_governance_refusals()
+
+
+@pytest.fixture
+def fake_tool_result_event(monkeypatch):
+    mod = types.ModuleType("strands.types._events")
+
+    class ToolResultEvent:
+        def __init__(self, tool_result):
+            self.tool_result = tool_result
+
+    mod.ToolResultEvent = ToolResultEvent
+    strands_mod = sys.modules.get("strands") or types.ModuleType("strands")
+    types_mod = sys.modules.get("strands.types") or types.ModuleType("strands.types")
+    monkeypatch.setitem(sys.modules, "strands", strands_mod)
+    monkeypatch.setitem(sys.modules, "strands.types", types_mod)
+    monkeypatch.setitem(sys.modules, "strands.types._events", mod)
+    return ToolResultEvent
+
+
+@pytest.fixture
+def moto_tables(monkeypatch):
+    with mock_aws():
+        resource = boto3.Session(region_name="us-east-1").resource("dynamodb")
+        resource.create_table(
+            TableName=LEDGER_TABLE,
+            KeySchema=[{"AttributeName": "pk", "KeyType": "HASH"},
+                       {"AttributeName": "sk", "KeyType": "RANGE"}],
+            AttributeDefinitions=[{"AttributeName": "pk", "AttributeType": "S"},
+                                   {"AttributeName": "sk", "AttributeType": "S"}],
+            BillingMode="PAY_PER_REQUEST",
+        )
+        resource.create_table(
+            TableName=EXEC_TABLE,
+            KeySchema=[{"AttributeName": "executionId", "KeyType": "HASH"}],
+            AttributeDefinitions=[{"AttributeName": "executionId", "AttributeType": "S"}],
+            BillingMode="PAY_PER_REQUEST",
+        )
+        resource.create_table(
+            TableName=BREAKER_TABLE,
+            KeySchema=[{"AttributeName": "pk", "KeyType": "HASH"},
+                       {"AttributeName": "sk", "KeyType": "RANGE"}],
+            AttributeDefinitions=[{"AttributeName": "pk", "AttributeType": "S"},
+                                   {"AttributeName": "sk", "AttributeType": "S"}],
+            BillingMode="PAY_PER_REQUEST",
+        )
+        monkeypatch.setenv("TOOL_EXECUTION_LEDGER_TABLE", LEDGER_TABLE)
+        monkeypatch.setenv("EXECUTIONS_TABLE", EXEC_TABLE)
+        # Patch the RESOURCE resolver, not _table/_get_dynamodb_client
+        # individually — _get_dynamodb_client derives from
+        # _get_dynamodb_resource().meta.client, so both the Table() and the
+        # fenced TransactWriteItems path must share this SAME moto-backed
+        # resource object or the conditional writes silently stop being
+        # mutually exclusive.
+        ledger.__reset_ledger_client_for_test()
+        monkeypatch.setattr(ledger, "_get_dynamodb_resource", lambda: resource)
+        __reset_breaker_client_for_test()
+        import governance.tool_breaker_store as store_mod
+        monkeypatch.setattr(store_mod, "_get_dynamodb_resource", lambda: resource)
+        try:
+            yield resource
+        finally:
+            __reset_breaker_client_for_test()
+
+
+def _seed_execution_row(resource, execution_id, node_id, generation=1):
+    resource.Table(EXEC_TABLE).put_item(Item={
+        "executionId": execution_id,
+        "nodeResults": {node_id: {"dispatchGeneration": generation}},
+    })
+
+
+def _dispatch(*, execution_id="exec-1", node_id="node-a", tool="close_ticket",
+              args=None, generation=1, output=None):
+    return {
+        "message_type": "workflow_compensation",
+        "execution_id": execution_id,
+        "node_id": f"{node_id}#comp",
+        "workflow_id": "wf-1",
+        "tool": tool,
+        "args": args if args is not None else {"ticketId": "${output.ticketId}"},
+        "compensation_generation": generation,
+    }
+
+
+def _recorded_output(**overrides):
+    base = {"ticketId": "T-42"}
+    base.update(overrides)
+    return base
+
+
+class _RegisteredTool:
+    """A stand-in real compensation tool (mirrors _FakeInnerTool in the
+    sibling composed-hook tests). Appends to a shared log so a test can prove
+    whether the real side effect ran."""
+
+    def __init__(self, name, executed_log, result=None):
+        self._name = name
+        self._log = executed_log
+        self._result = result or {
+            "toolUseId": "tu", "status": "success", "content": [{"text": "closed"}],
+        }
+
+    @property
+    def tool_name(self):
+        return self._name
+
+    @property
+    def tool_spec(self):
+        return {"name": self._name}
+
+    @property
+    def tool_type(self):
+        return "python"
+
+    def get_display_properties(self):
+        return {}
+
+    async def stream(self, tool_use, invocation_state, **kwargs):
+        from strands.types._events import ToolResultEvent
+        self._log.append(tool_use.get("input"))
+        yield ToolResultEvent(self._result)
+
+
+def _resolver(executed_log, name="close_ticket", result=None):
+    tool = _RegisteredTool(name, executed_log, result=result)
+    return lambda tool_name: tool if tool_name == name else None
+
+
+# ---------------------------------------------------------------------------
+# NO-BYPASS structural test: compensation path and agent path share ONE
+# ComposedToolHook object/construction, never a second installer.
+# ---------------------------------------------------------------------------
+
+
+class TestNoBypassStructural:
+    def test_compensation_hook_builder_returns_a_composed_tool_hook_instance(self):
+        """The compensation entry point must build (or accept) a real
+        ComposedToolHook — never a bespoke governance-only shortcut."""
+        hook = ce.build_compensation_hook(
+            org_id="org1", execution_id="exec-1", node_id="node-a#comp",
+            agent_id="agent-1", workflow_id="wf-1",
+            compensation_generation=1, denied_tools=set(),
+        )
+        assert isinstance(hook, ComposedToolHook)
+
+    def test_compensation_and_agent_paths_call_the_same_seam_function(self, monkeypatch):
+        """Structural proof: patch ComposedToolHook.__init__ once; assert the
+        compensation executor's hook-construction path invokes the SAME class
+        object agent_runner._install_tool_call_hooks uses — not a lookalike."""
+        calls = []
+        original_init = ComposedToolHook.__init__
+
+        def _spy_init(self, *a, **k):
+            calls.append((a, k))
+            return original_init(self, *a, **k)
+
+        monkeypatch.setattr(ComposedToolHook, "__init__", _spy_init)
+        ce.build_compensation_hook(
+            org_id="org1", execution_id="exec-1", node_id="node-a#comp",
+            agent_id="agent-1", workflow_id="wf-1",
+            compensation_generation=1, denied_tools=set(),
+        )
+        assert len(calls) == 1
+
+    def test_no_second_installer_module_exists(self):
+        """compensation_executor must NOT define its own deny-list/approval/
+        idempotency-ordering logic — it must import and delegate to the
+        existing seam objects, not reimplement them."""
+        import inspect
+        src = inspect.getsource(ce)
+        # The banned move: re-deriving the deny→breaker→approval→idempotency
+        # order locally instead of delegating to ComposedToolHook.
+        assert "def _on_before_tool_call" not in src
+        assert "ComposedToolHook" in src
+
+
+# ---------------------------------------------------------------------------
+# DENY -> escalate, no execution, no bypass
+# ---------------------------------------------------------------------------
+
+
+class TestGovernanceDeny:
+    def test_deny_never_executes_and_escalates(self, moto_tables, fake_tool_result_event, monkeypatch):
+        executed = []
+        resolver = _resolver(executed, name="close_ticket")
+        escalations = []
+        monkeypatch.setattr(ce, "_escalate", lambda **kw: escalations.append(kw))
+
+        _seed_execution_row(moto_tables, "exec-1", "node-a#comp", generation=1)
+
+        result = ce.execute_compensation(
+            _dispatch(),
+            recorded_output=_recorded_output(),
+            org_id="org1",
+            denied_tools={"close_ticket"},
+            tool_resolver=resolver,
+        )
+
+        assert executed == []
+        assert result.status == "compensation_failed"
+        assert result.escalated is True
+        assert len(escalations) == 1
+
+    def test_deny_creates_no_ledger_reservation(self, moto_tables, fake_tool_result_event, monkeypatch):
+        executed = []
+        resolver = _resolver(executed, name="close_ticket")
+        monkeypatch.setattr(ce, "_escalate", lambda **kw: None)
+        _seed_execution_row(moto_tables, "exec-1", "node-a#comp", generation=1)
+
+        ce.execute_compensation(
+            _dispatch(), recorded_output=_recorded_output(), org_id="org1",
+            denied_tools={"close_ticket"}, tool_resolver=resolver,
+        )
+
+        rows = moto_tables.Table(LEDGER_TABLE).scan()["Items"]
+        assert rows == []
+
+
+# ---------------------------------------------------------------------------
+# Double delivery -> exactly one side effect (ledger HIT_COMPLETED replay)
+# ---------------------------------------------------------------------------
+
+
+class TestDoubleDelivery:
+    def test_second_identical_dispatch_replays_no_second_side_effect(
+        self, moto_tables, fake_tool_result_event, monkeypatch,
+    ):
+        executed = []
+        resolver = _resolver(executed, name="close_ticket")
+        monkeypatch.setattr(ce, "_escalate", lambda **kw: None)
+        _seed_execution_row(moto_tables, "exec-1", "node-a#comp", generation=1)
+
+        first = ce.execute_compensation(
+            _dispatch(), recorded_output=_recorded_output(), org_id="org1",
+            denied_tools=set(), tool_resolver=resolver,
+        )
+        second = ce.execute_compensation(
+            _dispatch(), recorded_output=_recorded_output(), org_id="org1",
+            denied_tools=set(), tool_resolver=resolver,
+        )
+
+        assert len(executed) == 1  # exactly one real side effect
+        assert first.status == "compensated"
+        assert second.status == "compensated"
+        assert second.replayed is True
+
+
+# ---------------------------------------------------------------------------
+# Stale generation -> refused, no side effect
+# ---------------------------------------------------------------------------
+
+
+class TestStaleGeneration:
+    def test_stale_generation_refused_with_no_side_effect(
+        self, moto_tables, fake_tool_result_event, monkeypatch,
+    ):
+        executed = []
+        resolver = _resolver(executed, name="close_ticket")
+        monkeypatch.setattr(ce, "_escalate", lambda **kw: None)
+        # Execution row fenced at generation 2; dispatch carries stale gen 1.
+        _seed_execution_row(moto_tables, "exec-1", "node-a#comp", generation=2)
+
+        result = ce.execute_compensation(
+            _dispatch(generation=1), recorded_output=_recorded_output(),
+            org_id="org1", denied_tools=set(), tool_resolver=resolver,
+        )
+
+        assert executed == []
+        assert result.status == "compensation_failed"
+        assert result.error_class == "StaleWorkerFencedError"
+
+
+# ---------------------------------------------------------------------------
+# Breaker OPEN -> fast-fail, no execution
+# ---------------------------------------------------------------------------
+
+
+class TestBreakerOpen:
+    def test_breaker_open_fast_fails_without_execution(
+        self, moto_tables, fake_tool_result_event, monkeypatch,
+    ):
+        executed = []
+        resolver = _resolver(executed, name="close_ticket")
+        monkeypatch.setattr(ce, "_escalate", lambda **kw: None)
+        _seed_execution_row(moto_tables, "exec-1", "node-a#comp", generation=1)
+
+        target = BreakerTarget(kind="mcp_server", target_id="mcp-1")
+        moto_tables.Table(BREAKER_TABLE).put_item(Item={
+            "pk": "org1#mcp_server#mcp-1", "sk": "STATE", "state": "OPEN",
+            "openedAt": 1000, "failureCount": 5, "stateVersion": 1,
+            "windowStart": 0, "updatedAt": 1000, "ttl": 1000 + 86400,
+        })
+
+        result = ce.execute_compensation(
+            _dispatch(), recorded_output=_recorded_output(), org_id="org1",
+            denied_tools=set(), tool_resolver=resolver,
+            breaker_table=BREAKER_TABLE,
+            breaker_target_resolver=lambda name: target if name == "close_ticket" else None,
+            breaker_clock=lambda: 1005.0,
+        )
+
+        assert executed == []
+        assert result.status == "compensation_failed"
+
+        rows = moto_tables.Table(LEDGER_TABLE).scan()["Items"]
+        assert rows == []  # breaker fast-fail precedes reserve: no reservation
+
+
+# ---------------------------------------------------------------------------
+# Offloaded output rehydrated then rendered
+# ---------------------------------------------------------------------------
+
+
+class TestOffloadedRehydration:
+    def test_offloaded_output_rehydrated_before_render(
+        self, moto_tables, fake_tool_result_event, monkeypatch,
+    ):
+        executed = []
+        resolver = _resolver(executed, name="close_ticket")
+        monkeypatch.setattr(ce, "_escalate", lambda **kw: None)
+        _seed_execution_row(moto_tables, "exec-1", "node-a#comp", generation=1)
+
+        rehydrate_calls = []
+
+        def _fake_rehydrate(offloaded):
+            rehydrate_calls.append(offloaded)
+            return {"ticketId": "T-99"}
+
+        monkeypatch.setattr(ce, "_rehydrate_recorded_output", _fake_rehydrate)
+
+        offloaded = {"resultOffloaded": True, "resultRef": {"bucket": "b", "key": "k"}}
+        result = ce.execute_compensation(
+            _dispatch(), recorded_output=offloaded, org_id="org1",
+            denied_tools=set(), tool_resolver=resolver,
+        )
+
+        assert rehydrate_calls == [offloaded]
+        assert executed == [{"ticketId": "T-99"}]
+        assert result.status == "compensated"
+
+
+# ---------------------------------------------------------------------------
+# Missing/truncated output -> fail-closed to compensation_failed
+# ---------------------------------------------------------------------------
+
+
+class TestFailClosedOutput:
+    def test_missing_output_fails_closed(self, moto_tables, fake_tool_result_event, monkeypatch):
+        executed = []
+        resolver = _resolver(executed, name="close_ticket")
+        escalations = []
+        monkeypatch.setattr(ce, "_escalate", lambda **kw: escalations.append(kw))
+        _seed_execution_row(moto_tables, "exec-1", "node-a#comp", generation=1)
+
+        result = ce.execute_compensation(
+            _dispatch(), recorded_output=None, org_id="org1",
+            denied_tools=set(), tool_resolver=resolver,
+        )
+
+        assert executed == []
+        assert result.status == "compensation_failed"
+        assert result.error_class == "CompensationTemplateError"
+
+    def test_truncated_output_fails_closed(self, moto_tables, fake_tool_result_event, monkeypatch):
+        executed = []
+        resolver = _resolver(executed, name="close_ticket")
+        monkeypatch.setattr(ce, "_escalate", lambda **kw: None)
+        _seed_execution_row(moto_tables, "exec-1", "node-a#comp", generation=1)
+
+        result = ce.execute_compensation(
+            _dispatch(), recorded_output={"resultTruncated": True, "ticketId": "T-1"},
+            org_id="org1", denied_tools=set(), tool_resolver=resolver,
+        )
+
+        assert executed == []
+        assert result.status == "compensation_failed"
+
+
+# ---------------------------------------------------------------------------
+# Successful compensation emits the expected result contract
+# ---------------------------------------------------------------------------
+
+
+class TestResultContract:
+    def test_success_result_carries_expected_fields(
+        self, moto_tables, fake_tool_result_event, monkeypatch,
+    ):
+        executed = []
+        resolver = _resolver(executed, name="close_ticket")
+        monkeypatch.setattr(ce, "_escalate", lambda **kw: None)
+        _seed_execution_row(moto_tables, "exec-1", "node-a#comp", generation=1)
+
+        result = ce.execute_compensation(
+            _dispatch(), recorded_output=_recorded_output(), org_id="org1",
+            denied_tools=set(), tool_resolver=resolver,
+        )
+
+        assert result.status == "compensated"
+        assert result.execution_id == "exec-1"
+        assert result.node_id == "node-a#comp"
+        assert result.tool == "close_ticket"
+        assert executed == [{"ticketId": "T-42"}]
+
+
+# ---------------------------------------------------------------------------
+# CIT-121 key derivation
+# ---------------------------------------------------------------------------
+
+
+class TestKeyDerivation:
+    def test_key_uses_comp_namespace_and_call_index_zero(self, moto_tables, fake_tool_result_event, monkeypatch):
+        executed = []
+        resolver = _resolver(executed, name="close_ticket")
+        monkeypatch.setattr(ce, "_escalate", lambda **kw: None)
+        _seed_execution_row(moto_tables, "exec-1", "node-a#comp", generation=1)
+
+        ce.execute_compensation(
+            _dispatch(), recorded_output=_recorded_output(), org_id="org1",
+            denied_tools=set(), tool_resolver=resolver,
+        )
+
+        rows = moto_tables.Table(LEDGER_TABLE).scan()["Items"]
+        assert len(rows) == 1
+        row = rows[0]
+        assert row["pk"] == "org1#exec-1"
+        # sk = origNodeId(#comp already embedded in node_id)#0#tool#argsHash
+        assert row["sk"].startswith("node-a#comp#0#close_ticket#")

--- a/arbiter/workerWrapper/__tests__/test_tool_idempotency.py
+++ b/arbiter/workerWrapper/__tests__/test_tool_idempotency.py
@@ -22,11 +22,13 @@ if _PROJECT_ROOT not in sys.path:
 from arbiter.workerWrapper.tool_idempotency import (  # noqa: E402
     BypassMisflagError,
     CanonicalizationError,
+    COMPENSATION_MARKER,
     MODE_BYPASS,
     MODE_LEDGER,
     args_hash,
     build_key,
     build_partition_key,
+    build_sort_key,
     canonicalize,
     check_bypass_classification,
     classify_idempotency_mode,
@@ -198,6 +200,131 @@ class TestKeyDerivation:
         _, sk_a = build_key("o", "e", "n", 0, "t", {"x": 1})
         _, sk_b = build_key("o", "e", "n", 0, "t", {"x": 2})
         assert sk_a != sk_b
+
+
+# ---------------------------------------------------------------------------
+# f9ceb38e — compensation ledger-key collision fix
+#
+# The defect (verified empirically): a compensation for node id 'n1' derived
+# its key by handing build_key/build_sort_key the ALREADY-SUFFIXED string
+# 'n1#comp' as a plain node_id. A node literally NAMED 'n1#comp' running its
+# OWN original (non-compensation) call derives the identical sort key
+# ('n1#comp#0#TOOL#argsHash' either way) — the colliding party then replays
+# the other's recorded result via a ledger HIT_COMPLETED and skips its real
+# side effect. Fixed at two layers:
+#   1. common.workflow_contract._validate_identity now rejects the reserved
+#      '#' delimiter in any identifier that flows into a dispatch/result
+#      message build (covered by test_workflow_contract.py).
+#   2. Belt-and-braces, HERE: build_sort_key/build_key take an explicit
+#      is_compensation flag that appends COMPENSATION_MARKER as a 5th field
+#      AFTER hash_hex (never adjacent to node_id). hash_hex is always exactly
+#      64 lowercase hex characters with no '#', so an original (4-field) key
+#      can never end in the literal "#comp" a compensation (5-field) key
+#      appends — collision-freedom holds for EVERY possible node_id,
+#      independent of identifier hygiene. Two earlier designs (a marker
+#      segment adjacent to node_id; splitting the partition key) were tried
+#      and proven unsound/invasive respectively — see COMPENSATION_MARKER's
+#      docstring in tool_idempotency.py for why they were rejected.
+# ---------------------------------------------------------------------------
+
+
+class TestCompensationMarkerCollisionFix:
+    def test_concrete_regression_n1_comp_literal_node_id(self):
+        """The exact defect scenario: an ORIGINAL (non-compensation) call for
+        a node literally named 'n1#comp' must NOT collide with a
+        COMPENSATION call for a node named 'n1'."""
+        original_pk, original_sk = build_key(
+            "org1", "exec1", "n1#comp", 0, "TOOL", {"a": 1},
+            is_compensation=False,
+        )
+        compensation_pk, compensation_sk = build_key(
+            "org1", "exec1", "n1", 0, "TOOL", {"a": 1},
+            is_compensation=True,
+        )
+        assert original_pk == compensation_pk  # same org/execution partition
+        assert original_sk != compensation_sk  # sort keys MUST differ
+
+    def test_compensation_key_differs_from_same_node_original_key(self):
+        """The common case: a compensation for node 'n1' must not collide
+        with node 'n1's own original call, for identical tool/args/call
+        index (the two attempts a real double-delivery guard must tell
+        apart)."""
+        pk_a, sk_a = build_key("org1", "exec1", "n1", 0, "TOOL", {"a": 1}, is_compensation=False)
+        pk_b, sk_b = build_key("org1", "exec1", "n1", 0, "TOOL", {"a": 1}, is_compensation=True)
+        assert pk_a == pk_b
+        assert sk_a != sk_b
+
+    def test_compensation_marker_is_appended_after_the_hex_digest_field(self):
+        # Precondition the collision-freedom proof relies on: hash_hex is
+        # always exactly 64 lowercase hex characters (sha256 hexdigest,
+        # alphabet [0-9a-f]) with no '#', so appending "#" + COMPENSATION_
+        # MARKER after it can never be produced by hash_hex's own content —
+        # the boundary is anchored to a field callers cannot control the
+        # alphabet of, not to node_id (which callers fully control).
+        hash_hex = "0" * 64
+        assert all(c in "0123456789abcdef" for c in hash_hex)
+        original = build_sort_key("n", 0, "t", hash_hex, is_compensation=False)
+        compensation = build_sort_key("n", 0, "t", hash_hex, is_compensation=True)
+        assert compensation == f"{original}#{COMPENSATION_MARKER}"
+        assert not original.endswith(f"#{COMPENSATION_MARKER}")
+
+    @given(
+        node_id=st.text(min_size=0, max_size=40),
+        other_node_id=st.text(min_size=0, max_size=40),
+        call_index=st.integers(min_value=0, max_value=1000),
+        tool_name=st.text(min_size=1, max_size=40),
+        args=st.dictionaries(st.text(min_size=1, max_size=10), st.integers(), max_size=5),
+    )
+    @settings(max_examples=300, deadline=None)
+    def test_original_and_compensation_keys_never_equal_for_any_node_ids(
+        self, node_id, other_node_id, call_index, tool_name, args,
+    ):
+        """Property: for ARBITRARY node ids — including hostile ones
+        containing '#', the literal substring '#comp', unicode, and
+        empty-ish segments (the empty string itself, and strings composed
+        only of '#') — an ORIGINAL call's key and a COMPENSATION call's key
+        are NEVER equal, whether the two calls are for the same node id or
+        two different (possibly colliding-by-construction) node ids.
+
+        This must hold at the ``build_sort_key``/``build_key`` layer alone,
+        independent of ``common.workflow_contract``'s identifier-hygiene
+        rejection — it is the belt-and-braces guarantee, so the strategy
+        deliberately generates node ids a validator would reject (this
+        module has no opinion on identifier hygiene; the ``is_compensation``
+        flag alone must carry collision-freedom).
+        """
+        original_sk = build_sort_key(node_id, call_index, tool_name, "deadbeef", is_compensation=False)
+        compensation_sk = build_sort_key(
+            other_node_id, call_index, tool_name, "deadbeef", is_compensation=True,
+        )
+        assert original_sk != compensation_sk
+
+    @given(
+        node_id=st.one_of(
+            st.just(""),
+            st.just("#"),
+            st.just("##"),
+            st.just("#comp"),
+            st.just("n1#comp"),
+            st.text(alphabet=st.characters(min_codepoint=0x1F600, max_codepoint=0x1F64F), min_size=1, max_size=5),
+            st.text(min_size=0, max_size=40),
+        ),
+        call_index=st.integers(min_value=0, max_value=1000),
+        tool_name=st.text(min_size=1, max_size=40),
+    )
+    @settings(max_examples=300, deadline=None)
+    def test_same_node_id_original_vs_compensation_never_equal_hostile_ids(
+        self, node_id, call_index, tool_name,
+    ):
+        """Property, narrower and stronger than the above: for the SAME
+        hostile node id (including '#', '#comp', 'n1#comp', unicode, and
+        empty string), the ORIGINAL call's key for that id and the
+        COMPENSATION call's key for that SAME id are never equal — the
+        exact shape of the historical defect (one node id, two roles).
+        """
+        original_sk = build_sort_key(node_id, call_index, tool_name, "deadbeef", is_compensation=False)
+        compensation_sk = build_sort_key(node_id, call_index, tool_name, "deadbeef", is_compensation=True)
+        assert original_sk != compensation_sk
 
 
 # ---------------------------------------------------------------------------

--- a/arbiter/workerWrapper/compensation_executor.py
+++ b/arbiter/workerWrapper/compensation_executor.py
@@ -1,0 +1,590 @@
+"""CIT-123 slice 4 — WORKER-SIDE governed compensation execution.
+
+Consumes the compensation-dispatch CONTRACT slice 3 sends
+(``workflow_contract.build_compensation_dispatch_message`` /
+``is_workflow_compensation_message``) — message_type='workflow_compensation'
+carrying ``node_id`` (the compensation PSEUDO-node id, ``{origNodeId}#comp``),
+``tool``, the RAW unresolved ``args`` template, ``compensation_generation``,
+and (out of band, passed by the caller as ``recorded_output``) the
+compensating node's recorded output reference. Slice 3's executor file(s) and
+the stepRunner orchestration are NOT imported or depended upon here — only the
+wire-contract shape is consumed, matching the field names
+``build_compensation_dispatch_message`` emits (cited from
+``arbiter/common/workflow_contract.py`` on origin/main, commit c101ff0 not yet
+merged, so this module reads the dispatch dict directly rather than importing
+any slice-3-only helper).
+
+D2 — NO BYPASS BY CONSTRUCTION
+-------------------------------
+A compensation executes through the EXACT SAME ``ComposedToolHook`` seam an
+agent tool call uses: deny-list -> breaker pre-check -> approval-consume ->
+idempotency reserve/execute/finalize -> breaker observer
+(``tool_idempotency_hook.ComposedToolHook``, the identical class
+``agent_runner._install_tool_call_hooks`` installs for the LLM path). This
+module builds no second installer and no parallel governance/idempotency
+logic — ``build_compensation_hook`` constructs a REAL ``ComposedToolHook``
+(the very same class object) and ``execute_compensation`` drives it with a
+synthetic ``BeforeToolCallEvent``-shaped object (``tool_use`` dict +
+``selected_tool``), then awaits the (possibly hook-wrapped) tool's
+``stream()`` — LLM-free, no agent turn, no model call. This is exactly the
+technique ``test_composed_tool_governance.py`` / ``test_composed_tool_breaker_
+seam.py`` use to drive the hook in-process without a real strands runtime.
+
+On a governance DENY the compensation MUST escalate and MUST NOT execute —
+never bypass. On any other terminal failure (stale generation, breaker OPEN,
+unresolvable template, missing/offloaded-unrehydrated output, tool crash) the
+result is ``compensation_failed`` and — for a DENY specifically — an
+escalation is emitted (D6, reusing ``tools/escalate.py``'s event+metric
+shape). This module does NOT write the executor's ``#comp`` node-status rows
+or the interim sink's three durable writes (D6/D7) — that is slice 3/5's
+job; it emits a compensation-RESULT the caller (slice 3's
+``handle_compensation_result``, when merged) can consume, via
+``CompensationResult``.
+"""
+from __future__ import annotations
+
+import asyncio
+import os
+import sys
+from dataclasses import dataclass, field
+from typing import Any, Callable, Optional
+
+_HERE = os.path.dirname(os.path.abspath(__file__))
+if _HERE not in sys.path:
+    sys.path.insert(0, _HERE)
+
+from governance import tool_execution_ledger as ledger  # noqa: E402
+from tool_idempotency import build_key  # noqa: E402
+from tool_idempotency_hook import ComposedToolHook, IdempotencyToolHook  # noqa: E402
+from governance_tool_hook import GovernanceEvaluator  # noqa: E402
+
+try:
+    from common.compensation_template import (
+        render_compensation_args,
+        CompensationTemplateError,
+    )
+except ImportError:  # pragma: no cover — deferred-bundling fallback (mirrors
+    # index.py's existing convention for shared arbiter/common modules): a
+    # missing import must never let a compensation render unprotected. Fail
+    # closed rather than silently skip templating.
+    class CompensationTemplateError(Exception):  # type: ignore[no-redef]
+        pass
+
+    def render_compensation_args(template_args, recorded_output):  # type: ignore[no-redef]
+        raise CompensationTemplateError(
+            "compensation template renderer unavailable "
+            "(common.compensation_template import failed) — fail-closed"
+        )
+
+try:
+    from strands.hooks import BeforeToolCallEvent  # type: ignore  # noqa: F401
+    _STRANDS_AVAILABLE = True
+except ImportError:  # pragma: no cover — dev/CI without strands-agents
+    _STRANDS_AVAILABLE = False
+
+
+# --- Compensation-result contract (slice 4 -> slice 3's handle_compensation_
+#     result, once merged) --------------------------------------------------
+
+STATUS_COMPENSATED = "compensated"
+STATUS_COMPENSATION_FAILED = "compensation_failed"
+
+
+@dataclass
+class CompensationResult:
+    """Emitted back on the same contract the orchestrator expects: keyed by
+    the compensation pseudo-node id, carrying enough to let slice 3 advance
+    (or stop) the unwind without re-deriving anything this module already
+    computed."""
+
+    execution_id: str
+    node_id: str  # the '{origNodeId}#comp' pseudo-node id
+    workflow_id: str
+    tool: str
+    status: str  # STATUS_COMPENSATED | STATUS_COMPENSATION_FAILED
+    escalated: bool = False
+    replayed: bool = False
+    error_class: Optional[str] = None
+    error: Optional[str] = None
+    result: Any = None
+
+
+# --- Fake BeforeToolCallEvent (LLM-free direct governed invocation) --------
+
+
+class _DirectToolCallEvent:
+    """A minimal ``BeforeToolCallEvent``-shaped object: a ``tool_use`` dict
+    (``name``/``toolUseId``/``input``) and a mutable ``selected_tool``. This
+    is the EXACT surface ``ComposedToolHook._on_before_tool_call`` reads
+    (``event.tool_use`` / ``event.selected_tool``) — no strands runtime, no
+    agent turn, no model call is required to drive it, mirroring the fakes
+    the composed-hook test suite already uses to exercise the seam
+    in-process."""
+
+    def __init__(self, *, tool_name: str, tool_use_id: str, tool_input: dict, selected_tool: Any):
+        self.tool_use = {"name": tool_name, "toolUseId": tool_use_id, "input": tool_input}
+        self.selected_tool = selected_tool
+
+
+class _RegisteredAgentTool:
+    """Adapts a resolved compensation tool CALLABLE to the minimal AgentTool
+    surface (``tool_name``/``tool_spec``/``tool_type``/``stream``) the
+    ComposedToolHook and its wrappers delegate through. ``tool_resolver``
+    callers are expected to hand back an object already shaped this way
+    (e.g. a real ``@tool``-decorated strands function, or a test double); this
+    class exists only as a thin structural adapter when a resolver returns a
+    plain callable instead of a full AgentTool object."""
+
+    def __init__(self, name: str, fn: Callable[..., Any]):
+        self._name = name
+        self._fn = fn
+
+    @property
+    def tool_name(self) -> str:
+        return self._name
+
+    @property
+    def tool_spec(self) -> Any:
+        return {"name": self._name}
+
+    @property
+    def tool_type(self) -> str:
+        return "python"
+
+    def get_display_properties(self) -> dict[str, str]:
+        return {}
+
+    async def stream(self, tool_use: Any, invocation_state: dict[str, Any], **kwargs: Any):
+        from strands.types._events import ToolResultEvent
+
+        tool_use_id = str(tool_use.get("toolUseId", "")) if hasattr(tool_use, "get") else ""
+        tool_input = tool_use.get("input", {}) if hasattr(tool_use, "get") else {}
+        try:
+            output = self._fn(**tool_input) if isinstance(tool_input, dict) else self._fn(tool_input)
+        except Exception as exc:  # noqa: BLE001 — let the real crash discriminator see it
+            raise exc
+        if isinstance(output, dict) and "status" in output:
+            result = {**output, "toolUseId": tool_use_id}
+        else:
+            result = {"toolUseId": tool_use_id, "status": "success", "content": [{"text": str(output)}]}
+        yield ToolResultEvent(result)
+
+
+def _adapt_tool(tool_name: str, resolved: Any) -> Any:
+    """Return an AgentTool-shaped object for ``resolved``: pass through
+    objects that already look like one (have ``tool_name``/``stream``), else
+    wrap a plain callable via ``_RegisteredAgentTool``."""
+    if hasattr(resolved, "tool_name") and hasattr(resolved, "stream"):
+        return resolved
+    return _RegisteredAgentTool(tool_name, resolved)
+
+
+# --- Seam construction: delegates to the SAME ComposedToolHook the agent path
+#     installs (agent_runner._install_tool_call_hooks) — never reimplemented.
+
+
+def build_compensation_hook(
+    *,
+    org_id: str,
+    execution_id: str,
+    node_id: str,
+    agent_id: str,
+    workflow_id: str,
+    compensation_generation: Optional[int],
+    denied_tools: Optional[set[str]] = None,
+    approval_required_tools: Optional[set[str]] = None,
+    workflow_definition_id: str = "",
+    breaker: Any = None,
+) -> ComposedToolHook:
+    """Build the ONE ``ComposedToolHook`` a compensation call is driven
+    through — the identical class ``agent_runner._install_tool_call_hooks``
+    constructs for the agent (LLM) path. This is the ONLY place slice 4
+    assembles governance + idempotency; there is no bespoke deny/approval/
+    reserve ordering anywhere else in this module (see the module docstring's
+    D2 section) — a structural test asserts this file never defines its own
+    ``_on_before_tool_call``.
+    """
+    governance = GovernanceEvaluator(
+        agent_id=agent_id or "unknown-agent",
+        workflow_id=workflow_id or "unknown-workflow",
+        denied_tools=denied_tools if denied_tools is not None else set(),
+        eval_run_id=None,
+        approval_required_tools=approval_required_tools if approval_required_tools is not None else set(),
+        org_id=org_id or "",
+        workflow_definition_id=workflow_definition_id or "",
+        execution_id=execution_id or "",
+        node_id=node_id or "",
+    )
+    idempotency = IdempotencyToolHook(
+        org_id=org_id or "",
+        execution_id=execution_id or "",
+        node_id=node_id or "",
+        dispatch_generation=compensation_generation,
+    )
+    return ComposedToolHook(governance=governance, idempotency=idempotency, breaker=breaker)
+
+
+def _build_breaker(
+    *,
+    org_id: str,
+    execution_id: str,
+    node_id: str,
+    workflow_id: str,
+    agent_id: str,
+    breaker_table: Optional[str],
+    breaker_target_resolver: Optional[Callable[[str], Any]],
+    breaker_clock: Optional[Callable[[], float]] = None,
+):
+    """FAIL-OPEN by construction (mirrors ``agent_runner._build_tool_breaker``
+    exactly — the breaker is an availability optimisation, never a security
+    control): a missing table, resolver, or import degrades to ``None``
+    (breaker skipped), never aborts the compensation."""
+    if not breaker_table or breaker_target_resolver is None:
+        return None
+    try:
+        from tool_breaker_hook import ToolBreaker
+        from governance.tool_breaker_store import ToolBreakerStore, BreakerConfig
+    except ImportError:
+        return None
+    kwargs: dict[str, Any] = dict(
+        table_name=breaker_table, org_id=org_id or "", config=BreakerConfig.from_env(),
+    )
+    if breaker_clock is not None:
+        kwargs["clock"] = breaker_clock
+    store = ToolBreakerStore(**kwargs)
+    return ToolBreaker(
+        store=store,
+        target_resolver=breaker_target_resolver,
+        probe_owner=f"{execution_id or ''}#{node_id or ''}",
+    )
+
+
+# --- Rehydration (slice-2 renderer refuses offloaded refs by contract) -----
+
+
+def _rehydrate_recorded_output(recorded_output: Any) -> Any:
+    """Rehydrate an S3-offloaded recorded output BEFORE rendering (D4(a)).
+
+    The slice-2 renderer (``common.compensation_template``) refuses, by
+    contract, any ``recorded_output`` carrying a truthy ``resultOffloaded``
+    key or a ``resultRef`` key at all — it never fetches. This function is
+    the caller-side rehydration step the renderer's docstring explicitly
+    defers to a later slice: it recognises the SAME ledger-row vocabulary
+    (``resultOffloaded``/``resultRef``) and, when present, fetches the full
+    body via the ledger's own ``_fetch_result_ref`` (org-prefix re-checked —
+    never re-implemented here) using the compensation's ledger PK, then
+    returns the rehydrated plain dict so the renderer sees ordinary,
+    non-offloaded output. A non-offloaded ``recorded_output`` passes through
+    unchanged (including ``None`` / non-dict / ``resultTruncated`` shapes —
+    those are the renderer's own fail-closed checks, left untouched here).
+    """
+    if not isinstance(recorded_output, dict):
+        return recorded_output
+    result_ref = recorded_output.get("resultRef")
+    if not recorded_output.get("resultOffloaded") and result_ref is None:
+        return recorded_output
+    if result_ref is None:
+        # resultOffloaded=True but no resultRef: nothing to fetch — let the
+        # renderer's own fail-closed check raise a named error downstream.
+        return recorded_output
+    pk = recorded_output.get("_ledgerPk")
+    if not isinstance(pk, str) or not pk:
+        # No ledger PK context to re-check the org prefix against — fail
+        # closed rather than trust an unscoped ref (mirrors
+        # ledger._recorded_result's own "no pk -> fail closed" rule).
+        raise CompensationTemplateError(
+            "compensation rehydration: an offloaded recorded output was "
+            "supplied without a ledger PK for the org-prefix re-check "
+            "(fail-closed)"
+        )
+    fetched = ledger._fetch_result_ref(pk, result_ref)
+    return fetched if isinstance(fetched, dict) else {"value": fetched}
+
+
+# --- Escalation (D6: reuse tools/escalate.py's event+metric shape) ---------
+
+
+def _escalate(*, execution_id: str, node_id: str, tool: str, reason: str, agent_id: str = "") -> None:
+    """Emit exactly one escalation for a compensation DENY, reusing the
+    existing ``escalate`` tool's event+metric vocabulary (D6) rather than
+    inventing a second escalation channel. Best-effort: an escalation-path
+    failure must never mask the underlying DENY result (the caller has
+    already decided ``compensation_failed`` regardless)."""
+    try:
+        from tools.escalate import escalate as escalate_tool
+    except ImportError:
+        try:
+            from escalate import escalate as escalate_tool  # sibling-module layout
+        except ImportError:
+            return
+    try:
+        escalate_tool(
+            reason=reason,
+            project_id=execution_id,
+            agent_id=agent_id or "compensation-worker",
+            correlation_id=f"{execution_id}#{node_id}",
+        )
+    except Exception:  # noqa: BLE001 — escalation is best-effort, never masks the DENY
+        pass
+
+
+# --- Drive the composed hook synchronously (LLM-free) ----------------------
+
+
+def _drain(agen) -> list:
+    async def _run():
+        return [ev async for ev in agen]
+
+    return asyncio.run(_run())
+
+
+def _run_direct_governed_call(
+    *,
+    hook: ComposedToolHook,
+    tool_name: str,
+    tool_input: dict,
+    resolved_tool: Any,
+    node_id: str,
+) -> tuple[str, Any, Optional[str], Optional[str]]:
+    """Drive ``hook`` over a synthetic event for ONE direct tool call — no
+    agent turn, no model call. Returns
+    ``(status, tool_result_or_None, error_class_or_None, error_or_None)``.
+
+    ``status`` is one of: 'denied', 'stale_generation', 'breaker_open',
+    'executed'. The caller maps this (plus the drained ToolResult) onto the
+    final compensation-result status.
+
+    NOTE on stale-generation detection: ``_IdempotentToolWrapper.stream()``
+    deliberately does NOT raise ``StaleWorkerFencedError`` to its caller —
+    per its own docstring, a fenced-away worker's refusal is surfaced as an
+    error ToolResult ("... worker fenced by a newer dispatch generation
+    (no side effect performed)") so a real strands turn can continue rather
+    than crash. Since this module drives the SAME wrapper object with no
+    strands runtime in between, it must discriminate on that SAME stable,
+    documented marker text rather than inventing a second signalling path —
+    the ledger module is the single source of truth for the wording; this
+    check exists only at the boundary where the ToolResult must be turned
+    back into the compensation-result contract's error_class.
+    """
+    inner = _adapt_tool(tool_name, resolved_tool)
+    event = _DirectToolCallEvent(
+        tool_name=tool_name, tool_use_id=f"comp-{node_id}", tool_input=tool_input,
+        selected_tool=inner,
+    )
+
+    try:
+        hook._on_before_tool_call(event)
+    except ledger.StaleWorkerFencedError as exc:
+        return "stale_generation", None, type(exc).__name__, str(exc)
+
+    from governance_tool_hook import _GovernanceDeniedTool
+    if isinstance(event.selected_tool, _GovernanceDeniedTool):
+        return "denied", None, None, None
+
+    try:
+        from tool_breaker_hook import _CircuitOpenTool
+        if isinstance(event.selected_tool, _CircuitOpenTool):
+            events = _drain(event.selected_tool.stream(event.tool_use, {}))
+            result = events[0].tool_result if events else None
+            return "breaker_open", result, "CircuitOpenError", None
+    except ImportError:
+        pass
+
+    try:
+        events = _drain(event.selected_tool.stream(event.tool_use, {}))
+    except ledger.StaleWorkerFencedError as exc:  # pragma: no cover — defensive
+        return "stale_generation", None, type(exc).__name__, str(exc)
+    except Exception as exc:  # noqa: BLE001 — tool crash, structural (not message-matched)
+        return "executed", None, type(exc).__name__, str(exc)
+
+    result = events[0].tool_result if events else None
+    if _is_fenced_refusal_result(result):
+        return "stale_generation", result, "StaleWorkerFencedError", _result_text(result)
+
+    return "executed", result, None, None
+
+
+def _result_text(result: Any) -> str:
+    if not isinstance(result, dict):
+        return ""
+    content = result.get("content") or []
+    if content and isinstance(content[0], dict):
+        return content[0].get("text", "") or ""
+    return ""
+
+
+def _is_fenced_refusal_result(result: Any) -> bool:
+    """True when ``result`` is the STABLE, documented error ToolResult
+    ``_IdempotentToolWrapper.stream()`` yields for a stale-generation refusal
+    (see that method's ``ledger.StaleWorkerFencedError`` handler). Matching
+    on this exact, code-owned marker string — not a generic substring guess —
+    keeps this check tied to the ledger module's own contract."""
+    text = _result_text(result)
+    return "fenced by a newer dispatch generation" in text
+
+
+# --- Public entry point ------------------------------------------------------
+
+
+def execute_compensation(
+    dispatch: dict,
+    *,
+    recorded_output: Any,
+    org_id: str,
+    denied_tools: Optional[set[str]] = None,
+    tool_resolver: Callable[[str], Any],
+    agent_id: str = "compensation-worker",
+    workflow_definition_id: str = "",
+    approval_required_tools: Optional[set[str]] = None,
+    breaker_table: Optional[str] = None,
+    breaker_target_resolver: Optional[Callable[[str], Any]] = None,
+    breaker_clock: Optional[Callable[[], float]] = None,
+) -> CompensationResult:
+    """LLM-free, worker-side governed execution of ONE compensation dispatch.
+
+    ``dispatch`` is the wire-shaped compensation dispatch message (mirrors
+    ``workflow_contract.build_compensation_dispatch_message``'s output):
+    ``execution_id``, ``node_id`` (the '{origNodeId}#comp' pseudo-node id),
+    ``workflow_id``, ``tool``, ``args`` (the RAW unresolved template),
+    ``compensation_generation``. ``recorded_output`` is the compensating
+    node's recorded output (or an S3-offloaded reference shape) — the
+    RECORDED OUTPUT REFERENCE the dispatch contract carries out of band from
+    slice 3, per the task's field-name mirroring instruction.
+
+    Pipeline (fail-closed at every step, D2/D4 D3):
+      1. rehydrate an offloaded recorded_output (a).
+      2. render args via the slice-2 module (import only, never reimplement).
+      3. derive the CIT-121 key: sk = '{node_id}#0#{tool}#{argsHash}' — since
+         ``node_id`` already carries the '#comp' suffix, this yields exactly
+         '{origNodeId}#comp#0#{tool}#{argsHash}' (b).
+      4. drive the SAME ComposedToolHook seam a real agent tool call uses,
+         fenced on compensation_generation (c) — LLM-free, no agent turn.
+      5. on DENY: escalate, never execute (d).
+      6. return the compensation-result contract (e).
+    """
+    execution_id = dispatch.get("execution_id", "")
+    node_id = dispatch.get("node_id", "")
+    workflow_id = dispatch.get("workflow_id", "")
+    tool_name = dispatch.get("tool", "")
+    raw_args = dispatch.get("args") or {}
+    compensation_generation = dispatch.get("compensation_generation")
+
+    result_kwargs = dict(
+        execution_id=execution_id, node_id=node_id, workflow_id=workflow_id, tool=tool_name,
+    )
+
+    # --- (a) rehydrate BEFORE rendering -------------------------------------
+    try:
+        usable_output = _rehydrate_recorded_output(recorded_output)
+    except CompensationTemplateError as exc:
+        return CompensationResult(
+            **result_kwargs, status=STATUS_COMPENSATION_FAILED,
+            error_class=type(exc).__name__, error=str(exc),
+        )
+    except ledger.LedgerError as exc:
+        return CompensationResult(
+            **result_kwargs, status=STATUS_COMPENSATION_FAILED,
+            error_class=type(exc).__name__, error=str(exc),
+        )
+
+    # --- (a) render via the slice-2 module (import, never reimplement) -----
+    try:
+        rendered = render_compensation_args(raw_args, usable_output)
+    except CompensationTemplateError as exc:
+        return CompensationResult(
+            **result_kwargs, status=STATUS_COMPENSATION_FAILED,
+            error_class=type(exc).__name__, error=str(exc),
+        )
+
+    # --- resolve the tool BEFORE building the hook (fail fast, no reserve) -
+    resolved_tool = tool_resolver(tool_name)
+    if resolved_tool is None:
+        return CompensationResult(
+            **result_kwargs, status=STATUS_COMPENSATION_FAILED,
+            error_class="ToolNotFound", error=f"no compensation tool registered for {tool_name!r}",
+        )
+
+    # --- (b) CIT-121 key derivation, mirrored for replay detection ONLY —
+    # the actual reserve/dedupe decision is made by the IdempotencyToolHook
+    # inside build_compensation_hook's wrapper (never duplicated here as a
+    # second authority). This is purely observability: was a completed row
+    # already present before THIS call reserves/executes?
+    pk, sk = build_key(org_id or "", execution_id, node_id, 0, tool_name, rendered.args)
+    pre_existing_row = None
+    try:
+        pre_existing_row = ledger.get(pk, sk)
+    except ledger.LedgerError:
+        pre_existing_row = None  # best-effort observability only; never fail-closed on this
+    was_already_completed = bool(pre_existing_row and pre_existing_row.get("status") == ledger.STATUS_COMPLETED)
+
+    # --- (c) build the fenced breaker, then the SAME ComposedToolHook seam -
+    breaker = _build_breaker(
+        org_id=org_id, execution_id=execution_id, node_id=node_id,
+        workflow_id=workflow_id, agent_id=agent_id,
+        breaker_table=breaker_table, breaker_target_resolver=breaker_target_resolver,
+        breaker_clock=breaker_clock,
+    )
+    hook = build_compensation_hook(
+        org_id=org_id, execution_id=execution_id, node_id=node_id,
+        agent_id=agent_id, workflow_id=workflow_id,
+        compensation_generation=compensation_generation,
+        denied_tools=denied_tools, approval_required_tools=approval_required_tools,
+        workflow_definition_id=workflow_definition_id, breaker=breaker,
+    )
+
+    status, tool_result, error_class, error = _run_direct_governed_call(
+        hook=hook, tool_name=tool_name, tool_input=rendered.args,
+        resolved_tool=resolved_tool, node_id=node_id,
+    )
+
+    # --- (d) DENY -> escalate, never execute --------------------------------
+    if status == "denied":
+        _escalate(
+            execution_id=execution_id, node_id=node_id, tool=tool_name,
+            reason=f"compensation for {node_id!r} denied by governance deny-list",
+            agent_id=agent_id,
+        )
+        return CompensationResult(
+            **result_kwargs, status=STATUS_COMPENSATION_FAILED, escalated=True,
+            error_class="GovernanceDenied", error="compensation denied by governance deny-list",
+        )
+
+    if status == "stale_generation":
+        return CompensationResult(
+            **result_kwargs, status=STATUS_COMPENSATION_FAILED,
+            error_class=error_class or "StaleWorkerFencedError", error=error,
+        )
+
+    if status == "breaker_open":
+        return CompensationResult(
+            **result_kwargs, status=STATUS_COMPENSATION_FAILED,
+            error_class=error_class or "CircuitOpenError", error=error,
+        )
+
+    # status == 'executed' (covers WON/HIT_COMPLETED/HIT_FAILED/IN_FLIGHT —
+    # the wrapper's own internal branching; only a raised exception or an
+    # error-shaped ToolResult indicates this specific call did not succeed).
+    if error_class is not None:
+        return CompensationResult(
+            **result_kwargs, status=STATUS_COMPENSATION_FAILED,
+            error_class=error_class, error=error,
+        )
+
+    if isinstance(tool_result, dict) and tool_result.get("status") == "error":
+        text = ""
+        content = tool_result.get("content") or []
+        if content and isinstance(content[0], dict):
+            text = content[0].get("text", "")
+        replayed = "reserved by a concurrent" not in text and (
+            "fenced by a newer dispatch" not in text
+        )
+        return CompensationResult(
+            **result_kwargs, status=STATUS_COMPENSATION_FAILED,
+            error_class="ToolResultError", error=text or "compensation tool returned an error result",
+            replayed="idempotent replay" in text,
+        )
+
+    return CompensationResult(
+        **result_kwargs, status=STATUS_COMPENSATED, result=tool_result,
+        replayed=was_already_completed,
+    )

--- a/arbiter/workerWrapper/compensation_executor.py
+++ b/arbiter/workerWrapper/compensation_executor.py
@@ -58,6 +58,35 @@ from tool_idempotency import build_key  # noqa: E402
 from tool_idempotency_hook import ComposedToolHook, IdempotencyToolHook  # noqa: E402
 from governance_tool_hook import GovernanceEvaluator  # noqa: E402
 
+#: Wire-contract suffix slice 3's dispatch uses to mint the compensation
+#: PSEUDO-node id (``"{origNodeId}#comp"``) carried in the dispatch's
+#: ``node_id`` field — kept ONLY for stripping it back off below, never used
+#: to derive a ledger key by concatenation again. The actual collision
+#: protection is the ``is_compensation`` STRUCTURAL flag threaded into
+#: ``build_key`` / ``IdempotencyToolHook`` (see ``tool_idempotency.
+#: build_sort_key``'s docstring) — this constant exists so a dispatch's
+#: reporting/escalation messages can keep echoing the wire pseudo-id
+#: unchanged while the ORIGINAL node id (with the suffix stripped) is what
+#: actually reaches key derivation. Stripping is a display/compat nicety on
+#: top of the structural fix, not itself the fix: even if this strip were
+#: wrong or absent, ``is_compensation=True`` alone already guarantees no
+#: collision with any original call's key, because no valid (post-
+#: validation) node id can contain the reserved '#' delimiter this suffix
+#: is built from.
+_COMPENSATION_PSEUDO_ID_SUFFIX = "#comp"
+
+
+def _origin_node_id(pseudo_node_id: str) -> str:
+    """Strip the wire-contract ``'#comp'`` suffix, if present, to recover the
+    original node id for key derivation. A pseudo id missing the suffix
+    (already-bare, or a caller that changes the wire convention later) is
+    returned unchanged — safe either way, since ``is_compensation=True`` is
+    what actually prevents the key collision, not this string surgery.
+    """
+    if pseudo_node_id.endswith(_COMPENSATION_PSEUDO_ID_SUFFIX):
+        return pseudo_node_id[: -len(_COMPENSATION_PSEUDO_ID_SUFFIX)]
+    return pseudo_node_id
+
 try:
     from common.compensation_template import (
         render_compensation_args,
@@ -203,6 +232,16 @@ def build_compensation_hook(
     reserve ordering anywhere else in this module (see the module docstring's
     D2 section) — a structural test asserts this file never defines its own
     ``_on_before_tool_call``.
+
+    ``node_id`` here MUST be the ORIGINAL node id (the caller strips any
+    wire-contract ``'#comp'`` pseudo-id suffix via ``_origin_node_id`` before
+    calling this function) — never a string with a compensation marker
+    concatenated onto it. The ``IdempotencyToolHook`` below is always built
+    with ``is_compensation=True`` (this function is exclusively the
+    compensation-path hook builder), which is what actually makes the
+    resulting ledger key distinct from the SAME node's original-call key —
+    structurally, not by relying on ``node_id`` carrying a distinguishing
+    suffix.
     """
     governance = GovernanceEvaluator(
         agent_id=agent_id or "unknown-agent",
@@ -220,6 +259,7 @@ def build_compensation_hook(
         execution_id=execution_id or "",
         node_id=node_id or "",
         dispatch_generation=compensation_generation,
+        is_compensation=True,
     )
     return ComposedToolHook(governance=governance, idempotency=idempotency, breaker=breaker)
 
@@ -509,7 +549,19 @@ def execute_compensation(
     # inside build_compensation_hook's wrapper (never duplicated here as a
     # second authority). This is purely observability: was a completed row
     # already present before THIS call reserves/executes?
-    pk, sk = build_key(org_id or "", execution_id, node_id, 0, tool_name, rendered.args)
+    #
+    # ``origin_node_id`` strips the wire ``'#comp'`` pseudo-id suffix before
+    # key derivation and ``is_compensation=True`` is passed explicitly — the
+    # structural fix (see ``tool_idempotency.build_sort_key``'s docstring)
+    # that removes this key's correctness from depending on node-id string
+    # hygiene. ``node_id`` (the pseudo id) is still used for the
+    # CompensationResult / escalation messages below — that is a
+    # reporting/wire-contract concern, unrelated to the ledger key.
+    origin_node_id = _origin_node_id(node_id)
+    pk, sk = build_key(
+        org_id or "", execution_id, origin_node_id, 0, tool_name, rendered.args,
+        is_compensation=True,
+    )
     pre_existing_row = None
     try:
         pre_existing_row = ledger.get(pk, sk)
@@ -519,13 +571,13 @@ def execute_compensation(
 
     # --- (c) build the fenced breaker, then the SAME ComposedToolHook seam -
     breaker = _build_breaker(
-        org_id=org_id, execution_id=execution_id, node_id=node_id,
+        org_id=org_id, execution_id=execution_id, node_id=origin_node_id,
         workflow_id=workflow_id, agent_id=agent_id,
         breaker_table=breaker_table, breaker_target_resolver=breaker_target_resolver,
         breaker_clock=breaker_clock,
     )
     hook = build_compensation_hook(
-        org_id=org_id, execution_id=execution_id, node_id=node_id,
+        org_id=org_id, execution_id=execution_id, node_id=origin_node_id,
         agent_id=agent_id, workflow_id=workflow_id,
         compensation_generation=compensation_generation,
         denied_tools=denied_tools, approval_required_tools=approval_required_tools,

--- a/arbiter/workerWrapper/tool_idempotency.py
+++ b/arbiter/workerWrapper/tool_idempotency.py
@@ -62,6 +62,7 @@ __all__ = [
     "classify_idempotency_mode",
     "detect_write_verbs",
     "check_bypass_classification",
+    "COMPENSATION_MARKER",
     "MODE_LEDGER",
     "MODE_BYPASS",
 ]
@@ -149,6 +150,53 @@ def args_hash(tool_input: Any) -> str:
     return hashlib.sha256(canonical.encode("utf-8")).hexdigest()
 
 
+#: Fixed role-marker token appended AFTER the sort key's ``argsHash`` field
+#: (never adjacent to or overlapping ``node_id``) to structurally separate a
+#: compensation call's ledger row from any original call's row. This is the
+#: fix for the ledger-key collision (f9ceb38e).
+#:
+#: Two prior designs for this same fix were proven unsound and are
+#: deliberately NOT what shipped, recorded here so a future change does not
+#: reintroduce either:
+#:
+#: 1. A marker segment placed ADJACENT to ``node_id`` (e.g.
+#:    ``f"{node_id}#comp#{callIndex}#..."``) — REJECTED: for
+#:    ``node_id='n1#comp'`` (original call) vs ``node_id='n1'`` (compensation
+#:    call), both produce the identical string ``"n1#comp#0#TOOL#hash"``.
+#:    Any marker adjacent to a caller-controlled string can be imitated by
+#:    that string's own content, regardless of the marker's shape or content.
+#: 2. Moving the role split into the PARTITION key
+#:    (``f"{org_id}#{execution_id}#{'comp'|'orig'}"``) — REJECTED: it breaks
+#:    ``governance.tool_execution_ledger._split_pk``'s documented invariant
+#:    that a ledger PK decomposes via a single ``str.partition('#')`` into
+#:    exactly ``(orgId, executionId)``; a third segment corrupts the
+#:    ``executionId`` half used to derive the S3 offload key prefix
+#:    (``tool-results/{orgId}/{executionId}/...``) for EVERY row, not just
+#:    compensation rows.
+#:
+#: This (shipped) design appends the marker AFTER ``hash_hex`` instead.
+#: ``hash_hex`` is always exactly 64 lowercase hex characters (a SHA-256
+#: hexdigest, alphabet ``[0-9a-f]``, produced by :func:`args_hash`) with no
+#: trailing ``'#'`` — so an ORIGINAL key's last 5 characters are always hex
+#: digits and can NEVER equal the literal ``'#comp'`` a COMPENSATION key
+#: appends. Formally: an original key is
+#: ``f"{node_id}#{callIndex}#{toolName}#{hash_hex}"`` (ends in a hex digit,
+#: no field after ``hash_hex``); a compensation key is
+#: ``f"{node_id}#{callIndex}#{toolName}#{hash_hex}#comp"`` (ends in
+#: ``'#comp'``). For these to collide as strings for ANY
+#: ``node_id``/``callIndex``/``toolName``/``hash_hex`` values, the
+#: original's LAST 5 characters would have to equal ``'#comp'`` — but its
+#: last 5 characters are always 5 of the 64 hex digits of ``hash_hex``
+#: (``#`` is not in the hex alphabet), so this is impossible independent of
+#: every other field's content, including a hostile ``node_id`` containing
+#: ``'#'``, ``'#comp'``, empty string, or unicode. Unlike design 1, the
+#: marker's position is anchored to a field (``hash_hex``) whose ALPHABET
+#: excludes the delimiter, not to a field (``node_id``) callers control
+#: freely — that is what makes this collision-free without depending on
+#: node-id hygiene.
+COMPENSATION_MARKER = "comp"
+
+
 def build_partition_key(org_id: str, execution_id: str) -> str:
     """Ledger partition key: ``orgId#executionId``.
 
@@ -157,12 +205,27 @@ def build_partition_key(org_id: str, execution_id: str) -> str:
     resolved server-side (execution row / trusted env), never from a
     subprocess-supplied payload. ``executionId`` alone is globally unique, so
     correctness holds even when ``orgId`` is an empty/sentinel string.
+
+    Unchanged by the compensation-collision fix (f9ceb38e): the role split
+    lives entirely in the sort key's trailing marker (see
+    :data:`COMPENSATION_MARKER`), never here — a partition-key-based design
+    was considered and rejected (see that constant's docstring) because it
+    breaks ``governance.tool_execution_ledger._split_pk``'s single-partition
+    decomposition invariant.
     """
     return f"{org_id}#{execution_id}"
 
 
-def build_sort_key(node_id: str, call_index: int, tool_name: str, hash_hex: str) -> str:
-    """Ledger sort key: ``nodeId#callIndex#toolName#argsHash``.
+def build_sort_key(
+    node_id: str,
+    call_index: int,
+    tool_name: str,
+    hash_hex: str,
+    *,
+    is_compensation: bool = False,
+) -> str:
+    """Ledger sort key: ``nodeId#callIndex#toolName#argsHash``, or
+    ``nodeId#callIndex#toolName#argsHash#comp`` when ``is_compensation``.
 
     ``toolName`` and ``argsHash`` are included even though
     ``(executionId, nodeId, callIndex)`` is already unique within one attempt:
@@ -172,8 +235,21 @@ def build_sort_key(node_id: str, call_index: int, tool_name: str, hash_hex: str)
     absorbed. Dispatch generation is deliberately NOT in the key (that would
     mint a fresh key on every re-dispatch and guarantee duplicates — the
     opposite of the goal); cross-dispatch closure is PR2's worker fence.
+
+    ``is_compensation=False`` (the default) produces the EXACT SAME 4-field
+    string every existing caller and stored row already uses — byte-
+    identical, zero format change for the non-compensation path.
+    ``is_compensation=True`` appends :data:`COMPENSATION_MARKER` as a 5th
+    field AFTER ``hash_hex`` — see that constant's docstring for the proof
+    that this is collision-free with EVERY possible original-call key,
+    independent of ``node_id``'s content. This is the structural,
+    belt-and-braces fix for the f9ceb38e ledger-key collision: a compensation
+    call's key can never coincide with any original call's key, whether or
+    not ``node_id`` happens to contain the reserved ``'#'`` delimiter or the
+    literal substring ``'#comp'``.
     """
-    return f"{node_id}#{call_index}#{tool_name}#{hash_hex}"
+    base = f"{node_id}#{call_index}#{tool_name}#{hash_hex}"
+    return f"{base}#{COMPENSATION_MARKER}" if is_compensation else base
 
 
 def build_key(
@@ -183,12 +259,21 @@ def build_key(
     call_index: int,
     tool_name: str,
     tool_input: Any,
+    *,
+    is_compensation: bool = False,
 ) -> tuple[str, str]:
-    """Derive the ``(partitionKey, sortKey)`` ledger key for a tool call."""
+    """Derive the ``(partitionKey, sortKey)`` ledger key for a tool call.
+
+    ``is_compensation`` is forwarded to :func:`build_sort_key` only — see
+    that function's and :data:`COMPENSATION_MARKER`'s docstrings for why
+    appending the marker AFTER ``hash_hex`` (not adjacent to ``node_id``, and
+    not in the partition key) is what makes collision-freedom hold for every
+    possible ``node_id``, not merely well-behaved ones.
+    """
     hash_hex = args_hash(tool_input)
     return (
         build_partition_key(org_id, execution_id),
-        build_sort_key(node_id, call_index, tool_name, hash_hex),
+        build_sort_key(node_id, call_index, tool_name, hash_hex, is_compensation=is_compensation),
     )
 
 

--- a/arbiter/workerWrapper/tool_idempotency_hook.py
+++ b/arbiter/workerWrapper/tool_idempotency_hook.py
@@ -444,6 +444,15 @@ class IdempotencyToolHook:
     ``mode_resolver`` maps a tool name to ``'ledger'``/``'bypass'`` (fail-safe
     default ``'ledger'`` via ``classify_idempotency_mode``); when absent every
     tool is ledger-protected.
+
+    ``is_compensation`` is a STRUCTURAL flag, not a string convention: the
+    caller (``compensation_executor.build_compensation_hook``) sets it
+    explicitly because it already knows it is building the compensation
+    path's hook, rather than the collision-prone alternative of suffixing
+    ``node_id`` itself with a marker like ``"#comp"`` before handing it here.
+    Forwarded verbatim to ``tool_idempotency.build_key`` so a compensation
+    call's ledger key can never coincide with an original call's key for any
+    ``node_id`` value — see that function's docstring.
     """
 
     def __init__(
@@ -455,6 +464,7 @@ class IdempotencyToolHook:
         mode_resolver: Callable[[str], str] | None = None,
         dispatch_generation: int | None = None,
         client_token_param_resolver: Callable[[str], str | None] | None = None,
+        is_compensation: bool = False,
     ):
         self._org_id = org_id or ""
         self._execution_id = execution_id or ""
@@ -462,6 +472,7 @@ class IdempotencyToolHook:
         self._mode_resolver = mode_resolver
         self._dispatch_generation = dispatch_generation
         self._client_token_param_resolver = client_token_param_resolver
+        self._is_compensation = is_compensation
         self._call_index = 0
 
     @property
@@ -509,6 +520,7 @@ class IdempotencyToolHook:
             pk, sk = build_key(
                 self._org_id, self._execution_id, self._node_id,
                 call_index, tool_name, tool_input,
+                is_compensation=self._is_compensation,
             )
         except Exception:  # noqa: BLE001 — canonicalization failure: fail closed
             # A side-effecting call whose key cannot be derived must not run


### PR DESCRIPTION
## Summary

Fourth slice of compensation actions: the worker now executes a dispatched compensation, and it does so through the same governed seam as any agent tool call - so a compensation cannot bypass governance.

- `build_compensation_hook` constructs the same `ComposedTooLHook` class that `agent_runner` installs, driven by a synthetic before-tool-call event: LLM-free, no agent turn, no second installer. Seam order (deny-list → breaker → approval-consume → idempotency reservation) is inherited, not re-implemented
- PipeLine: rehydrate an S3-offLoaded recorded output, render args via the merged slice-2 renderer, resolve the tool, then drive the
- Governance DENY escalates: zero side effects, zero ledger rows, node marked compensation_failed - never a bypass
- Stale `compensationGeneration` and an OPEN breaker both fail closed before any reservation; missing or truncated output fails closed to compensation_failed
- Idempotency key derived so a re-driven unwind replays the recorded result rather than repeating the side effect

## Also fixes an idempotency-key collision (high severity)

Post-approval probing found the ledger sort key joins segments with `#` while node ids were validated only as non-empty - so a node literally named "ni#comp" derived exactly the compensation key for node `ni`. The colliding party would replay the other's recorded result and skip its real side effect, letting a compensation report 'compensated' while performing no rollback.

Fixed at two layers: `#` is now rejected in identity fields at message build, and the compensation marker moved to after the 64-character hex args hash (an alphabet that excludes `*`), so keys are structurally non-colliding for any node id rather than depending on identifier hygiene. Two weaker designs were tried and rejected first, documented inline.

## Testing

- 13 red-first tests for the execution path: deny-escalates, forced double delivery yields one side effect, stale generation refused, breaker fast-fail with no target call, rehydrate-then-render, fail-closed on missing/truncated output, plus a structural no-bypass test asserting the shared hook composition
- Hypothesis property test proving original and compensation keys never collide for arbitrary node ids (including `*`, multi-`#`, unicode, empty, literal `#comp`) with the concrete `ni#comp` regression case
- Review independently re-derived the original exploit, confirmed rejection, and bit the property test twice by mutation
- Scoped pytest 1043 passing; full arbiter suite 1960 passing, zero failures on main, pre-fix branch and fix branch

## Notes

- Does not depend on the unmerged orchestration slice: only the dispatch wire contract is consumed
- Residual, deliberately out of scope and tracked: the TypeScript workfLow create/update path (`workflow-resolver.ts`) still accepts "# in node ids. The Python build path now rejects it, so the exploit is closed where keys are minted
- Read paths never validated identities even before this change, so legacy stored data with *# still parses - no migration required