### PR TITLE
chore(telemetry): default the trace backend to Cloudwatch spans

### DIFF
--- a/backend/lib/__tests__/telemetry-stack.test.ts
+++ b/backend/lib/__tests__/telemetry-stack.test.ts
@@ -916,13 +916,13 @@ describe("TelemetryStack — TraceQueryHandler (waterfall trace viewer, pass 1)"
     expect(joined).toContain("logs:getqueryresults");
   });
 
-  test("TraceQueryHandler Lambda has a TRACE_BACKEND environment variable defaulting to xray", () => {
+  test("TraceQueryHandler Lambda has a TRACE_BACKEND environment variable defaulting to spans", () => {
     const { template } = buildStack();
     template.hasResourceProperties("AWS::Lambda::Function", {
       Handler: "trace-query-handler.handler",
       Environment: {
         Variables: Match.objectLike({
-          TRACE_BACKEND: "xray",
+          TRACE_BACKEND: "spans",
         }),
       },
     });

--- a/backend/lib/telemetry-stack.ts
+++ b/backend/lib/telemetry-stack.ts
@@ -664,7 +664,7 @@ export class TelemetryStack extends cdk.Stack {
           // Transaction Search is enabled account-wide. See
           // docs/TRACING_RUNBOOK.md cutover procedure.
           TRACE_BACKEND:
-            process.env.TRACE_BACKEND === "spans" ? "spans" : "xray",
+            process.env.TRACE_BACKEND === "xray" ? "xray" : "spans",
         },
         logGroup: new logs.LogGroup(this, "TraceQueryHandlerLogs", {
           retention: logs.RetentionDays.ONE_WEEK,

--- a/backend/lib/telemetry-stack.ts
+++ b/backend/lib/telemetry-stack.ts
@@ -659,9 +659,12 @@ export class TelemetryStack extends cdk.Stack {
           PROJECTS_TABLE: props.projectsTable.tableName,
           ENVIRONMENT: props.environment,
           // Dual-backend dispatch (design §3 "SIMPLEST safe option"):
-          // defaults to `xray` (today's behavior, unchanged) until an
-          // operator flips this to `spans` post-cutover, once
-          // Transaction Search is enabled account-wide. See
+          // defaults to `spans`, overridable per environment via
+          // TRACE_BACKEND=xray. `spans` requires CloudWatch Transaction
+          // Search to be enabled in the target account/region; `xray`
+          // remains supported as a fallback (see the xray:Get* grant
+          // below). Viewer end-to-end verification against `spans` and
+          // removal of the xray:Get* grant are still outstanding — see
           // docs/TRACING_RUNBOOK.md cutover procedure.
           TRACE_BACKEND:
             process.env.TRACE_BACKEND === "xray" ? "xray" : "spans",
@@ -715,11 +718,13 @@ export class TelemetryStack extends cdk.Stack {
     // --- Transaction Search span-query port (design §3 dual-backend,
     // §4 "Least-privilege IAM") ---------------------------------------
     // Added ALONGSIDE the xray:Get* grant above, not instead of it — the
-    // default backend is still `xray` during the transition (TRACE_BACKEND
-    // env, default `xray`), so removing xray:Get* now would blind the
-    // default path. Both permission sets are granted so flipping
-    // TRACE_BACKEND=spans post-cutover requires no IAM change (design §3
-    // "Reversible ... needs no IAM change").
+    // default backend is now `spans`, but `xray` remains a supported
+    // fallback (operator override via TRACE_BACKEND=xray), so the
+    // xray:Get* grant stays until viewer end-to-end verification against
+    // `spans` is complete and that grant's removal is confirmed safe.
+    // Both permission sets are granted so flipping TRACE_BACKEND either
+    // way requires no IAM change (design §3 "Reversible ... needs no IAM
+    // change").
     //
     // logs:StartQuery DOES support resource-level scoping (unlike
     // GetQueryResults/StopQuery, which operate on an opaque queryId with


### PR DESCRIPTION
## Summary

Deployed dev already runs the trace query handler with `TRACE_BACKEND=spans` (Transaction Search is active), but main still defaults it to `xray` - the flip exists only as a deploy-time value. This codifies it in CDK, closing a code-versus-deployed drift whose failure mode is silent: any deploy from main would quietly revert dev to the X-Ray Get* APIs, which are draining under Transaction Search, leaving the waterfall viewer progressively blind with nothing failing.

- Two files, three lines: the telemetry stack's default becomes "spans"

## Why now

The value being correct in the account but wrong in the repository is the worst combination: nothing alerts, and the next routine deploy re-introduces the bug that was already diagnosed and fixed once.

## Reviewer caveat worth confirming

Making "spans" the default changes behaviour for **every** environment on its next deploy, not just dev. Spans requires Cloudwatch Transaction Search enabled in that account and region; where it is not, the viewer would return empty rather than error. Transaction Search was enabled account-wide for the dev account on 2026-08-02 - please confirm the same holds for any other account this stack targets before merging, or gate the default per environment.

## Follow-ups (not in this PR)

From the tracked cutover finding:

- Remove the now-unneeded `xray: Get*` IAM grant and flip the pinned telemetry test to assert its absence
- End-to-end viewer verification (server plus browser) against real spans data

## Notes

- The branch predates a long run of merges to main. It merged cleanly when checked locally, so CI should evaluate a clean merge ref - if GitHub reports conflicts, merging main in will clear it