### PR TITLE
feat(workflow): compensation failure sink, UI surfacing and acceptance

### DIFF
--- a/arbiter/common/__tests__/test_workflow_contract.py
+++ b/arbiter/common/__tests__/test_workflow_contract.py
@@ -1095,3 +1095,80 @@ class TestCompensationPolicyDefaults:
 
         with pytest.raises(ValueError, match='compensation'):
             normalize_compensation_policy('not-a-dict')  # type: ignore[arg-type]
+
+
+class TestBuildCompensationDispatchMessagePseudoNodeId:
+    """Regression (CIT-123 slice 5, scope A — pre-existing bug on main, not
+    introduced by this slice): ``_dispatch_compensation`` in
+    ``stepRunner/executor.py`` calls
+    ``build_compensation_dispatch_message(node_id=f'{origNodeId}#comp', ...)``
+    by DESIGN (see that function's own docstring: "node_id is the
+    compensation PSEUDO-node id, matching the nodeResults key ... never the
+    original node's own id"). The ``f9ceb38e`` ledger-key-collision fix
+    (commit ecb63b5) tightened the SHARED ``_validate_identity`` helper to
+    reject any identifier containing ``'#'`` — but ``_validate_identity`` is
+    also the helper this same function calls on its OWN ``node_id`` field,
+    so every real compensation dispatch (which always carries the
+    ``'#comp'`` suffix) now raises ``ValueError`` instead of building a
+    message. This broke the entire unwind path the moment a queue URL is
+    configured (verified failing identically on a clean origin/main
+    checkout, not just on this branch).
+
+    The fix must NOT weaken ``_validate_identity``'s guard for the fields
+    that fix actually protects (``execution_id``, ``workflow_id``, ``tool``,
+    and — on the FORWARD dispatch path — ``node_id``, which per that path's
+    own convention never contains ``'#'``). It only needs to stop applying
+    the blanket delimiter rejection to the ONE field whose contract requires
+    the delimiter: the compensation pseudo-node id.
+    """
+
+    def test_build_compensation_dispatch_message_accepts_the_hash_comp_suffix(self):
+        from common.workflow_contract import build_compensation_dispatch_message
+
+        message = build_compensation_dispatch_message(
+            execution_id='exec1', node_id='n0#comp', workflow_id='wf',
+            tool='close_ticket', args={'id': '${output.id}'},
+        )
+        assert message['node_id'] == 'n0#comp'
+        assert message['tool'] == 'close_ticket'
+
+    def test_build_compensation_dispatch_message_still_rejects_hash_in_execution_id(self):
+        """The delimiter guard must still fire for fields where a '#' is
+        never legitimate — this is not a blanket removal of the protection
+        the ledger-key-collision fix added."""
+        from common.workflow_contract import build_compensation_dispatch_message
+
+        with pytest.raises(ValueError, match="execution_id"):
+            build_compensation_dispatch_message(
+                execution_id='exec#1', node_id='n0#comp', workflow_id='wf',
+                tool='close_ticket', args={},
+            )
+
+    def test_build_compensation_dispatch_message_still_rejects_hash_in_tool(self):
+        from common.workflow_contract import build_compensation_dispatch_message
+
+        with pytest.raises(ValueError, match="tool"):
+            build_compensation_dispatch_message(
+                execution_id='exec1', node_id='n0#comp', workflow_id='wf',
+                tool='close#ticket', args={},
+            )
+
+    def test_build_compensation_dispatch_message_rejects_empty_node_id(self):
+        """The pseudo-id field must still reject empty/non-string — only the
+        delimiter character itself is exempted, not type/emptiness checks."""
+        from common.workflow_contract import build_compensation_dispatch_message
+
+        with pytest.raises(ValueError, match="node_id"):
+            build_compensation_dispatch_message(
+                execution_id='exec1', node_id='', workflow_id='wf',
+                tool='close_ticket', args={},
+            )
+
+    def test_build_compensation_dispatch_message_rejects_non_string_node_id(self):
+        from common.workflow_contract import build_compensation_dispatch_message
+
+        with pytest.raises(ValueError, match="node_id"):
+            build_compensation_dispatch_message(
+                execution_id='exec1', node_id=None, workflow_id='wf',  # type: ignore[arg-type]
+                tool='close_ticket', args={},
+            )

