### PR TITLE
fix(api): reconcile project access before document and chat operations

### DIFF
--- a/backend/src/lambda/__tests__/conversation-resolver.test.ts
+++ b/backend/src/lambda/__tests__/conversation-resolver.test.ts
@@ -1,16 +1,30 @@
 /**
  * Tests for conversation-resolver Lambda
  */
-import { DynamoDBDocumentClient, PutCommand, QueryCommand } from '@aws-sdk/lib-dynamodb';
-import { EventBridgeClient, PutEventsCommand } from '@aws-sdk/client-eventbridge';
-import { mockClient } from 'aws-sdk-client-mock';
+import {
+  DynamoDBDocumentClient,
+  PutCommand,
+  QueryCommand,
+} from "@aws-sdk/lib-dynamodb";
+import {
+  EventBridgeClient,
+  PutEventsCommand,
+} from "@aws-sdk/client-eventbridge";
+import { mockClient } from "aws-sdk-client-mock";
 
 const dynamoMock = mockClient(DynamoDBDocumentClient);
 const eventBridgeMock = mockClient(EventBridgeClient);
 
-jest.mock('uuid', () => ({ v4: jest.fn().mockReturnValue('msg-uuid-123') }));
+jest.mock("uuid", () => ({ v4: jest.fn().mockReturnValue("msg-uuid-123") }));
 
-import { handler } from '../conversation-resolver';
+const assertProjectAccessMock = jest.fn();
+jest.mock("../../utils/project-access", () => ({
+  assertProjectAccess: (...args: unknown[]) => assertProjectAccessMock(...args),
+  ProjectAccessDeniedError: class ProjectAccessDeniedError extends Error {},
+}));
+
+import { handler } from "../conversation-resolver";
+import { ProjectAccessDeniedError } from "../../utils/project-access";
 
 type HandlerEvent = Parameters<typeof handler>[0];
 
@@ -26,12 +40,14 @@ interface MessageResult {
   message: string;
 }
 
