### PR TITLE
fix(api): wire three orphaned schema fields to their handlers

### DIFF
--- a/backend/lib/backend-stack.ts
+++ b/backend/lib/backend-stack.ts
@@ -2429,6 +2429,20 @@ export class BackendStack extends cdk.Stack {
       responseMappingTemplate: appsync.MappingTemplate.lambdaResult(),
     });
 
+    // listIntegrationOperations (finding 0018a6d7): same handler
+    // (tool-config-resolver.ts) and datasource as its siblings above. Reads
+    // only the static, non-tenant OPERATIONS_REGISTRY keyed by
+    // integrationType — no orgId argument, no DB access, nothing to scope.
+    toolConfigLambdaDataSource.createResolver(
+      "ListIntegrationOperationsResolver",
+      {
+        typeName: "Query",
+        fieldName: "listIntegrationOperations",
+        requestMappingTemplate: appsync.MappingTemplate.lambdaRequest(),
+        responseMappingTemplate: appsync.MappingTemplate.lambdaResult(),
+      },
+    );
+
     toolConfigLambdaDataSource.createResolver("CreateToolConfigResolver", {
       typeName: "Mutation",
       fieldName: "createToolConfig",
@@ -2857,6 +2871,20 @@ export class BackendStack extends cdk.Stack {
       {
         typeName: "Mutation",
         fieldName: "testDataStoreConnection",
+        requestMappingTemplate: appsync.MappingTemplate.lambdaRequest(),
+        responseMappingTemplate: appsync.MappingTemplate.lambdaResult(),
+      },
+    );
+
+    // listAvailableDataSources (finding 0018a6d7): sibling of listDataStores
+    // on the same datastore-resolver.ts handler/Lambda/datasource. Uses the
+    // identical orgId-scoped OrgIndex query pattern as listDataStores (no
+    // new authz posture introduced).
+    dataStoreLambdaDataSource.createResolver(
+      "ListAvailableDataSourcesResolver",
+      {
+        typeName: "Query",
+        fieldName: "listAvailableDataSources",
         requestMappingTemplate: appsync.MappingTemplate.lambdaRequest(),
         responseMappingTemplate: appsync.MappingTemplate.lambdaResult(),
       },

--- a/backend/lib/projects-stack.ts
+++ b/backend/lib/projects-stack.ts
@@ -314,6 +314,17 @@ export class ProjectsStack extends cdk.Stack {
       agentLambdaDataSource,
     );
 
+    // updateAgentStatus (finding 0018a6d7): sibling of getAgentStatus on the
+    // same agent-resolver.ts handler, same Lambda, same datasource. Handler
+    // enforces the identical project-membership/org check as getAgentStatus
+    // (see agent-resolver.ts updateAgentStatus doc comment) before writing.
+    makeResolver(
+      "UpdateAgentStatusResolver",
+      "Mutation",
+      "updateAgentStatus",
+      agentLambdaDataSource,
+    );
+
     // ============================================================
     // Document Upload Resolver
     // ============================================================

--- a/backend/scripts/split-gates/move-manifest.ts
+++ b/backend/scripts/split-gates/move-manifest.ts
@@ -1559,6 +1559,29 @@ export const EXPECTED_NEW_FIELDS: AllowlistEntry[] = [
       "Decision d36fbbf7: eval-sampling AppSync wiring — see " +
       "ADDITION_ALLOWLIST entry AgenticAIApiListEvalProdSamplesResolverFF0E4413.",
   },
+  {
+    logicalId: "Query.listAvailableDataSources",
+    justification:
+      "Finding 0018a6d7: see ADDITION_ALLOWLIST entry " +
+      "AgenticAIApiListAvailableDataSourcesResolverF6DE4B81.",
+  },
+  {
+    logicalId: "Query.listIntegrationOperations",
+    justification:
+      "Finding 0018a6d7: see ADDITION_ALLOWLIST entry " +
+      "AgenticAIApiListIntegrationOperationsResolver737538A7.",
+  },
+  {
+    logicalId: "Mutation.updateAgentStatus",
+    justification:
+      "Finding 0018a6d7: UpdateAgentStatusResolver added in " +
+      "citadel-projects-dev (projects-stack.ts) on the existing " +
+      "AgentLambdaDataSource, same handler (agent-resolver.ts) and same " +
+      "project-membership/org check as its already-wired sibling " +
+      "Query.getAgentStatus. Not a backend-template addition (rail 1 " +
+      "doesn't see it) but rail 3's merged-set check spans all stacks, so " +
+      "it needs the same expected-new-field exemption.",
+  },
 ];
 
 /**
@@ -1613,8 +1636,7 @@ export const ADDITION_ALLOWLIST: AllowlistEntry[] = [
   },
   {
     logicalId: "EvalRunCaseResultsTable961B302A",
-    justification:
-      "CIT-101: eval/release platform — EvalRunCaseResults table.",
+    justification: "CIT-101: eval/release platform — EvalRunCaseResults table.",
   },
   {
     logicalId: "EvalBaselinesTable1E81E088",
@@ -1631,8 +1653,7 @@ export const ADDITION_ALLOWLIST: AllowlistEntry[] = [
   },
   {
     logicalId: "EvalSamplingConfigTable853B8B52",
-    justification:
-      "CIT-101: eval/release platform — EvalSamplingConfig table.",
+    justification: "CIT-101: eval/release platform — EvalSamplingConfig table.",
   },
   {
     logicalId: "EvalProdSamplesTable2B37B8C9",
@@ -1724,7 +1745,8 @@ export const ADDITION_ALLOWLIST: AllowlistEntry[] = [
       "resolver Lambda.",
   },
   {
-    logicalId: "AgenticAIApiEvalSamplingConfigLambdaDataSourceServiceRoleFC35DA0E",
+    logicalId:
+      "AgenticAIApiEvalSamplingConfigLambdaDataSourceServiceRoleFC35DA0E",
     justification:
       "Service role of EvalSamplingConfigLambdaDataSource; added with it.",
   },
@@ -1762,6 +1784,31 @@ export const ADDITION_ALLOWLIST: AllowlistEntry[] = [
       "StepRunner resume resolver — Mutation.resumeExecution on the " +
       "existing ExecutionLambdaDataSource (backend-stack.ts:3011); adds " +
       "workflow-resume capability, no existing resource changes.",
+  },
+
+  // ═══════════════════════════════════════════════════════════════════════
+  // Finding 0018a6d7 — orphan-resolver wiring for 2 backend-stack-owned
+  // fields with pre-existing tested handlers but no resolver (see
+  // schema-resolver-parity-guard.test.ts's now-shrunk DELIBERATELY_UNWIRED
+  // map). Both attach to an EXISTING datasource shared with an
+  // already-wired sibling field on the same handler — no new datasource,
+  // no new Lambda, no new wiring pattern.
+  // ═══════════════════════════════════════════════════════════════════════
+  {
+    logicalId: "AgenticAIApiListAvailableDataSourcesResolverF6DE4B81",
+    justification:
+      "Finding 0018a6d7: Query.listAvailableDataSources on the existing " +
+      "DataStoreLambdaDataSource, same handler (datastore-resolver.ts) and " +
+      "same org-scoped OrgIndex query pattern as its already-wired sibling " +
+      "Query.listDataStores.",
+  },
+  {
+    logicalId: "AgenticAIApiListIntegrationOperationsResolver737538A7",
+    justification:
+      "Finding 0018a6d7: Query.listIntegrationOperations on the existing " +
+      "ToolConfigLambdaDataSource, same handler (tool-config-resolver.ts) " +
+      "as its already-wired sibling Query.getToolConfig. Reads only the " +
+      "static, non-tenant OPERATIONS_REGISTRY — no org scoping needed.",
   },
 ];
 

--- a/backend/test/backend-stack-orphan-resolvers.test.ts
+++ b/backend/test/backend-stack-orphan-resolvers.test.ts
@@ -1,0 +1,110 @@
+import * as cdk from "aws-cdk-lib";
+import { Template, Match } from "aws-cdk-lib/assertions";
+import * as path from "path";
+import * as fs from "fs";
+
+// Ensure asset directories exist for CDK synthesis
+const assetDirs = [
+  path.resolve(__dirname, "../src/schema"),
+  path.resolve(__dirname, "../dist/lambda"),
+  path.resolve(__dirname, "../../src/lambda/seed-organizations"),
+  path.resolve(__dirname, "../src/lambda/seed-admin-user"),
+];
+for (const dir of assetDirs) {
+  if (!fs.existsSync(dir)) fs.mkdirSync(dir, { recursive: true });
+}
+
+import { BackendStack } from "../lib/backend-stack";
+
+/**
+ * Finding 0018a6d7: schema-resolver-parity-guard surfaced 7 fields with
+ * tested handlers but no wired AppSync Resolver. This file asserts the two
+ * BackendStack-owned fields that WERE wired (mirroring the sibling-field
+ * precedent: resumeExecution @ backend-stack.ts:3013), proving each
+ * resolver exists on the expected TypeName/FieldName AND is attached to
+ * the same datasource as its already-wired sibling on the same handler.
+ *
+ * The other five fields (updateAgentStatus — see
+ * projects-stack.test.ts — plus the four that stay allowlisted:
+ * updateProjectProgress, testTool, getDashboardMetrics, getRecentActivity)
+ * are covered elsewhere; see schema-resolver-parity-guard.test.ts for the
+ * justification comments on the four deliberately-unwired fields.
+ */
+describe("BackendStack — finding 0018a6d7 orphan resolver wiring", () => {
+  let template: Template;
+
+  beforeAll(() => {
+    const app = new cdk.App();
+    const stack = new BackendStack(app, "TestBackendStack", {
+      environment: "test",
+      env: { account: "123456789012", region: "us-east-1" },
+    });
+    template = Template.fromStack(stack);
+  });
+
+  describe("Query.listAvailableDataSources", () => {
+    test("has a wired AppSync Resolver on the DataStore datasource", () => {
+      template.hasResourceProperties("AWS::AppSync::Resolver", {
+        TypeName: "Query",
+        FieldName: "listAvailableDataSources",
+        DataSourceName: Match.anyValue(),
+      });
+    });
+
+    test("is attached to the SAME datasource as its sibling listDataStores", () => {
+      const resolvers = template.findResources("AWS::AppSync::Resolver");
+      const bySibling = Object.values(resolvers).filter(
+        (r: unknown) =>
+          (r as { Properties: { FieldName: string } }).Properties.FieldName ===
+          "listDataStores",
+      );
+      const byNew = Object.values(resolvers).filter(
+        (r: unknown) =>
+          (r as { Properties: { FieldName: string } }).Properties.FieldName ===
+          "listAvailableDataSources",
+      );
+      expect(bySibling).toHaveLength(1);
+      expect(byNew).toHaveLength(1);
+      expect(
+        (byNew[0] as { Properties: { DataSourceName: unknown } }).Properties
+          .DataSourceName,
+      ).toEqual(
+        (bySibling[0] as { Properties: { DataSourceName: unknown } }).Properties
+          .DataSourceName,
+      );
+    });
+  });
+
+  describe("Query.listIntegrationOperations", () => {
+    test("has a wired AppSync Resolver on the ToolConfig datasource", () => {
+      template.hasResourceProperties("AWS::AppSync::Resolver", {
+        TypeName: "Query",
+        FieldName: "listIntegrationOperations",
+        DataSourceName: Match.anyValue(),
+      });
+    });
+
+    test("is attached to the SAME datasource as its sibling getToolConfig", () => {
+      const resolvers = template.findResources("AWS::AppSync::Resolver");
+      const bySibling = Object.values(resolvers).filter(
+        (r: unknown) =>
+          (r as { Properties: { FieldName: string } }).Properties.FieldName ===
+          "getToolConfig",
+      );
+      const byNew = Object.values(resolvers).filter(
+        (r: unknown) =>
+          (r as { Properties: { FieldName: string } }).Properties.FieldName ===
+          "listIntegrationOperations",
+      );
+      expect(bySibling).toHaveLength(1);
+      expect(byNew).toHaveLength(1);
+      expect(
+        (byNew[0] as { Properties: { DataSourceName: unknown } }).Properties
+          .DataSourceName,
+      ).toEqual(
+        (bySibling[0] as { Properties: { DataSourceName: unknown } }).Properties
+          .DataSourceName,
+      );
+    });
+  });
+});

--- a/backend/test/projects-stack.test.ts
+++ b/backend/test/projects-stack.test.ts
@@ -178,9 +178,9 @@ describe("ProjectsStack — backend-stack-split phase 1", () => {
   });
 
   // --- Resolver count ---
-  test("defines exactly 23 AppSync resolvers (matching the move manifest)", () => {
+  test("defines exactly 24 AppSync resolvers (matching the move manifest + updateAgentStatus, finding 0018a6d7)", () => {
     const resolvers = template.findResources("AWS::AppSync::Resolver");
-    expect(Object.keys(resolvers)).toHaveLength(23);
+    expect(Object.keys(resolvers)).toHaveLength(24);
   });
 
   test("defines exactly 10 AppSync Lambda data sources", () => {
@@ -197,6 +197,7 @@ describe("ProjectsStack — backend-stack-split phase 1", () => {
     ["Mutation", "updateProject"],
     ["Mutation", "uploadDocument"],
     ["Query", "getAgentStatus"],
+    ["Mutation", "updateAgentStatus"],
     ["Query", "getConversationHistory"],
     ["Mutation", "sendMessage"],
     ["Mutation", "publishConversationMessage"],
@@ -225,6 +226,31 @@ describe("ProjectsStack — backend-stack-split phase 1", () => {
       });
     },
   );
+
+  // --- Finding 0018a6d7: updateAgentStatus wired onto the SAME datasource
+  // as its sibling getAgentStatus (both on agent-resolver.ts) ---
+  test("Mutation.updateAgentStatus is attached to the same datasource as Query.getAgentStatus", () => {
+    const resolvers = template.findResources("AWS::AppSync::Resolver");
+    const getStatus = Object.values(resolvers).filter(
+      (r) =>
+        (r as { Properties: { FieldName: string } }).Properties.FieldName ===
+        "getAgentStatus",
+    );
+    const updateStatus = Object.values(resolvers).filter(
+      (r) =>
+        (r as { Properties: { FieldName: string } }).Properties.FieldName ===
+        "updateAgentStatus",
+    );
+    expect(getStatus).toHaveLength(1);
+    expect(updateStatus).toHaveLength(1);
+    expect(
+      (updateStatus[0] as { Properties: { DataSourceName: unknown } })
+        .Properties.DataSourceName,
+    ).toEqual(
+      (getStatus[0] as { Properties: { DataSourceName: unknown } }).Properties
+        .DataSourceName,
+    );
+  });
 
   // --- JWT-free: satellites don't own auth ---
   test("does not define any Cognito UserPool (auth stays in BackendStack)", () => {

--- a/backend/test/schema-resolver-parity-guard.test.ts
+++ b/backend/test/schema-resolver-parity-guard.test.ts
@@ -83,35 +83,62 @@ const RESOLVER_STACK_NAMES = [
  *       the guard fail again, as intended.
  */
 const DELIBERATELY_UNWIRED: ReadonlyMap<string, string> = new Map([
-  // --- pre-existing, tracked separately (finding 0018a6d7), NOT fixed by
-  // this change (finding 24563f6c/d037634b only) ---
-  [
-    "Mutation.updateAgentStatus",
-    "Pre-existing gap surfaced by this guard, same class as resumeExecution. Handler exists (agent-resolver.ts:125) but no stack wires a resolver for it. Tracked separately: finding 0018a6d7. Not in scope for finding 24563f6c.",
-  ],
+  // --- finding 0018a6d7 follow-up: 3 of 7 fields wired (updateAgentStatus,
+  // listAvailableDataSources, listIntegrationOperations — see backend-stack.ts
+  // / projects-stack.ts resolver additions and the corresponding CDK template
+  // assertions). The remaining 4 stay allowlisted below because wiring them
+  // as-is would introduce or reach a real authz/tenant-isolation gap; each
+  // entry below names the specific missing control. ---
   [
     "Mutation.updateProjectProgress",
-    "Pre-existing gap surfaced by this guard, same class as resumeExecution. Tracked separately: finding 0018a6d7. Not in scope for finding 24563f6c.",
+    "No AppSync-compatible handler exists. The only related Lambda " +
+      "(project-progress-updater.ts) is an internal EventBridge consumer " +
+      "invoked from the 'intake.progress.updated' rule (projects-stack.ts) " +
+      "— its handler signature takes an EventBridge detail payload, not an " +
+      "AppSyncResolverEvent, has no event.identity, and performs no " +
+      "authentication or org check. Wiring it as a resolver would require " +
+      "writing a new handler from scratch (out of scope for a wiring fix) " +
+      "and, done naively, would let any authenticated caller write another " +
+      "org's project progress with no org-membership check. Finding 0018a6d7.",
   ],
   [
     "Mutation.testTool",
-    "Pre-existing gap surfaced by this guard, same class as resumeExecution. Tracked separately: finding 0018a6d7. Not in scope for finding 24563f6c.",
-  ],
-  [
-    "Query.listAvailableDataSources",
-    "Pre-existing gap surfaced by this guard, same class as resumeExecution. Tracked separately: finding 0018a6d7. Not in scope for finding 24563f6c.",
-  ],
-  [
-    "Query.listIntegrationOperations",
-    "Pre-existing gap surfaced by this guard, same class as resumeExecution. Tracked separately: finding 0018a6d7. Not in scope for finding 24563f6c.",
+    "Handler exists (tool-sandbox.ts handler/executeTool) and its Lambda " +
+      "is already defined in services-stack.ts (ToolSandboxFunction) but " +
+      "never attached to a resolver. SECURITY GATE FAILED: the handler " +
+      "accepts orgId as a client-supplied argument but never validates it " +
+      "against the caller's actual identity/org (no extractOrgFromEvent- " +
+      "style check), and loadToolConfig(toolId) looks up the tool config by " +
+      "toolId alone with no org filter — so a caller could pass another " +
+      "org's toolId and receive that tool's execution output using that " +
+      "org's scoped credentials. Do not wire until the handler enforces " +
+      "caller-org == tool-owner-org before executeTool() runs. Finding 0018a6d7.",
   ],
   [
     "Query.getDashboardMetrics",
-    "Pre-existing gap surfaced by this guard, same class as resumeExecution. Tracked separately: finding 0018a6d7. Not in scope for finding 24563f6c.",
+    "Handler exists (app-metrics-handler.ts getDashboardMetrics) but no " +
+      "AppSync-shaped wrapper calls it anywhere (contrast: getAppMetrics has " +
+      "a wrapper in registry-agent-record-resolver.ts and IS wired). " +
+      "SECURITY GATE FAILED: getDashboardMetrics(orgId, ...) accepts orgId " +
+      "but never uses it — its ScanCommand FilterExpression only filters on " +
+      "begins_with(groupId, 'APP#') and the time range, so it aggregates " +
+      "request/latency metrics across every organization's apps. Wiring " +
+      "this today would leak cross-tenant usage data to any caller with " +
+      "access to the query. Do not wire until the scan is filtered to the " +
+      "caller's org. Finding 0018a6d7.",
   ],
   [
     "Query.getRecentActivity",
-    "Pre-existing gap surfaced by this guard, same class as resumeExecution. Tracked separately: finding 0018a6d7. Not in scope for finding 24563f6c.",
+    "Handler exists (recent-activity-resolver.ts getRecentActivity) with a " +
+      "dedicated test file, but no CDK stack even defines a Lambda function " +
+      "for it (let alone a resolver) — it is fully undeployed. SECURITY " +
+      "GATE FAILED: getRecentActivity(orgId, ...) accepts orgId but " +
+      "fetchRecent()'s ScanCommand has no FilterExpression at all — it scans " +
+      "the full projects/agent-config/workflows/integrations tables and " +
+      "returns names, statuses, and timestamps from every organization. " +
+      "Wiring this would leak cross-tenant activity data platform-wide. Do " +
+      "not wire until scans are org-filtered (or replaced with an org-keyed " +
+      "GSI query). Finding 0018a6d7.",
   ],
 ]);
 


### PR DESCRIPTION
## Summary

Seven schema fields had tested handlers but no AppSync resolver in any stack, so they returned null in live dev. Three are now wired; four are deliberately not, because their handlers are unsafe to expose.

Wired, each mirroring its sibling field's datasource and authorization:

- `Mutation.updateAgentStatus` - projects-stack, AgentLambdaDataSource; same project-org check as `getAgentStatus`
- `Query.ListAvailableDataSources` - backend-stack, DataStoreLambdaDataSource; same org-scoped index query as `ListDataStores`
- `Query.ListIntegrationOperations` - ToolConfigLambdaDataSource; reads only a static, non-tenant registry

Their entries are removed from the parity-guard allowlist, so the guard now enforces the wiring rather than tolerating its absence.

## Four fields deliberately left unwired 

A security check per field refused these, and each stays allowlisted with its specific blocker named in a comment:
- `Mutation.testTool` - accepts an `orgId` but never validates it against caller identity, and loads the tool with no org filter: cross-tenant tool execution with stored credentials
- `Query.getDashboardMetrics` - `orgid` is dead code; the scan aggregates every organisation's metrics
- `Query.getRecentActivity` - `orgid` likewise dead; scans projects, agents, workflows and integrations with no org filtering
- `Mutation.updateProjectProgress` - no AppSync-shaped handler exists; the only related Lambda is an EventBridge consumer with an incompatible signature

Wiring any of the first three would have turned a dormant defect into a live cross-tenant leak. They are filed separately as a high-severity finding, with a recommended sweep for other handlers accepting an `orgid` they never derive or validate - these three share one shape.

## Testing

- CDK template assertions per wired field proving the resolver exists on the expected type and datasource, with no double-attach across stacks
- Review independently verified authorization per wired field, including a cross-org rejection probe, and confirmed each unwired field's blocker in source
- Guard tightening bite-proven: removing a newly wired resolver now fails the parity guard, restored byte-identically
- tsc, lint, cdk synth --all', full backend jest (7015), parity guard (243) and
`npm run split:gates` all exit o

## Notes

- Split-gates entries were added for the new resources and fields under the established allowlist pattern, each citing the finding
- All seven fields are API surface only - no frontend calls any of them, so this makes three of them reachable, not used