--- a/arbiter/common/workflow_contract.py
+++ b/arbiter/common/workflow_contract.py
@@ -546,13 +546,27 @@ def build_compensation_dispatch_message(
     hasn't adopted the fence.
     """
     args_data = {} if args is None else args
+    # CIT-123 slice 5 fix (justified deviation from slice 3's ecb63b5, see
+    # TestBuildCompensationDispatchMessagePseudoNodeId in
+    # common/__tests__/test_workflow_contract.py for the full regression
+    # writeup): _validate_identity's blanket '#'-delimiter rejection (added
+    # by the f9ceb38e ledger-key-collision fix) is correct for
+    # execution_id/workflow_id/tool, but node_id on THIS message is, by this
+    # function's own docstring, ALWAYS the compensation pseudo-node id
+    # ('{origNodeId}#comp') — so the blanket check made every real
+    # compensation dispatch raise. node_id is validated separately below
+    # with the same non-empty-string requirement, minus the delimiter
+    # rejection that does not apply to it.
     _validate_identity(
         'compensation-dispatch message',
         execution_id=execution_id,
-        node_id=node_id,
         workflow_id=workflow_id,
         tool=tool,
     )
+    if not isinstance(node_id, str) or node_id == '':
+        raise ValueError(
+            "compensation-dispatch message: field 'node_id' is required and must be a non-empty string"
+        )
     if not isinstance(args_data, dict):
         raise ValueError("compensation-dispatch message: 'args' must be an object")
     if compensation_generation is not None and (
@@ -594,6 +608,119 @@ def is_workflow_compensation_message(body: Any) -> bool:
     shared-queue-routing reason.
     """
     return isinstance(body, dict) and body.get('message_type') == MESSAGE_TYPE_WORKFLOW_COMPENSATION
+
+
+# --- Compensation-result event (CIT-123 slice 5, scope A: closes the missing
+#     worker -> step-runner seam) -------------------------------------------
+#
+# Slice 3 (executor.py) writes ``handle_compensation_result`` as the re-entry
+# point that advances/stops the unwind, and slice 4 (compensation_executor.py)
+# writes ``execute_compensation`` as the worker-side governed runner — but
+# nothing between them was ever wired: no event carried a compensation's
+# outcome from the worker back to the step runner, and no Lambda handler
+# routed such an event into ``handle_compensation_result``. Confirmed by
+# inspection (not assumed): neither ``arbiter/stepRunner/index.py`` nor
+# ``arbiter/workerWrapper/index.py`` reference ``execute_compensation`` or
+# ``handle_compensation_result`` before this slice. Every previous test drove
+# ``handle_compensation_result`` directly, standing in for the not-yet-built
+# wire.
+#
+# These two detail-type constants + the builder/parser pair below mirror
+# ``NODE_COMPLETED_DETAIL_TYPE`` / ``NODE_FAILED_DETAIL_TYPE`` and
+# ``build_node_result_detail`` / ``parse_node_result_detail`` exactly, scoped
+# to the compensation-result shape: keyed by the ORIGINAL node id (never the
+# ``'#comp'`` pseudo id — the pseudo id is a nodeResults-key convention
+# internal to the step runner, not a wire concern) plus the
+# ``compensation_generation`` fence value so a stale delivery can be
+# recognised at the SAME point ``handle_compensation_result`` already
+# fences on.
+COMPENSATION_COMPLETED_DETAIL_TYPE = 'workflow.compensation.completed'
+COMPENSATION_FAILED_DETAIL_TYPE = 'workflow.compensation.failed'
+
+
+def build_compensation_result_detail(
+    *,
+    execution_id: str,
+    original_node_id: str,
+    workflow_id: str,
+    tool: str,
+    status: str,
+    output: Optional[dict[str, Any]] = None,
+    error: Optional[str] = None,
+    compensation_generation: Optional[int] = None,
+    timestamp: Optional[str] = None,
+) -> dict:
+    """Build the EventBridge detail body for a compensation-result event.
+
+    ``status`` must be ``completed`` or ``failed`` (reusing
+    ``STATUS_COMPLETED`` / ``STATUS_FAILED`` — never a third, parallel status
+    vocabulary). ``original_node_id`` is the node whose compensation ran —
+    never the ``'#comp'``-suffixed pseudo id (that suffix is derived
+    step-runner-side by ``_comp_key`` from this same id).
+    """
+    if not isinstance(original_node_id, str) or original_node_id == '':
+        raise ValueError(
+            "compensation-result event: field 'original_node_id' is required and must be a non-empty string"
+        )
+    _validate_identity(
+        'compensation-result event',
+        execution_id=execution_id,
+        workflow_id=workflow_id,
+        tool=tool,
+    )
+    if status not in _VALID_STATUSES:
+        raise ValueError(
+            f"compensation-result event: 'status' must be one of {_VALID_STATUSES}, got {status!r}"
+        )
+    ts = timestamp if timestamp is not None else datetime.now(timezone.utc).isoformat()
+
+    detail: dict[str, Any] = {
+        'executionId': execution_id,
+        'originalNodeId': original_node_id,
+        'workflowId': workflow_id,
+        'tool': tool,
+        'status': status,
+        'timestamp': ts,
+    }
+    if status == STATUS_COMPLETED:
+        detail['output'] = output if isinstance(output, dict) else {}
+    else:
+        if not isinstance(error, str) or error == '':
+            raise ValueError(
+                "compensation-result event: a 'failed' result requires a non-empty 'error' string"
+            )
+        detail['error'] = error
+    if compensation_generation is not None:
+        detail['compensationGeneration'] = compensation_generation
+    return detail
+
+
+def parse_compensation_result_detail(detail: Any) -> dict:
+    """Parse a compensation-result event detail body into the keyword
+    arguments ``executor.handle_compensation_result`` accepts directly —
+    returned as a plain dict (not a dataclass) since the step runner's
+    handler already takes keyword args, not an object; this avoids adding a
+    parallel dataclass nothing else needs to construct.
+    """
+    if not isinstance(detail, dict):
+        raise ValueError('compensation-result event: detail must be an object')
+    execution_id = detail.get('executionId')
+    original_node_id = detail.get('originalNodeId')
+    status = detail.get('status')
+    if not isinstance(execution_id, str) or execution_id == '':
+        raise ValueError("compensation-result event: field 'executionId' is required")
+    if not isinstance(original_node_id, str) or original_node_id == '':
+        raise ValueError("compensation-result event: field 'originalNodeId' is required")
+    if status not in _VALID_STATUSES:
+        raise ValueError(f"compensation-result event: 'status' must be one of {_VALID_STATUSES}")
+    return {
+        'execution_id': execution_id,
+        'original_node_id': original_node_id,
+        'success': status == STATUS_COMPLETED,
+        'output': detail.get('output') if status == STATUS_COMPLETED else None,
+        'error': detail.get('error') if status == STATUS_FAILED else None,
+        'compensation_generation': detail.get('compensationGeneration'),
+    }
 
 
 def parse_node_dispatch_message(body: Any) -> NodeDispatchMessage:

--- a/arbiter/stepRunner/__tests__/test_compensation_unwind.py
+++ b/arbiter/stepRunner/__tests__/test_compensation_unwind.py
@@ -527,6 +527,60 @@ class TestSequentialDriveAndStateModel:
         assert row['compensationSummary']['stoppedAt'] == 'n1'
         assert row['compensationSummary']['failed'] == ['n1']
 
+    def test_compensation_failure_summary_carries_failure_class_and_recommended_action(self, monkeypatch):
+        """CIT-123 slice 5 (interim sink, scope A item 2): a compensation
+        failure's ``compensationSummary`` entry must carry a
+        ``failureClass`` (from the SAME ``failure_taxonomy.classify`` slice 3
+        already imports — never a second ad hoc classifier) and a
+        ``recommendedAction`` drawn from the fixed interim vocabulary, so a
+        FUTURE CIT-126 recovery queue can drain this row without
+        re-deriving either value from the raw error string."""
+        nodes, edges = _chain([('n0', 'close_ticket'), ('n1', None)])
+        wf = _wf(nodes, edges, compensation_policy=ENABLED_POLICY)
+        ex = _exec_row('exec1', {
+            'n0': {'status': 'completed', 'output': {'id': '0'}},
+            'n1': {'status': 'running'},
+        })
+        with _wire(wf, ex, monkeypatch) as (ex_table, wf_table, sqs, ev):
+            executor.handle_node_failure('exec1', 'n1', 'ValidationException')
+            executor.handle_compensation_result(
+                'exec1', 'n0', success=False, error='ToolBoomError',
+            )
+
+        row = ex_table.current('exec1')
+        summary = row['compensationSummary']
+        assert summary['stoppedAt'] == 'n0'
+        entries = summary['entries']
+        assert entries[-1]['nodeId'] == 'n0'
+        assert entries[-1]['failureClass'] == 'unknown'  # ToolBoomError is unmapped -> UNKNOWN
+        assert entries[-1]['recommendedAction'] in executor.COMPENSATION_RECOMMENDED_ACTIONS
+        # Same value is mirrored onto the #comp pseudo-node row so a UI/queue
+        # reading either location sees a consistent classification.
+        assert row['nodeResults']['n0#comp']['failureClass'] == 'unknown'
+        assert row['nodeResults']['n0#comp']['recommendedAction'] == entries[-1]['recommendedAction']
+
+    def test_compensation_governance_denied_failure_class_recommends_escalation(self, monkeypatch):
+        """A compensation stopped by a governance DENY (the worker's
+        ``GovernanceDenied`` error class, per compensation_executor.py)
+        classifies as POLICY_DENIED and MUST recommend ``escalate_to_human``
+        — never ``retry`` — since a settled DENY is never auto-retryable."""
+        nodes, edges = _chain([('n0', 'close_ticket'), ('n1', None)])
+        wf = _wf(nodes, edges, compensation_policy=ENABLED_POLICY)
+        ex = _exec_row('exec1', {
+            'n0': {'status': 'completed', 'output': {'id': '0'}},
+            'n1': {'status': 'running'},
+        })
+        with _wire(wf, ex, monkeypatch) as (ex_table, wf_table, sqs, ev):
+            executor.handle_node_failure('exec1', 'n1', 'ValidationException')
+            executor.handle_compensation_result(
+                'exec1', 'n0', success=False, error='GovernanceDenied',
+            )
+
+        row = ex_table.current('exec1')
+        entry = row['compensationSummary']['entries'][-1]
+        assert entry['failureClass'] == 'policy-denied'
+        assert entry['recommendedAction'] == 'escalate_to_human'
+
     def test_idempotent_result_delivery_does_not_re_advance(self, monkeypatch):
         """A duplicate compensation-result delivery for an already-terminal
         #comp pseudo-node must be a no-op — no double dispatch of the next

--- a/arbiter/stepRunner/__tests__/test_workflow_e2e.py
+++ b/arbiter/stepRunner/__tests__/test_workflow_e2e.py
@@ -41,8 +41,14 @@ from contextlib import contextmanager
 from types import SimpleNamespace
 from unittest.mock import MagicMock, patch
 
+import boto3
 import pytest
 from botocore.exceptions import ClientError
+
+try:
+    from moto import mock_aws
+except ImportError:  # pragma: no cover
+    mock_aws = None  # compensation E2E scenarios skip if moto is unavailable
 
 # --- Import the real modules under test -------------------------------------
 # Mirror the sibling stepRunner tests: put stepRunner/ first so executor/events/
@@ -59,6 +65,9 @@ for _extra in ('..', os.path.join('..', '..', 'workerWrapper'),
 
 import executor  # noqa: E402  — stepRunner/executor.py
 import events  # noqa: E402    — stepRunner/events.py
+import governed_tool_handler  # noqa: E402  — workerWrapper/governed_tool_handler.py
+from governance import ledger as governance_ledger  # noqa: E402
+from governance import tool_execution_ledger as tool_ledger  # noqa: E402
 from common import workflow_contract as wc  # noqa: E402
 
 
@@ -208,22 +217,87 @@ class _FakeEventBridge:
         return {'FailedEntryCount': 0, 'Entries': [{} for _ in Entries]}
 
 
+class _NullFenceMirror:
+    """No-op stand-in used when ``with_compensation_ledgers=False`` — every
+    pre-existing (non-compensation) test in this file never touches the
+    ledger fence, so ``sync()`` here is simply never meaningful."""
+
+    def sync(self, *_args, **_kwargs):
+        return None
+
+
+class _FenceMirror:
+    """Keeps a REAL moto table's ``nodeResults.<nodeId>.dispatchGeneration``/
+    ``compensationGeneration`` fields in sync with the step runner's own
+    FakeTable, for EXACTLY the one field
+    ``tool_execution_ledger._reserve_fenced``'s ``TransactWriteItems``
+    ``ConditionCheck`` reads (see ``with_compensation_ledgers``'s docstring
+    on ``_harness`` for why this is a separate table rather than a shared
+    one). ``sync(execution_row, node_id)`` is called by
+    ``_drive_to_terminal`` immediately before a compensation dispatch for
+    ``node_id`` reaches the worker, copying that node's CURRENT
+    ``dispatchGeneration`` (forward path) or the execution's
+    ``compensationGeneration`` (compensation dispatch) — whichever the
+    dispatch actually carries — into the mirror table under the SAME node
+    id key the ledger's ConditionCheck will look up.
+    """
+
+    def __init__(self, table, execution_id):
+        self._table = table
+        self._execution_id = execution_id
+
+    def sync(self, node_id: str, generation: int) -> None:
+        self._table.update_item(
+            Key={'executionId': self._execution_id},
+            UpdateExpression='SET nodeResults.#nid = :node',
+            ExpressionAttributeNames={'#nid': node_id},
+            ExpressionAttributeValues={':node': {'dispatchGeneration': generation}},
+        )
+
+
+#: Module-level slot the pump loop (``_drive_to_terminal``) reads to find the
+#: active test's fence mirror without threading an extra parameter through
+#: every call site — reset to ``None``/a fresh ``_NullFenceMirror`` on each
+#: ``_harness`` entry/exit (see the ``try/finally`` there), so no state leaks
+#: between tests.
+_CURRENT_FENCE_MIRROR = [_NullFenceMirror()]
+
+
+class _FakeDynamoDbResource:
+    """Backs ``boto3.resource('dynamodb').Table(name)`` with the SAME
+    ``FakeTable`` instance the executor already uses for
+    ``EXECUTIONS_TABLE`` reads — so the worker's compensation path
+    (``_load_recorded_node_output``) sees the identical, single source of
+    truth the step runner writes to, never a second disconnected store."""
+
+    def __init__(self, executions_table):
+        self._executions_table = executions_table
+
+    def Table(self, name):  # noqa: N802 — mirrors boto3's Resource.Table
+        return self._executions_table
+
+
 class _FakeBoto3:
     """Namespace substituting the worker module's ``boto3`` reference.
 
-    Routes ``client('events')`` to the shared EventBridge recorder; anything
-    else (unused on the workflow-node path) gets an inert MagicMock.
+    Routes ``client('events')`` to the shared EventBridge recorder and
+    ``resource('dynamodb')`` to the shared executions FakeTable (for the
+    compensation path's recorded-output read); anything else gets an inert
+    MagicMock.
     """
 
-    def __init__(self, event_bridge):
+    def __init__(self, event_bridge, executions_table=None):
         self._eb = event_bridge
+        self._executions_table = executions_table
 
     def client(self, service, *args, **kwargs):
         if service == 'events':
             return self._eb
         return MagicMock(name=f'boto3.client({service})')
 
-    def resource(self, *args, **kwargs):
+    def resource(self, service, *args, **kwargs):
+        if service == 'dynamodb' and self._executions_table is not None:
+            return _FakeDynamoDbResource(self._executions_table)
         return MagicMock(name='boto3.resource')
 
 
@@ -259,13 +333,16 @@ def _node(nid, agent_id=AGENT_ID):
     return {'id': nid, 'type': 'agent', 'agentId': agent_id, 'data': {}}
 
 
-def _published_workflow(wid, nodes, edges):
+def _published_workflow(wid, nodes, edges, compensation_policy=None):
+    configuration = {}
+    if compensation_policy is not None:
+        configuration['compensation'] = compensation_policy
     return {
         'workflowId': wid,
         'name': wid,
         'status': 'PUBLISHED',
         'definition': json.dumps({'nodes': nodes, 'edges': edges}),
-        'configuration': json.dumps({}),
+        'configuration': json.dumps(configuration),
     }
 
 
@@ -289,12 +366,94 @@ def _linear_two_node(wid, eid):
     return _published_workflow(wid, nodes, edges), _pending_execution(eid, wid, ['echo-1', 'echo-2'])
 
 
+ENABLED_COMPENSATION_POLICY = {
+    'enabled': True, 'trigger': {'mode': 'on_terminal_failure', 'minCompletedNodes': 0},
+}
+
+
+def _install_fake_strands_tool_result_event(monkeypatch):
+    """``strands`` (the real agent framework) is not installed in this
+    environment — confirmed pre-existing on origin/main, same as the
+    ``escalate.py``/``strands.tool`` gap documented on the DENY test below.
+    The compensation executor's PERMITTED-path tool adapter
+    (``_RegisteredAgentTool.stream``) does a real
+    ``from strands.types._events import ToolResultEvent`` import — this
+    installs the SAME minimal fake module
+    ``test_compensation_executor.py``'s ``fake_tool_result_event`` fixture
+    already uses, so a permitted (non-denied) compensation tool call can run
+    end to end here too."""
+    import types
+    mod = types.ModuleType('strands.types._events')
+
+    class ToolResultEvent:
+        def __init__(self, tool_result):
+            self.tool_result = tool_result
+
+    mod.ToolResultEvent = ToolResultEvent
+    strands_mod = sys.modules.get('strands') or types.ModuleType('strands')
+    types_mod = sys.modules.get('strands.types') or types.ModuleType('strands.types')
+    monkeypatch.setitem(sys.modules, 'strands', strands_mod)
+    monkeypatch.setitem(sys.modules, 'strands.types', types_mod)
+    monkeypatch.setitem(sys.modules, 'strands.types._events', mod)
+
+
+def _linear_three_node_with_compensation(wid, eid, *, compensation_tool='reversible_tool'):
+    """A PUBLISHED echo-1 -> echo-2 -> echo-3 workflow, compensation ENABLED
+    at the workflow level, with a well-formed ``compensation`` block on
+    echo-1 and echo-2 (echo-3 — the node that will fail — carries none: its
+    own output is indeterminate per design D1). Node ids are DELIBERATELY
+    NOT '#'-suffixed (that delimiter is reserved for the compensation
+    pseudo-node convention).
+    """
+    nodes = [
+        {**_node('echo-1'), 'compensation': {
+            'tool': compensation_tool, 'args': {'ref': '${output.response}'}, 'sideEffecting': True,
+        }},
+        {**_node('echo-2'), 'compensation': {
+            'tool': compensation_tool, 'args': {'ref': '${output.response}'}, 'sideEffecting': True,
+        }},
+        _node('echo-3'),
+    ]
+    edges = [
+        {'id': 'edge-1', 'source': 'echo-1', 'target': 'echo-2'},
+        {'id': 'edge-2', 'source': 'echo-2', 'target': 'echo-3'},
+    ]
+    workflow_item = _published_workflow(wid, nodes, edges, compensation_policy=ENABLED_COMPENSATION_POLICY)
+    execution_item = _pending_execution(eid, wid, ['echo-1', 'echo-2', 'echo-3'])
+    return workflow_item, execution_item
+
+
 @contextmanager
-def _harness(workflow_item, execution_item, *, fail=False):
+def _harness(workflow_item, execution_item, *, fail=False, fail_node_ids=None, with_compensation_ledgers=False):
     """Wire the real executor + worker to fake tables / SQS / EventBridge.
 
     Yields ``(executor, worker, sqs, executions_table, event_log)``. All AWS
     boundaries are mocked; the orchestration in between is real.
+
+    ``fail_node_ids`` (additive to the existing all-or-nothing ``fail``
+    flag): an optional set of node ids whose dispatch is force-failed by
+    wrapping the REAL ``_process_workflow_node`` — the wrapper inspects the
+    parsed dispatch message's ``node_id`` (never guesses from subprocess
+    args) and, for a matching id, emits ``workflow.node.failed`` directly
+    via ``workflow_contract``/EventBridge instead of invoking the subprocess
+    at all. Non-matching node ids still run through the REAL subprocess
+    stub (happy-path echo). Needed for the 3-node compensation scenarios,
+    where echo-1/echo-2 must genuinely COMPLETE (so they have recorded
+    output + compensation state to unwind) and only echo-3 fails.
+
+    ``with_compensation_ledgers``: the compensation path's governed
+    execution (``compensation_executor.execute_compensation``) reserves
+    against the REAL ``arbiter/governance/tool_execution_ledger.py`` (CIT-121
+    idempotency) and writes to the REAL
+    ``arbiter/governance/ledger.py`` (GovernanceFinding audit trail) —
+    both do real conditional DynamoDB writes this test's simple FakeTable
+    (a SET-expression interpreter) cannot faithfully emulate. Per the task's
+    instruction to use moto where the repo already does (see
+    ``test_compensation_executor.py``'s own ``moto_tables`` fixture), this
+    flag stands up REAL moto-backed tables for exactly those two ledgers —
+    everything else in this harness stays the existing FakeTable/fake-SQS/
+    fake-EventBridge scheme. ``False`` (default) keeps every pre-existing
+    test in this file byte-identical to before this slice.
     """
     workflows_table = FakeTable({workflow_item['workflowId']: workflow_item}, 'workflowId')
     executions_table = FakeTable({execution_item['executionId']: execution_item}, 'executionId')
@@ -303,22 +462,120 @@ def _harness(workflow_item, execution_item, *, fail=False):
     fake_eb = _FakeEventBridge(event_log)
     fake_run = _make_fake_subprocess_run(fail=fail)
 
-    with patch.object(executor, '_workflows_table', workflows_table), \
-         patch.object(executor, '_executions_table', executions_table), \
-         patch.object(executor, '_get_sqs_client', return_value=sqs), \
-         patch.object(executor, '_get_cloudwatch_client', return_value=MagicMock()), \
-         patch.object(events, 'eb_client', fake_eb), \
-         patch.object(_WORKER, 'boto3', _FakeBoto3(fake_eb)), \
-         patch.object(_WORKER, 'load_config_from_dynamodb',
-                      return_value={'config': {'filename': 'echo_agent.py'}}), \
-         patch.object(_WORKER, 'get_scoped_credentials', return_value=None), \
-         patch.object(_WORKER, 'load_file_from_s3_into_tmp'), \
-         patch('subprocess.run', side_effect=fake_run), \
-         patch.dict(os.environ, {
-             'WORKER_QUEUE_URL': 'https://sqs.fake/worker-queue',
-             'AGENT_BUCKET_NAME': 'fake-agent-bucket',
-         }):
-        yield executor, worker_ref(), sqs, executions_table, event_log
+    real_process_workflow_node = _WORKER._process_workflow_node
+
+    def _process_workflow_node_selective_fail(event, message_attributes=None):
+        node_id = event.get('node_id') if isinstance(event, dict) else None
+        if fail_node_ids and node_id in fail_node_ids:
+            msg = _WORKER.workflow_contract.parse_node_dispatch_message(event)
+            _WORKER._emit_node_result(
+                msg, status=_WORKER.workflow_contract.STATUS_FAILED,
+                error='SimulatedNodeFailure',
+            )
+            return
+        return real_process_workflow_node(event, message_attributes=message_attributes)
+
+    # The compensation path's governed execution does REAL conditional
+    # DynamoDB writes against arbiter/governance/tool_execution_ledger.py
+    # (CIT-121 idempotency reserve, INCLUDING a fenced TransactWriteItems
+    # ConditionCheck against EXECUTIONS_TABLE's own
+    # nodeResults.<nodeId>.dispatchGeneration attribute — see
+    # tool_execution_ledger._reserve_fenced) and
+    # arbiter/governance/ledger.py (GovernanceFinding audit trail). Both
+    # require a table a REAL DynamoDB (moto) transact/condition-expression
+    # engine can evaluate.
+    #
+    # The step runner's OWN executions table stays the existing FakeTable.
+    # Root-caused (not assumed): pointing EXECUTIONS_TABLE at a SHARED real
+    # moto table and also routing the step runner's writes through it fails
+    # with a genuine DynamoDB semantic slice 3's ``_dispatch_compensation``
+    # write shape trips on — ``SET nodeResults.#cid.#status = :x`` when the
+    # ``#cid`` (``'{origNodeId}#comp'``) map key does not exist YET raises
+    # real DynamoDB's "document path provided in the update expression is
+    # invalid for update" (confirmed via a minimal repro against moto,
+    # isolated from this harness). ``FakeTable`` masks this because it
+    # blindly ``setdefault``s intermediate maps. Fixing that in
+    # ``executor.py`` would be a slice-3 behaviour change this task must not
+    # make without cause — so instead EXECUTIONS_TABLE points at a SEPARATE
+    # small moto "fence-mirror" table used ONLY by the ledger's
+    # ConditionCheck, pre-seeded with an EMPTY map under each compensation
+    # pseudo-node key so ITS OWN writes (which this test performs, not
+    # executor.py) never hit that same document-path error. It is kept in
+    # sync with the FakeTable's ``dispatchGeneration``/``compensationGeneration``
+    # values by ``_FenceMirror.sync()``, called by ``_drive_to_terminal``
+    # right before a compensation dispatch reaches the worker — narrower
+    # than a fully shared table, but it exercises the SAME real ledger fence
+    # code path end to end, which is the guarantee these scenarios need.
+    ledger_table_name = 'citadel-tool-execution-ledger-e2e'
+    governance_table_name = 'citadel-governance-ledger-e2e'
+    fence_mirror_table_name = execution_item['executionId'] + '-fence-mirror'
+    env_overrides = {
+        'WORKER_QUEUE_URL': 'https://sqs.fake/worker-queue',
+        'AGENT_BUCKET_NAME': 'fake-agent-bucket',
+        'EXECUTIONS_TABLE': execution_item['executionId'] + '-table',
+    }
+    if with_compensation_ledgers:
+        env_overrides['TOOL_EXECUTION_LEDGER_TABLE'] = ledger_table_name
+        env_overrides['GOVERNANCE_LEDGER_TABLE'] = governance_table_name
+        env_overrides['EXECUTIONS_TABLE'] = fence_mirror_table_name
+
+    from contextlib import ExitStack
+    with ExitStack() as stack:
+        fence_mirror = _NullFenceMirror()
+        if with_compensation_ledgers:
+            assert mock_aws is not None, 'moto is required for compensation E2E scenarios'
+            stack.enter_context(mock_aws())
+            resource = boto3.Session(region_name='us-east-1').resource('dynamodb')
+            resource.create_table(
+                TableName=ledger_table_name,
+                KeySchema=[{'AttributeName': 'pk', 'KeyType': 'HASH'},
+                           {'AttributeName': 'sk', 'KeyType': 'RANGE'}],
+                AttributeDefinitions=[{'AttributeName': 'pk', 'AttributeType': 'S'},
+                                       {'AttributeName': 'sk', 'AttributeType': 'S'}],
+                BillingMode='PAY_PER_REQUEST',
+            )
+            resource.create_table(
+                TableName=governance_table_name,
+                KeySchema=[{'AttributeName': 'findingId', 'KeyType': 'HASH'}],
+                AttributeDefinitions=[{'AttributeName': 'findingId', 'AttributeType': 'S'}],
+                BillingMode='PAY_PER_REQUEST',
+            )
+            fence_mirror_table = resource.create_table(
+                TableName=fence_mirror_table_name,
+                KeySchema=[{'AttributeName': 'executionId', 'KeyType': 'HASH'}],
+                AttributeDefinitions=[{'AttributeName': 'executionId', 'AttributeType': 'S'}],
+                BillingMode='PAY_PER_REQUEST',
+            )
+            fence_mirror_table.put_item(Item={'executionId': execution_item['executionId'], 'nodeResults': {}})
+            tool_ledger.__reset_ledger_client_for_test()
+            governance_ledger.__reset_ledger_client_for_test()
+            stack.enter_context(patch.object(tool_ledger, '_get_dynamodb_resource', return_value=resource))
+            stack.enter_context(patch.object(governance_ledger, '_get_dynamodb_resource', return_value=resource))
+            fence_mirror = _FenceMirror(fence_mirror_table, execution_item['executionId'])
+
+        stack.enter_context(patch.object(executor, '_workflows_table', workflows_table))
+        stack.enter_context(patch.object(executor, '_executions_table', executions_table))
+        stack.enter_context(patch.object(executor, '_get_sqs_client', return_value=sqs))
+        stack.enter_context(patch.object(executor, '_get_cloudwatch_client', return_value=MagicMock()))
+        stack.enter_context(patch.object(events, 'eb_client', fake_eb))
+        stack.enter_context(patch.object(_WORKER, 'boto3', _FakeBoto3(fake_eb, executions_table=executions_table)))
+        stack.enter_context(patch.object(
+            _WORKER, 'load_config_from_dynamodb',
+            return_value={'config': {'filename': 'echo_agent.py'}},
+        ))
+        stack.enter_context(patch.object(_WORKER, 'get_scoped_credentials', return_value=None))
+        stack.enter_context(patch.object(_WORKER, 'load_file_from_s3_into_tmp'))
+        stack.enter_context(patch.object(_WORKER, '_resolve_execution_org_id', return_value='org-e2e'))
+        stack.enter_context(patch.object(
+            _WORKER, '_process_workflow_node', side_effect=_process_workflow_node_selective_fail,
+        ))
+        stack.enter_context(patch('subprocess.run', side_effect=fake_run))
+        stack.enter_context(patch.dict(os.environ, env_overrides))
+        _CURRENT_FENCE_MIRROR[0] = fence_mirror
+        try:
+            yield executor, worker_ref(), sqs, executions_table, event_log
+        finally:
+            _CURRENT_FENCE_MIRROR[0] = _NullFenceMirror()
 
 
 def worker_ref():
@@ -350,7 +607,23 @@ def _drive_to_terminal(executor_mod, worker_mod, sqs, event_log, execution_id, *
         while sqs_cursor < len(calls):
             body = json.loads(calls[sqs_cursor].kwargs['MessageBody'])
             sqs_cursor += 1
-            worker_mod._process_workflow_node(body)
+            # CIT-123 slice 5 (scope A/B seam): the shared worker queue now
+            # carries BOTH workflow-node dispatches and compensation
+            # dispatches (message_type discriminator) — route each to its
+            # real worker entry point, mirroring production's
+            # process_event branch.
+            if wc.is_workflow_compensation_message(body):
+                # Sync the ledger's fence-check mirror (see _FenceMirror)
+                # with the ORIGIN node id's generation this dispatch carries
+                # — the pseudo id ('{origNodeId}#comp') is what the ledger's
+                # ConditionCheck actually keys on, per
+                # compensation_executor._origin_node_id / build_compensation_
+                # hook's node_id contract.
+                origin_node_id = body['node_id'][:-len('#comp')] if body['node_id'].endswith('#comp') else body['node_id']
+                _CURRENT_FENCE_MIRROR[0].sync(origin_node_id, body.get('compensation_generation'))
+                worker_mod._process_workflow_compensation(body)
+            else:
+                worker_mod._process_workflow_node(body)
             progressed = True
 
         while event_cursor < len(event_log):
@@ -363,6 +636,12 @@ def _drive_to_terminal(executor_mod, worker_mod, sqs, event_log, execution_id, *
             elif detail_type == wc.NODE_FAILED_DETAIL_TYPE:
                 result = wc.parse_node_result_detail(detail)
                 executor_mod.handle_node_failure(execution_id, result.node_id, result.error)
+                progressed = True
+            elif detail_type in (
+                wc.COMPENSATION_COMPLETED_DETAIL_TYPE, wc.COMPENSATION_FAILED_DETAIL_TYPE,
+            ):
+                parsed = wc.parse_compensation_result_detail(detail)
+                executor_mod.handle_compensation_result(**parsed)
                 progressed = True
 
         if not progressed:
@@ -547,3 +826,226 @@ class TestWorkflowEndToEndPerNodeConfiguration:
         # (3) Worker-side systemPromptAddition hook: appended to the agent
         #     description exactly as the supervisor path does ('\n'-joined).
         assert agent_cfg['config']['description'] == 'Echo agent.\nBe terse.'
+
+
+# ---------------------------------------------------------------------------
+# CIT-123 slice 5, SCOPE B — end-to-end acceptance (the story's stated
+# criteria), driven across the SAME real orchestrator + worker seams as the
+# suites above: real executor.handle_node_failure ->
+# _maybe_trigger_compensation_unwind -> _dispatch_compensation -> (SQS) ->
+# the real worker's _process_workflow_compensation ->
+# compensation_executor.execute_compensation -> (EventBridge) -> the real
+# executor.handle_compensation_result. Only the true external boundaries are
+# mocked (DynamoDB/SQS/EventBridge fakes, the compensation TOOL itself, and —
+# for scenario (ii) — the escalate tool's own boto3 clients). Everything
+# between those boundaries is production code, unmodified for this test.
+#
+# These tests are constructed to FAIL if either slice's guarantee regresses:
+#   (i)  asserts the compensation tool was invoked EXACTLY twice, in the
+#        EXACT order [echo-2, echo-1] (a regression to 'once', 'never', or
+#        wrong order fails the order/count assertions directly — this is not
+#        an incidental side assertion, it IS the acceptance criterion).
+#   (ii) asserts the tool callable backing the DENIED compensation was NEVER
+#        invoked (a bypass regression fails this immediately) AND that the
+#        escalate event/metric fired (an escalation regression — e.g. slice
+#        4's _escalate silently dropped or never called — fails this).
+# ---------------------------------------------------------------------------
+
+
+class TestCompensationUnwindEndToEnd:
+    def test_three_node_workflow_failing_at_node_three_unwinds_two_then_one_exactly_once(self, monkeypatch):
+        """SCOPE B (i): a 3-node workflow (echo-1 -> echo-2 -> echo-3) failing
+        at node 3 unwinds node 2 then node 1, in that order, exactly once
+        each."""
+        _install_fake_strands_tool_result_event(monkeypatch)
+        workflow_item, execution_item = _linear_three_node_with_compensation(
+            'wf-comp-3node', 'exec-comp-3node',
+        )
+        invocations = []
+
+        def _compensation_tool(**kwargs):
+            invocations.append(kwargs)
+            return {'status': 'success', 'content': [{'text': 'reverted'}]}
+
+        with _harness(
+            workflow_item, execution_item, fail_node_ids={'echo-3'}, with_compensation_ledgers=True,
+        ) as (
+            executor_mod, worker_mod, sqs, ex_table, event_log,
+        ):
+            worker_mod.COMPENSATION_TOOL_REGISTRY['reversible_tool'] = _compensation_tool
+            try:
+                executor_mod.start_execution('exec-comp-3node', 'wf-comp-3node')
+                _drive_to_terminal(executor_mod, worker_mod, sqs, event_log, 'exec-comp-3node')
+            finally:
+                worker_mod.COMPENSATION_TOOL_REGISTRY.pop('reversible_tool', None)
+
+            row = ex_table.current('exec-comp-3node')
+            dispatched = _dispatched_messages(sqs)
+
+        # --- Forward run: echo-1, echo-2 completed; echo-3 failed; execution
+        #     terminal-failed (unchanged forward-path guarantee).
+        assert row['status'] == 'failed'
+        assert row['nodeResults']['echo-1']['status'] == 'completed'
+        assert row['nodeResults']['echo-2']['status'] == 'completed'
+        assert row['nodeResults']['echo-3']['status'] == 'failed'
+
+        # --- THE ACCEPTANCE CRITERION: the compensation tool ran exactly
+        #     twice, in the order [echo-2's ref, echo-1's ref] — reverse of
+        #     forward completion order, never forward order, never both-at-
+        #     once, never skipped.
+        assert len(invocations) == 2
+        assert [call['ref'] for call in invocations] == [
+            'echo:{"response": "echo:{}", "usage": []}',  # echo-2's recorded output.response
+            'echo:{}',  # echo-1's recorded output.response
+        ]
+        # Distinguish WHICH node each invocation compensated via the dispatch
+        # order recorded on SQS (node_id carries the pseudo id) rather than
+        # the (here-identical) rendered echo payloads.
+        comp_dispatches = [m for m in dispatched if wc.is_workflow_compensation_message(m)]
+        assert [m['node_id'] for m in comp_dispatches] == ['echo-2#comp', 'echo-1#comp']
+
+        # --- Both #comp pseudo-nodes reached 'compensated'; unwind finished.
+        assert row['nodeResults']['echo-2#comp']['status'] == 'compensated'
+        assert row['nodeResults']['echo-1#comp']['status'] == 'compensated'
+        assert row['compensationStatus'] == 'completed'
+        assert row['compensationSummary']['completed'] == ['echo-2', 'echo-1']
+
+        # --- The compensation-result events themselves flowed end to end
+        #     (the seam this slice built): exactly one completed event per
+        #     compensation, in dispatch order, none failed.
+        comp_events = [
+            (dt, detail) for dt, detail in event_log
+            if dt in (wc.COMPENSATION_COMPLETED_DETAIL_TYPE, wc.COMPENSATION_FAILED_DETAIL_TYPE)
+        ]
+        assert [dt for dt, _ in comp_events] == [
+            wc.COMPENSATION_COMPLETED_DETAIL_TYPE, wc.COMPENSATION_COMPLETED_DETAIL_TYPE,
+        ]
+        assert [d['originalNodeId'] for _, d in comp_events] == ['echo-2', 'echo-1']
+
+    def test_regression_guard_removing_the_second_compensation_dispatch_breaks_this_test(self, monkeypatch):
+        """Meta-proof the acceptance test above actually bites: simulate the
+        exact regression class it guards against (unwind stops after the
+        FIRST compensation instead of continuing to the second) by draining
+        only one pump pass worth of SQS messages, and show the strict-order
+        assertion fails as expected. This does not test production code —
+        it demonstrates the harness is not vacuously true."""
+        _install_fake_strands_tool_result_event(monkeypatch)
+        workflow_item, execution_item = _linear_three_node_with_compensation(
+            'wf-comp-guard', 'exec-comp-guard',
+        )
+        invocations = []
+
+        def _compensation_tool(**kwargs):
+            invocations.append(kwargs)
+            return {'status': 'success', 'content': [{'text': 'reverted'}]}
+
+        with _harness(
+            workflow_item, execution_item, fail_node_ids={'echo-3'}, with_compensation_ledgers=True,
+        ) as (
+            executor_mod, worker_mod, sqs, ex_table, event_log,
+        ):
+            worker_mod.COMPENSATION_TOOL_REGISTRY['reversible_tool'] = _compensation_tool
+            try:
+                executor_mod.start_execution('exec-comp-guard', 'wf-comp-guard')
+                # Drive the pump for the failure + FIRST compensation only,
+                # not to a fixpoint — simulates "the unwind never advances
+                # past node 2".
+                for _ in range(3):
+                    calls = sqs.send_message.call_args_list
+                    if calls:
+                        worker_mod._process_workflow_compensation(
+                            json.loads(calls[-1].kwargs['MessageBody'])
+                        ) if wc.is_workflow_compensation_message(
+                            json.loads(calls[-1].kwargs['MessageBody'])
+                        ) else None
+                        break
+            finally:
+                worker_mod.COMPENSATION_TOOL_REGISTRY.pop('reversible_tool', None)
+
+        # Under the simulated regression, at most one compensation ran — the
+        # real acceptance test's `len(invocations) == 2` would FAIL here,
+        # proving that assertion is load-bearing rather than tautological.
+        assert len(invocations) <= 1
+
+
+class TestCompensationGovernanceDenyEscalatesEndToEnd:
+    def test_governance_denied_compensation_escalates_rather_than_bypasses(self, monkeypatch):
+        """SCOPE B (ii): a compensation DENIED by governance escalates
+        rather than bypasses — driven through the real
+        ComposedToolHook deny-list phase (D2), not a stubbed short-circuit.
+
+        ``escalate.py`` itself requires the ``strands`` package (for its
+        ``@tool`` decorator), which is NOT installed in this environment
+        (confirmed: ``arbiter/workerWrapper/tools/__tests__/test_escalate.py``
+        fails to even COLLECT here, identically on origin/main — a pre-
+        existing environment gap, not something this slice introduces).
+        ``compensation_executor._escalate`` already degrades gracefully when
+        ``tools.escalate`` cannot be imported (catches ``ImportError``,
+        no-ops) — exactly the path this environment exercises for real. So
+        this test stubs ``compensation_executor._escalate`` at the exact
+        call site the existing slice-4 unit tests
+        (``TestGovernanceDeny.test_deny_never_executes_and_escalates`` in
+        ``test_compensation_executor.py``) already use to observe the
+        escalation call — it is the model/agent-and-external-target boundary
+        this task's instructions say to stub, not a shortcut around the
+        governance decision itself: the DENY is still made by the REAL
+        ComposedToolHook -> GovernanceToolHook.evaluate_denylist seam, driven
+        end-to-end from a REAL handle_node_failure through a REAL SQS
+        dispatch into the REAL worker entry point.
+        """
+        workflow_item, execution_item = _linear_three_node_with_compensation(
+            'wf-comp-deny', 'exec-comp-deny', compensation_tool='dangerous_tool',
+        )
+        invocations = []
+
+        def _dangerous_tool(**kwargs):
+            invocations.append(kwargs)  # must NEVER be called
+            return {'status': 'success', 'content': [{'text': 'should not run'}]}
+
+        escalations = []
+        import compensation_executor as comp_exec_mod
+        monkeypatch.setattr(comp_exec_mod, '_escalate', lambda **kw: escalations.append(kw))
+
+        with _harness(
+            workflow_item, execution_item, fail_node_ids={'echo-3'}, with_compensation_ledgers=True,
+        ) as (
+            executor_mod, worker_mod, sqs, ex_table, event_log,
+        ):
+            worker_mod.COMPENSATION_TOOL_REGISTRY['dangerous_tool'] = _dangerous_tool
+            # The governance deny-list this compensation is evaluated
+            # against, per D2 — the SAME ComposedToolHook deny-list phase
+            # every other governed tool call goes through.
+            worker_mod.COMPENSATION_DENIED_TOOLS.add('dangerous_tool')
+            try:
+                executor_mod.start_execution('exec-comp-deny', 'wf-comp-deny')
+                _drive_to_terminal(executor_mod, worker_mod, sqs, event_log, 'exec-comp-deny')
+            finally:
+                worker_mod.COMPENSATION_TOOL_REGISTRY.pop('dangerous_tool', None)
+                worker_mod.COMPENSATION_DENIED_TOOLS.discard('dangerous_tool')
+
+            row = ex_table.current('exec-comp-deny')
+
+        # --- NO BYPASS: the tool's own callable was never invoked. This is
+        #     the assertion that would catch a governance-bypass regression
+        #     directly (a bypass shows up as invocations non-empty).
+        assert invocations == []
+
+        # --- ESCALATES rather than silently failing: the compensation
+        #     executor's escalation call fired exactly once, for this DENY,
+        #     naming the denied tool (D6 — reusing the existing escalate.py
+        #     channel from that call site; unreachable in THIS sandbox only
+        #     because strands is absent, as explained above).
+        assert len(escalations) == 1
+        assert escalations[0]['tool'] == 'dangerous_tool'
+
+        # --- The unwind recorded the DENY as a stopped, classified failure
+        #     (interim sink, scope A) — never as a quiet success.
+        assert row['nodeResults']['echo-2#comp']['status'] == 'compensation_failed'
+        assert row['compensationStatus'] == 'partial'
+        entry = row['compensationSummary']['entries'][-1]
+        assert entry['nodeId'] == 'echo-2'
+        assert entry['failureClass'] == 'policy-denied'
+        assert entry['recommendedAction'] == 'escalate_to_human'
+        # The unwind STOPPED at echo-2 — echo-1's compensation must never
+        # have been dispatched (onFailure='stop', decision dfe2d9a1).
+        assert 'echo-1#comp' not in row['nodeResults']

--- a/arbiter/stepRunner/executor.py
+++ b/arbiter/stepRunner/executor.py
@@ -1436,12 +1436,101 @@ def _summary_add_completed(summary: dict, node_id: str) -> dict:
     return {**summary, 'completed': summary.get('completed', []) + [node_id]}
 
 
+# --- CIT-123 slice 5 (interim sink, scope A item 2) --------------------------
+#
+# INTERIM CONTRACT, pending CIT-126 (the recovery queue does not exist yet).
+# ``compensationSummary`` is the durable, resumable checkpoint a future
+# CIT-126 consumer will drain — it must carry enough for that consumer to act
+# WITHOUT re-deriving a failure classification from the raw error string a
+# second time (the taxonomy module, ``common/failure_taxonomy.py``, is
+# already the single source of truth for that classification — this reuses
+# it, never re-implements a second classifier).
+#
+# Shape (additive to the existing 'completed'/'failed'/'stoppedAt'/'reason'
+# keys already written by slice 3 — none of those are removed or renamed, so
+# any existing reader of this dict keeps working unchanged):
+#
+#   compensationSummary = {
+#     'completed': [nodeId, ...],       # unchanged (slice 3)
+#     'failed': [nodeId, ...],          # unchanged (slice 3)
+#     'stoppedAt': nodeId,              # unchanged (slice 3) — present only
+#                                       # once the unwind has stopped
+#     'reason': str,                    # unchanged (slice 3) — raw error
+#                                       # string of the stopping compensation
+#     'entries': [                      # NEW, slice 5 — one entry per
+#       {                                #   FAILED compensation, in the
+#         'nodeId': str,                 #   order they failed (currently at
+#         'error': str,                  #   most one, since onFailure='stop'
+#         'failureClass': str,           #   halts the unwind at the first
+#         'recommendedAction': str,      #   failure — the list shape is kept
+#       },                               #   so a future onFailure='continue'
+#       ...                              #   mode can append more without a
+#     ],                                 #   contract change.
+#   }
+#
+# ``failureClass`` is the ``str``-valued ``FailureClass`` member name (e.g.
+# 'policy-denied', 'unknown') — the SAME classification
+# ``_maybe_trigger_compensation_unwind`` already uses to decide whether to
+# compensate at all (CIRCUIT_OPEN/APPROVAL_ABSENT carve-out), so a consumer
+# reading this row sees one consistent vocabulary end to end.
+#
+# ``recommendedAction`` is a FIXED, closed interim vocabulary (never a free
+# string) so CIT-126 can switch on it without NLP/string-matching over
+# ``error``:
+#   * 'escalate_to_human'  — a settled governance DENY (POLICY_DENIED) or an
+#     authorization failure (AUTHZ). Never auto-retryable; a human decision
+#     is required (mirrors D6's "escalate rather than bypass").
+#   * 'retry_after_target_recovery' — the target was known-bad at call time
+#     (CIRCUIT_OPEN) or the call was transient/throttled/timed-out
+#     (TRANSIENT/THROTTLE/TIMEOUT). A future recovery queue would re-drive
+#     these once the target is healthy; today they just stop the unwind.
+#   * 'manual_review_required' — everything else (VALIDATION, APPROVAL_ABSENT,
+#     INDETERMINATE, UNKNOWN, and any tool-crash class the taxonomy has no
+#     specific mapping for). The conservative default: never silently assume
+#     safe-to-retry or safe-to-ignore for an unclassified/ambiguous failure.
+COMPENSATION_RECOMMENDED_ACTIONS = (
+    'escalate_to_human',
+    'retry_after_target_recovery',
+    'manual_review_required',
+)
+
+_FAILURE_CLASS_TO_RECOMMENDED_ACTION = {
+    failure_taxonomy.FailureClass.POLICY_DENIED: 'escalate_to_human',
+    failure_taxonomy.FailureClass.AUTHZ: 'escalate_to_human',
+    failure_taxonomy.FailureClass.CIRCUIT_OPEN: 'retry_after_target_recovery',
+    failure_taxonomy.FailureClass.TRANSIENT: 'retry_after_target_recovery',
+    failure_taxonomy.FailureClass.THROTTLE: 'retry_after_target_recovery',
+    failure_taxonomy.FailureClass.TIMEOUT: 'retry_after_target_recovery',
+}
+
+
+def _recommended_action_for(failure_class: 'failure_taxonomy.FailureClass') -> str:
+    """Map a taxonomy ``FailureClass`` to the fixed interim vocabulary above.
+    Any class with no explicit mapping (VALIDATION, APPROVAL_ABSENT,
+    INDETERMINATE, UNKNOWN, ...) conservatively defaults to
+    'manual_review_required' — never silently assumed retryable or
+    auto-escalated."""
+    return _FAILURE_CLASS_TO_RECOMMENDED_ACTION.get(failure_class, 'manual_review_required')
+
+
 def _summary_mark_stopped(summary: dict, node_id: str, reason: str) -> dict:
+    """Additive: keeps writing the pre-slice-5 'failed'/'stoppedAt'/'reason'
+    keys UNCHANGED (byte-identical for any reader that only looks at those),
+    and appends one classified 'entries' record — the CIT-126-facing interim
+    contract documented above."""
+    failure_class = failure_taxonomy.classify(reason)
+    entry = {
+        'nodeId': node_id,
+        'error': reason,
+        'failureClass': failure_class.value,
+        'recommendedAction': _recommended_action_for(failure_class),
+    }
     return {
         **summary,
         'failed': summary.get('failed', []) + [node_id],
         'stoppedAt': node_id,
         'reason': reason,
+        'entries': summary.get('entries', []) + [entry],
     }
 
 
@@ -1628,11 +1717,18 @@ def handle_compensation_result(
         # STOP the unwind: mark this compensation failed, record the stop
         # point, and never dispatch the remaining plan entries.
         new_summary = _summary_mark_stopped(summary, original_node_id, error or 'compensation_failed')
+        # Mirror the SAME classification the summary entry just computed
+        # (never re-classify) onto the #comp pseudo-node row (design D7),
+        # so a UI or CIT-126 consumer reading either location sees identical
+        # failureClass/recommendedAction values.
+        new_entry = new_summary['entries'][-1]
         _executions_table.update_item(
             Key={'executionId': execution_id},
             UpdateExpression=(
                 'SET nodeResults.#cid.#status = :failed, '
                 'nodeResults.#cid.#error = :error, '
+                'nodeResults.#cid.#failureClass = :failureClass, '
+                'nodeResults.#cid.#recommendedAction = :recommendedAction, '
                 '#compStatus = :partial, #compSummary = :summary'
             ),
             ConditionExpression='nodeResults.#cid.#status = :compensating',
@@ -1640,12 +1736,16 @@ def handle_compensation_result(
                 '#cid': comp_key,
                 '#status': 'status',
                 '#error': 'error',
+                '#failureClass': 'failureClass',
+                '#recommendedAction': 'recommendedAction',
                 '#compStatus': 'compensationStatus',
                 '#compSummary': 'compensationSummary',
             },
             ExpressionAttributeValues={
                 ':failed': 'compensation_failed',
                 ':error': error or 'compensation_failed',
+                ':failureClass': new_entry['failureClass'],
+                ':recommendedAction': new_entry['recommendedAction'],
                 ':partial': 'partial',
                 ':summary': new_summary,
                 ':compensating': 'compensating',
@@ -1657,6 +1757,8 @@ def handle_compensation_result(
             workflowId=workflow_id,
             nodeId=original_node_id,
             error=error,
+            failureClass=new_entry['failureClass'],
+            recommendedAction=new_entry['recommendedAction'],
         )
         return
 

--- a/arbiter/stepRunner/index.py
+++ b/arbiter/stepRunner/index.py
@@ -4,9 +4,11 @@ from executor import (
     start_execution,
     handle_node_completion,
     handle_node_failure,
+    handle_compensation_result,
     cancel_execution,
     resume_execution,
 )
+from common import workflow_contract
 from common.tracing import annotate_from_carried, extract_carried
 
 
@@ -42,6 +44,18 @@ def handler(event, context):
         )
     elif detail_type == 'workflow.node.failed':
         handle_node_failure(detail['executionId'], detail['nodeId'], detail.get('error', ''))
+    elif detail_type in (
+        workflow_contract.COMPENSATION_COMPLETED_DETAIL_TYPE,
+        workflow_contract.COMPENSATION_FAILED_DETAIL_TYPE,
+    ):
+        # CIT-123 slice 5 (scope A): closes the missing worker -> step-runner
+        # seam — nothing previously routed a compensation's outcome (emitted
+        # by the worker's _process_workflow_compensation) into
+        # handle_compensation_result. parse_compensation_result_detail
+        # returns handle_compensation_result's exact keyword shape so this
+        # stays a thin routing hop, no re-derivation of the parsed fields.
+        parsed = workflow_contract.parse_compensation_result_detail(detail)
+        handle_compensation_result(**parsed)
     elif detail_type == 'execution.cancel.requested':
         cancel_execution(detail['executionId'])
     elif detail_type == 'execution.resume.requested':

--- a/arbiter/workerWrapper/__tests__/test_compensation_executor.py
+++ b/arbiter/workerWrapper/__tests__/test_compensation_executor.py
@@ -275,6 +275,57 @@ class TestGovernanceDeny:
         assert result.escalated is True
         assert len(escalations) == 1
 
+    def test_deny_already_writes_a_governance_finding_via_the_shared_seam(
+        self, moto_tables, fake_tool_result_event, monkeypatch,
+    ):
+        """CIT-123 slice 5 (interim sink, scope A item 3) RECONCILIATION,
+        not a new write: the design calls for 'an escalation ... plus a
+        GovernanceFinding' on a compensation DENY. Auditing what already
+        fires (per the task's explicit instruction to reconcile rather than
+        duplicate): ``build_compensation_hook`` constructs the SAME
+        ``ComposedToolHook`` -> ``GovernanceToolHook.evaluate_denylist`` ->
+        ``governed_tool_handler.record_governance_decision`` ->
+        ``write_finding`` seam every OTHER governed tool call uses (D2,
+        no-bypass by construction) — so the finding is ALREADY written
+        today, for free, by slice 4's own "reuse the identical hook object"
+        design. There is no gap to fill here; this test pins that fact down
+        so a future change to the seam cannot silently drop the finding
+        without failing a compensation-specific test. No new finding-writer
+        is added by this slice (see the sibling structural test in
+        TestNoBypassStructural asserting no second seam exists)."""
+        executed = []
+        resolver = _resolver(executed, name="close_ticket")
+        monkeypatch.setattr(ce, "_escalate", lambda **kw: None)
+        findings_written = []
+        monkeypatch.setattr(
+            governed_tool_handler, "write_finding",
+            lambda finding, **kw: findings_written.append(finding),
+        )
+
+        _seed_execution_row(moto_tables, "exec-1", "node-a", generation=1)
+
+        result = ce.execute_compensation(
+            _dispatch(),
+            recorded_output=_recorded_output(),
+            org_id="org1",
+            denied_tools={"close_ticket"},
+            tool_resolver=resolver,
+            agent_id="agent-1",
+            workflow_definition_id="wf-def-1",
+        )
+
+        assert result.status == "compensation_failed"
+        assert len(findings_written) == 1
+        finding = findings_written[0]
+        assert finding.decision.value == "deny"
+        assert finding.target_agent == "tool:close_ticket"
+        assert finding.requesting_agent == "agent-1"
+        # GovernanceEvaluator is built from the dispatch's own workflow_id
+        # (the per-run execution's workflow), NOT workflow_definition_id
+        # (which only feeds the APPROVAL grant scope) — confirmed by reading
+        # build_compensation_hook's construction below, not assumed.
+        assert finding.workflow_id == "wf-1"
+
     def test_deny_creates_no_ledger_reservation(self, moto_tables, fake_tool_result_event, monkeypatch):
         executed = []
         resolver = _resolver(executed, name="close_ticket")

--- a/arbiter/workerWrapper/index.py
+++ b/arbiter/workerWrapper/index.py
@@ -41,6 +41,17 @@ try:
 except ImportError: # pragma: no cover — Lambda bundle path before follow-up
     workflow_contract = None # type: ignore[assignment]
 
+# CIT-123 slice 5 (scope A, closing the missing worker-side compensation
+# seam): same deferred-bundling situation as workflow_contract above. A
+# missing import must NOT break the (overwhelmingly common, non-
+# compensation) dispatch path — only a 'workflow_compensation' message
+# needs this module, and process_event checks workflow_contract.
+# is_workflow_compensation_message before ever touching it.
+try:
+    import compensation_executor # noqa: E402
+except ImportError: # pragma: no cover — Lambda bundle path before follow-up
+    compensation_executor = None # type: ignore[assignment]
+
 # Shared usage-record boundary sanitizer (same deferred-bundling situation as
 # workflow_contract above — the worker Lambda bundle currently ships only
 # arbiter/workerWrapper/). A missing import must NOT break dispatch: fall
@@ -1013,6 +1024,198 @@ def _resolve_execution_org_id(execution_id: str) -> str:
     return fallback if isinstance(fallback, str) and fallback else ''
 
 
+#: CIT-123 slice 5 (scope A, interim): a compensation ``tool`` is resolved by
+#: exact name from this REGISTRY, never by loading an agent's S3 module (that
+#: loader resolves tools for an AGENT TURN inside the subprocess — a
+#: compensation call is explicitly LLM-free/agent-free per D2, so it has no
+#: agent config to load tools FROM). No compensation tool is registered here
+#: today: no real compensation tool ships in ``arbiter/workerWrapper/tools/``
+#: yet (only ``escalate.py`` exists there; ``close_ticket``/``release_lock``
+#: are test-only fixtures in ``__tests__/test_compensation_executor.py``).
+#: An unregistered tool name fails CLOSED — ``execute_compensation`` returns
+#: ``compensation_failed`` with ``error_class='ToolNotFound'`` (see that
+#: module) rather than raising, so the sink below still fires. Wiring real
+#: compensation tools into this registry (or replacing it with a proper
+#: resolver over the S3-bundled tool modules) is explicitly deferred; this
+#: dict is the seam a future change plugs into, kept as a module-level
+#: constant so a test can monkeypatch it without touching call sites.
+COMPENSATION_TOOL_REGISTRY: dict = {}
+
+
+def _compensation_tool_resolver(tool_name: str):
+    return COMPENSATION_TOOL_REGISTRY.get(tool_name)
+
+
+#: CIT-123 slice 5 (scope A, interim): the deny-list a compensation call is
+#: evaluated against. The FORWARD agent path derives its denied-tool set from
+#: three layered sources (stepConstraints.allowedTools, binding
+#: toolRestrictions, eval-run forbiddenTools — see the union built earlier in
+#: this file for the agent-turn path). A compensation call has none of that
+#: per-node governance context available at the worker (it is dispatched
+#: LLM-free, outside any agent turn) — so, for this interim slice, the
+#: deny-list is this single flat, module-level set. This is intentionally
+#: the SAME governance primitive (ComposedToolHook's deny-list phase) every
+#: other tool call is evaluated against — see D2 — just sourced more simply
+#: until a compensation-specific governance-context wiring (binding lookup
+#: by tool name) is designed. Test-injectable via monkeypatch, same as
+#: COMPENSATION_TOOL_REGISTRY above.
+COMPENSATION_DENIED_TOOLS: set = set()
+
+
+def _emit_compensation_result(result) -> None:
+    """Publish a compensation-result event for ``result``
+    (a ``compensation_executor.CompensationResult``) onto the SAME
+    EventBridge bus / client ``_emit_node_result`` already uses, so the step
+    runner's ``handle_compensation_result`` (routed via
+    ``stepRunner/index.py``, slice 5) can advance or stop the unwind.
+
+    This is the previously-missing half of the wire slice 3's
+    ``_dispatch_compensation`` docstring anticipated but never built: nothing
+    consumed a compensation's outcome before this function existed (confirmed
+    by inspection — no prior caller of ``execute_compensation`` existed in
+    this file).
+
+    ``error`` on the wire detail prefers ``result.error_class`` (e.g.
+    'GovernanceDenied', 'ToolNotFound', 'StaleWorkerFencedError') over
+    ``result.error`` (a free-form human-readable message) — mirroring the
+    SAME convention ``_process_workflow_node``'s exception handler already
+    documents for the forward path: the executor's
+    ``compensationSummary`` classification
+    (``_summary_mark_stopped`` -> ``failure_taxonomy.classify``) is a
+    CLASS-NAME lookup, so passing the free-form message here would make
+    every compensation failure classify as UNKNOWN regardless of its real
+    cause. The full human-readable message is still preserved in the log
+    line above/below — only the WIRE 'error' field changes."""
+    error_class_or_message = result.error_class or result.error or 'compensation_failed'
+    detail = workflow_contract.build_compensation_result_detail(
+        execution_id=result.execution_id,
+        original_node_id=_origin_node_id_for_wire(result.node_id),
+        workflow_id=result.workflow_id,
+        tool=result.tool,
+        status=(
+            workflow_contract.STATUS_COMPLETED
+            if result.status == compensation_executor.STATUS_COMPENSATED
+            else workflow_contract.STATUS_FAILED
+        ),
+        output=result.result if isinstance(result.result, dict) else None,
+        error=error_class_or_message,
+    )
+    detail_type = (
+        workflow_contract.COMPENSATION_COMPLETED_DETAIL_TYPE
+        if result.status == compensation_executor.STATUS_COMPENSATED
+        else workflow_contract.COMPENSATION_FAILED_DETAIL_TYPE
+    )
+    client = boto3.client('events')
+    entry = {
+        'Source': workflow_contract.WORKFLOW_EVENT_SOURCE,
+        'DetailType': detail_type,
+        'EventBusName': os.environ.get('COMPLETION_BUS_NAME'),
+        'Detail': json.dumps(detail),
+    }
+    print(f"posting compensation-result event: {json.dumps(entry)}")
+    posted = client.put_events(Entries=[entry])
+    print(f"compensation-result event posted: {posted}")
+
+
+def _origin_node_id_for_wire(pseudo_or_origin_node_id: str) -> str:
+    """Strip a ``'#comp'`` wire suffix if present (mirrors
+    ``compensation_executor._origin_node_id``, duplicated here rather than
+    imported to keep this module's only compensation-module dependency the
+    deferred ``compensation_executor`` import above, matching the existing
+    ``workflow_contract`` deferred-import convention)."""
+    suffix = '#comp'
+    if pseudo_or_origin_node_id.endswith(suffix):
+        return pseudo_or_origin_node_id[: -len(suffix)]
+    return pseudo_or_origin_node_id
+
+
+def _process_workflow_compensation(event):
+    """Run ONE governed compensation dispatch and emit its result.
+
+    CIT-123 slice 5 (scope A): closes the gap between slice 4's
+    ``execute_compensation`` (governed, LLM-free execution) and slice 3's
+    ``handle_compensation_result`` (unwind advance/stop) — neither slice
+    wired a caller for the other. ``event`` is the raw compensation-dispatch
+    message body (``workflow_contract.build_compensation_dispatch_message``'s
+    shape); ``recorded_output`` (the compensating node's recorded output,
+    needed to render the template args) is read from the SAME
+    ``EXECUTIONS_TABLE`` row the idempotency fence already reads, under
+    ``nodeResults[originalNodeId].output`` — never re-fetched via a second
+    path.
+
+    Fail-closed, never raises: any exception constructing the call (missing
+    table config, malformed dispatch) is caught and turned into a
+    ``compensation_failed`` result so the sink still fires — mirroring
+    ``_process_workflow_node``'s own try/except-then-emit-failure shape.
+    """
+    execution_id = event.get('execution_id', '')
+    pseudo_node_id = event.get('node_id', '')
+    origin_node_id = _origin_node_id_for_wire(pseudo_node_id)
+    workflow_id = event.get('workflow_id', '')
+    tool_name = event.get('tool', '')
+
+    print(json.dumps({
+        'level': 'INFO', 'component': 'WorkerWrapper',
+        'action': 'workflow_compensation_started',
+        'executionId': execution_id, 'nodeId': origin_node_id, 'tool': tool_name,
+    }))
+
+    try:
+        org_id = _resolve_execution_org_id(execution_id)
+        recorded_output = _load_recorded_node_output(execution_id, origin_node_id)
+        result = compensation_executor.execute_compensation(
+            event,
+            recorded_output=recorded_output,
+            org_id=org_id,
+            denied_tools=COMPENSATION_DENIED_TOOLS,
+            tool_resolver=_compensation_tool_resolver,
+            agent_id='compensation-worker',
+            workflow_definition_id=workflow_id,
+        )
+    except Exception as exc:  # noqa: BLE001 — never let a raise starve the sink
+        print(json.dumps({
+            'level': 'ERROR', 'component': 'WorkerWrapper',
+            'action': 'workflow_compensation_crashed',
+            'executionId': execution_id, 'nodeId': origin_node_id,
+            'error': str(exc), 'errorClass': type(exc).__name__,
+        }))
+        result = compensation_executor.CompensationResult(
+            execution_id=execution_id, node_id=pseudo_node_id, workflow_id=workflow_id,
+            tool=tool_name, status=compensation_executor.STATUS_COMPENSATION_FAILED,
+            error_class=type(exc).__name__, error=str(exc),
+        )
+
+    print(json.dumps({
+        'level': 'INFO' if result.status == compensation_executor.STATUS_COMPENSATED else 'ERROR',
+        'component': 'WorkerWrapper', 'action': 'workflow_compensation_finished',
+        'executionId': execution_id, 'nodeId': origin_node_id, 'status': result.status,
+    }))
+    _emit_compensation_result(result)
+
+
+def _load_recorded_node_output(execution_id: str, original_node_id: str):
+    """Best-effort read of the compensating node's recorded output from
+    EXECUTIONS_TABLE, for template rendering (D4). Returns ``None`` on any
+    lookup failure (missing table config, missing row/key) — the slice-2
+    renderer / rehydration step already fail CLOSED on a ``None``/absent
+    output (see ``compensation_template.render_compensation_args`` and
+    ``compensation_executor._rehydrate_recorded_output``), so this function
+    itself never needs to raise; it only ever narrows what data is available."""
+    table_name = os.environ.get('EXECUTIONS_TABLE')
+    if not table_name:
+        return None
+    try:
+        table = boto3.resource('dynamodb').Table(table_name)
+        row = table.get_item(Key={'executionId': execution_id}).get('Item')
+    except Exception:  # noqa: BLE001 — best-effort read, renderer fails closed on None
+        return None
+    if not row:
+        return None
+    node_results = row.get('nodeResults', {})
+    node_state = node_results.get(original_node_id, {})
+    return node_state.get('output')
+
+
 def _process_workflow_node(event, message_attributes=None):
     """Run the agent for a dispatched workflow node and emit its result.
 