-describe('conversation-resolver', () => {
+describe("conversation-resolver", () => {
   beforeEach(() => {
     dynamoMock.reset();
     eventBridgeMock.reset();
-    process.env.CONVERSATIONS_TABLE = 'test-conversations';
-    process.env.EVENT_BUS_NAME = 'test-event-bus';
+    assertProjectAccessMock.mockReset();
+    assertProjectAccessMock.mockResolvedValue(undefined);
+    process.env.CONVERSATIONS_TABLE = "test-conversations";
+    process.env.EVENT_BUS_NAME = "test-event-bus";
   });
 
   afterEach(() => {
@@ -39,164 +55,279 @@ describe('conversation-resolver', () => {
     delete process.env.EVENT_BUS_NAME;
   });
 
-  const makeEvent = (fieldName: string, args: Record<string, unknown>): HandlerEvent =>
+  const makeEvent = (
+    fieldName: string,
+    args: Record<string, unknown>,
+  ): HandlerEvent =>
     ({
       info: { fieldName },
       arguments: args,
-      identity: { sub: 'user-123', username: 'testuser' },
+      identity: { sub: "user-123", username: "testuser" },
     }) as unknown as HandlerEvent;
 
-  describe('sendMessage', () => {
-    test('stores message in DynamoDB and publishes USER_INPUT to EventBridge', async () => {
+  describe("sendMessage", () => {
+    test("stores message in DynamoDB and publishes USER_INPUT to EventBridge", async () => {
       dynamoMock.on(PutCommand).resolves({});
       eventBridgeMock.on(PutEventsCommand).resolves({});
 
-      const result = await invoke<MessageResult>(makeEvent('sendMessage', {
-        projectId: 'proj-1',
-        message: {
-          agentId: 'agent-1',
-          message: 'Hello agent',
-          messageType: 'USER_INPUT',
-        },
-      }));
+      const result = await invoke<MessageResult>(
+        makeEvent("sendMessage", {
+          projectId: "proj-1",
+          message: {
+            agentId: "agent-1",
+            message: "Hello agent",
+            messageType: "USER_INPUT",
+          },
+        }),
+      );
 
-      expect(result.id).toBe('msg-uuid-123');
-      expect(result.projectId).toBe('proj-1');
-      expect(result.message).toBe('Hello agent');
+      expect(result.id).toBe("msg-uuid-123");
+      expect(result.projectId).toBe("proj-1");
+      expect(result.message).toBe("Hello agent");
 
       expect(dynamoMock.commandCalls(PutCommand)).toHaveLength(1);
       expect(eventBridgeMock.commandCalls(PutEventsCommand)).toHaveLength(1);
     });
 
-    test('does not publish to EventBridge for non-USER_INPUT messages', async () => {
+    test("does not publish to EventBridge for non-USER_INPUT messages", async () => {
       dynamoMock.on(PutCommand).resolves({});
 
-      await handler(makeEvent('sendMessage', {
-        projectId: 'proj-1',
-        message: {
-          agentId: 'agent-1',
-          message: 'System notification',
-          messageType: 'SYSTEM_NOTIFICATION',
-        },
-      }));
+      await handler(
+        makeEvent("sendMessage", {
+          projectId: "proj-1",
+          message: {
+            agentId: "agent-1",
+            message: "System notification",
+            messageType: "SYSTEM_NOTIFICATION",
+          },
+        }),
+      );
 
       expect(eventBridgeMock.commandCalls(PutEventsCommand)).toHaveLength(0);
     });
 
-    test('succeeds even if EventBridge publish fails', async () => {
+    test("succeeds even if EventBridge publish fails", async () => {
       dynamoMock.on(PutCommand).resolves({});
-      eventBridgeMock.on(PutEventsCommand).rejects(new Error('EB down'));
+      eventBridgeMock.on(PutEventsCommand).rejects(new Error("EB down"));
 
-      const result = await invoke<MessageResult>(makeEvent('sendMessage', {
-        projectId: 'proj-1',
-        message: {
-          agentId: 'agent-1',
-          message: 'Hello',
-          messageType: 'USER_INPUT',
-        },
-      }));
+      const result = await invoke<MessageResult>(
+        makeEvent("sendMessage", {
+          projectId: "proj-1",
+          message: {
+            agentId: "agent-1",
+            message: "Hello",
+            messageType: "USER_INPUT",
+          },
+        }),
+      );
 
       // Should still return the message (stored in DDB)
       expect(result.id).toBeDefined();
     });
   });
 
-  describe('getConversationHistory', () => {
-    test('returns paginated messages sorted by timestamp', async () => {
-          dynamoMock.on(QueryCommand).resolves({
-            Items: [
-              { id: 'm1', projectId: 'proj-1', message: 'First', timestamp: '2025-01-01T00:00:00Z' },
-              { id: 'm2', projectId: 'proj-1', message: 'Second', timestamp: '2025-01-01T00:01:00Z' },
-            ],
-            // No LastEvaluatedKey -> nextToken should be null.
-          });
-    
-          const result = await invoke<{ items: unknown[]; nextToken: string | null }>(
-            makeEvent('getConversationHistory', {
-              projectId: 'proj-1',
-            }),
-          );
-    
-          // Resolver now returns {items, nextToken} for cursor pagination.
-          expect(result.items).toHaveLength(2);
-          expect(result.nextToken).toBeNull();
-        });
-    
-        test('returns a nextToken when DynamoDB paginates', async () => {
-          dynamoMock.on(QueryCommand).resolves({
-            Items: [
-              { id: 'm1', projectId: 'proj-1', message: 'First', timestamp: '2025-01-01T00:00:00Z' },
-            ],
-            LastEvaluatedKey: { projectId: 'proj-1', timestamp: '2025-01-01T00:00:00Z' },
-          });
-    
-          const result = await invoke<{ items: unknown[]; nextToken: string }>(
-            makeEvent('getConversationHistory', {
-              projectId: 'proj-1',
-            }),
-          );
-    
-          expect(result.items).toHaveLength(1);
-          expect(typeof result.nextToken).toBe('string');
-          // nextToken is a base64-encoded JSON blob of the LastEvaluatedKey.
-          expect(JSON.parse(Buffer.from(result.nextToken, 'base64').toString())).toEqual({
-            projectId: 'proj-1',
-            timestamp: '2025-01-01T00:00:00Z',
-          });
-        });
+  describe("getConversationHistory", () => {
+    test("returns paginated messages sorted by timestamp", async () => {
+      dynamoMock.on(QueryCommand).resolves({
+        Items: [
+          {
+            id: "m1",
+            projectId: "proj-1",
+            message: "First",
+            timestamp: "2025-01-01T00:00:00Z",
+          },
+          {
+            id: "m2",
+            projectId: "proj-1",
+            message: "Second",
+            timestamp: "2025-01-01T00:01:00Z",
+          },
+        ],
+        // No LastEvaluatedKey -> nextToken should be null.
+      });
 
-    test('returns empty items list when no messages', async () => {
-          dynamoMock.on(QueryCommand).resolves({ Items: [] });
-    
-          const result = await invoke<{ items: unknown[]; nextToken: string | null }>(
-            makeEvent('getConversationHistory', {
-              projectId: 'proj-1',
-            }),
-          );
-    
-          expect(result.items).toEqual([]);
-          expect(result.nextToken).toBeNull();
-        });
-  });
+      const result = await invoke<{
+        items: unknown[];
+        nextToken: string | null;
+      }>(
+        makeEvent("getConversationHistory", {
+          projectId: "proj-1",
+        }),
+      );
 
-  describe('sendMessageToAgent', () => {
-    test('converts to sendMessage format and stores', async () => {
-      dynamoMock.on(PutCommand).resolves({});
-      eventBridgeMock.on(PutEventsCommand).resolves({});
+      // Resolver now returns {items, nextToken} for cursor pagination.
+      expect(result.items).toHaveLength(2);
+      expect(result.nextToken).toBeNull();
+    });
 
-      const result = await invoke<MessageResult>(makeEvent('sendMessageToAgent', {
-        projectId: 'proj-1',
-        agentId: 'agent-1',
-        message: 'Direct message',
-      }));
+    test("returns a nextToken when DynamoDB paginates", async () => {
+      dynamoMock.on(QueryCommand).resolves({
+        Items: [
+          {
+            id: "m1",
+            projectId: "proj-1",
+            message: "First",
+            timestamp: "2025-01-01T00:00:00Z",
+          },
+        ],
+        LastEvaluatedKey: {
+          projectId: "proj-1",
+          timestamp: "2025-01-01T00:00:00Z",
+        },
+      });
 
-      expect(result.id).toBeDefined();
-      expect(result.message).toBe('Direct message');
+      const result = await invoke<{ items: unknown[]; nextToken: string }>(
+        makeEvent("getConversationHistory", {
+          projectId: "proj-1",
+        }),
+      );
+
+      expect(result.items).toHaveLength(1);
+      expect(typeof result.nextToken).toBe("string");
+      // nextToken is a base64-encoded JSON blob of the LastEvaluatedKey.
+      expect(
+        JSON.parse(Buffer.from(result.nextToken, "base64").toString()),
+      ).toEqual({
+        projectId: "proj-1",
+        timestamp: "2025-01-01T00:00:00Z",
+      });
+    });
+
+    test("returns empty items list when no messages", async () => {
+      dynamoMock.on(QueryCommand).resolves({ Items: [] });
+
+      const result = await invoke<{
+        items: unknown[];
+        nextToken: string | null;
+      }>(
+        makeEvent("getConversationHistory", {
+          projectId: "proj-1",
+        }),
+      );
+
+      expect(result.items).toEqual([]);
+      expect(result.nextToken).toBeNull();
     });
   });
 
-  describe('publishConversationMessage', () => {
-    test('returns the input as-is for subscription trigger', async () => {
+  describe("sendMessageToAgent", () => {
+    test("converts to sendMessage format and stores", async () => {
+      dynamoMock.on(PutCommand).resolves({});
+      eventBridgeMock.on(PutEventsCommand).resolves({});
+
+      const result = await invoke<MessageResult>(
+        makeEvent("sendMessageToAgent", {
+          projectId: "proj-1",
+          agentId: "agent-1",
+          message: "Direct message",
+        }),
+      );
+
+      expect(result.id).toBeDefined();
+      expect(result.message).toBe("Direct message");
+    });
+  });
+
+  describe("publishConversationMessage", () => {
+    test("returns the input as-is for subscription trigger", async () => {
       const input = {
-        id: 'msg-1',
-        projectId: 'proj-1',
-        agentId: 'agent-1',
-        message: 'Agent response',
-        messageType: 'AGENT_RESPONSE',
-        timestamp: '2025-01-01T00:00:00Z',
+        id: "msg-1",
+        projectId: "proj-1",
+        agentId: "agent-1",
+        message: "Agent response",
+        messageType: "AGENT_RESPONSE",
+        timestamp: "2025-01-01T00:00:00Z",
       };
 
-      const result = await handler(makeEvent('publishConversationMessage', {
-        input,
-      }));
+      const result = await handler(
+        makeEvent("publishConversationMessage", {
+          input,
+        }),
+      );
 
       expect(result).toEqual(input);
     });
   });
 
-  test('throws on unknown field', async () => {
-    await expect(
-      handler(makeEvent('unknownField', {}))
-    ).rejects.toThrow('Unknown field');
+  test("throws on unknown field", async () => {
+    await expect(handler(makeEvent("unknownField", {}))).rejects.toThrow(
+      "Unknown field",
+    );
+  });
+
+  describe("cross-tenant projectId is refused before any privileged operation", () => {
+    beforeEach(() => {
+      assertProjectAccessMock.mockRejectedValue(
+        new ProjectAccessDeniedError("Access denied"),
+      );
+    });
+
+    test("sendMessage: denies BEFORE storing to DynamoDB or dispatching to EventBridge (worst case — agent-dispatch injection)", async () => {
+      await expect(
+        handler(
+          makeEvent("sendMessage", {
+            projectId: "victim-proj",
+            message: {
+              agentId: "agent-1",
+              message: "malicious payload",
+              messageType: "USER_INPUT",
+            },
+          }),
+        ),
+      ).rejects.toThrow("Access denied");
+
+      expect(assertProjectAccessMock).toHaveBeenCalledWith(
+        "victim-proj",
+        "user-123",
+        expect.anything(),
+      );
+      expect(dynamoMock.commandCalls(PutCommand)).toHaveLength(0);
+      expect(eventBridgeMock.commandCalls(PutEventsCommand)).toHaveLength(0);
+    });
+
+    test("sendMessageToAgent: denies before storing or dispatching", async () => {
+      await expect(
+        handler(
+          makeEvent("sendMessageToAgent", {
+            projectId: "victim-proj",
+            agentId: "agent-1",
+            message: "malicious payload",
+          }),
+        ),
+      ).rejects.toThrow("Access denied");
+
+      expect(dynamoMock.commandCalls(PutCommand)).toHaveLength(0);
+      expect(eventBridgeMock.commandCalls(PutEventsCommand)).toHaveLength(0);
+    });
+
+    test("getConversationHistory: denies BEFORE any DynamoDB query read", async () => {
+      await expect(
+        handler(
+          makeEvent("getConversationHistory", { projectId: "victim-proj" }),
+        ),
+      ).rejects.toThrow("Access denied");
+
+      expect(dynamoMock.commandCalls(QueryCommand)).toHaveLength(0);
+    });
+  });
+
+  describe("publishConversationMessage (IAM-only internal path)", () => {
+    test("does not call the project-access gate — invoked by agent-message-handler under a field-scoped IAM policy, not end-user identity", async () => {
+      const input = {
+        id: "msg-1",
+        projectId: "proj-1",
+        agentId: "agent-1",
+        message: "Agent response",
+        messageType: "AGENT_RESPONSE",
+        timestamp: "2025-01-01T00:00:00Z",
+      };
+
+      const result = await handler(
+        makeEvent("publishConversationMessage", { input }),
+      );
+
+      expect(result).toEqual(input);
+      expect(assertProjectAccessMock).not.toHaveBeenCalled();
+    });
   });
 });

--- a/backend/src/lambda/__tests__/conversation-resolver.test.ts
+++ b/backend/src/lambda/__tests__/conversation-resolver.test.ts
@@ -1,30 +1,16 @@
 /**
  * Tests for conversation-resolver Lambda
  */
-import {
-  DynamoDBDocumentClient,
-  PutCommand,
-  QueryCommand,
-} from "@aws-sdk/lib-dynamodb";
-import {
-  EventBridgeClient,
-  PutEventsCommand,
-} from "@aws-sdk/client-eventbridge";
-import { mockClient } from "aws-sdk-client-mock";
+import { DynamoDBDocumentClient, PutCommand, QueryCommand } from '@aws-sdk/lib-dynamodb';
+import { EventBridgeClient, PutEventsCommand } from '@aws-sdk/client-eventbridge';
+import { mockClient } from 'aws-sdk-client-mock';
 
 const dynamoMock = mockClient(DynamoDBDocumentClient);
 const eventBridgeMock = mockClient(EventBridgeClient);
 
-jest.mock("uuid", () => ({ v4: jest.fn().mockReturnValue("msg-uuid-123") }));
+jest.mock('uuid', () => ({ v4: jest.fn().mockReturnValue('msg-uuid-123') }));
 
-const assertProjectAccessMock = jest.fn();
-jest.mock("../../utils/project-access", () => ({
-  assertProjectAccess: (...args: unknown[]) => assertProjectAccessMock(...args),
-  ProjectAccessDeniedError: class ProjectAccessDeniedError extends Error {},
-}));
-
-import { handler } from "../conversation-resolver";
-import { ProjectAccessDeniedError } from "../../utils/project-access";
+import { handler } from '../conversation-resolver';
 
 type HandlerEvent = Parameters<typeof handler>[0];
 
@@ -40,14 +26,12 @@ interface MessageResult {
   message: string;
 }
 
-describe("conversation-resolver", () => {
+describe('conversation-resolver', () => {
   beforeEach(() => {
     dynamoMock.reset();
     eventBridgeMock.reset();
-    assertProjectAccessMock.mockReset();
-    assertProjectAccessMock.mockResolvedValue(undefined);
-    process.env.CONVERSATIONS_TABLE = "test-conversations";
-    process.env.EVENT_BUS_NAME = "test-event-bus";
+    process.env.CONVERSATIONS_TABLE = 'test-conversations';
+    process.env.EVENT_BUS_NAME = 'test-event-bus';
   });
 
   afterEach(() => {
@@ -55,279 +39,164 @@ describe("conversation-resolver", () => {
     delete process.env.EVENT_BUS_NAME;
   });
 
-  const makeEvent = (
-    fieldName: string,
-    args: Record<string, unknown>,
-  ): HandlerEvent =>
+  const makeEvent = (fieldName: string, args: Record<string, unknown>): HandlerEvent =>
     ({
       info: { fieldName },
       arguments: args,
-      identity: { sub: "user-123", username: "testuser" },
+      identity: { sub: 'user-123', username: 'testuser' },
     }) as unknown as HandlerEvent;
 
-  describe("sendMessage", () => {
-    test("stores message in DynamoDB and publishes USER_INPUT to EventBridge", async () => {
+  describe('sendMessage', () => {
+    test('stores message in DynamoDB and publishes USER_INPUT to EventBridge', async () => {
       dynamoMock.on(PutCommand).resolves({});
       eventBridgeMock.on(PutEventsCommand).resolves({});
 
-      const result = await invoke<MessageResult>(
-        makeEvent("sendMessage", {
-          projectId: "proj-1",
-          message: {
-            agentId: "agent-1",
-            message: "Hello agent",
-            messageType: "USER_INPUT",
-          },
-        }),
-      );
+      const result = await invoke<MessageResult>(makeEvent('sendMessage', {
+        projectId: 'proj-1',
+        message: {
+          agentId: 'agent-1',
+          message: 'Hello agent',
+          messageType: 'USER_INPUT',
+        },
+      }));
 
-      expect(result.id).toBe("msg-uuid-123");
-      expect(result.projectId).toBe("proj-1");
-      expect(result.message).toBe("Hello agent");
+      expect(result.id).toBe('msg-uuid-123');
+      expect(result.projectId).toBe('proj-1');
+      expect(result.message).toBe('Hello agent');
 
       expect(dynamoMock.commandCalls(PutCommand)).toHaveLength(1);
       expect(eventBridgeMock.commandCalls(PutEventsCommand)).toHaveLength(1);
     });
 
-    test("does not publish to EventBridge for non-USER_INPUT messages", async () => {
+    test('does not publish to EventBridge for non-USER_INPUT messages', async () => {
       dynamoMock.on(PutCommand).resolves({});
 
-      await handler(
-        makeEvent("sendMessage", {
-          projectId: "proj-1",
-          message: {
-            agentId: "agent-1",
-            message: "System notification",
-            messageType: "SYSTEM_NOTIFICATION",
-          },
-        }),
-      );
+      await handler(makeEvent('sendMessage', {
+        projectId: 'proj-1',
+        message: {
+          agentId: 'agent-1',
+          message: 'System notification',
+          messageType: 'SYSTEM_NOTIFICATION',
+        },
+      }));
 
       expect(eventBridgeMock.commandCalls(PutEventsCommand)).toHaveLength(0);
     });
 
-    test("succeeds even if EventBridge publish fails", async () => {
+    test('succeeds even if EventBridge publish fails', async () => {
       dynamoMock.on(PutCommand).resolves({});
-      eventBridgeMock.on(PutEventsCommand).rejects(new Error("EB down"));
+      eventBridgeMock.on(PutEventsCommand).rejects(new Error('EB down'));
 
-      const result = await invoke<MessageResult>(
-        makeEvent("sendMessage", {
-          projectId: "proj-1",
-          message: {
-            agentId: "agent-1",
-            message: "Hello",
-            messageType: "USER_INPUT",
-          },
-        }),
-      );
+      const result = await invoke<MessageResult>(makeEvent('sendMessage', {
+        projectId: 'proj-1',
+        message: {
+          agentId: 'agent-1',
+          message: 'Hello',
+          messageType: 'USER_INPUT',
+        },
+      }));
 
       // Should still return the message (stored in DDB)
       expect(result.id).toBeDefined();
     });
   });
 
-  describe("getConversationHistory", () => {
-    test("returns paginated messages sorted by timestamp", async () => {
-      dynamoMock.on(QueryCommand).resolves({
-        Items: [
-          {
-            id: "m1",
-            projectId: "proj-1",
-            message: "First",
-            timestamp: "2025-01-01T00:00:00Z",
-          },
-          {
-            id: "m2",
-            projectId: "proj-1",
-            message: "Second",
-            timestamp: "2025-01-01T00:01:00Z",
-          },
-        ],
-        // No LastEvaluatedKey -> nextToken should be null.
-      });
+  describe('getConversationHistory', () => {
+    test('returns paginated messages sorted by timestamp', async () => {
+          dynamoMock.on(QueryCommand).resolves({
+            Items: [
+              { id: 'm1', projectId: 'proj-1', message: 'First', timestamp: '2025-01-01T00:00:00Z' },
+              { id: 'm2', projectId: 'proj-1', message: 'Second', timestamp: '2025-01-01T00:01:00Z' },
+            ],
+            // No LastEvaluatedKey -> nextToken should be null.
+          });
+    
+          const result = await invoke<{ items: unknown[]; nextToken: string | null }>(
+            makeEvent('getConversationHistory', {
+              projectId: 'proj-1',
+            }),
+          );
+    
+          // Resolver now returns {items, nextToken} for cursor pagination.
+          expect(result.items).toHaveLength(2);
+          expect(result.nextToken).toBeNull();
+        });
+    
+        test('returns a nextToken when DynamoDB paginates', async () => {
+          dynamoMock.on(QueryCommand).resolves({
+            Items: [
+              { id: 'm1', projectId: 'proj-1', message: 'First', timestamp: '2025-01-01T00:00:00Z' },
+            ],
+            LastEvaluatedKey: { projectId: 'proj-1', timestamp: '2025-01-01T00:00:00Z' },
+          });
+    
+          const result = await invoke<{ items: unknown[]; nextToken: string }>(
+            makeEvent('getConversationHistory', {
+              projectId: 'proj-1',
+            }),
+          );
+    
+          expect(result.items).toHaveLength(1);
+          expect(typeof result.nextToken).toBe('string');
+          // nextToken is a base64-encoded JSON blob of the LastEvaluatedKey.
+          expect(JSON.parse(Buffer.from(result.nextToken, 'base64').toString())).toEqual({
+            projectId: 'proj-1',
+            timestamp: '2025-01-01T00:00:00Z',
+          });
+        });
 
-      const result = await invoke<{
-        items: unknown[];
-        nextToken: string | null;
-      }>(
-        makeEvent("getConversationHistory", {
-          projectId: "proj-1",
-        }),
-      );
-
-      // Resolver now returns {items, nextToken} for cursor pagination.
-      expect(result.items).toHaveLength(2);
-      expect(result.nextToken).toBeNull();
-    });
-
-    test("returns a nextToken when DynamoDB paginates", async () => {
-      dynamoMock.on(QueryCommand).resolves({
-        Items: [
-          {
-            id: "m1",
-            projectId: "proj-1",
-            message: "First",
-            timestamp: "2025-01-01T00:00:00Z",
-          },
-        ],
-        LastEvaluatedKey: {
-          projectId: "proj-1",
-          timestamp: "2025-01-01T00:00:00Z",
-        },
-      });
-
-      const result = await invoke<{ items: unknown[]; nextToken: string }>(
-        makeEvent("getConversationHistory", {
-          projectId: "proj-1",
-        }),
-      );
-
-      expect(result.items).toHaveLength(1);
-      expect(typeof result.nextToken).toBe("string");
-      // nextToken is a base64-encoded JSON blob of the LastEvaluatedKey.
-      expect(
-        JSON.parse(Buffer.from(result.nextToken, "base64").toString()),
-      ).toEqual({
-        projectId: "proj-1",
-        timestamp: "2025-01-01T00:00:00Z",
-      });
-    });
-
-    test("returns empty items list when no messages", async () => {
-      dynamoMock.on(QueryCommand).resolves({ Items: [] });
-
-      const result = await invoke<{
-        items: unknown[];
-        nextToken: string | null;
-      }>(
-        makeEvent("getConversationHistory", {
-          projectId: "proj-1",
-        }),
-      );
-
-      expect(result.items).toEqual([]);
-      expect(result.nextToken).toBeNull();
-    });
+    test('returns empty items list when no messages', async () => {
+          dynamoMock.on(QueryCommand).resolves({ Items: [] });
+    
+          const result = await invoke<{ items: unknown[]; nextToken: string | null }>(
+            makeEvent('getConversationHistory', {
+              projectId: 'proj-1',
+            }),
+          );
+    
+          expect(result.items).toEqual([]);
+          expect(result.nextToken).toBeNull();
+        });
   });
 
-  describe("sendMessageToAgent", () => {
-    test("converts to sendMessage format and stores", async () => {
+  describe('sendMessageToAgent', () => {
+    test('converts to sendMessage format and stores', async () => {
       dynamoMock.on(PutCommand).resolves({});
       eventBridgeMock.on(PutEventsCommand).resolves({});
 
-      const result = await invoke<MessageResult>(
-        makeEvent("sendMessageToAgent", {
-          projectId: "proj-1",
-          agentId: "agent-1",
-          message: "Direct message",
-        }),
-      );
+      const result = await invoke<MessageResult>(makeEvent('sendMessageToAgent', {
+        projectId: 'proj-1',
+        agentId: 'agent-1',
+        message: 'Direct message',
+      }));
 
       expect(result.id).toBeDefined();
-      expect(result.message).toBe("Direct message");
+      expect(result.message).toBe('Direct message');
     });
   });
 
-  describe("publishConversationMessage", () => {
-    test("returns the input as-is for subscription trigger", async () => {
+  describe('publishConversationMessage', () => {
+    test('returns the input as-is for subscription trigger', async () => {
       const input = {
-        id: "msg-1",
-        projectId: "proj-1",
-        agentId: "agent-1",
-        message: "Agent response",
-        messageType: "AGENT_RESPONSE",
-        timestamp: "2025-01-01T00:00:00Z",
+        id: 'msg-1',
+        projectId: 'proj-1',
+        agentId: 'agent-1',
+        message: 'Agent response',
+        messageType: 'AGENT_RESPONSE',
+        timestamp: '2025-01-01T00:00:00Z',
       };
 
-      const result = await handler(
-        makeEvent("publishConversationMessage", {
-          input,
-        }),
-      );
+      const result = await handler(makeEvent('publishConversationMessage', {
+        input,
+      }));
 
       expect(result).toEqual(input);
     });
   });
 
-  test("throws on unknown field", async () => {
-    await expect(handler(makeEvent("unknownField", {}))).rejects.toThrow(
-      "Unknown field",
-    );
-  });
-
-  describe("cross-tenant projectId is refused before any privileged operation", () => {
-    beforeEach(() => {
-      assertProjectAccessMock.mockRejectedValue(
-        new ProjectAccessDeniedError("Access denied"),
-      );
-    });
-
-    test("sendMessage: denies BEFORE storing to DynamoDB or dispatching to EventBridge (worst case — agent-dispatch injection)", async () => {
-      await expect(
-        handler(
-          makeEvent("sendMessage", {
-            projectId: "victim-proj",
-            message: {
-              agentId: "agent-1",
-              message: "malicious payload",
-              messageType: "USER_INPUT",
-            },
-          }),
-        ),
-      ).rejects.toThrow("Access denied");
-
-      expect(assertProjectAccessMock).toHaveBeenCalledWith(
-        "victim-proj",
-        "user-123",
-        expect.anything(),
-      );
-      expect(dynamoMock.commandCalls(PutCommand)).toHaveLength(0);
-      expect(eventBridgeMock.commandCalls(PutEventsCommand)).toHaveLength(0);
-    });
-
-    test("sendMessageToAgent: denies before storing or dispatching", async () => {
-      await expect(
-        handler(
-          makeEvent("sendMessageToAgent", {
-            projectId: "victim-proj",
-            agentId: "agent-1",
-            message: "malicious payload",
-          }),
-        ),
-      ).rejects.toThrow("Access denied");
-
-      expect(dynamoMock.commandCalls(PutCommand)).toHaveLength(0);
-      expect(eventBridgeMock.commandCalls(PutEventsCommand)).toHaveLength(0);
-    });
-
-    test("getConversationHistory: denies BEFORE any DynamoDB query read", async () => {
-      await expect(
-        handler(
-          makeEvent("getConversationHistory", { projectId: "victim-proj" }),
-        ),
-      ).rejects.toThrow("Access denied");
-
-      expect(dynamoMock.commandCalls(QueryCommand)).toHaveLength(0);
-    });
-  });
-
-  describe("publishConversationMessage (IAM-only internal path)", () => {
-    test("does not call the project-access gate — invoked by agent-message-handler under a field-scoped IAM policy, not end-user identity", async () => {
-      const input = {
-        id: "msg-1",
-        projectId: "proj-1",
-        agentId: "agent-1",
-        message: "Agent response",
-        messageType: "AGENT_RESPONSE",
-        timestamp: "2025-01-01T00:00:00Z",
-      };
-
-      const result = await handler(
-        makeEvent("publishConversationMessage", { input }),
-      );
-
-      expect(result).toEqual(input);
-      expect(assertProjectAccessMock).not.toHaveBeenCalled();
-    });
+  test('throws on unknown field', async () => {
+    await expect(
+      handler(makeEvent('unknownField', {}))
+    ).rejects.toThrow('Unknown field');
   });
 });

--- a/backend/src/lambda/__tests__/document-resolver.test.ts
+++ b/backend/src/lambda/__tests__/document-resolver.test.ts
@@ -1,0 +1,188 @@
+/**
+ * Tests for document-resolver Lambda
+ *
+ * Security fix for finding 60a5a6ae (CRE item 1): getProjectDocument,
+ * getDocumentVersion, listDocumentVersions, and generateDocumentPdf must
+ * reconcile the client-supplied projectId against the caller BEFORE any S3
+ * read, presign, or Lambda invocation (cross-tenant IDOR).
+ */
+import {
+  S3Client,
+  GetObjectCommand,
+  ListObjectVersionsCommand,
+} from "@aws-sdk/client-s3";
+import { LambdaClient, InvokeCommand } from "@aws-sdk/client-lambda";
+import { mockClient } from "aws-sdk-client-mock";
+
+const s3Mock = mockClient(S3Client);
+const lambdaMock = mockClient(LambdaClient);
+
+jest.mock("@aws-sdk/s3-request-presigner", () => ({
+  getSignedUrl: jest
+    .fn()
+    .mockResolvedValue("https://signed-url.example.com/doc.pdf"),
+}));
+
+jest.mock("../../utils/appsync", () => ({
+  getUserId: jest.fn().mockReturnValue("user-123"),
+}));
+
+const assertProjectAccessMock = jest.fn();
+jest.mock("../../utils/project-access", () => ({
+  assertProjectAccess: (...args: unknown[]) => assertProjectAccessMock(...args),
+  ProjectAccessDeniedError: class ProjectAccessDeniedError extends Error {},
+}));
+
+import { getSignedUrl } from "@aws-sdk/s3-request-presigner";
+import { handler } from "../document-resolver";
+import { ProjectAccessDeniedError } from "../../utils/project-access";
+
+type HandlerEvent = Parameters<typeof handler>[0];
+
+const invokeHandler = handler as (event: HandlerEvent) => Promise<unknown>;
+
+const makeEvent = (
+  fieldName: string,
+  args: Record<string, unknown>,
+): HandlerEvent =>
+  ({
+    info: { fieldName },
+    arguments: args,
+    identity: { sub: "user-123", username: "testuser" },
+  }) as unknown as HandlerEvent;
+
+describe("document-resolver", () => {
+  beforeEach(() => {
+    s3Mock.reset();
+    lambdaMock.reset();
+    assertProjectAccessMock.mockReset();
+    (getSignedUrl as jest.Mock).mockClear();
+    process.env.SESSION_BUCKET = "test-session-bucket";
+    process.env.PDF_GENERATOR_FUNCTION = "test-pdf-generator";
+  });
+
+  afterEach(() => {
+    delete process.env.SESSION_BUCKET;
+    delete process.env.PDF_GENERATOR_FUNCTION;
+  });
+
+  describe("cross-tenant projectId is refused before any privileged operation", () => {
+    beforeEach(() => {
+      assertProjectAccessMock.mockRejectedValue(
+        new ProjectAccessDeniedError("Access denied"),
+      );
+    });
+
+    test("getProjectDocument: denies and never calls S3", async () => {
+      await expect(
+        invokeHandler(
+          makeEvent("getProjectDocument", {
+            projectId: "victim-proj",
+            documentKey: "design.md",
+          }),
+        ),
+      ).rejects.toThrow("Access denied");
+
+      expect(assertProjectAccessMock).toHaveBeenCalledWith(
+        "victim-proj",
+        "user-123",
+        expect.anything(),
+      );
+      expect(s3Mock.commandCalls(GetObjectCommand)).toHaveLength(0);
+    });
+
+    test("getDocumentVersion: denies and never calls S3", async () => {
+      await expect(
+        invokeHandler(
+          makeEvent("getDocumentVersion", {
+            projectId: "victim-proj",
+            documentKey: "design.md",
+            versionId: "v1",
+          }),
+        ),
+      ).rejects.toThrow("Access denied");
+
+      expect(s3Mock.commandCalls(GetObjectCommand)).toHaveLength(0);
+    });
+
+    test("listDocumentVersions: denies and never calls S3", async () => {
+      await expect(
+        invokeHandler(
+          makeEvent("listDocumentVersions", {
+            projectId: "victim-proj",
+            documentKey: "design.md",
+          }),
+        ),
+      ).rejects.toThrow("Access denied");
+
+      expect(s3Mock.commandCalls(ListObjectVersionsCommand)).toHaveLength(0);
+    });
+
+    test("generateDocumentPdf: denies BEFORE any presign and before Lambda invoke (worst case — cross-tenant read + presigned URL mint)", async () => {
+      await expect(
+        invokeHandler(
+          makeEvent("generateDocumentPdf", {
+            projectId: "victim-proj",
+            documentKey: "design.md",
+          }),
+        ),
+      ).rejects.toThrow("Access denied");
+
+      // ZERO presign calls recorded — the acceptance criterion.
+      expect(getSignedUrl).toHaveBeenCalledTimes(0);
+      expect(lambdaMock.commandCalls(InvokeCommand)).toHaveLength(0);
+    });
+  });
+
+  describe("legitimate same-org access still works", () => {
+    beforeEach(() => {
+      assertProjectAccessMock.mockResolvedValue(undefined);
+    });
+
+    test("getProjectDocument returns document content", async () => {
+      s3Mock.on(GetObjectCommand).resolves({
+        Body: {
+          transformToString: async () => "file contents",
+        } as unknown as never,
+        VersionId: "v1",
+        LastModified: new Date("2026-01-01T00:00:00Z"),
+      });
+
+      const result = (await invokeHandler(
+        makeEvent("getProjectDocument", {
+          projectId: "my-proj",
+          documentKey: "design.md",
+        }),
+      )) as { content: string };
+
+      expect(result.content).toBe("file contents");
+      expect(assertProjectAccessMock).toHaveBeenCalledWith(
+        "my-proj",
+        "user-123",
+        expect.anything(),
+      );
+      expect(s3Mock.commandCalls(GetObjectCommand)).toHaveLength(1);
+    });
+
+    test("generateDocumentPdf returns a signed URL", async () => {
+      lambdaMock.on(InvokeCommand).resolves({});
+
+      const result = (await invokeHandler(
+        makeEvent("generateDocumentPdf", {
+          projectId: "my-proj",
+          documentKey: "design.md",
+        }),
+      )) as { url: string; expiresIn: number };
+
+      expect(result.url).toBe("https://signed-url.example.com/doc.pdf");
+      expect(getSignedUrl).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  test("throws on unknown field", async () => {
+    assertProjectAccessMock.mockResolvedValue(undefined);
+    await expect(invokeHandler(makeEvent("unknownField", {}))).rejects.toThrow(
+      "Unknown field",
+    );
+  });
+});

--- a/backend/src/lambda/__tests__/document-upload-resolver.test.ts
+++ b/backend/src/lambda/__tests__/document-upload-resolver.test.ts
@@ -1,30 +1,50 @@
 /**
  * Tests for document-upload-resolver Lambda
  */
-import { S3Client, ListObjectsV2Command } from '@aws-sdk/client-s3';
+import {
+  S3Client,
+  ListObjectsV2Command,
+  PutObjectCommand,
+  DeleteObjectCommand,
+} from "@aws-sdk/client-s3";
 import {
   BedrockAgentClient,
+  DeleteKnowledgeBaseDocumentsCommand,
   GetKnowledgeBaseDocumentsCommand,
   type GetKnowledgeBaseDocumentsCommandOutput,
-} from '@aws-sdk/client-bedrock-agent';
-import { SSMClient, GetParameterCommand } from '@aws-sdk/client-ssm';
-import { DynamoDBDocumentClient, QueryCommand, GetCommand } from '@aws-sdk/lib-dynamodb';
-import { mockClient } from 'aws-sdk-client-mock';
+} from "@aws-sdk/client-bedrock-agent";
+import { SSMClient, GetParameterCommand } from "@aws-sdk/client-ssm";
+import {
+  DynamoDBDocumentClient,
+  QueryCommand,
+  GetCommand,
+} from "@aws-sdk/lib-dynamodb";
+import { mockClient } from "aws-sdk-client-mock";
 
 const s3Mock = mockClient(S3Client);
 const bedrockMock = mockClient(BedrockAgentClient);
 const ssmMock = mockClient(SSMClient);
 const ddbMock = mockClient(DynamoDBDocumentClient);
 
-jest.mock('@aws-sdk/s3-request-presigner', () => ({
-  getSignedUrl: jest.fn().mockResolvedValue('https://signed-url.example.com/upload'),
+jest.mock("@aws-sdk/s3-request-presigner", () => ({
+  getSignedUrl: jest
+    .fn()
+    .mockResolvedValue("https://signed-url.example.com/upload"),
 }));
 
-jest.mock('../../utils/appsync', () => ({
-  getUserId: jest.fn().mockReturnValue('user-123'),
+jest.mock("../../utils/appsync", () => ({
+  getUserId: jest.fn().mockReturnValue("user-123"),
 }));
 
-import { handler } from '../document-upload-resolver';
+const assertProjectAccessMock = jest.fn();
+jest.mock("../../utils/project-access", () => ({
+  assertProjectAccess: (...args: unknown[]) => assertProjectAccessMock(...args),
+  ProjectAccessDeniedError: class ProjectAccessDeniedError extends Error {},
+}));
+
+import { getSignedUrl } from "@aws-sdk/s3-request-presigner";
+import { handler } from "../document-upload-resolver";
+import { ProjectAccessDeniedError } from "../../utils/project-access";
 
 type HandlerEvent = Parameters<typeof handler>[0];
 
@@ -58,21 +78,26 @@ async function invoke<T>(event: HandlerEvent): Promise<T> {
   return (await invokeHandler(event)) as T;
 }
 
-describe('document-upload-resolver', () => {
+describe("document-upload-resolver", () => {
   beforeEach(() => {
     s3Mock.reset();
     bedrockMock.reset();
     ssmMock.reset();
     ddbMock.reset();
-    process.env.DOCUMENT_BUCKET = 'test-docs-bucket';
-    process.env.KB_ID_PARAM = '/citadel/kb/id';
-    process.env.DS_ID_PARAM = '/citadel/ds/id';
-    process.env.EVENT_BUS_NAME = 'citadel-agents-test';
+    assertProjectAccessMock.mockReset();
+    assertProjectAccessMock.mockResolvedValue(undefined);
+    (getSignedUrl as jest.Mock).mockClear();
+    process.env.DOCUMENT_BUCKET = "test-docs-bucket";
+    process.env.KB_ID_PARAM = "/citadel/kb/id";
+    process.env.DS_ID_PARAM = "/citadel/ds/id";
+    process.env.EVENT_BUS_NAME = "citadel-agents-test";
     // INGESTION_TABLE is left unset by default so status reads fall back to the
     // KB query path; individual tests opt in to the jobs-table path.
     delete process.env.INGESTION_TABLE;
     // SSM resolves KB + DS ids (cached at module level after first call)
-    ssmMock.on(GetParameterCommand).resolves({ Parameter: { Value: 'kb-or-ds-id' } });
+    ssmMock
+      .on(GetParameterCommand)
+      .resolves({ Parameter: { Value: "kb-or-ds-id" } });
   });
 
   afterEach(() => {
@@ -83,221 +108,397 @@ describe('document-upload-resolver', () => {
     delete process.env.INGESTION_TABLE;
   });
 
-  const makeEvent = (fieldName: string, args: Record<string, unknown>): HandlerEvent =>
+  const makeEvent = (
+    fieldName: string,
+    args: Record<string, unknown>,
+  ): HandlerEvent =>
     ({
       info: { fieldName },
       arguments: args,
-      identity: { sub: 'user-123' },
+      identity: { sub: "user-123" },
     }) as unknown as HandlerEvent;
 
-  describe('generateDocumentUploadUrl', () => {
-    test('returns signed URL for valid PDF upload', async () => {
-      const result = await invoke<UploadUrlResult>(makeEvent('generateDocumentUploadUrl', {
-        input: {
-          projectId: 'proj-1',
-          fileName: 'report.pdf',
-          fileType: 'application/pdf',
-          fileSize: 1024,
-        },
-      }));
+  describe("generateDocumentUploadUrl", () => {
+    test("returns signed URL for valid PDF upload", async () => {
+      const result = await invoke<UploadUrlResult>(
+        makeEvent("generateDocumentUploadUrl", {
+          input: {
+            projectId: "proj-1",
+            fileName: "report.pdf",
+            fileType: "application/pdf",
+            fileSize: 1024,
+          },
+        }),
+      );
 
-      expect(result.uploadUrl).toBe('https://signed-url.example.com/upload');
-      expect(result.documentKey).toContain('proj-1');
+      expect(result.uploadUrl).toBe("https://signed-url.example.com/upload");
+      expect(result.documentKey).toContain("proj-1");
       expect(result.expiresIn).toBe(900);
     });
 
-    test('rejects files exceeding 10MB', async () => {
+    test("rejects files exceeding 10MB", async () => {
       await expect(
-        invokeHandler(makeEvent('generateDocumentUploadUrl', {
-          input: {
-            projectId: 'proj-1',
-            fileName: 'huge.pdf',
-            fileType: 'application/pdf',
-            fileSize: 11 * 1024 * 1024,
-          },
-        }))
-      ).rejects.toThrow('exceeds maximum');
+        invokeHandler(
+          makeEvent("generateDocumentUploadUrl", {
+            input: {
+              projectId: "proj-1",
+              fileName: "huge.pdf",
+              fileType: "application/pdf",
+              fileSize: 11 * 1024 * 1024,
+            },
+          }),
+        ),
+      ).rejects.toThrow("exceeds maximum");
     });
 
-    test('rejects unsupported file types', async () => {
+    test("rejects unsupported file types", async () => {
       await expect(
-        invokeHandler(makeEvent('generateDocumentUploadUrl', {
-          input: {
-            projectId: 'proj-1',
-            fileName: 'image.png',
-            fileType: 'image/png',
-            fileSize: 1024,
-          },
-        }))
-      ).rejects.toThrow('not allowed');
+        invokeHandler(
+          makeEvent("generateDocumentUploadUrl", {
+            input: {
+              projectId: "proj-1",
+              fileName: "image.png",
+              fileType: "image/png",
+              fileSize: 1024,
+            },
+          }),
+        ),
+      ).rejects.toThrow("not allowed");
     });
 
-    test('accepts DOCX files', async () => {
-      const result = await invoke<UploadUrlResult>(makeEvent('generateDocumentUploadUrl', {
-        input: {
-          projectId: 'proj-1',
-          fileName: 'doc.docx',
-          fileType: 'application/vnd.openxmlformats-officedocument.wordprocessingml.document',
-          fileSize: 2048,
-        },
-      }));
+    test("accepts DOCX files", async () => {
+      const result = await invoke<UploadUrlResult>(
+        makeEvent("generateDocumentUploadUrl", {
+          input: {
+            projectId: "proj-1",
+            fileName: "doc.docx",
+            fileType:
+              "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
+            fileSize: 2048,
+          },
+        }),
+      );
 
       expect(result.uploadUrl).toBeDefined();
     });
 
-    test('accepts TXT files', async () => {
-      const result = await invoke<UploadUrlResult>(makeEvent('generateDocumentUploadUrl', {
-        input: {
-          projectId: 'proj-1',
-          fileName: 'notes.txt',
-          fileType: 'text/plain',
-          fileSize: 512,
-        },
-      }));
+    test("accepts TXT files", async () => {
+      const result = await invoke<UploadUrlResult>(
+        makeEvent("generateDocumentUploadUrl", {
+          input: {
+            projectId: "proj-1",
+            fileName: "notes.txt",
+            fileType: "text/plain",
+            fileSize: 512,
+          },
+        }),
+      );
 
       expect(result.uploadUrl).toBeDefined();
     });
 
-    test('accepts Markdown files', async () => {
-      const result = await invoke<UploadUrlResult>(makeEvent('generateDocumentUploadUrl', {
-        input: {
-          projectId: 'proj-1',
-          fileName: 'readme.md',
-          fileType: 'text/markdown',
-          fileSize: 256,
-        },
-      }));
+    test("accepts Markdown files", async () => {
+      const result = await invoke<UploadUrlResult>(
+        makeEvent("generateDocumentUploadUrl", {
+          input: {
+            projectId: "proj-1",
+            fileName: "readme.md",
+            fileType: "text/markdown",
+            fileSize: 256,
+          },
+        }),
+      );
 
       expect(result.uploadUrl).toBeDefined();
     });
   });
 
-  describe('retired client-side ingestion fields', () => {
-    test('ingestDocument is no longer a handled field', async () => {
+  describe("retired client-side ingestion fields", () => {
+    test("ingestDocument is no longer a handled field", async () => {
       await expect(
-        invokeHandler(makeEvent('ingestDocument', {
-          projectId: 'proj-1',
-          documentKey: 'proj-1/a.pdf',
-        }))
-      ).rejects.toThrow('Unknown field');
+        invokeHandler(
+          makeEvent("ingestDocument", {
+            projectId: "proj-1",
+            documentKey: "proj-1/a.pdf",
+          }),
+        ),
+      ).rejects.toThrow("Unknown field");
     });
 
-    test('notifyDocumentReady is no longer a handled field', async () => {
+    test("notifyDocumentReady is no longer a handled field", async () => {
       await expect(
-        invokeHandler(makeEvent('notifyDocumentReady', {
-          projectId: 'proj-1',
-          documentKey: 'proj-1/a.pdf',
-          fileName: 'a.pdf',
-          fileSize: 2048,
-          fileType: 'application/pdf',
-        }))
-      ).rejects.toThrow('Unknown field');
+        invokeHandler(
+          makeEvent("notifyDocumentReady", {
+            projectId: "proj-1",
+            documentKey: "proj-1/a.pdf",
+            fileName: "a.pdf",
+            fileSize: 2048,
+            fileType: "application/pdf",
+          }),
+        ),
+      ).rejects.toThrow("Unknown field");
     });
   });
 
-  describe('listProjectDocuments', () => {
-    test('reads ingestion status from the jobs table when INGESTION_TABLE is set', async () => {
-      process.env.INGESTION_TABLE = 'citadel-document-ingestion-test';
+  describe("listProjectDocuments", () => {
+    test("reads ingestion status from the jobs table when INGESTION_TABLE is set", async () => {
+      process.env.INGESTION_TABLE = "citadel-document-ingestion-test";
       s3Mock.on(ListObjectsV2Command).resolves({
         Contents: [
-          { Key: 'proj-1/a.pdf', Size: 100, LastModified: new Date('2026-01-01T00:00:00Z') },
-          { Key: 'proj-1/b.pdf', Size: 200, LastModified: new Date('2026-01-02T00:00:00Z') },
+          {
+            Key: "proj-1/a.pdf",
+            Size: 100,
+            LastModified: new Date("2026-01-01T00:00:00Z"),
+          },
+          {
+            Key: "proj-1/b.pdf",
+            Size: 200,
+            LastModified: new Date("2026-01-02T00:00:00Z"),
+          },
         ],
       });
       ddbMock.on(QueryCommand).resolves({
         Items: [
-          { projectId: 'proj-1', documentKey: 'proj-1/a.pdf', status: 'INDEXED' },
-          { projectId: 'proj-1', documentKey: 'proj-1/b.pdf', status: 'FAILED', statusReason: 'oops' },
+          {
+            projectId: "proj-1",
+            documentKey: "proj-1/a.pdf",
+            status: "INDEXED",
+          },
+          {
+            projectId: "proj-1",
+            documentKey: "proj-1/b.pdf",
+            status: "FAILED",
+            statusReason: "oops",
+          },
         ],
       });
 
       const result = await invoke<ProjectDocumentResult[]>(
-        makeEvent('listProjectDocuments', { projectId: 'proj-1' }),
+        makeEvent("listProjectDocuments", { projectId: "proj-1" }),
       );
 
       expect(result).toHaveLength(2);
-      const a = result.find((r) => r.documentKey === 'proj-1/a.pdf');
-      const b = result.find((r) => r.documentKey === 'proj-1/b.pdf');
-      expect(a!.status).toBe('INDEXED');
-      expect(b!.status).toBe('FAILED');
-      expect(b!.statusReason).toBe('oops');
+      const a = result.find((r) => r.documentKey === "proj-1/a.pdf");
+      const b = result.find((r) => r.documentKey === "proj-1/b.pdf");
+      expect(a!.status).toBe("INDEXED");
+      expect(b!.status).toBe("FAILED");
+      expect(b!.statusReason).toBe("oops");
       // Source of truth is the table — no KB query needed.
-      expect(bedrockMock.commandCalls(GetKnowledgeBaseDocumentsCommand)).toHaveLength(0);
+      expect(
+        bedrockMock.commandCalls(GetKnowledgeBaseDocumentsCommand),
+      ).toHaveLength(0);
     });
 
-    test('falls back to the KB query when the jobs-table read fails', async () => {
-      process.env.INGESTION_TABLE = 'citadel-document-ingestion-test';
-      const errorSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+    test("falls back to the KB query when the jobs-table read fails", async () => {
+      process.env.INGESTION_TABLE = "citadel-document-ingestion-test";
+      const errorSpy = jest
+        .spyOn(console, "error")
+        .mockImplementation(() => {});
       s3Mock.on(ListObjectsV2Command).resolves({
-        Contents: [{ Key: 'proj-1/a.pdf', Size: 100, LastModified: new Date('2026-01-01T00:00:00Z') }],
+        Contents: [
+          {
+            Key: "proj-1/a.pdf",
+            Size: 100,
+            LastModified: new Date("2026-01-01T00:00:00Z"),
+          },
+        ],
       });
-      ddbMock.on(QueryCommand).rejects(new Error('table unavailable'));
+      ddbMock.on(QueryCommand).rejects(new Error("table unavailable"));
       bedrockMock.on(GetKnowledgeBaseDocumentsCommand).resolves({
-        documentDetails: [{ status: 'INDEXED', identifier: { custom: { id: 'proj-1/a.pdf' } } }],
+        documentDetails: [
+          { status: "INDEXED", identifier: { custom: { id: "proj-1/a.pdf" } } },
+        ],
       } as unknown as GetKnowledgeBaseDocumentsCommandOutput);
 
       const result = await invoke<ProjectDocumentResult[]>(
-        makeEvent('listProjectDocuments', { projectId: 'proj-1' }),
+        makeEvent("listProjectDocuments", { projectId: "proj-1" }),
       );
 
       expect(result).toHaveLength(1);
-      expect(result[0].status).toBe('INDEXED');
+      expect(result[0].status).toBe("INDEXED");
       expect(errorSpy).toHaveBeenCalled();
       errorSpy.mockRestore();
     });
 
-    test('degrades to UNKNOWN (does not throw) when both table and KB fail', async () => {
-      const errorSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+    test("degrades to UNKNOWN (does not throw) when both table and KB fail", async () => {
+      const errorSpy = jest
+        .spyOn(console, "error")
+        .mockImplementation(() => {});
       // INGESTION_TABLE unset -> straight to KB fallback, which also fails.
       s3Mock.on(ListObjectsV2Command).resolves({
-        Contents: [{ Key: 'proj-1/a.pdf', Size: 100, LastModified: new Date('2026-01-01T00:00:00Z') }],
+        Contents: [
+          {
+            Key: "proj-1/a.pdf",
+            Size: 100,
+            LastModified: new Date("2026-01-01T00:00:00Z"),
+          },
+        ],
       });
-      bedrockMock.on(GetKnowledgeBaseDocumentsCommand).rejects(new Error('throttled'));
+      bedrockMock
+        .on(GetKnowledgeBaseDocumentsCommand)
+        .rejects(new Error("throttled"));
 
       const result = await invoke<ProjectDocumentResult[]>(
-        makeEvent('listProjectDocuments', { projectId: 'proj-1' }),
+        makeEvent("listProjectDocuments", { projectId: "proj-1" }),
       );
 
       expect(result).toHaveLength(1);
-      expect(result[0].status).toBe('UNKNOWN');
+      expect(result[0].status).toBe("UNKNOWN");
       expect(errorSpy).toHaveBeenCalled();
       errorSpy.mockRestore();
     });
   });
 
-  describe('getDocumentIngestionStatus', () => {
-    test('reads the jobs table as source of truth', async () => {
-      process.env.INGESTION_TABLE = 'citadel-document-ingestion-test';
+  describe("getDocumentIngestionStatus", () => {
+    test("reads the jobs table as source of truth", async () => {
+      process.env.INGESTION_TABLE = "citadel-document-ingestion-test";
       ddbMock.on(GetCommand).resolves({
-        Item: { projectId: 'proj-1', documentKey: 'proj-1/a.pdf', status: 'INDEXED', updatedAt: '2026-01-01T00:00:00Z' },
+        Item: {
+          projectId: "proj-1",
+          documentKey: "proj-1/a.pdf",
+          status: "INDEXED",
+          updatedAt: "2026-01-01T00:00:00Z",
+        },
       });
 
       const result = await invoke<IngestionStatusResult>(
-        makeEvent('getDocumentIngestionStatus', { documentKey: 'proj-1/a.pdf' }),
+        makeEvent("getDocumentIngestionStatus", {
+          documentKey: "proj-1/a.pdf",
+        }),
       );
 
-      expect(result.status).toBe('INDEXED');
-      expect(bedrockMock.commandCalls(GetKnowledgeBaseDocumentsCommand)).toHaveLength(0);
+      expect(result.status).toBe("INDEXED");
+      expect(
+        bedrockMock.commandCalls(GetKnowledgeBaseDocumentsCommand),
+      ).toHaveLength(0);
     });
 
-    test('falls back to the KB query when the row is absent', async () => {
-      process.env.INGESTION_TABLE = 'citadel-document-ingestion-test';
+    test("falls back to the KB query when the row is absent", async () => {
+      process.env.INGESTION_TABLE = "citadel-document-ingestion-test";
       ddbMock.on(GetCommand).resolves({ Item: undefined });
       bedrockMock.on(GetKnowledgeBaseDocumentsCommand).resolves({
-        documentDetails: [{ status: 'PARTIALLY_INDEXED', identifier: { custom: { id: 'proj-1/a.pdf' } } }],
+        documentDetails: [
+          {
+            status: "PARTIALLY_INDEXED",
+            identifier: { custom: { id: "proj-1/a.pdf" } },
+          },
+        ],
       } as unknown as GetKnowledgeBaseDocumentsCommandOutput);
 
       const result = await invoke<IngestionStatusResult>(
-        makeEvent('getDocumentIngestionStatus', { documentKey: 'proj-1/a.pdf' }),
+        makeEvent("getDocumentIngestionStatus", {
+          documentKey: "proj-1/a.pdf",
+        }),
       );
 
-      expect(result.status).toBe('PARTIALLY_INDEXED');
+      expect(result.status).toBe("PARTIALLY_INDEXED");
     });
   });
 
-  test('throws on unknown field', async () => {
-    await expect(
-      invokeHandler(makeEvent('unknownField', {}))
-    ).rejects.toThrow('Unknown field');
+  test("throws on unknown field", async () => {
+    await expect(invokeHandler(makeEvent("unknownField", {}))).rejects.toThrow(
+      "Unknown field",
+    );
+  });
+
+  describe("cross-tenant projectId is refused before any privileged operation", () => {
+    beforeEach(() => {
+      assertProjectAccessMock.mockRejectedValue(
+        new ProjectAccessDeniedError("Access denied"),
+      );
+    });
+
+    test("generateDocumentUploadUrl (upload, worst case — cross-tenant WRITE): denies BEFORE any presign", async () => {
+      await expect(
+        invokeHandler(
+          makeEvent("generateDocumentUploadUrl", {
+            input: {
+              projectId: "victim-proj",
+              fileName: "report.pdf",
+              fileType: "application/pdf",
+              fileSize: 1024,
+            },
+          }),
+        ),
+      ).rejects.toThrow("Access denied");
+
+      expect(assertProjectAccessMock).toHaveBeenCalledWith(
+        "victim-proj",
+        "user-123",
+        expect.anything(),
+      );
+      // ZERO presign calls recorded — the acceptance criterion for the worst-case write path.
+      expect(getSignedUrl).toHaveBeenCalledTimes(0);
+      expect(s3Mock.commandCalls(PutObjectCommand)).toHaveLength(0);
+    });
+
+    test("listProjectDocuments: denies and never lists S3", async () => {
+      await expect(
+        invokeHandler(
+          makeEvent("listProjectDocuments", { projectId: "victim-proj" }),
+        ),
+      ).rejects.toThrow("Access denied");
+
+      expect(s3Mock.commandCalls(ListObjectsV2Command)).toHaveLength(0);
+    });
+
+    test("getDocumentIngestionStatus: denies and never reads DynamoDB/KB", async () => {
+      await expect(
+        invokeHandler(
+          makeEvent("getDocumentIngestionStatus", {
+            projectId: "victim-proj",
+            documentKey: "victim-proj/a.pdf",
+          }),
+        ),
+      ).rejects.toThrow("Access denied");
+
+      expect(ddbMock.commandCalls(GetCommand)).toHaveLength(0);
+      expect(
+        bedrockMock.commandCalls(GetKnowledgeBaseDocumentsCommand),
+      ).toHaveLength(0);
+    });
+
+    test("deleteDocument: denies BEFORE deleting from KB or S3 (destructive op)", async () => {
+      await expect(
+        invokeHandler(
+          makeEvent("deleteDocument", {
+            projectId: "victim-proj",
+            documentKey: "victim-proj/a.pdf",
+          }),
+        ),
+      ).rejects.toThrow("Access denied");
+
+      expect(
+        bedrockMock.commandCalls(DeleteKnowledgeBaseDocumentsCommand),
+      ).toHaveLength(0);
+      expect(s3Mock.commandCalls(DeleteObjectCommand)).toHaveLength(0);
+    });
+  });
+
+  describe("legitimate same-org access still works", () => {
+    beforeEach(() => {
+      assertProjectAccessMock.mockResolvedValue(undefined);
+    });
+
+    test("generateDocumentUploadUrl succeeds and reconciles projectId first", async () => {
+      const result = await invoke<UploadUrlResult>(
+        makeEvent("generateDocumentUploadUrl", {
+          input: {
+            projectId: "my-proj",
+            fileName: "report.pdf",
+            fileType: "application/pdf",
+            fileSize: 1024,
+          },
+        }),
+      );
+
+      expect(result.uploadUrl).toBe("https://signed-url.example.com/upload");
+      expect(assertProjectAccessMock).toHaveBeenCalledWith(
+        "my-proj",
+        "user-123",
+        expect.anything(),
+      );
+      expect(getSignedUrl).toHaveBeenCalledTimes(1);
+    });
   });
 });

--- a/backend/src/lambda/__tests__/run-id-client-strip.test.ts
+++ b/backend/src/lambda/__tests__/run-id-client-strip.test.ts
@@ -133,19 +133,11 @@ describe("runId client-strip — chat message (conversation-resolver sendMessage
   beforeEach(() => {
     process.env.CONVERSATIONS_TABLE = "test-conversations";
     process.env.EVENT_BUS_NAME = "test-event-bus";
-    process.env.PROJECTS_TABLE = "test-projects";
-    // sendMessage now reconciles projectId against the caller (finding
-    // 60a5a6ae, CRE item 1) — this test is about runId stripping, not
-    // access control, so satisfy the gate with an owner match.
-    ddbMock.on(GetCommand).resolves({
-      Item: { owner: "user-123", organization: "org-1" },
-    });
   });
 
   afterEach(() => {
     delete process.env.CONVERSATIONS_TABLE;
     delete process.env.EVENT_BUS_NAME;
-    delete process.env.PROJECTS_TABLE;
   });
 
   test("ignores a client-supplied runId planted in the message input and mints a fresh one", async () => {

--- a/backend/src/lambda/__tests__/run-id-client-strip.test.ts
+++ b/backend/src/lambda/__tests__/run-id-client-strip.test.ts
@@ -133,11 +133,19 @@ describe("runId client-strip — chat message (conversation-resolver sendMessage
   beforeEach(() => {
     process.env.CONVERSATIONS_TABLE = "test-conversations";
     process.env.EVENT_BUS_NAME = "test-event-bus";
+    process.env.PROJECTS_TABLE = "test-projects";
+    // sendMessage now reconciles projectId against the caller (finding
+    // 60a5a6ae, CRE item 1) — this test is about runId stripping, not
+    // access control, so satisfy the gate with an owner match.
+    ddbMock.on(GetCommand).resolves({
+      Item: { owner: "user-123", organization: "org-1" },
+    });
   });
 
   afterEach(() => {
     delete process.env.CONVERSATIONS_TABLE;
     delete process.env.EVENT_BUS_NAME;
+    delete process.env.PROJECTS_TABLE;
   });
 
   test("ignores a client-supplied runId planted in the message input and mints a fresh one", async () => {

--- a/backend/src/lambda/conversation-resolver.ts
+++ b/backend/src/lambda/conversation-resolver.ts
@@ -15,7 +15,6 @@ import {
 } from "@aws-sdk/client-eventbridge";
 import { v4 as uuidv4 } from "uuid";
 import { mintRunId, buildDispatchContext } from "../utils/run-id";
-import { assertProjectAccess } from "../utils/project-access";
 
 const dynamoClient = new DynamoDBClient({});
 const docClient = DynamoDBDocumentClient.from(dynamoClient);
@@ -53,14 +52,6 @@ interface AppSyncEvent {
 async function sendMessage(event: AppSyncEvent) {
   const { projectId, message } = event.arguments;
   const userId = event.identity.sub;
-
-  // Security fix (finding 60a5a6ae, CRE item 1): projectId is client-supplied
-  // and drives both the DynamoDB write and the EventBridge dispatch that
-  // triggers another tenant's agents (prompt/message injection). Reconcile
-  // it against the caller BEFORE any write — reusing the same gate
-  // project-resolver.ts's getProject enforces. Fail closed on any
-  // identity/lookup failure.
-  await assertProjectAccess(projectId, userId, event);
 
   console.log("Sending message:", {
     projectId,
@@ -167,13 +158,6 @@ async function getConversationHistory(event: AppSyncEvent) {
     limit?: number;
     nextToken?: string;
   };
-  const userId = event.identity.sub;
-
-  // Security fix (finding 60a5a6ae, CRE item 1): projectId is client-supplied
-  // and drives the DynamoDB query — reconcile it against the caller BEFORE
-  // any read (cross-tenant conversation disclosure otherwise). Reuses the
-  // same gate as sendMessage.
-  await assertProjectAccess(projectId, userId, event);
 
   console.log("Getting conversation history for project:", projectId);
 

--- a/backend/src/lambda/conversation-resolver.ts
+++ b/backend/src/lambda/conversation-resolver.ts
@@ -15,6 +15,7 @@ import {
 } from "@aws-sdk/client-eventbridge";
 import { v4 as uuidv4 } from "uuid";
 import { mintRunId, buildDispatchContext } from "../utils/run-id";
+import { assertProjectAccess } from "../utils/project-access";
 
 const dynamoClient = new DynamoDBClient({});
 const docClient = DynamoDBDocumentClient.from(dynamoClient);
@@ -52,6 +53,14 @@ interface AppSyncEvent {
 async function sendMessage(event: AppSyncEvent) {
   const { projectId, message } = event.arguments;
   const userId = event.identity.sub;
+
+  // Security fix (finding 60a5a6ae, CRE item 1): projectId is client-supplied
+  // and drives both the DynamoDB write and the EventBridge dispatch that
+  // triggers another tenant's agents (prompt/message injection). Reconcile
+  // it against the caller BEFORE any write — reusing the same gate
+  // project-resolver.ts's getProject enforces. Fail closed on any
+  // identity/lookup failure.
+  await assertProjectAccess(projectId, userId, event);
 
   console.log("Sending message:", {
     projectId,
@@ -158,6 +167,13 @@ async function getConversationHistory(event: AppSyncEvent) {
     limit?: number;
     nextToken?: string;
   };
+  const userId = event.identity.sub;
+
+  // Security fix (finding 60a5a6ae, CRE item 1): projectId is client-supplied
+  // and drives the DynamoDB query — reconcile it against the caller BEFORE
+  // any read (cross-tenant conversation disclosure otherwise). Reuses the
+  // same gate as sendMessage.
+  await assertProjectAccess(projectId, userId, event);
 
   console.log("Getting conversation history for project:", projectId);
 

--- a/backend/src/lambda/document-resolver.ts
+++ b/backend/src/lambda/document-resolver.ts
@@ -4,9 +4,15 @@
  */
 
 import { AppSyncResolverHandler } from "aws-lambda";
-import { S3Client, GetObjectCommand, ListObjectVersionsCommand } from "@aws-sdk/client-s3";
+import {
+  S3Client,
+  GetObjectCommand,
+  ListObjectVersionsCommand,
+} from "@aws-sdk/client-s3";
 import { getSignedUrl } from "@aws-sdk/s3-request-presigner";
 import { LambdaClient, InvokeCommand } from "@aws-sdk/client-lambda";
+import { getUserId } from "../utils/appsync";
+import { assertProjectAccess } from "../utils/project-access";
 
 const s3 = new S3Client({});
 const lambda = new LambdaClient({});
@@ -18,7 +24,11 @@ function s3Key(projectId: string, documentKey: string): string {
   return `${projectId}/${documentKey}`;
 }
 
-async function getProjectDocument(projectId: string, documentKey: string, versionId?: string) {
+async function getProjectDocument(
+  projectId: string,
+  documentKey: string,
+  versionId?: string,
+) {
   const cmd = new GetObjectCommand({
     Bucket: SESSION_BUCKET,
     Key: s3Key(projectId, documentKey),
@@ -48,29 +58,42 @@ async function listDocumentVersions(projectId: string, documentKey: string) {
   }));
 }
 
-async function generateDocumentPdf(projectId: string, documentKey: string): Promise<{ url: string; expiresIn: number }> {
+async function generateDocumentPdf(
+  projectId: string,
+  documentKey: string,
+): Promise<{ url: string; expiresIn: number }> {
   const key = s3Key(projectId, documentKey);
   const pdfKey = key.replace(/\.md$/, ".pdf");
 
   // Invoke PDF generator synchronously
-  await lambda.send(new InvokeCommand({
-    FunctionName: PDF_GENERATOR_FUNCTION,
-    InvocationType: "RequestResponse",
-    Payload: Buffer.from(JSON.stringify({
-      Records: [{
-        s3: {
-          bucket: { name: SESSION_BUCKET },
-          object: { key },
-        },
-      }],
-    })),
-  }));
+  await lambda.send(
+    new InvokeCommand({
+      FunctionName: PDF_GENERATOR_FUNCTION,
+      InvocationType: "RequestResponse",
+      Payload: Buffer.from(
+        JSON.stringify({
+          Records: [
+            {
+              s3: {
+                bucket: { name: SESSION_BUCKET },
+                object: { key },
+              },
+            },
+          ],
+        }),
+      ),
+    }),
+  );
 
   // Return presigned URL to the generated PDF
-  const url = await getSignedUrl(s3, new GetObjectCommand({
-    Bucket: SESSION_BUCKET,
-    Key: pdfKey,
-  }), { expiresIn: 900 });
+  const url = await getSignedUrl(
+    s3,
+    new GetObjectCommand({
+      Bucket: SESSION_BUCKET,
+      Key: pdfKey,
+    }),
+    { expiresIn: 900 },
+  );
 
   return { url, expiresIn: 900 };
 }
@@ -82,11 +105,31 @@ interface DocumentResolverArguments {
   versionId?: string;
 }
 
-export const handler: AppSyncResolverHandler<DocumentResolverArguments, unknown> = async (event) => {
-  const { info, arguments: args } = event;
+export const handler: AppSyncResolverHandler<
+  DocumentResolverArguments,
+  unknown
+> = async (event) => {
+  const { info, arguments: args, identity } = event;
   const { projectId, documentKey, versionId } = args;
+  const fieldName = info.fieldName;
 
-  switch (info.fieldName) {
+  // Security fix (finding 60a5a6ae, CRE item 1): projectId is client-supplied
+  // and used to build every S3 key in this resolver. Reconcile it against
+  // the caller BEFORE any S3 read, presign, or Lambda invocation — reusing
+  // the same gate project-resolver.ts's getProject already enforces. Fail
+  // closed on any identity/lookup failure.
+  const knownFields = new Set([
+    "getProjectDocument",
+    "getDocumentVersion",
+    "listDocumentVersions",
+    "generateDocumentPdf",
+  ]);
+  if (knownFields.has(fieldName)) {
+    const userId = getUserId(identity);
+    await assertProjectAccess(projectId, userId, event);
+  }
+
+  switch (fieldName) {
     case "getProjectDocument":
       return getProjectDocument(projectId, documentKey);
     case "getDocumentVersion":
@@ -96,6 +139,6 @@ export const handler: AppSyncResolverHandler<DocumentResolverArguments, unknown>
     case "generateDocumentPdf":
       return generateDocumentPdf(projectId, documentKey);
     default:
-      throw new Error(`Unknown field: ${info.fieldName}`);
+      throw new Error(`Unknown field: ${fieldName}`);
   }
 };

--- a/backend/src/lambda/document-upload-resolver.ts
+++ b/backend/src/lambda/document-upload-resolver.ts
@@ -10,16 +10,26 @@
  */
 
 import { AppSyncResolverHandler } from "aws-lambda";
-import { S3Client, PutObjectCommand, DeleteObjectCommand, ListObjectsV2Command } from "@aws-sdk/client-s3";
-import { getSignedUrl } from "@aws-sdk/s3-request-presigner";
-import { BedrockAgentClient, DeleteKnowledgeBaseDocumentsCommand } from "@aws-sdk/client-bedrock-agent";
-import { DynamoDBClient } from "@aws-sdk/client-dynamodb";
-import { DynamoDBDocumentClient, GetCommand, QueryCommand } from "@aws-sdk/lib-dynamodb";
-import { getUserId } from "../utils/appsync";
 import {
-  getKbIds,
-  pollStatuses,
-} from "./document-ingestion-shared";
+  S3Client,
+  PutObjectCommand,
+  DeleteObjectCommand,
+  ListObjectsV2Command,
+} from "@aws-sdk/client-s3";
+import { getSignedUrl } from "@aws-sdk/s3-request-presigner";
+import {
+  BedrockAgentClient,
+  DeleteKnowledgeBaseDocumentsCommand,
+} from "@aws-sdk/client-bedrock-agent";
+import { DynamoDBClient } from "@aws-sdk/client-dynamodb";
+import {
+  DynamoDBDocumentClient,
+  GetCommand,
+  QueryCommand,
+} from "@aws-sdk/lib-dynamodb";
+import { getUserId } from "../utils/appsync";
+import { assertProjectAccess } from "../utils/project-access";
+import { getKbIds, pollStatuses } from "./document-ingestion-shared";
 
 const s3Client = new S3Client({});
 const bedrockAgentClient = new BedrockAgentClient({});
@@ -44,7 +54,7 @@ interface UploadUrlResponse {
  */
 async function generateUploadUrl(
   input: GenerateUploadUrlInput,
-  userId: string
+  userId: string,
 ): Promise<UploadUrlResponse> {
   const { projectId, fileName, fileType, fileSize } = input;
 
@@ -52,7 +62,7 @@ async function generateUploadUrl(
   const maxSize = 10 * 1024 * 1024; // 10MB
   if (fileSize > maxSize) {
     throw new Error(
-      `File size ${fileSize} exceeds maximum allowed size of ${maxSize} bytes (10MB)`
+      `File size ${fileSize} exceeds maximum allowed size of ${maxSize} bytes (10MB)`,
     );
   }
 
@@ -66,7 +76,7 @@ async function generateUploadUrl(
 
   if (!allowedTypes.includes(fileType)) {
     throw new Error(
-      `File type ${fileType} is not allowed. Supported types: PDF, DOCX, TXT, MD`
+      `File type ${fileType} is not allowed. Supported types: PDF, DOCX, TXT, MD`,
     );
   }
 
@@ -124,7 +134,9 @@ interface ProjectDocument {
 }
 
 /** Read jobs rows for a project keyed by documentKey. Throws on table errors. */
-async function readJobsForProject(projectId: string): Promise<Map<string, { status: string; statusReason?: string }>> {
+async function readJobsForProject(
+  projectId: string,
+): Promise<Map<string, { status: string; statusReason?: string }>> {
   const tableName = process.env.INGESTION_TABLE;
   const map = new Map<string, { status: string; statusReason?: string }>();
   if (!tableName) {
@@ -134,14 +146,24 @@ async function readJobsForProject(projectId: string): Promise<Map<string, { stat
   }
   let nextToken: Record<string, unknown> | undefined;
   do {
-    const resp = await ddb.send(new QueryCommand({
-      TableName: tableName,
-      KeyConditionExpression: "projectId = :pid",
-      ExpressionAttributeValues: { ":pid": projectId },
-      ExclusiveStartKey: nextToken,
-    }));
-    for (const item of (resp.Items ?? []) as Array<{ documentKey?: string; status?: string; statusReason?: string }>) {
-      if (item.documentKey) map.set(item.documentKey, { status: item.status ?? "UNKNOWN", statusReason: item.statusReason });
+    const resp = await ddb.send(
+      new QueryCommand({
+        TableName: tableName,
+        KeyConditionExpression: "projectId = :pid",
+        ExpressionAttributeValues: { ":pid": projectId },
+        ExclusiveStartKey: nextToken,
+      }),
+    );
+    for (const item of (resp.Items ?? []) as Array<{
+      documentKey?: string;
+      status?: string;
+      statusReason?: string;
+    }>) {
+      if (item.documentKey)
+        map.set(item.documentKey, {
+          status: item.status ?? "UNKNOWN",
+          statusReason: item.statusReason,
+        });
     }
     nextToken = resp.LastEvaluatedKey;
   } while (nextToken);
@@ -153,13 +175,20 @@ async function readJobsForProject(projectId: string): Promise<Map<string, { stat
  * truth for ingestion status; on any table read failure we degrade gracefully
  * to a direct Bedrock KB query (never failing the whole list).
  */
-async function listProjectDocuments(projectId: string): Promise<ProjectDocument[]> {
-  const response = await s3Client.send(new ListObjectsV2Command({ Bucket: DOCUMENT_BUCKET, Prefix: `${projectId}/` }));
+async function listProjectDocuments(
+  projectId: string,
+): Promise<ProjectDocument[]> {
+  const response = await s3Client.send(
+    new ListObjectsV2Command({
+      Bucket: DOCUMENT_BUCKET,
+      Prefix: `${projectId}/`,
+    }),
+  );
   const items: ProjectDocument[] = (response.Contents || []).map((obj) => ({
     documentKey: obj.Key!,
-    fileName: obj.Key!.split('/').slice(1).join('/'),
+    fileName: obj.Key!.split("/").slice(1).join("/"),
     size: obj.Size ?? 0,
-    lastModified: obj.LastModified?.toISOString() ?? '',
+    lastModified: obj.LastModified?.toISOString() ?? "",
     status: undefined,
     statusReason: undefined,
   }));
@@ -171,10 +200,17 @@ async function listProjectDocuments(projectId: string): Promise<ProjectDocument[
     const jobs = await readJobsForProject(projectId);
     return items.map((item) => {
       const j = jobs.get(item.documentKey);
-      return { ...item, status: j?.status ?? 'NOT_FOUND', statusReason: j?.statusReason };
+      return {
+        ...item,
+        status: j?.status ?? "NOT_FOUND",
+        statusReason: j?.statusReason,
+      };
     });
   } catch (tableErr) {
-    console.error('listProjectDocuments: jobs-table read failed, falling back to KB query', tableErr);
+    console.error(
+      "listProjectDocuments: jobs-table read failed, falling back to KB query",
+      tableErr,
+    );
   }
 
   // Fallback path: direct Bedrock KB query (chunked <=10 inside pollStatuses).
@@ -182,11 +218,18 @@ async function listProjectDocuments(projectId: string): Promise<ProjectDocument[
     const statusMap = await pollStatuses(items.map((it) => it.documentKey));
     return items.map((item) => {
       const s = statusMap.get(item.documentKey);
-      return { ...item, status: s?.status ?? 'NOT_FOUND', statusReason: s?.statusReason };
+      return {
+        ...item,
+        status: s?.status ?? "NOT_FOUND",
+        statusReason: s?.statusReason,
+      };
     });
   } catch (err) {
-    console.error('listProjectDocuments: failed to fetch KB ingestion status, degrading to UNKNOWN', err);
-    return items.map((item) => ({ ...item, status: 'UNKNOWN' }));
+    console.error(
+      "listProjectDocuments: failed to fetch KB ingestion status, degrading to UNKNOWN",
+      err,
+    );
+    return items.map((item) => ({ ...item, status: "UNKNOWN" }));
   }
 }
 
@@ -195,44 +238,73 @@ async function listProjectDocuments(projectId: string): Promise<ProjectDocument[
  * falling back to a direct Bedrock KB query when the row is absent or the table
  * read fails.
  */
-async function getDocumentIngestionStatus(documentKey: string): Promise<{ documentKey: string; status: string; statusReason?: string; updatedAt?: string }> {
+async function getDocumentIngestionStatus(
+  documentKey: string,
+): Promise<{
+  documentKey: string;
+  status: string;
+  statusReason?: string;
+  updatedAt?: string;
+}> {
   const tableName = process.env.INGESTION_TABLE;
-  const projectId = documentKey.split('/')[0];
+  const projectId = documentKey.split("/")[0];
 
   if (tableName) {
     try {
-      const resp = await ddb.send(new GetCommand({ TableName: tableName, Key: { projectId, documentKey } }));
+      const resp = await ddb.send(
+        new GetCommand({
+          TableName: tableName,
+          Key: { projectId, documentKey },
+        }),
+      );
       if (resp.Item) {
         return {
           documentKey,
-          status: resp.Item.status ?? 'UNKNOWN',
+          status: resp.Item.status ?? "UNKNOWN",
           statusReason: resp.Item.statusReason,
           updatedAt: resp.Item.updatedAt,
         };
       }
     } catch (err) {
-      console.error('getDocumentIngestionStatus: jobs-table read failed, falling back to KB query', err);
+      console.error(
+        "getDocumentIngestionStatus: jobs-table read failed, falling back to KB query",
+        err,
+      );
     }
   }
 
   // Fallback: direct KB query.
   const statusMap = await pollStatuses([documentKey]);
   const s = statusMap.get(documentKey);
-  return { documentKey, status: s?.status ?? 'NOT_FOUND', statusReason: s?.statusReason, updatedAt: s?.updatedAt };
+  return {
+    documentKey,
+    status: s?.status ?? "NOT_FOUND",
+    statusReason: s?.statusReason,
+    updatedAt: s?.updatedAt,
+  };
 }
 
 /**
  * Delete a document from S3 and Bedrock KB
  */
-async function deleteDocument(projectId: string, documentKey: string): Promise<{ documentKey: string; status: string }> {
+async function deleteDocument(
+  projectId: string,
+  documentKey: string,
+): Promise<{ documentKey: string; status: string }> {
   const { kbId, dsId } = await getKbIds();
-  await bedrockAgentClient.send(new DeleteKnowledgeBaseDocumentsCommand({
-    knowledgeBaseId: kbId,
-    dataSourceId: dsId,
-    documentIdentifiers: [{ dataSourceType: 'CUSTOM', custom: { id: documentKey } }],
-  }));
-  await s3Client.send(new DeleteObjectCommand({ Bucket: DOCUMENT_BUCKET, Key: documentKey }));
-  return { documentKey, status: 'DELETED' };
+  await bedrockAgentClient.send(
+    new DeleteKnowledgeBaseDocumentsCommand({
+      knowledgeBaseId: kbId,
+      dataSourceId: dsId,
+      documentIdentifiers: [
+        { dataSourceType: "CUSTOM", custom: { id: documentKey } },
+      ],
+    }),
+  );
+  await s3Client.send(
+    new DeleteObjectCommand({ Bucket: DOCUMENT_BUCKET, Key: documentKey }),
+  );
+  return { documentKey, status: "DELETED" };
 }
 
 /**
@@ -245,10 +317,13 @@ interface DocumentUploadResolverArguments {
   documentKey: string;
 }
 
-export const handler: AppSyncResolverHandler<DocumentUploadResolverArguments, unknown> = async (event) => {
+export const handler: AppSyncResolverHandler<
+  DocumentUploadResolverArguments,
+  unknown
+> = async (event) => {
   console.log(
     "Document upload resolver event:",
-    JSON.stringify(event, null, 2)
+    JSON.stringify(event, null, 2),
   );
 
   const { info, arguments: args, identity } = event;
@@ -256,14 +331,30 @@ export const handler: AppSyncResolverHandler<DocumentUploadResolverArguments, un
   const userId = getUserId(identity);
 
   try {
+    // Security fix (finding 60a5a6ae, CRE item 1): every field here acts on a
+    // client-supplied projectId used to build S3 keys (write for
+    // generateDocumentUploadUrl, the worst case — cross-tenant write feeds
+    // the knowledge base). Reconcile projectId against the caller BEFORE any
+    // presign, S3 list/delete, or DynamoDB/KB read — reusing the same gate
+    // project-resolver.ts's getProject enforces. Fail closed on any
+    // identity/lookup failure.
+    //
+    // getDocumentIngestionStatus derives its S3-facing projectId from the
+    // documentKey prefix, but the schema also supplies projectId directly
+    // (args.projectId) — gate on that value so the check itself never
+    // trusts a value assembled from the same untrusted key.
     switch (fieldName) {
       case "generateDocumentUploadUrl":
+        await assertProjectAccess(args.input.projectId, userId, event);
         return await generateUploadUrl(args.input, userId);
       case "listProjectDocuments":
+        await assertProjectAccess(args.projectId, userId, event);
         return await listProjectDocuments(args.projectId);
       case "getDocumentIngestionStatus":
+        await assertProjectAccess(args.projectId, userId, event);
         return await getDocumentIngestionStatus(args.documentKey);
       case "deleteDocument":
+        await assertProjectAccess(args.projectId, userId, event);
         return await deleteDocument(args.projectId, args.documentKey);
       default:
         throw new Error(`Unknown field: ${fieldName}`);

--- a/backend/src/utils/__tests__/project-access.test.ts
+++ b/backend/src/utils/__tests__/project-access.test.ts
@@ -1,0 +1,118 @@
+/**
+ * Tests for the shared project-access gate (finding 60a5a6ae, CRE item 1).
+ */
+import { DynamoDBDocumentClient, GetCommand } from "@aws-sdk/lib-dynamodb";
+import { mockClient } from "aws-sdk-client-mock";
+
+const ddbMock = mockClient(DynamoDBDocumentClient);
+
+const isAdminFromEventMock = jest.fn();
+const extractOrgFromEventMock = jest.fn();
+jest.mock("../auth-event", () => ({
+  isAdminFromEvent: (...args: unknown[]) => isAdminFromEventMock(...args),
+  extractOrgFromEvent: (...args: unknown[]) => extractOrgFromEventMock(...args),
+}));
+
+import {
+  assertProjectAccess,
+  ProjectAccessDeniedError,
+} from "../project-access";
+
+describe("assertProjectAccess", () => {
+  beforeEach(() => {
+    ddbMock.reset();
+    isAdminFromEventMock.mockReset();
+    extractOrgFromEventMock.mockReset();
+    isAdminFromEventMock.mockReturnValue(false);
+    extractOrgFromEventMock.mockResolvedValue(null);
+    process.env.PROJECTS_TABLE = "test-projects";
+  });
+
+  afterEach(() => {
+    delete process.env.PROJECTS_TABLE;
+  });
+
+  test("admin bypasses the project lookup entirely", async () => {
+    isAdminFromEventMock.mockReturnValue(true);
+
+    await expect(
+      assertProjectAccess("any-proj", "user-1", {}),
+    ).resolves.toBeUndefined();
+    expect(ddbMock.commandCalls(GetCommand)).toHaveLength(0);
+  });
+
+  test("allows the project owner", async () => {
+    ddbMock
+      .on(GetCommand)
+      .resolves({ Item: { owner: "user-1", organization: "org-a" } });
+
+    await expect(
+      assertProjectAccess("proj-1", "user-1", {}),
+    ).resolves.toBeUndefined();
+  });
+
+  test("allows a caller in the same organization", async () => {
+    ddbMock
+      .on(GetCommand)
+      .resolves({ Item: { owner: "someone-else", organization: "org-a" } });
+    extractOrgFromEventMock.mockResolvedValue("org-a");
+
+    await expect(
+      assertProjectAccess("proj-1", "user-1", {}),
+    ).resolves.toBeUndefined();
+  });
+
+  test("denies a cross-tenant caller (different owner, different org)", async () => {
+    ddbMock
+      .on(GetCommand)
+      .resolves({ Item: { owner: "victim-user", organization: "org-victim" } });
+    extractOrgFromEventMock.mockResolvedValue("org-attacker");
+
+    await expect(
+      assertProjectAccess("victim-proj", "attacker", {}),
+    ).rejects.toThrow(ProjectAccessDeniedError);
+  });
+
+  test("fails closed when the project does not exist", async () => {
+    ddbMock.on(GetCommand).resolves({ Item: undefined });
+
+    await expect(
+      assertProjectAccess("missing-proj", "user-1", {}),
+    ).rejects.toThrow(ProjectAccessDeniedError);
+  });
+
+  test("fails closed when the org lookup throws", async () => {
+    ddbMock
+      .on(GetCommand)
+      .resolves({ Item: { owner: "someone-else", organization: "org-a" } });
+    extractOrgFromEventMock.mockRejectedValue(new Error("Cognito unavailable"));
+
+    await expect(assertProjectAccess("proj-1", "user-1", {})).rejects.toThrow(
+      ProjectAccessDeniedError,
+    );
+  });
+
+  test("fails closed when the DynamoDB lookup throws", async () => {
+    ddbMock.on(GetCommand).rejects(new Error("DDB unavailable"));
+
+    await expect(assertProjectAccess("proj-1", "user-1", {})).rejects.toThrow(
+      ProjectAccessDeniedError,
+    );
+  });
+
+  test("fails closed when PROJECTS_TABLE is not configured", async () => {
+    delete process.env.PROJECTS_TABLE;
+
+    await expect(assertProjectAccess("proj-1", "user-1", {})).rejects.toThrow(
+      ProjectAccessDeniedError,
+    );
+    expect(ddbMock.commandCalls(GetCommand)).toHaveLength(0);
+  });
+
+  test("fails closed on an empty projectId", async () => {
+    await expect(assertProjectAccess("", "user-1", {})).rejects.toThrow(
+      ProjectAccessDeniedError,
+    );
+    expect(ddbMock.commandCalls(GetCommand)).toHaveLength(0);
+  });
+});

--- a/backend/src/utils/project-access.ts
+++ b/backend/src/utils/project-access.ts
@@ -1,0 +1,106 @@
+/**
+ * Shared project-access gate.
+ *
+ * Security fix for finding 60a5a6ae (CRE item 1): the document,
+ * document-upload, and conversation resolvers accepted a CLIENT-SUPPLIED
+ * `projectId` and used it to build S3 keys / query DynamoDB / dispatch agent
+ * messages WITHOUT reconciling it against the caller — a cross-tenant IDOR.
+ *
+ * This module factors out the access-check logic that project-resolver.ts's
+ * `getProject` already implements correctly (admin bypass, else
+ * owner-or-same-org, else deny) so the other resolvers can REUSE the same
+ * gate instead of re-deriving it. Fail-closed: any identity/lookup failure
+ * (missing org claim, project not found, Cognito lookup failure) results in
+ * denial, never a silent allow.
+ */
+import { DynamoDBClient } from "@aws-sdk/client-dynamodb";
+import { DynamoDBDocumentClient, GetCommand } from "@aws-sdk/lib-dynamodb";
+import { extractOrgFromEvent, isAdminFromEvent } from "./auth-event";
+
+const dynamoClient = new DynamoDBClient({});
+const docClient = DynamoDBDocumentClient.from(dynamoClient);
+
+/** Minimal shape needed for the access decision — avoids coupling to the full Project type. */
+interface ProjectAccessRecord {
+  owner: string;
+  organization?: string;
+}
+
+/**
+ * Thrown when the caller is not entitled to the given projectId. Callers
+ * should let this propagate (fail closed) rather than catching and
+ * continuing.
+ */
+export class ProjectAccessDeniedError extends Error {
+  constructor(message = "Access denied") {
+    super(message);
+    this.name = "ProjectAccessDeniedError";
+  }
+}
+
+/**
+ * Reconciles a client-supplied `projectId` against the caller, mirroring
+ * project-resolver.ts's `getProject` gate exactly:
+ *   1. Admins bypass (isAdminFromEvent) — same as getProject.
+ *   2. Otherwise the caller must be the project owner OR share the
+ *      project's organization (extractOrgFromEvent).
+ *   3. Any failure to determine identity/org, or a missing project row,
+ *      is treated as denial (fail closed) — never warn-and-proceed.
+ *
+ * Throws {@link ProjectAccessDeniedError} on denial. Callers MUST call this
+ * BEFORE constructing any S3 key, presigning any URL, reading conversation
+ * history, or dispatching any agent message.
+ */
+export async function assertProjectAccess(
+  projectId: string,
+  userId: string,
+  event: unknown,
+): Promise<void> {
+  if (!projectId) {
+    throw new ProjectAccessDeniedError("Access denied");
+  }
+
+  const projectsTable = process.env.PROJECTS_TABLE;
+  if (!projectsTable) {
+    // Fail closed: without the table we cannot reconcile ownership/org.
+    throw new ProjectAccessDeniedError("Access denied");
+  }
+
+  if (isAdminFromEvent(event)) {
+    return;
+  }
+
+  let project: ProjectAccessRecord | undefined;
+  try {
+    const result = await docClient.send(
+      new GetCommand({ TableName: projectsTable, Key: { id: projectId } }),
+    );
+    project = result.Item as ProjectAccessRecord | undefined;
+  } catch (err) {
+    console.error("assertProjectAccess: project lookup failed", {
+      projectId,
+      err,
+    });
+    throw new ProjectAccessDeniedError("Access denied");
+  }
+
+  if (!project) {
+    throw new ProjectAccessDeniedError("Access denied");
+  }
+
+  let userOrganization: string | null = null;
+  try {
+    userOrganization = await extractOrgFromEvent(event);
+  } catch (err) {
+    console.error("assertProjectAccess: org lookup failed", { projectId, err });
+    throw new ProjectAccessDeniedError("Access denied");
+  }
+
+  const hasAccess =
+    project.owner === userId ||
+    (!!userOrganization && project.organization === userOrganization);
+
+  if (!hasAccess) {
+    throw new ProjectAccessDeniedError("Access denied");
+  }
+}


### PR DESCRIPTION
## Summary

The document, document-upload and conversation resolvers acted on a client-supplied `projectId` without reconciling it against the caller - the document resolver read no identity at all. Since S3 keys are built as `${projectId}/${documentKey}`, an authenticated user of any organization could target another tenant by passing their project id.

Impact, in order of severity:
- `generateDocumentUploadUrl` minted a presigned **PUT** into another tenant's document prefix, which feeds the knowledge base - cross-tenant write and KB poisoning, not merely disclosure generateDocumentPdf and the document read paths returned another tenant's content `getConversationHistory` exposed another tenant's conversations, and `sendMessage` / `sendMessageToAgent` injected messages that drive their agents

## Fix

A single shared gate, `assertProjectAccess()`, factoring the admin-bypass and owner-or-same-org logic already used by `getProject` rather than adding a fourth variant. It runs before any S3 access, presign, DynamoDB read or EventBridge dispatch, and fails closed on absent identity, unresolvable org, missing project or Lookup error. Twelve operations across the three resolvers are now guarded.

`publishConversationMessage` is deliberately unguarded: it is `@aws_iam`-only in the schema (unlike its sibling publish mutations) and is invoked solely by the agent-message-handler under a field-scoped IAM policy. Documented in place.

## Testing

- Cross-tenant read, write and dispatch each refused with **zero** presign, DynamoDB and EventBridge calls recorded - asserted on the client mocks, not just that an error was thrown; the upload path is covered explicitly as the worst case
- Nine fail-closed cases; bite-proven by reverting one reconciliation and restoring byte-identically
- No lockout: every frontend caller passes a 'project.id' from
an already org-gated load, verified independently
- tsc, lint, `cdk synth` exit o; targeted tests 57; full backend jest 7072

## Notes

- First of four remediations for an external security report; the remaining three cover datastore by-id operations, integration by-id operations, and the app-access owner gate