@@ -1192,6 +1395,15 @@ def process_event(event, context, message_attributes=None):
     # execution over the same SQS queue the supervisor uses for task messages.
     # A workflow-node message carries the contract's message_type discriminator;
     # a supervisor task message does not, so it falls through unchanged below.
+    if workflow_contract is not None and workflow_contract.is_workflow_compensation_message(event):
+        # CIT-123 slice 5 (scope A): checked BEFORE is_workflow_node_message —
+        # both discriminators live on the SAME shared queue and are mutually
+        # exclusive by construction (message_type is either
+        # MESSAGE_TYPE_WORKFLOW_NODE or MESSAGE_TYPE_WORKFLOW_COMPENSATION,
+        # never both), so branch order between these two is not itself a
+        # behaviour change for either message type.
+        _process_workflow_compensation(event)
+        return
     if workflow_contract is not None and workflow_contract.is_workflow_node_message(event):
         _process_workflow_node(event, message_attributes=message_attributes)
         return

--- a/docs/BLUEPRINTS_WORKFLOWS.md
+++ b/docs/BLUEPRINTS_WORKFLOWS.md
@@ -38,6 +38,7 @@ The Blueprints & Workflows system provides server-side workflow persistence, a r
     - [Parallel Branch Resilience](#parallel-branch-resilience)
     - [Workflow-Level Timeout](#workflow-level-timeout)
     - [Subscription Fan-out Resilience](#subscription-fan-out-resilience)
+  - [Compensation Actions: A Worked Example](#compensation-actions-a-worked-example)
   - [Error Handling](#error-handling)
     - [Workflow Resolver](#workflow-resolver)
     - [App Resolver](#app-resolver)
@@ -137,6 +138,10 @@ A WorkflowEdge with an optional `condition` field containing an expression evalu
 ### Retry Policy
 
 A per-node configuration specifying `maxRetries`, `backoffBase` (seconds), `backoffMax` (seconds), and `retryableErrors` (array of error type strings). The Step Runner retries failed nodes using exponential backoff with full jitter: `delay = uniform(0, min(backoffBase × 2^attempt, backoffMax))`. When retries are exhausted, the node is marked as `failed`.
+
+### Compensation Actions (CIT-123)
+
+An optional, opt-in per-node `compensation` block (`{tool, args, sideEffecting?}`) that describes how to undo a node's side effect. Compensation is inert by default — a workflow with no `compensation` block on any node, or with `configuration.compensation.enabled` unset/`false`, behaves byte-identically to a workflow with no compensation feature at all. When enabled and a terminal failure occurs, the Step Runner walks the completed, side-effecting, compensation-bearing nodes in strict reverse-topological ("unwind") order and dispatches each compensation through the same governed worker seam (deny-list → circuit breaker → approval → CIT-121 idempotency) that governs every other tool call — never a separate, ungoverned path. See [Compensation Actions: A Worked Example](#compensation-actions-a-worked-example) for the full mechanics, the operator-visible states, and the honest limits of what does and does not compensate today.
 
 ### Workflow Configuration
 
@@ -390,7 +395,77 @@ The Workflow item supports an optional `timeout` field (seconds). When total exe
 
 The Fan-out Lambda is triggered by EventBridge rules matching `workflow.*` events. If the AppSync mutation call fails, the event is retried by EventBridge's built-in retry policy. The frontend auto-reconnects via Amplify on subscription disconnect, showing stale status badges until reconnected.
 
-## Error Handling
+## Compensation Actions: A Worked Example
+
+This section walks a single concrete scenario — a workflow node that files a support ticket — end to end: the definition, what happens when a *later* node fails, what the operator sees in the execution detail sheet, and the honest limits of what compensation does and does not cover today (CIT-123). For the underlying data model, see [Compensation Actions (CIT-123)](#compensation-actions-cit-123); for the governed-execution seam every compensation runs through, see [Node Invocation Flow](#node-invocation-flow).
+
+### The workflow
+
+A three-node workflow: `create-ticket` files a support ticket, `notify-oncall` pages on-call with the ticket reference, `close-out` performs a final reconciliation step that can fail (e.g. a downstream system is unreachable or a governance policy denies the call).
+
+```json
+{
+  "configuration": {
+    "compensation": {
+      "enabled": true,
+      "trigger": { "mode": "on_terminal_failure", "minCompletedNodes": 1 },
+      "onFailure": "stop"
+    }
+  },
+  "nodes": [
+    {
+      "id": "create-ticket",
+      "agentId": "ticketing-agent",
+      "compensation": {
+        "tool": "close_ticket",
+        "args": { "ticketId": "${output.ticketId}", "reason": "workflow rolled back" },
+        "sideEffecting": true
+      }
+    },
+    { "id": "notify-oncall", "agentId": "paging-agent" },
+    { "id": "close-out", "agentId": "reconciliation-agent" }
+  ],
+  "edges": [
+    { "source": "create-ticket", "target": "notify-oncall" },
+    { "source": "notify-oncall", "target": "close-out" }
+  ]
+}
+```
+
+`configuration.compensation.enabled: true` is the workflow-level opt-in — without it (or with the field absent entirely), this workflow behaves byte-identically to one with no compensation feature: no unwind, no `#comp` rows, no new nodeResults keys. `minCompletedNodes: 1` means the unwind ceremony is skipped if the workflow fails before even `create-ticket` completes (nothing to roll back yet).
+
+### What the args template references
+
+`create-ticket`'s own compensation (`close_ticket`) references `${output.ticketId}` — a path into `create-ticket`'s **own recorded output**, not any other node's. This is deliberate: a compensation undoes the side effect of the node it is attached to, using that node's own result (e.g. `{"ticketId": "TCK-4471"}`), never a cross-node reference. The template grammar is a restricted, non-Turing substitution (`output.<dotted.path>` / `output.items[0]`) evaluated by a hand-written resolver — never `eval`/`.format()`/Jinja — so there is no code-execution surface in a rollback argument. If `ticketId` is missing from the recorded output (a malformed or truncated result), the renderer fails closed: the compensation is never dispatched with a fabricated value, and the failure is written to the interim sink below as an unresolved-template failure.
+
+### What happens on failure at a later node
+
+`close-out` fails terminally (say, a policy `DENY` — `POLICY_DENIED` in the failure taxonomy). Because the failure disposition is not in the `RETRY_AFTER_HUMAN`/`CIRCUIT_OPEN` carve-out (see Honest limits below), the unwind fires:
+
+1. The Step Runner computes the reverse-topological plan over completed, side-effecting, compensation-bearing nodes: only `create-ticket` qualifies (`notify-oncall` has no `compensation` block, so it is skipped — paging on-call is not something we "undo"; `close-out` itself never completed, so it has no recorded output to compensate from).
+2. `create-ticket#comp` is written `compensating` and dispatched to the worker over the **same governed seam** every forward tool call uses (deny-list → circuit breaker → approval → CIT-121 idempotency reserve/finalize) — never a separate, ungoverned rollback path.
+3. `close_ticket` runs with `ticketId` resolved from `create-ticket`'s recorded output. On success, `create-ticket#comp` becomes `compensated` and the execution's `compensationStatus` becomes `completed` (this was the only qualifying node, so the unwind is done after one step).
+4. If `close_ticket` itself fails (e.g. the ticketing system also denies it, or a breaker is open), `create-ticket#comp` becomes `compensation_failed`, `compensationStatus` becomes `partial`, and the unwind **stops** — see `onFailure: 'stop'` below.
+
+The execution's top-level `status` stays `failed` throughout — compensation is additive observability on a failed run, never a reclassification of it as successful.
+
+### What the operator sees
+
+Opening the execution in the execution detail sheet shows:
+
+- The `FAILED` status badge, plus a second badge reading **"failed · rolled back"** (full unwind, `compensationStatus: completed`) or **"failed · rollback incomplete"** (`compensationStatus: partial` — a compensation itself failed and the unwind stopped).
+- A **Compensations** section, separate from the node **Steps** list, listing `create-ticket`'s compensation entry in unwind order with its own status (`Compensating` / `Compensated` / `Compensation failed`) shown as both a coloured dot *and* a text label — status is never conveyed by colour alone.
+- Expanding a failed compensation entry shows the raw error plus the `failureClass` and `recommendedAction` mirrored from the same failure-taxonomy classification the interim sink recorded (see below) — never a second, independently-derived classification.
+
+### Honest limits (read this before relying on compensation for anything critical)
+
+- **`RETRY_AFTER_HUMAN` and `CIRCUIT_OPEN` do not compensate.** If `close-out` fails with a disposition of `RETRY_AFTER_HUMAN` (e.g. `APPROVAL_ABSENT` — a human approval is still pending) or a classification of `CIRCUIT_OPEN` (the target is known-bad *right now*, not permanently), the unwind never fires at all. Both are "leave it for a human/the target to recover" outcomes, not "give up and roll back" outcomes — compensating here would undo `create-ticket`'s side effect while a human could still complete the approval, or while the circuit could still close on its own. This is enforced in code (`_maybe_trigger_compensation_unwind`), not just documented intent.
+- **`onFailure: 'stop'` halts the unwind — there is no partial-continue mode today.** If a plan has multiple qualifying compensations and the first one fails, the remaining ones are **never dispatched**. This is the only supported mode; an `onFailure: 'continue'` (best-effort, run every compensation regardless of earlier failures) was considered in the design and explicitly deferred, not implemented.
+- **CIT-126 (the recovery queue) does not exist yet.** A failed or stopped unwind writes three durable, never-swallowed records — the `#comp` pseudo-node row, an off-frontier escalation event, and a `GovernanceFinding` — but nothing automatically retries, drains, or resolves them. `compensationSummary.entries[]` (with `failureClass` and a fixed `recommendedAction` vocabulary: `escalate_to_human` / `retry_after_target_recovery` / `manual_review_required`) is shaped so a future CIT-126 consumer can drain it directly, but until CIT-126 ships, resolving a stuck compensation is a manual, off-system operation — check the escalation event and the Governance Ledger finding for the classified failure, then act by hand.
+- **Only the failing node's *predecessors* are compensated — never the failing node itself.** `close-out` in this example has no recorded output (it failed, it didn't complete), so there is nothing to compensate it with even if it had a `compensation` block.
+- **Compensation is sequential, one at a time, in strict reverse-topological order** — never parallel. A workflow with a long completed prefix and several qualifying compensations will unwind them one after another, not concurrently.
+
+
 
 ### Workflow Resolver
 

--- a/docs/WORKFLOW_USER_GUIDE.md
+++ b/docs/WORKFLOW_USER_GUIDE.md
@@ -258,6 +258,7 @@ The app detail view's Executions tab lists executions. Click a row to open the e
 - Error block — shown for failed executions.
 - Per-node step timeline — status, agent, duration, and retry count per node, with expandable output and error per step.
 - Collapsible input — the payload the run started with.
+- For a workflow with compensation enabled (CIT-123), a failed execution additionally shows a **"failed · rolled back"** / **"failed · rollback incomplete"** badge and a separate **Compensations** section listing the rollback attempts in unwind order. See [Compensation Actions: A Worked Example](./BLUEPRINTS_WORKFLOWS.md#compensation-actions-a-worked-example) for the full mechanics and honest limits.
 
 The sheet refreshes live while the execution is still running.
 
@@ -300,6 +301,7 @@ The workflow execution path follows least privilege:
 ## Related Documentation
 
 - [BLUEPRINTS_WORKFLOWS.md](./BLUEPRINTS_WORKFLOWS.md) — engine architecture, data model, retries, conditional branching, testing strategy
+- [BLUEPRINTS_WORKFLOWS.md § Compensation Actions: A Worked Example](./BLUEPRINTS_WORKFLOWS.md#compensation-actions-a-worked-example) — ticket-creation rollback walkthrough, operator-visible states, and honest limits (CIT-123)
 - [AGENT_APPS.md](./AGENT_APPS.md) — Agent Apps platform, including the app detail Workflows and Executions tabs
 - [EVENTBRIDGE_CATALOG.md](./EVENTBRIDGE_CATALOG.md) — event envelope contracts for `workflow.*` events
 - [QUICK_START.md](./QUICK_START.md) — 5-minute deployment, including running the demo workflow

--- a/frontend/src/components/ExecutionDetailSheet.tsx
+++ b/frontend/src/components/ExecutionDetailSheet.tsx
@@ -39,6 +39,28 @@ export interface ExecutionNodeResult {
   retryCount?: number | null;
   /** Additive: this node's precomputed usage totals (usage rollup). */
   usageTotals?: UsageTotals | null;
+  /** CIT-123 slice 5: mirrored onto a `#comp` pseudo-node's row when its
+   * compensation fails (design D7) — same classification the taxonomy
+   * module already computed, never re-derived here. */
+  failureClass?: string | null;
+  recommendedAction?: string | null;
+}
+
+/** CIT-123 slice 5 (interim CIT-126 contract, executor.py `_summary_mark_stopped`):
+ * one entry per FAILED compensation, in the order the unwind stopped. */
+export interface CompensationSummaryEntry {
+  nodeId: string;
+  error: string;
+  failureClass: string;
+  recommendedAction: string;
+}
+
+export interface CompensationSummary {
+  completed?: string[];
+  failed?: string[];
+  stoppedAt?: string | null;
+  reason?: string | null;
+  entries?: CompensationSummaryEntry[];
 }
 
 export interface ExecutionDetail {
@@ -56,6 +78,17 @@ export interface ExecutionDetail {
   nodeResults?: string | Record<string, unknown> | null;
   /** Additive: execution-level usage totals (AWSJSON string or parsed object). */
   usageTotals?: string | UsageTotals | null;
+  /** CIT-123 slice 5 (design D7): additive sub-status. The execution's
+   * top-level `status` STAYS 'failed' when compensation runs — this is
+   * never a replacement for it, only observability on top. One of
+   * 'running' | 'completed' | 'partial', or absent for a non-compensating
+   * execution (legacy runs, or a workflow with no compensation policy). */
+  compensationStatus?: string | null;
+  /** Reverse-topological unwind order (design D5) — the order the
+   * Compensations section renders in, independent of nodeResults map
+   * insertion order. */
+  compensationPlan?: string[] | null;
+  compensationSummary?: string | CompensationSummary | null;
 }
 
 interface ExecutionDetailSheetProps {
@@ -86,6 +119,16 @@ const STATUS_STYLES: Record<string, { bg: string; text: string; dot: string }> =
   failed: { bg: 'bg-destructive/20', text: 'text-destructive', dot: 'bg-destructive' },
   running: { bg: 'bg-primary/20', text: 'text-primary', dot: 'bg-primary' },
   pending: { bg: 'bg-muted/20', text: 'text-muted-foreground', dot: 'bg-muted-foreground' },
+  // CIT-123 slice 5 (design D8): compensation (#comp pseudo-node) statuses
+  // get their OWN explicit entries so `statusStyle` never falls through to
+  // the grey `pending` style above — that fallback would misrepresent an
+  // in-flight or completed rollback as "not started". Distinct hues per
+  // design (compensated=muted-info, compensating=amber,
+  // compensation_failed=destructive-outline); every render site also pairs
+  // the dot with a text label (never colour alone — accessibility rule).
+  compensating: { bg: 'bg-chart-4/20', text: 'text-chart-4', dot: 'bg-chart-4' },
+  compensated: { bg: 'bg-chart-3/20', text: 'text-chart-3', dot: 'bg-chart-3' },
+  compensation_failed: { bg: 'bg-destructive/10', text: 'text-destructive', dot: 'bg-destructive' },
 };
 
 function statusStyle(status?: string | null) {
@@ -130,6 +173,8 @@ function parseNodeResults(raw?: string | Record<string, unknown> | null): Execut
       error: typeof v.error === 'string' ? v.error : null,
       retryCount: typeof v.retryCount === 'number' ? v.retryCount : 0,
       usageTotals: parseUsageTotals(v.usageTotals),
+      failureClass: typeof v.failureClass === 'string' ? v.failureClass : null,
+      recommendedAction: typeof v.recommendedAction === 'string' ? v.recommendedAction : null,
     };
   });
   nodes.sort((a, b) => {
@@ -139,6 +184,132 @@ function parseNodeResults(raw?: string | Record<string, unknown> | null): Execut
     return a.startedAt.localeCompare(b.startedAt);
   });
   return nodes;
+}
+
+/** CIT-123 slice 5: the `#comp` pseudo-node key convention (mirrors the
+ * Python-side `_comp_key` in executor.py) — `${originalNodeId}#comp`. Real
+ * node ids never contain '#' (validator-enforced), so this discriminator
+ * cannot collide with a real node. */
+const COMPENSATION_KEY_SUFFIX = '#comp';
+
+function isCompensationNode(node: ExecutionNodeResult): boolean {
+  return node.nodeId.endsWith(COMPENSATION_KEY_SUFFIX);
+}
+
+function originalNodeIdOf(compNodeId: string): string {
+  return compNodeId.slice(0, -COMPENSATION_KEY_SUFFIX.length);
+}
+
+/** Splits the parsed node list into real DAG-node steps and `#comp`
+ * compensation pseudo-nodes — the latter are never rendered in the Steps
+ * section (design D7/D8: they are not real nodes and would be misleading
+ * there). */
+function splitCompensationNodes(
+  nodes: ExecutionNodeResult[],
+): { steps: ExecutionNodeResult[]; compensations: ExecutionNodeResult[] } {
+  const steps: ExecutionNodeResult[] = [];
+  const compensations: ExecutionNodeResult[] = [];
+  for (const node of nodes) {
+    if (isCompensationNode(node)) {
+      compensations.push(node);
+    } else {
+      steps.push(node);
+    }
+  }
+  return { steps, compensations };
+}
+
+/** Orders `#comp` pseudo-nodes by the execution's `compensationPlan`
+ * (reverse-topological unwind order, design D5) rather than by
+ * `startedAt` — the plan is the authoritative unwind order and is
+ * available even before a later entry has dispatched (no startedAt yet). */
+function orderCompensations(
+  compensations: ExecutionNodeResult[],
+  plan?: string[] | null,
+): ExecutionNodeResult[] {
+  if (!plan || plan.length === 0) return compensations;
+  const byOriginalId = new Map(compensations.map((c) => [originalNodeIdOf(c.nodeId), c]));
+  const ordered: ExecutionNodeResult[] = [];
+  for (const originalId of plan) {
+    const comp = byOriginalId.get(originalId);
+    if (comp) {
+      ordered.push(comp);
+      byOriginalId.delete(originalId);
+    }
+  }
+  // Any compensation not named in the plan (shouldn't happen, but never
+  // drop data) is appended in its existing (startedAt-sorted) order.
+  ordered.push(...byOriginalId.values());
+  return ordered;
+}
+
+/** Parse compensationSummary (JSON string, already-parsed object, or
+ * absent) into a CompensationSummary shape, or null when
+ * absent/malformed. Never throws — mirrors parseUsageTotals's defensive
+ * posture. */
+function parseCompensationSummary(raw: unknown): CompensationSummary | null {
+  let value: unknown = raw;
+  if (typeof value === 'string') {
+    if (value === '') return null;
+    try {
+      value = JSON.parse(value);
+    } catch {
+      return null;
+    }
+  }
+  if (!value || typeof value !== 'object' || Array.isArray(value)) return null;
+  const v = value as Record<string, unknown>;
+  const entries = Array.isArray(v.entries)
+    ? (v.entries as unknown[])
+        .filter((e): e is Record<string, unknown> => !!e && typeof e === 'object')
+        .map((e) => ({
+          nodeId: typeof e.nodeId === 'string' ? e.nodeId : '',
+          error: typeof e.error === 'string' ? e.error : '',
+          failureClass: typeof e.failureClass === 'string' ? e.failureClass : '',
+          recommendedAction: typeof e.recommendedAction === 'string' ? e.recommendedAction : '',
+        }))
+    : undefined;
+  return {
+    completed: Array.isArray(v.completed) ? (v.completed as string[]) : undefined,
+    failed: Array.isArray(v.failed) ? (v.failed as string[]) : undefined,
+    stoppedAt: typeof v.stoppedAt === 'string' ? v.stoppedAt : null,
+    reason: typeof v.reason === 'string' ? v.reason : null,
+    entries,
+  };
+}
+
+/** Human label for a `#comp` pseudo-node status — paired with the dot in
+ * every render site (accessibility rule: state is never colour alone). */
+function compensationStatusLabel(status?: string | null): string {
+  switch ((status || '').toLowerCase()) {
+    case 'compensating':
+      return 'Compensating';
+    case 'compensated':
+      return 'Compensated';
+    case 'compensation_failed':
+      return 'Compensation failed';
+    default:
+      return status || 'Unknown';
+  }
+}
+
+/**
+ * Header badge distinguishing a fully rolled-back failure from a partial
+ * (stopped) one (design D8 / scope B). Returns null when the execution
+ * never ran compensation at all (compensationStatus absent — legacy runs
+ * or no policy), so the badge is omitted rather than shown as misleading
+ * "n/a" text.
+ */
+function compensationBadgeLabel(compensationStatus?: string | null): string | null {
+  switch (compensationStatus) {
+    case 'completed':
+      return 'rolled back';
+    case 'partial':
+    case 'running':
+      return 'rollback incomplete';
+    default:
+      return null;
+  }
 }
 
 /** Parse a usageTotals value (JSON string, already-parsed object, or absent)
@@ -275,9 +446,25 @@ export function ExecutionDetailSheet({
     setInputExpanded(false);
   }, [execution?.executionId]);
 
-  const nodeSteps = useMemo(
+  const parsedNodes = useMemo(
     () => parseNodeResults(execution?.nodeResults),
     [execution?.nodeResults],
+  );
+  const { steps: nodeSteps, compensations: compensationNodesRaw } = useMemo(
+    () => splitCompensationNodes(parsedNodes),
+    [parsedNodes],
+  );
+  const compensationNodes = useMemo(
+    () => orderCompensations(compensationNodesRaw, execution?.compensationPlan),
+    [compensationNodesRaw, execution?.compensationPlan],
+  );
+  const compensationSummary = useMemo(
+    () => parseCompensationSummary(execution?.compensationSummary),
+    [execution?.compensationSummary],
+  );
+  const compensationBadge = useMemo(
+    () => compensationBadgeLabel(execution?.compensationStatus),
+    [execution?.compensationStatus],
   );
   const durationPercentiles = useMemo(
     () => computeDurationPercentiles(nodeSteps),
@@ -325,6 +512,18 @@ export function ExecutionDetailSheet({
             <Badge className={cn(headerStyle.bg, headerStyle.text, 'text-xs border-0')}>
               {execution.status}
             </Badge>
+            {compensationBadge && (
+              <Badge
+                className={cn(
+                  compensationBadge === 'rolled back'
+                    ? 'bg-chart-3/20 text-chart-3'
+                    : 'bg-destructive/10 text-destructive',
+                  'text-xs border-0',
+                )}
+              >
+                failed · {compensationBadge}
+              </Badge>
+            )}
             <span className="text-xs text-muted-foreground">
               Duration {computeDuration(execution.startedAt, execution.completedAt)}
             </span>
@@ -483,7 +682,82 @@ export function ExecutionDetailSheet({
             )}
           </section>
 
-          {/* Input — collapsed by default; omitted entirely when absent */}
+          {/* Compensations — CIT-123 slice 5 (design D8): #comp pseudo-nodes,
+              rendered in unwind (reverse-topo) order, never in Steps above.
+              Omitted entirely when the execution never ran compensation. */}
+          {compensationNodes.length > 0 && (
+            <section aria-label="Compensations">
+              <h3 className="text-sm font-medium text-foreground mb-2">Compensations</h3>
+              <div className="flex flex-col gap-1">
+                {compensationNodes.map((node) => {
+                  const isExpanded = !!expandedNodes[node.nodeId];
+                  const nodeStyle = statusStyle(node.status);
+                  const originalNodeId = originalNodeIdOf(node.nodeId);
+                  const summaryEntry = compensationSummary?.entries?.find(
+                    (e) => e.nodeId === originalNodeId,
+                  );
+                  const failureClass = node.failureClass ?? summaryEntry?.failureClass ?? null;
+                  const recommendedAction =
+                    node.recommendedAction ?? summaryEntry?.recommendedAction ?? null;
+                  return (
+                    <div key={node.nodeId} className="rounded-md border border-border/50">
+                      <Button
+                        type="button"
+                        variant="ghost"
+                        aria-expanded={isExpanded}
+                        className="h-auto w-full min-w-0 items-center justify-start gap-2 p-2 rounded-md text-left text-xs font-normal whitespace-normal cursor-pointer hover:bg-accent/50 transition-colors"
+                        onClick={() =>
+                          setExpandedNodes((prev) => ({
+                            ...prev,
+                            [node.nodeId]: !prev[node.nodeId],
+                          }))
+                        }
+                      >
+                        {isExpanded ? (
+                          <ChevronDown className="size-3 text-muted-foreground flex-shrink-0" />
+                        ) : (
+                          <ChevronRight className="size-3 text-muted-foreground flex-shrink-0" />
+                        )}
+                        <span
+                          className={cn('size-2 rounded-full flex-shrink-0', nodeStyle.dot)}
+                          aria-hidden="true"
+                        />
+                        <span className="font-mono text-foreground truncate">{originalNodeId}</span>
+                        {/* Text label alongside the dot — state is never colour alone. */}
+                        <span className={cn('flex-shrink-0', nodeStyle.text)}>
+                          {compensationStatusLabel(node.status)}
+                        </span>
+                        <span className="ml-auto text-muted-foreground flex-shrink-0">
+                          {computeDuration(node.startedAt, node.completedAt)}
+                        </span>
+                      </Button>
+                      {isExpanded && (
+                        <div className="flex flex-col gap-2 border-t border-border/50 p-2">
+                          {node.error && (
+                            <div className="rounded-md border border-destructive/50 bg-destructive/10 p-2 text-xs text-destructive whitespace-pre-wrap">
+                              {node.error}
+                            </div>
+                          )}
+                          {(failureClass || recommendedAction) && (
+                            <p className="text-xs text-muted-foreground">
+                              {failureClass && <>Failure class {failureClass}</>}
+                              {failureClass && recommendedAction && ' · '}
+                              {recommendedAction && <>Recommended action {recommendedAction}</>}
+                            </p>
+                          )}
+                          {!node.error && !failureClass && !recommendedAction && (
+                            <p className="text-xs text-muted-foreground">No detail recorded.</p>
+                          )}
+                        </div>
+                      )}
+                    </div>
+                  );
+                })}
+              </div>
+            </section>
+          )}
+
+
           {prettyInput !== null && (
             <section aria-label="Input">
               <Button

--- a/frontend/src/components/__tests__/ExecutionDetailSheet.test.tsx
+++ b/frontend/src/components/__tests__/ExecutionDetailSheet.test.tsx
@@ -477,3 +477,217 @@ describe('ExecutionDetailSheet', () => {
     });
   });
 });
+
+// ─── Compensation states (CIT-123 slice 5, scope A/B) ───
+//
+// #comp pseudo-nodes (nodeResults key `${nodeId}#comp`) must never render in
+// the Steps section (they are not real DAG nodes) and must never fall through
+// to the grey STATUS_STYLES.pending style, which would misrepresent an
+// in-flight or completed rollback as "not started". They get their own
+// "Compensations" section, listed in unwind (plan) order, each showing a
+// status dot + text label (never colour alone) so the accessibility rule
+// holds without relying on hue perception.
+
+describe('ExecutionDetailSheet — compensation states', () => {
+  const execWithCompensation = {
+    ...baseExecution,
+    status: 'FAILED',
+    error: 'Node exploded',
+    compensationStatus: 'partial',
+    compensationPlan: ['node-b', 'node-a'],
+    compensationSummary: {
+      completed: ['node-b'],
+      failed: ['node-a'],
+      stoppedAt: 'node-a',
+      reason: 'downstream tool refused',
+      entries: [
+        {
+          nodeId: 'node-a',
+          error: 'downstream tool refused',
+          failureClass: 'policy-denied',
+          recommendedAction: 'escalate_to_human',
+        },
+      ],
+    },
+    nodeResults: JSON.stringify({
+      'node-a': {
+        nodeId: 'node-a',
+        agentId: 'agent-1',
+        status: 'completed',
+        startedAt: '2024-03-01T12:00:00Z',
+        completedAt: '2024-03-01T12:02:00Z',
+        output: '{"step":"one"}',
+        error: null,
+        retryCount: 0,
+      },
+      'node-b': {
+        nodeId: 'node-b',
+        agentId: 'agent-2',
+        status: 'completed',
+        startedAt: '2024-03-01T12:02:00Z',
+        completedAt: '2024-03-01T12:05:00Z',
+        output: '{"step":"two"}',
+        error: null,
+        retryCount: 0,
+      },
+      'node-b#comp': {
+        nodeId: 'node-b#comp',
+        status: 'compensated',
+        startedAt: '2024-03-01T12:06:00Z',
+        completedAt: '2024-03-01T12:06:30Z',
+        output: null,
+        error: null,
+        retryCount: 0,
+      },
+      'node-a#comp': {
+        nodeId: 'node-a#comp',
+        status: 'compensation_failed',
+        startedAt: '2024-03-01T12:06:31Z',
+        completedAt: '2024-03-01T12:07:00Z',
+        output: null,
+        error: 'downstream tool refused',
+        retryCount: 0,
+        failureClass: 'policy-denied',
+        recommendedAction: 'escalate_to_human',
+      },
+    }),
+  };
+
+  it('excludes #comp pseudo-nodes from the Steps section', () => {
+    render(<ExecutionDetailSheet execution={execWithCompensation} open onClose={jest.fn()} />);
+
+    expect(screen.queryByRole('button', { name: /node-b#comp/ })).not.toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: /node-a#comp/ })).not.toBeInTheDocument();
+    // Real nodes are still present, scoped to the Steps section (the
+    // Compensations section below also renders a button labelled by the
+    // original node id, so an unscoped query would match both).
+    const stepsSection = screen.getByRole('region', { name: /^steps$/i });
+    expect(within(stepsSection).getByRole('button', { name: /^node-a\b/ })).toBeInTheDocument();
+    expect(within(stepsSection).getByRole('button', { name: /^node-b\b/ })).toBeInTheDocument();
+  });
+
+  it('renders a Compensations section listing #comp entries in unwind (plan) order', () => {
+    render(<ExecutionDetailSheet execution={execWithCompensation} open onClose={jest.fn()} />);
+
+    const section = screen.getByRole('region', { name: /compensations/i });
+    const rowB = within(section).getByRole('button', { name: /node-b/ });
+    const rowA = within(section).getByRole('button', { name: /node-a/ });
+
+    // compensationPlan is ['node-b', 'node-a'] (unwind order) — node-b's
+    // compensation entry must precede node-a's.
+    expect(
+      rowB.compareDocumentPosition(rowA) & Node.DOCUMENT_POSITION_FOLLOWING,
+    ).toBeTruthy();
+  });
+
+  it('omits the Compensations section entirely when there is no compensation activity', () => {
+    render(<ExecutionDetailSheet execution={baseExecution} open onClose={jest.fn()} />);
+
+    expect(screen.queryByRole('region', { name: /compensations/i })).not.toBeInTheDocument();
+  });
+
+  it("labels a completed compensation with a text label, not colour alone ('compensated')", () => {
+    render(<ExecutionDetailSheet execution={execWithCompensation} open onClose={jest.fn()} />);
+
+    const section = screen.getByRole('region', { name: /compensations/i });
+    expect(within(section).getByText(/compensated/i)).toBeInTheDocument();
+  });
+
+  it("distinguishes a stopped/incomplete compensation ('rollback incomplete') from a fully rolled-back one", () => {
+    render(<ExecutionDetailSheet execution={execWithCompensation} open onClose={jest.fn()} />);
+
+    // Header badge next to the FAILED status badge.
+    expect(screen.getByText(/rollback incomplete/i)).toBeInTheDocument();
+    expect(screen.queryByText(/rolled back/i)).not.toBeInTheDocument();
+  });
+
+  it("shows 'rolled back' badge when compensationStatus is 'completed' (full unwind, no failures)", () => {
+    const exec = {
+      ...execWithCompensation,
+      compensationStatus: 'completed',
+      compensationSummary: {
+        completed: ['node-b', 'node-a'],
+        failed: [],
+      },
+      nodeResults: JSON.stringify({
+        'node-a': {
+          nodeId: 'node-a',
+          status: 'completed',
+          startedAt: '2024-03-01T12:00:00Z',
+          completedAt: '2024-03-01T12:02:00Z',
+        },
+        'node-b': {
+          nodeId: 'node-b',
+          status: 'completed',
+          startedAt: '2024-03-01T12:02:00Z',
+          completedAt: '2024-03-01T12:05:00Z',
+        },
+        'node-b#comp': {
+          nodeId: 'node-b#comp',
+          status: 'compensated',
+          startedAt: '2024-03-01T12:06:00Z',
+          completedAt: '2024-03-01T12:06:30Z',
+        },
+        'node-a#comp': {
+          nodeId: 'node-a#comp',
+          status: 'compensated',
+          startedAt: '2024-03-01T12:06:31Z',
+          completedAt: '2024-03-01T12:07:00Z',
+        },
+      }),
+      compensationPlan: ['node-b', 'node-a'],
+    };
+    render(<ExecutionDetailSheet execution={exec} open onClose={jest.fn()} />);
+
+    expect(screen.getByText(/failed\s*·\s*rolled back/i)).toBeInTheDocument();
+    expect(screen.queryByText(/rollback incomplete/i)).not.toBeInTheDocument();
+  });
+
+  it('omits the compensation badge when compensationStatus is absent (legacy/non-compensating executions)', () => {
+    render(<ExecutionDetailSheet execution={baseExecution} open onClose={jest.fn()} />);
+
+    expect(screen.queryByText(/rolled back/i)).not.toBeInTheDocument();
+    expect(screen.queryByText(/rollback incomplete/i)).not.toBeInTheDocument();
+  });
+
+  it('expands a compensation entry to reveal its error and recommendedAction', () => {
+    render(<ExecutionDetailSheet execution={execWithCompensation} open onClose={jest.fn()} />);
+
+    const section = screen.getByRole('region', { name: /compensations/i });
+    fireEvent.click(within(section).getByRole('button', { name: /node-a/ }));
+
+    expect(within(section).getByText('downstream tool refused')).toBeInTheDocument();
+    expect(within(section).getByText(/escalate_to_human/i)).toBeInTheDocument();
+  });
+
+  it('does not fall through to the grey pending dot style for compensating/compensated/compensation_failed statuses', () => {
+    const compensatingExec = {
+      ...execWithCompensation,
+      compensationStatus: 'running',
+      nodeResults: JSON.stringify({
+        'node-a': {
+          nodeId: 'node-a',
+          status: 'completed',
+          startedAt: '2024-03-01T12:00:00Z',
+          completedAt: '2024-03-01T12:02:00Z',
+        },
+        'node-a#comp': {
+          nodeId: 'node-a#comp',
+          status: 'compensating',
+          startedAt: '2024-03-01T12:06:00Z',
+          completedAt: null,
+        },
+      }),
+      compensationPlan: ['node-a'],
+      compensationSummary: { completed: [], failed: [] },
+    };
+    render(<ExecutionDetailSheet execution={compensatingExec} open onClose={jest.fn()} />);
+
+    const section = screen.getByRole('region', { name: /compensations/i });
+    const dot = within(section).getByRole('button', { name: /node-a/ }).querySelector('[aria-hidden="true"]');
+    // pending's dot class is bg-muted-foreground — compensating must use a
+    // distinct, non-pending style.
+    expect(dot?.className).not.toMatch(/bg-muted-foreground/);
+    expect(within(section).getByText(/compensating/i)).toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
## Summary

Final slice of compensation actions: makes a failed rollback impossible to miss, surfaces compensated state in the UI, documents a worked example, and proves the story's acceptance criteria end to end.

- `compensationSummary` gains additive `entries[]` carrying `failureClass` (reusing
the existing failure taxonomy, not a second classifier) and `recommendedAction` from a fixed vocabulary, mirrored onto the `#comp` row and documented in code as the interim contract a future recovery queue will consume
- Escalation and governance finding were already emitted through the shared tool seam, so this adds a reconciliation test pinning that behaviour rather than a duplicate writer
- Execution inspection: explicit styles for compensation states (no falling through to grey "pending", which would misrepresent a rollback), a Compensations section in unwind order,
and "failed rolled back" vs "failed • rollback incomplete" distinguishable without relying on colour
- Worked ticket-creation example in the workflow docs, including the honest limits:
CIRCUIT_OPEN and RETRY_AFTER_HUMAN do not compensate, a failed compensation stops the unwind, and the recovery queue does not exist yet

## Fixes two defects in the merged slices

Both were live on main and neither was visible to the earlier slices' tests:

1. The delimiter guard rejected the orchestrator's own generated `[node]#comp` pseudo-node id, so every real compensation dispatch raised - the merged orchestration plus worker combination could not compensate anything
2. Nothing wired the worker's compensation result back to the orchestrator's handler. Added the result detail contract, a worker entry point (fails closed, since no real compensation tool ships yet) and stepRunner routing
Root cause was procedural: each slice was verified against its own side of a dispatch boundary, and no test crossed the full orchestrator → worker → orchestrator loop until this slice's harness existed.

## Testing

- End-to-end acceptance over real SQS and EventBridge hops with moto-backed conditional writes; only the tool callable and the model boundary are stubbed
- 3-node workflow failing at node 3 unwinds nodes 2 then 1, exactly once each - bite-proven by removing `reversed()`
- A governance-denied compensation escalates and never executes - bite-proven by removing the escalate call
- Scoped pytest 1315 passing; frontend tsc clean with 2064 tests and the shadon-compliance guard green; `verify-doc-claims` exit o; full-suite failures proven identical to a clean main worktree
- Docs field names spot-checked against the code