### PR TITLE
fix(api): reconcile organization on every by-id datastore operation

### DIFF
--- a/backend/src/lambda/__tests__/datastore-resolver-create.test.ts
+++ b/backend/src/lambda/__tests__/datastore-resolver-create.test.ts
@@ -8,96 +8,137 @@
 
 // ---- Mock setup ----
 const mockDynamoSend = jest.fn();
-jest.mock('@aws-sdk/client-dynamodb', () => ({
+jest.mock("@aws-sdk/client-dynamodb", () => ({
   DynamoDBClient: jest.fn().mockImplementation(() => ({})),
 }));
-jest.mock('@aws-sdk/lib-dynamodb', () => {
-  const actual = jest.requireActual('@aws-sdk/lib-dynamodb');
+jest.mock("@aws-sdk/lib-dynamodb", () => {
+  const actual = jest.requireActual("@aws-sdk/lib-dynamodb");
   return {
     ...actual,
     DynamoDBDocumentClient: {
       from: jest.fn().mockReturnValue({ send: mockDynamoSend }),
     },
-    PutCommand: jest.fn().mockImplementation((input) => ({ _type: 'Put', input })),
-    GetCommand: jest.fn().mockImplementation((input) => ({ _type: 'Get', input })),
-    UpdateCommand: jest.fn().mockImplementation((input) => ({ _type: 'Update', input })),
-    DeleteCommand: jest.fn().mockImplementation((input) => ({ _type: 'Delete', input })),
-    QueryCommand: jest.fn().mockImplementation((input) => ({ _type: 'Query', input })),
+    PutCommand: jest
+      .fn()
+      .mockImplementation((input) => ({ _type: "Put", input })),
+    GetCommand: jest
+      .fn()
+      .mockImplementation((input) => ({ _type: "Get", input })),
+    UpdateCommand: jest
+      .fn()
+      .mockImplementation((input) => ({ _type: "Update", input })),
+    DeleteCommand: jest
+      .fn()
+      .mockImplementation((input) => ({ _type: "Delete", input })),
+    QueryCommand: jest
+      .fn()
+      .mockImplementation((input) => ({ _type: "Query", input })),
   };
 });
 
 const mockSecretsSend = jest.fn();
-jest.mock('@aws-sdk/client-secrets-manager', () => ({
-  SecretsManagerClient: jest.fn().mockImplementation(() => ({ send: mockSecretsSend })),
-  CreateSecretCommand: jest.fn().mockImplementation((input) => ({ _type: 'CreateSecret', input })),
-  GetSecretValueCommand: jest.fn().mockImplementation((input) => ({ _type: 'GetSecretValue', input })),
-  DeleteSecretCommand: jest.fn().mockImplementation((input) => ({ _type: 'DeleteSecret', input })),
+jest.mock("@aws-sdk/client-secrets-manager", () => ({
+  SecretsManagerClient: jest
+    .fn()
+    .mockImplementation(() => ({ send: mockSecretsSend })),
+  CreateSecretCommand: jest
+    .fn()
+    .mockImplementation((input) => ({ _type: "CreateSecret", input })),
+  GetSecretValueCommand: jest
+    .fn()
+    .mockImplementation((input) => ({ _type: "GetSecretValue", input })),
+  DeleteSecretCommand: jest
+    .fn()
+    .mockImplementation((input) => ({ _type: "DeleteSecret", input })),
 }));
 
 const mockAdapter = {
-  category: 'datastore' as const,
-  spec: { type: 'KNOWLEDGE_BASE', provider: 'AWS', category: 'datastore' as const, authentication: { method: 'IAM_ROLE', fields: [], secretStructure: {} }, configuration: { required: [], optional: [], ssmParameters: [] } },
+  category: "datastore" as const,
+  spec: {
+    type: "KNOWLEDGE_BASE",
+    provider: "AWS",
+    category: "datastore" as const,
+    authentication: { method: "IAM_ROLE", fields: [], secretStructure: {} },
+    configuration: { required: [], optional: [], ssmParameters: [] },
+  },
   requiredPolicies: jest.fn().mockReturnValue({ provision: [], connect: [] }),
-  provision: jest.fn().mockResolvedValue({ resourceArn: 'arn:aws:bedrock:us-east-1:123:knowledge-base/KB1' }),
+  provision: jest
+    .fn()
+    .mockResolvedValue({
+      resourceArn: "arn:aws:bedrock:us-east-1:123:knowledge-base/KB1",
+    }),
   connect: jest.fn().mockResolvedValue(undefined),
   disconnect: jest.fn().mockResolvedValue(undefined),
   deprovision: jest.fn().mockResolvedValue(undefined),
-  testConnection: jest.fn().mockResolvedValue({ success: true, message: 'OK' }),
-  getMetrics: jest.fn().mockResolvedValue({ size: '0 MB', records: 0 }),
+  testConnection: jest.fn().mockResolvedValue({ success: true, message: "OK" }),
+  getMetrics: jest.fn().mockResolvedValue({ size: "0 MB", records: 0 }),
 };
-jest.mock('../adapters/registry', () => ({
+jest.mock("../adapters/registry", () => ({
   getAdapter: jest.fn().mockReturnValue(mockAdapter),
 }));
 
 const mockPolicyManager = {
-  getAccountContext: jest.fn().mockResolvedValue({ accountId: '123456789012', region: 'us-east-1' }),
+  getAccountContext: jest
+    .fn()
+    .mockResolvedValue({ accountId: "123456789012", region: "us-east-1" }),
   ensureRole: jest.fn().mockResolvedValue(undefined),
   assumeScopedRole: jest.fn().mockResolvedValue({
-    accessKeyId: 'AKID', secretAccessKey: 'SECRET', sessionToken: 'TOKEN',
+    accessKeyId: "AKID",
+    secretAccessKey: "SECRET",
+    sessionToken: "TOKEN",
   }),
   deleteRole: jest.fn().mockResolvedValue(undefined),
 };
-jest.mock('../../utils/policy-manager', () => ({
+jest.mock("../../utils/policy-manager", () => ({
   PolicyManager: jest.fn().mockImplementation(() => mockPolicyManager),
 }));
 
-jest.mock('uuid', () => ({ v4: jest.fn().mockReturnValue('test-uuid') }));
+jest.mock("uuid", () => ({ v4: jest.fn().mockReturnValue("test-uuid") }));
 
-process.env.DATASTORES_TABLE = 'TestDataStoresTable';
+process.env.DATASTORES_TABLE = "TestDataStoresTable";
 
-import { handler } from '../datastore-resolver';
+import { handler } from "../datastore-resolver";
 
 type HandlerEvent = Parameters<typeof handler>[0];
 
-describe('createDataStore - config enrichment', () => {
+describe("createDataStore - config enrichment", () => {
   beforeEach(() => {
     jest.clearAllMocks();
     // Default: QueryCommand returns empty (no idempotent match)
     // PutCommand succeeds, UpdateCommand succeeds
     mockDynamoSend.mockImplementation((cmd: { _type?: string }) => {
-      if (cmd._type === 'Query') return Promise.resolve({ Items: [] });
-      if (cmd._type === 'Put') return Promise.resolve({});
-      if (cmd._type === 'Update') return Promise.resolve({ Attributes: { dataStoreId: 'test-uuid', status: 'CONNECTED', version: 1 } });
+      if (cmd._type === "Query") return Promise.resolve({ Items: [] });
+      if (cmd._type === "Put") return Promise.resolve({});
+      if (cmd._type === "Update")
+        return Promise.resolve({
+          Attributes: {
+            dataStoreId: "test-uuid",
+            status: "CONNECTED",
+            version: 1,
+          },
+        });
       return Promise.resolve({});
     });
   });
 
   const makeCreateEvent = (input: Record<string, unknown>): HandlerEvent =>
     ({
-      info: { fieldName: 'createDataStore' },
+      info: { fieldName: "createDataStore" },
       arguments: { input },
-      identity: { username: 'test-user' },
+      // Identity org must match input.orgId ('org-test') — createDataStore
+      // now rejects a mismatched client-supplied orgId (finding ca76d041).
+      identity: { username: "test-user", "custom:organization": "org-test" },
     }) as unknown as HandlerEvent;
 
-  test('injects input.name into config as name field for CREATE_NEW', async () => {
+  test("injects input.name into config as name field for CREATE_NEW", async () => {
     const event = makeCreateEvent({
-      name: 'og-test-kb',
-      type: 'KNOWLEDGE_BASE',
-      category: 'KNOWLEDGE_BASE',
-      provisionMode: 'CREATE_NEW',
-      orgId: 'org-test',
-      config: JSON.stringify({ resourceName: 'og-test-kb' }),
-      clientRequestToken: 'tok-123',
+      name: "og-test-kb",
+      type: "KNOWLEDGE_BASE",
+      category: "KNOWLEDGE_BASE",
+      provisionMode: "CREATE_NEW",
+      orgId: "org-test",
+      config: JSON.stringify({ resourceName: "og-test-kb" }),
+      clientRequestToken: "tok-123",
     });
 
     await handler(event);
@@ -105,42 +146,45 @@ describe('createDataStore - config enrichment', () => {
     // The adapter.provision should receive config with name field set
     expect(mockAdapter.provision).toHaveBeenCalledTimes(1);
     const provisionConfig = mockAdapter.provision.mock.calls[0][0];
-    expect(provisionConfig.name).toBe('og-test-kb');
+    expect(provisionConfig.name).toBe("og-test-kb");
   });
 
-  test('does not overwrite existing config.name with input.name', async () => {
+  test("does not overwrite existing config.name with input.name", async () => {
     const event = makeCreateEvent({
-      name: 'display-name',
-      type: 'KNOWLEDGE_BASE',
-      category: 'KNOWLEDGE_BASE',
-      provisionMode: 'CREATE_NEW',
-      orgId: 'org-test',
-      config: JSON.stringify({ name: 'explicit-config-name', resourceName: 'rn' }),
-      clientRequestToken: 'tok-456',
+      name: "display-name",
+      type: "KNOWLEDGE_BASE",
+      category: "KNOWLEDGE_BASE",
+      provisionMode: "CREATE_NEW",
+      orgId: "org-test",
+      config: JSON.stringify({
+        name: "explicit-config-name",
+        resourceName: "rn",
+      }),
+      clientRequestToken: "tok-456",
     });
 
     await handler(event);
 
     const provisionConfig = mockAdapter.provision.mock.calls[0][0];
     // Existing config.name should be preserved
-    expect(provisionConfig.name).toBe('explicit-config-name');
+    expect(provisionConfig.name).toBe("explicit-config-name");
   });
 
-  test('injects input.name into config for CONNECT_EXISTING too', async () => {
+  test("injects input.name into config for CONNECT_EXISTING too", async () => {
     const event = makeCreateEvent({
-      name: 'my-existing-store',
-      type: 'S3',
-      category: 'S3_STORAGE',
-      provisionMode: 'CONNECT_EXISTING',
-      orgId: 'org-test',
-      config: JSON.stringify({ bucketName: 'my-bucket' }),
-      clientRequestToken: 'tok-789',
+      name: "my-existing-store",
+      type: "S3",
+      category: "S3_STORAGE",
+      provisionMode: "CONNECT_EXISTING",
+      orgId: "org-test",
+      config: JSON.stringify({ bucketName: "my-bucket" }),
+      clientRequestToken: "tok-789",
     });
 
     await handler(event);
 
     expect(mockAdapter.connect).toHaveBeenCalledTimes(1);
     const connectConfig = mockAdapter.connect.mock.calls[0][0];
-    expect(connectConfig.name).toBe('my-existing-store');
+    expect(connectConfig.name).toBe("my-existing-store");
   });
 });

--- a/backend/src/lambda/__tests__/datastore-resolver-delete.test.ts
+++ b/backend/src/lambda/__tests__/datastore-resolver-delete.test.ts
@@ -7,91 +7,121 @@
 
 // ---- Mock setup ----
 const mockDynamoSend = jest.fn();
-jest.mock('@aws-sdk/client-dynamodb', () => ({
+jest.mock("@aws-sdk/client-dynamodb", () => ({
   DynamoDBClient: jest.fn().mockImplementation(() => ({})),
 }));
-jest.mock('@aws-sdk/lib-dynamodb', () => {
-  const actual = jest.requireActual('@aws-sdk/lib-dynamodb');
+jest.mock("@aws-sdk/lib-dynamodb", () => {
+  const actual = jest.requireActual("@aws-sdk/lib-dynamodb");
   return {
     ...actual,
     DynamoDBDocumentClient: {
       from: jest.fn().mockReturnValue({ send: mockDynamoSend }),
     },
-    PutCommand: jest.fn().mockImplementation((input) => ({ _type: 'Put', input })),
-    GetCommand: jest.fn().mockImplementation((input) => ({ _type: 'Get', input })),
-    UpdateCommand: jest.fn().mockImplementation((input) => ({ _type: 'Update', input })),
-    DeleteCommand: jest.fn().mockImplementation((input) => ({ _type: 'Delete', input })),
-    QueryCommand: jest.fn().mockImplementation((input) => ({ _type: 'Query', input })),
+    PutCommand: jest
+      .fn()
+      .mockImplementation((input) => ({ _type: "Put", input })),
+    GetCommand: jest
+      .fn()
+      .mockImplementation((input) => ({ _type: "Get", input })),
+    UpdateCommand: jest
+      .fn()
+      .mockImplementation((input) => ({ _type: "Update", input })),
+    DeleteCommand: jest
+      .fn()
+      .mockImplementation((input) => ({ _type: "Delete", input })),
+    QueryCommand: jest
+      .fn()
+      .mockImplementation((input) => ({ _type: "Query", input })),
   };
 });
 
 const mockSecretsSend = jest.fn();
-jest.mock('@aws-sdk/client-secrets-manager', () => ({
-  SecretsManagerClient: jest.fn().mockImplementation(() => ({ send: mockSecretsSend })),
-  CreateSecretCommand: jest.fn().mockImplementation((input) => ({ _type: 'CreateSecret', input })),
-  GetSecretValueCommand: jest.fn().mockImplementation((input) => ({ _type: 'GetSecretValue', input })),
-  DeleteSecretCommand: jest.fn().mockImplementation((input) => ({ _type: 'DeleteSecret', input })),
+jest.mock("@aws-sdk/client-secrets-manager", () => ({
+  SecretsManagerClient: jest
+    .fn()
+    .mockImplementation(() => ({ send: mockSecretsSend })),
+  CreateSecretCommand: jest
+    .fn()
+    .mockImplementation((input) => ({ _type: "CreateSecret", input })),
+  GetSecretValueCommand: jest
+    .fn()
+    .mockImplementation((input) => ({ _type: "GetSecretValue", input })),
+  DeleteSecretCommand: jest
+    .fn()
+    .mockImplementation((input) => ({ _type: "DeleteSecret", input })),
 }));
 
 const mockAdapter = {
   requiredPolicies: jest.fn().mockReturnValue({ provision: [], connect: [] }),
-  provision: jest.fn().mockResolvedValue({ resourceArn: 'arn:aws:s3:::test-bucket' }),
+  provision: jest
+    .fn()
+    .mockResolvedValue({ resourceArn: "arn:aws:s3:::test-bucket" }),
   connect: jest.fn().mockResolvedValue(undefined),
   disconnect: jest.fn().mockResolvedValue(undefined),
   deprovision: jest.fn().mockResolvedValue(undefined),
-  testConnection: jest.fn().mockResolvedValue({ success: true, message: 'OK' }),
-  getMetrics: jest.fn().mockResolvedValue({ size: '0 MB', records: 0 }),
+  testConnection: jest.fn().mockResolvedValue({ success: true, message: "OK" }),
+  getMetrics: jest.fn().mockResolvedValue({ size: "0 MB", records: 0 }),
 };
-jest.mock('../adapters/registry', () => ({
+jest.mock("../adapters/registry", () => ({
   getAdapter: jest.fn().mockReturnValue(mockAdapter),
 }));
 
 const mockPolicyManager = {
-  getAccountContext: jest.fn().mockResolvedValue({ accountId: '123456789012', region: 'us-east-1' }),
+  getAccountContext: jest
+    .fn()
+    .mockResolvedValue({ accountId: "123456789012", region: "us-east-1" }),
   ensureRole: jest.fn().mockResolvedValue(undefined),
   assumeScopedRole: jest.fn().mockResolvedValue({
-    accessKeyId: 'AKID', secretAccessKey: 'SECRET', sessionToken: 'TOKEN',
+    accessKeyId: "AKID",
+    secretAccessKey: "SECRET",
+    sessionToken: "TOKEN",
   }),
   deleteRole: jest.fn().mockResolvedValue(undefined),
 };
-jest.mock('../../utils/policy-manager', () => ({
+jest.mock("../../utils/policy-manager", () => ({
   PolicyManager: jest.fn().mockImplementation(() => mockPolicyManager),
 }));
 
-jest.mock('uuid', () => ({ v4: jest.fn().mockReturnValue('test-uuid') }));
+jest.mock("uuid", () => ({ v4: jest.fn().mockReturnValue("test-uuid") }));
 
-process.env.DATASTORES_TABLE = 'TestDataStoresTable';
+process.env.DATASTORES_TABLE = "TestDataStoresTable";
 
-import { handler } from '../datastore-resolver';
+import { handler } from "../datastore-resolver";
 
 type HandlerEvent = Parameters<typeof handler>[0];
 
-describe('deleteDataStore - infrastructure cleanup', () => {
+describe("deleteDataStore - infrastructure cleanup", () => {
   beforeEach(() => {
     jest.clearAllMocks();
   });
 
   const makeDeleteEvent = (dataStoreId: string): HandlerEvent =>
     ({
-      info: { fieldName: 'deleteDataStore' },
+      info: { fieldName: "deleteDataStore" },
       arguments: { dataStoreId },
-      identity: { username: 'test-user' },
+      // Identity org must match the row's orgId ('org-test' — see the
+      // Item fixtures below) — deleteDataStore now reconciles the row's
+      // org against the caller before any cleanup (finding ca76d041).
+      identity: { username: "test-user", "custom:organization": "org-test" },
     }) as unknown as HandlerEvent;
 
   /** Invokes the handler and casts the result to the delete-result shape. */
-  const invokeDelete = async (dataStoreId: string): Promise<{ success: boolean }> =>
+  const invokeDelete = async (
+    dataStoreId: string,
+  ): Promise<{ success: boolean }> =>
     (await handler(makeDeleteEvent(dataStoreId))) as { success: boolean };
 
-  test('calls adapter.deprovision for CREATE_NEW data stores', async () => {
+  test("calls adapter.deprovision for CREATE_NEW data stores", async () => {
     // Mock getDataStore returning a provisioned store
     mockDynamoSend.mockResolvedValueOnce({
       Item: {
-        dataStoreId: 'ds-123',
-        type: 'S3',
-        status: 'CONNECTED',
-        provisionMode: 'CREATE_NEW',
-        config: JSON.stringify({ bucketName: 'my-bucket' }),
-        secretArn: 'arn:aws:secretsmanager:us-east-1:123:secret:test',
+        dataStoreId: "ds-123",
+        type: "S3",
+        status: "CONNECTED",
+        provisionMode: "CREATE_NEW",
+        orgId: "org-test",
+        config: JSON.stringify({ bucketName: "my-bucket" }),
+        secretArn: "arn:aws:secretsmanager:us-east-1:123:secret:test",
         version: 1,
       },
     });
@@ -99,76 +129,85 @@ describe('deleteDataStore - infrastructure cleanup', () => {
     mockDynamoSend.mockResolvedValue({});
     mockSecretsSend.mockResolvedValue({});
 
-    const result = await invokeDelete('ds-123');
+    const result = await invokeDelete("ds-123");
 
     expect(result.success).toBe(true);
     expect(mockAdapter.deprovision).toHaveBeenCalledWith(
-      { bucketName: 'my-bucket' },
-      expect.anything()
+      { bucketName: "my-bucket" },
+      expect.anything(),
     );
   });
 
-  test('does NOT call adapter.deprovision for CONNECT_EXISTING data stores', async () => {
+  test("does NOT call adapter.deprovision for CONNECT_EXISTING data stores", async () => {
     mockDynamoSend.mockResolvedValueOnce({
       Item: {
-        dataStoreId: 'ds-456',
-        type: 'S3',
-        status: 'CONNECTED',
-        provisionMode: 'CONNECT_EXISTING',
-        config: JSON.stringify({ bucketName: 'existing-bucket' }),
-        secretArn: 'arn:aws:secretsmanager:us-east-1:123:secret:test',
+        dataStoreId: "ds-456",
+        type: "S3",
+        status: "CONNECTED",
+        provisionMode: "CONNECT_EXISTING",
+        orgId: "org-test",
+        config: JSON.stringify({ bucketName: "existing-bucket" }),
+        secretArn: "arn:aws:secretsmanager:us-east-1:123:secret:test",
         version: 1,
       },
     });
     mockDynamoSend.mockResolvedValue({});
     mockSecretsSend.mockResolvedValue({});
 
-    const result = await invokeDelete('ds-456');
+    const result = await invokeDelete("ds-456");
 
     expect(result.success).toBe(true);
     expect(mockAdapter.deprovision).not.toHaveBeenCalled();
   });
 
-  test('calls adapter.disconnect before deprovision', async () => {
+  test("calls adapter.disconnect before deprovision", async () => {
     const callOrder: string[] = [];
-    mockAdapter.disconnect.mockImplementation(async () => { callOrder.push('disconnect'); });
-    mockAdapter.deprovision.mockImplementation(async () => { callOrder.push('deprovision'); });
+    mockAdapter.disconnect.mockImplementation(async () => {
+      callOrder.push("disconnect");
+    });
+    mockAdapter.deprovision.mockImplementation(async () => {
+      callOrder.push("deprovision");
+    });
 
     mockDynamoSend.mockResolvedValueOnce({
       Item: {
-        dataStoreId: 'ds-789',
-        type: 'S3',
-        status: 'CONNECTED',
-        provisionMode: 'CREATE_NEW',
-        config: JSON.stringify({ bucketName: 'bucket' }),
+        dataStoreId: "ds-789",
+        type: "S3",
+        status: "CONNECTED",
+        provisionMode: "CREATE_NEW",
+        orgId: "org-test",
+        config: JSON.stringify({ bucketName: "bucket" }),
         version: 1,
       },
     });
     mockDynamoSend.mockResolvedValue({});
     mockSecretsSend.mockResolvedValue({});
 
-    await handler(makeDeleteEvent('ds-789'));
+    await handler(makeDeleteEvent("ds-789"));
 
-    expect(callOrder).toEqual(['disconnect', 'deprovision']);
+    expect(callOrder).toEqual(["disconnect", "deprovision"]);
   });
 
-  test('continues deletion even if deprovision fails', async () => {
-    mockAdapter.deprovision.mockRejectedValueOnce(new Error('deprovision failed'));
+  test("continues deletion even if deprovision fails", async () => {
+    mockAdapter.deprovision.mockRejectedValueOnce(
+      new Error("deprovision failed"),
+    );
 
     mockDynamoSend.mockResolvedValueOnce({
       Item: {
-        dataStoreId: 'ds-fail',
-        type: 'S3',
-        status: 'CONNECTED',
-        provisionMode: 'CREATE_NEW',
-        config: JSON.stringify({ bucketName: 'bucket' }),
+        dataStoreId: "ds-fail",
+        type: "S3",
+        status: "CONNECTED",
+        provisionMode: "CREATE_NEW",
+        orgId: "org-test",
+        config: JSON.stringify({ bucketName: "bucket" }),
         version: 1,
       },
     });
     mockDynamoSend.mockResolvedValue({});
     mockSecretsSend.mockResolvedValue({});
 
-    const result = await invokeDelete('ds-fail');
+    const result = await invokeDelete("ds-fail");
 
     // Should still succeed — deprovision failure is non-fatal
     expect(result.success).toBe(true);

--- a/backend/src/lambda/__tests__/datastore-resolver-item-org-scoping.test.ts
+++ b/backend/src/lambda/__tests__/datastore-resolver-item-org-scoping.test.ts
@@ -1,0 +1,418 @@
+/**
+ * Cross-org item-level authz tests for datastore-resolver.ts (finding
+ * ca76d041, datastore half; CRE item 2).
+ *
+ * Before this fix: getDataStore, updateDataStore, deleteDataStore,
+ * connectDataStore, disconnectDataStore, and testDataStoreConnection all
+ * acted on a client-supplied dataStoreId with NO reconciliation against the
+ * caller's org — a cross-tenant IDOR. deleteDataStore is the worst case:
+ * it deprovisions infrastructure, force-deletes the Secrets Manager secret,
+ * and deletes the citadel-ds IAM role for the TARGET row's org, regardless
+ * of who the caller is. createDataStore additionally trusted a
+ * client-supplied input.orgId with no server-side derivation.
+ *
+ * Fix: fetch-then-verify via the shared `assertRowOrg` helper
+ * (backend/src/utils/auth-event.ts) — load the row, reconcile its orgId
+ * against the caller's server-derived org (extractOrgFromEvent), and refuse
+ * BEFORE any mutation, secret deletion, IAM change, or adapter/provider
+ * call. Admins bypass, mirroring the read-path admin bypass already used by
+ * listDataStores/getDataStoreStats/listAvailableDataSources.
+ */
+
+// ---- Mock setup ----
+const mockDynamoSend = jest.fn();
+jest.mock("@aws-sdk/client-dynamodb", () => ({
+  DynamoDBClient: jest.fn().mockImplementation(() => ({})),
+}));
+jest.mock("@aws-sdk/lib-dynamodb", () => {
+  const actual = jest.requireActual("@aws-sdk/lib-dynamodb");
+  return {
+    ...actual,
+    DynamoDBDocumentClient: {
+      from: jest.fn().mockReturnValue({ send: mockDynamoSend }),
+    },
+    PutCommand: jest
+      .fn()
+      .mockImplementation((input) => ({ _type: "Put", input })),
+    GetCommand: jest
+      .fn()
+      .mockImplementation((input) => ({ _type: "Get", input })),
+    UpdateCommand: jest
+      .fn()
+      .mockImplementation((input) => ({ _type: "Update", input })),
+    DeleteCommand: jest
+      .fn()
+      .mockImplementation((input) => ({ _type: "Delete", input })),
+    QueryCommand: jest
+      .fn()
+      .mockImplementation((input) => ({ _type: "Query", input })),
+  };
+});
+
+const mockSecretsSend = jest.fn();
+jest.mock("@aws-sdk/client-secrets-manager", () => ({
+  SecretsManagerClient: jest
+    .fn()
+    .mockImplementation(() => ({ send: mockSecretsSend })),
+  CreateSecretCommand: jest
+    .fn()
+    .mockImplementation((input) => ({ _type: "CreateSecret", input })),
+  GetSecretValueCommand: jest
+    .fn()
+    .mockImplementation((input) => ({ _type: "GetSecretValue", input })),
+  DeleteSecretCommand: jest
+    .fn()
+    .mockImplementation((input) => ({ _type: "DeleteSecret", input })),
+}));
+
+const mockAdapter = {
+  requiredPolicies: jest.fn().mockReturnValue({ provision: [], connect: [] }),
+  provision: jest
+    .fn()
+    .mockResolvedValue({ resourceArn: "arn:aws:s3:::victim-bucket" }),
+  connect: jest.fn().mockResolvedValue(undefined),
+  disconnect: jest.fn().mockResolvedValue(undefined),
+  deprovision: jest.fn().mockResolvedValue(undefined),
+  testConnection: jest.fn().mockResolvedValue({ success: true, message: "OK" }),
+  getMetrics: jest.fn().mockResolvedValue({ size: "0 MB", records: 0 }),
+};
+jest.mock("../adapters/registry", () => ({
+  getAdapter: jest.fn().mockReturnValue(mockAdapter),
+}));
+
+const mockPolicyManager = {
+  getAccountContext: jest
+    .fn()
+    .mockResolvedValue({ accountId: "123456789012", region: "us-east-1" }),
+  ensureRole: jest.fn().mockResolvedValue(undefined),
+  assumeScopedRole: jest.fn().mockResolvedValue({
+    accessKeyId: "AKID",
+    secretAccessKey: "SECRET",
+    sessionToken: "TOKEN",
+  }),
+  deleteRole: jest.fn().mockResolvedValue(undefined),
+};
+jest.mock("../../utils/policy-manager", () => ({
+  PolicyManager: jest.fn().mockImplementation(() => mockPolicyManager),
+}));
+
+jest.mock("uuid", () => ({ v4: jest.fn().mockReturnValue("test-uuid") }));
+
+process.env.DATASTORES_TABLE = "TestDataStoresTable";
+
+import { handler } from "../datastore-resolver";
+
+type HandlerEvent = Parameters<typeof handler>[0];
+
+/** The victim row: belongs to org-victim, has a secretArn and is CREATE_NEW
+ * (so deleteDataStore's worst-case path — deprovision + secret delete + IAM
+ * role delete — would fire if the guard did not block it). */
+const VICTIM_ROW = {
+  dataStoreId: "ds-victim",
+  name: "Victim Store",
+  type: "S3",
+  category: "S3_STORAGE",
+  status: "CONNECTED",
+  provisionMode: "CREATE_NEW",
+  orgId: "org-victim",
+  config: JSON.stringify({ bucketName: "victim-bucket" }),
+  secretArn: "arn:aws:secretsmanager:us-east-1:123:secret:victim",
+  version: 1,
+};
+
+/**
+ * Builds an event whose caller org resolves via the real
+ * extractOrgFromEvent/isAdminFromEvent (auth-event.ts is NOT mocked in this
+ * file — assertRowOrg's internal calls to those functions must observe the
+ * same identity the test sets, which only works end-to-end through the real
+ * claim-reading path, not through a jest.mock spy on the sibling exports).
+ */
+function makeEvent(
+  fieldName: string,
+  args: Record<string, unknown>,
+  identity: Record<string, unknown> = {
+    sub: "attacker-1",
+    "custom:organization": "org-attacker",
+  },
+): HandlerEvent {
+  return {
+    info: { fieldName },
+    arguments: args,
+    identity,
+  } as unknown as HandlerEvent;
+}
+
+const ATTACKER_IDENTITY = {
+  sub: "attacker-1",
+  "custom:organization": "org-attacker",
+};
+const SAME_ORG_IDENTITY = {
+  sub: "victim-user",
+  "custom:organization": "org-victim",
+};
+const ADMIN_IDENTITY = { sub: "admin-1", "custom:role": "admin" };
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  // GetCommand always returns the victim row; everything else is a no-op
+  // success unless a test overrides it — if the guard fails to block, every
+  // one of these would otherwise "succeed".
+  mockDynamoSend.mockImplementation((cmd: { _type?: string }) => {
+    if (cmd._type === "Get")
+      return Promise.resolve({ Item: { ...VICTIM_ROW } });
+    if (cmd._type === "Update")
+      return Promise.resolve({ Attributes: { ...VICTIM_ROW } });
+    return Promise.resolve({});
+  });
+  mockSecretsSend.mockResolvedValue({});
+});
+
+describe("cross-org caller is refused before any mutation/side-effect", () => {
+  test("getDataStore: cross-org caller is denied", async () => {
+    await expect(
+      handler(
+        makeEvent(
+          "getDataStore",
+          { dataStoreId: "ds-victim" },
+          ATTACKER_IDENTITY,
+        ),
+      ),
+    ).rejects.toThrow(/access denied/i);
+  });
+
+  test("updateDataStore: cross-org caller is denied and zero DynamoDB writes occur", async () => {
+    await expect(
+      handler(
+        makeEvent(
+          "updateDataStore",
+          { input: { dataStoreId: "ds-victim", version: 1, name: "pwned" } },
+          ATTACKER_IDENTITY,
+        ),
+      ),
+    ).rejects.toThrow(/access denied/i);
+
+    const updateCalls = mockDynamoSend.mock.calls.filter(
+      ([cmd]: [{ _type?: string }]) => cmd._type === "Update",
+    );
+    expect(updateCalls).toHaveLength(0);
+  });
+
+  test("deleteDataStore: cross-org caller is denied; zero deprovision/secret-delete/IAM-delete/DynamoDB-delete calls", async () => {
+    await expect(
+      handler(
+        makeEvent(
+          "deleteDataStore",
+          { dataStoreId: "ds-victim" },
+          ATTACKER_IDENTITY,
+        ),
+      ),
+    ).rejects.toThrow(/access denied/i);
+
+    expect(mockAdapter.disconnect).not.toHaveBeenCalled();
+    expect(mockAdapter.deprovision).not.toHaveBeenCalled();
+    expect(mockSecretsSend).not.toHaveBeenCalled();
+    expect(mockPolicyManager.deleteRole).not.toHaveBeenCalled();
+    const deleteCalls = mockDynamoSend.mock.calls.filter(
+      ([cmd]: [{ _type?: string }]) => cmd._type === "Delete",
+    );
+    expect(deleteCalls).toHaveLength(0);
+  });
+
+  test("connectDataStore: cross-org caller is denied; zero adapter.connect / DynamoDB update calls", async () => {
+    await expect(
+      handler(
+        makeEvent(
+          "connectDataStore",
+          { dataStoreId: "ds-victim" },
+          ATTACKER_IDENTITY,
+        ),
+      ),
+    ).rejects.toThrow(/access denied/i);
+
+    expect(mockAdapter.connect).not.toHaveBeenCalled();
+    const updateCalls = mockDynamoSend.mock.calls.filter(
+      ([cmd]: [{ _type?: string }]) => cmd._type === "Update",
+    );
+    expect(updateCalls).toHaveLength(0);
+  });
+
+  test("disconnectDataStore: cross-org caller is denied; zero adapter.disconnect / DynamoDB update calls", async () => {
+    await expect(
+      handler(
+        makeEvent(
+          "disconnectDataStore",
+          { dataStoreId: "ds-victim" },
+          ATTACKER_IDENTITY,
+        ),
+      ),
+    ).rejects.toThrow(/access denied/i);
+
+    expect(mockAdapter.disconnect).not.toHaveBeenCalled();
+    const updateCalls = mockDynamoSend.mock.calls.filter(
+      ([cmd]: [{ _type?: string }]) => cmd._type === "Update",
+    );
+    expect(updateCalls).toHaveLength(0);
+  });
+
+  test("testDataStoreConnection: cross-org caller is denied; zero secret reads / adapter.testConnection calls", async () => {
+    await expect(
+      handler(
+        makeEvent(
+          "testDataStoreConnection",
+          { dataStoreId: "ds-victim" },
+          ATTACKER_IDENTITY,
+        ),
+      ),
+    ).rejects.toThrow(/access denied/i);
+
+    expect(mockAdapter.testConnection).not.toHaveBeenCalled();
+    expect(mockSecretsSend).not.toHaveBeenCalled();
+  });
+});
+
+describe("legitimate same-org callers still succeed", () => {
+  test("getDataStore: same-org caller succeeds", async () => {
+    const result = (await handler(
+      makeEvent(
+        "getDataStore",
+        { dataStoreId: "ds-victim" },
+        SAME_ORG_IDENTITY,
+      ),
+    )) as { dataStoreId: string };
+
+    expect(result.dataStoreId).toBe("ds-victim");
+  });
+
+  test("deleteDataStore: same-org caller succeeds and performs cleanup", async () => {
+    const result = (await handler(
+      makeEvent(
+        "deleteDataStore",
+        { dataStoreId: "ds-victim" },
+        SAME_ORG_IDENTITY,
+      ),
+    )) as { success: boolean };
+
+    expect(result.success).toBe(true);
+    expect(mockAdapter.deprovision).toHaveBeenCalledTimes(1);
+    expect(mockSecretsSend).toHaveBeenCalled();
+    expect(mockPolicyManager.deleteRole).toHaveBeenCalledTimes(1);
+  });
+
+  test("admin caller may act cross-org (bypass preserved)", async () => {
+    const result = (await handler(
+      makeEvent("getDataStore", { dataStoreId: "ds-victim" }, ADMIN_IDENTITY),
+    )) as { dataStoreId: string };
+
+    expect(result.dataStoreId).toBe("ds-victim");
+  });
+});
+
+describe("createDataStore rejects a foreign/mismatched orgId", () => {
+  beforeEach(() => {
+    mockDynamoSend.mockImplementation((cmd: { _type?: string }) => {
+      if (cmd._type === "Query") return Promise.resolve({ Items: [] });
+      return Promise.resolve({});
+    });
+  });
+
+  test("rejects when input.orgId does not match the server-derived caller org", async () => {
+    await expect(
+      handler(
+        makeEvent(
+          "createDataStore",
+          {
+            input: {
+              name: "sneaky",
+              type: "S3",
+              category: "S3_STORAGE",
+              provisionMode: "CONNECT_EXISTING",
+              orgId: "org-foreign",
+              config: JSON.stringify({ bucketName: "b" }),
+              clientRequestToken: "tok-reject-1",
+            },
+          },
+          { sub: "user-real", "custom:organization": "org-real" },
+        ),
+      ),
+    ).rejects.toThrow(/access denied|org/i);
+
+    const putCalls = mockDynamoSend.mock.calls.filter(
+      ([cmd]: [{ _type?: string }]) => cmd._type === "Put",
+    );
+    expect(putCalls).toHaveLength(0);
+  });
+
+  test("accepts when input.orgId matches the server-derived caller org", async () => {
+    mockDynamoSend.mockImplementation((cmd: { _type?: string }) => {
+      if (cmd._type === "Query") return Promise.resolve({ Items: [] });
+      if (cmd._type === "Put") return Promise.resolve({});
+      if (cmd._type === "Update") {
+        return Promise.resolve({
+          Attributes: {
+            dataStoreId: "test-uuid",
+            status: "CONNECTED",
+            version: 1,
+          },
+        });
+      }
+      return Promise.resolve({});
+    });
+
+    const result = (await handler(
+      makeEvent(
+        "createDataStore",
+        {
+          input: {
+            name: "legit",
+            type: "S3",
+            category: "S3_STORAGE",
+            provisionMode: "CONNECT_EXISTING",
+            orgId: "org-real",
+            config: JSON.stringify({ bucketName: "b" }),
+            clientRequestToken: "tok-accept-1",
+          },
+        },
+        { sub: "user-real", "custom:organization": "org-real" },
+      ),
+    )) as { dataStoreId: string };
+
+    expect(result.dataStoreId).toBe("test-uuid");
+  });
+
+  test("admin may create with an explicit orgId (bypass preserved)", async () => {
+    mockDynamoSend.mockImplementation((cmd: { _type?: string }) => {
+      if (cmd._type === "Query") return Promise.resolve({ Items: [] });
+      if (cmd._type === "Put") return Promise.resolve({});
+      if (cmd._type === "Update") {
+        return Promise.resolve({
+          Attributes: {
+            dataStoreId: "test-uuid",
+            status: "CONNECTED",
+            version: 1,
+          },
+        });
+      }
+      return Promise.resolve({});
+    });
+
+    const result = (await handler(
+      makeEvent(
+        "createDataStore",
+        {
+          input: {
+            name: "admin-created",
+            type: "S3",
+            category: "S3_STORAGE",
+            provisionMode: "CONNECT_EXISTING",
+            orgId: "org-any",
+            config: JSON.stringify({ bucketName: "b" }),
+            clientRequestToken: "tok-admin-1",
+          },
+        },
+        ADMIN_IDENTITY,
+      ),
+    )) as { dataStoreId: string };
+
+    expect(result.dataStoreId).toBe("test-uuid");
+  });
+});

--- a/backend/src/lambda/__tests__/datastore-resolver.property.test.ts
+++ b/backend/src/lambda/__tests__/datastore-resolver.property.test.ts
@@ -1,74 +1,97 @@
-import * as fc from 'fast-check';
-
+import * as fc from "fast-check";
 
 // ---- Mock setup ----
 
 // Track all DynamoDB calls
 const mockDynamoSend = jest.fn();
-jest.mock('@aws-sdk/client-dynamodb', () => ({
+jest.mock("@aws-sdk/client-dynamodb", () => ({
   DynamoDBClient: jest.fn().mockImplementation(() => ({})),
 }));
-jest.mock('@aws-sdk/lib-dynamodb', () => {
-  const actual = jest.requireActual('@aws-sdk/lib-dynamodb');
+jest.mock("@aws-sdk/lib-dynamodb", () => {
+  const actual = jest.requireActual("@aws-sdk/lib-dynamodb");
   return {
     ...actual,
     DynamoDBDocumentClient: {
       from: jest.fn().mockReturnValue({ send: mockDynamoSend }),
     },
-    PutCommand: jest.fn().mockImplementation((input) => ({ _type: 'Put', input })),
-    GetCommand: jest.fn().mockImplementation((input) => ({ _type: 'Get', input })),
-    UpdateCommand: jest.fn().mockImplementation((input) => ({ _type: 'Update', input })),
-    DeleteCommand: jest.fn().mockImplementation((input) => ({ _type: 'Delete', input })),
-    QueryCommand: jest.fn().mockImplementation((input) => ({ _type: 'Query', input })),
+    PutCommand: jest
+      .fn()
+      .mockImplementation((input) => ({ _type: "Put", input })),
+    GetCommand: jest
+      .fn()
+      .mockImplementation((input) => ({ _type: "Get", input })),
+    UpdateCommand: jest
+      .fn()
+      .mockImplementation((input) => ({ _type: "Update", input })),
+    DeleteCommand: jest
+      .fn()
+      .mockImplementation((input) => ({ _type: "Delete", input })),
+    QueryCommand: jest
+      .fn()
+      .mockImplementation((input) => ({ _type: "Query", input })),
   };
 });
 
 const mockSecretsSend = jest.fn();
-jest.mock('@aws-sdk/client-secrets-manager', () => ({
-  SecretsManagerClient: jest.fn().mockImplementation(() => ({ send: mockSecretsSend })),
-  CreateSecretCommand: jest.fn().mockImplementation((input) => ({ _type: 'CreateSecret', input })),
-  GetSecretValueCommand: jest.fn().mockImplementation((input) => ({ _type: 'GetSecretValue', input })),
-  UpdateSecretCommand: jest.fn().mockImplementation((input) => ({ _type: 'UpdateSecret', input })),
-  DeleteSecretCommand: jest.fn().mockImplementation((input) => ({ _type: 'DeleteSecret', input })),
+jest.mock("@aws-sdk/client-secrets-manager", () => ({
+  SecretsManagerClient: jest
+    .fn()
+    .mockImplementation(() => ({ send: mockSecretsSend })),
+  CreateSecretCommand: jest
+    .fn()
+    .mockImplementation((input) => ({ _type: "CreateSecret", input })),
+  GetSecretValueCommand: jest
+    .fn()
+    .mockImplementation((input) => ({ _type: "GetSecretValue", input })),
+  UpdateSecretCommand: jest
+    .fn()
+    .mockImplementation((input) => ({ _type: "UpdateSecret", input })),
+  DeleteSecretCommand: jest
+    .fn()
+    .mockImplementation((input) => ({ _type: "DeleteSecret", input })),
 }));
 
 // Mock the registry
 const mockAdapter = {
   requiredPolicies: jest.fn().mockReturnValue({ provision: [], connect: [] }),
-  provision: jest.fn().mockResolvedValue({ resourceArn: 'arn:aws:s3:::test-bucket' }),
+  provision: jest
+    .fn()
+    .mockResolvedValue({ resourceArn: "arn:aws:s3:::test-bucket" }),
   connect: jest.fn().mockResolvedValue(undefined),
   disconnect: jest.fn().mockResolvedValue(undefined),
-  testConnection: jest.fn().mockResolvedValue({ success: true, message: 'OK' }),
-  getMetrics: jest.fn().mockResolvedValue({ size: '0 MB', records: 0 }),
+  testConnection: jest.fn().mockResolvedValue({ success: true, message: "OK" }),
+  getMetrics: jest.fn().mockResolvedValue({ size: "0 MB", records: 0 }),
 };
-jest.mock('../adapters/registry', () => ({
+jest.mock("../adapters/registry", () => ({
   getAdapter: jest.fn().mockReturnValue(mockAdapter),
 }));
 
 // Mock the PolicyManager
 const mockPolicyManager = {
-  getAccountContext: jest.fn().mockResolvedValue({ accountId: '123456789012', region: 'us-east-1' }),
+  getAccountContext: jest
+    .fn()
+    .mockResolvedValue({ accountId: "123456789012", region: "us-east-1" }),
   ensureRole: jest.fn().mockResolvedValue(undefined),
   assumeScopedRole: jest.fn().mockResolvedValue({
-    accessKeyId: 'AKID',
-    secretAccessKey: 'SECRET',
-    sessionToken: 'TOKEN',
+    accessKeyId: "AKID",
+    secretAccessKey: "SECRET",
+    sessionToken: "TOKEN",
   }),
   deleteRole: jest.fn().mockResolvedValue(undefined),
 };
-jest.mock('../../utils/policy-manager', () => ({
+jest.mock("../../utils/policy-manager", () => ({
   PolicyManager: jest.fn().mockImplementation(() => mockPolicyManager),
 }));
 
-jest.mock('uuid', () => ({
-  v4: jest.fn().mockReturnValue('test-uuid-1234'),
+jest.mock("uuid", () => ({
+  v4: jest.fn().mockReturnValue("test-uuid-1234"),
 }));
 
 // Set env before import
-process.env.DATASTORES_TABLE = 'TestDataStoresTable';
+process.env.DATASTORES_TABLE = "TestDataStoresTable";
 
 // Import handler after all mocks
-import { handler } from '../datastore-resolver';
+import { handler } from "../datastore-resolver";
 
 type HandlerEvent = Parameters<typeof handler>[0];
 
@@ -77,7 +100,7 @@ type HandlerEvent = Parameters<typeof handler>[0];
  * (each command constructor is replaced by `{ _type, input }`).
  */
 interface FakeCommand {
-  _type: 'Put' | 'Get' | 'Update' | 'Delete' | 'Query';
+  _type: "Put" | "Get" | "Update" | "Delete" | "Query";
   input: {
     Item?: Record<string, unknown>;
     Key?: Record<string, unknown>;
@@ -97,34 +120,65 @@ interface DataStoreResult {
 // ---- Generators ----
 
 const dataStoreTypeArb = fc.constantFrom(
-  'S3', 'DYNAMODB', 'RDS_POSTGRESQL', 'RDS_MYSQL',
-  'AURORA_POSTGRESQL', 'AURORA_MYSQL', 'REDSHIFT', 'OPENSEARCH',
-  'NEPTUNE', 'TIMESTREAM', 'ELASTICACHE_REDIS', 'KEYSPACES',
-  'DOCUMENTDB', 'LAKE_FORMATION', 'S3_TABLES', 'SAGEMAKER_LAKEHOUSE',
-  'SAGEMAKER_FEATURE_STORE', 'KNOWLEDGE_BASE',
-  'EXTERNAL_POSTGRESQL', 'EXTERNAL_MYSQL', 'EXTERNAL_MONGODB',
+  "S3",
+  "DYNAMODB",
+  "RDS_POSTGRESQL",
+  "RDS_MYSQL",
+  "AURORA_POSTGRESQL",
+  "AURORA_MYSQL",
+  "REDSHIFT",
+  "OPENSEARCH",
+  "NEPTUNE",
+  "TIMESTREAM",
+  "ELASTICACHE_REDIS",
+  "KEYSPACES",
+  "DOCUMENTDB",
+  "LAKE_FORMATION",
+  "S3_TABLES",
+  "SAGEMAKER_LAKEHOUSE",
+  "SAGEMAKER_FEATURE_STORE",
+  "KNOWLEDGE_BASE",
+  "EXTERNAL_POSTGRESQL",
+  "EXTERNAL_MYSQL",
+  "EXTERNAL_MONGODB",
 );
 
 const categoryArb = fc.constantFrom(
-  'S3_STORAGE', 'NOSQL_DATABASE', 'RELATIONAL_DATABASE',
-  'KNOWLEDGE_BASE', 'DATA_WAREHOUSE', 'SEARCH_ENGINE',
+  "S3_STORAGE",
+  "NOSQL_DATABASE",
+  "RELATIONAL_DATABASE",
+  "KNOWLEDGE_BASE",
+  "DATA_WAREHOUSE",
+  "SEARCH_ENGINE",
 );
 
-const provisionModeArb = fc.constantFrom('CREATE_NEW', 'CONNECT_EXISTING');
+const provisionModeArb = fc.constantFrom("CREATE_NEW", "CONNECT_EXISTING");
 
 const nameArb = fc.stringMatching(/^[A-Za-z][A-Za-z0-9 -]{2,30}$/);
 
 const orgIdArb = fc.stringMatching(/^org-[a-z0-9]{8}$/);
 
-const clientRequestTokenArb = fc.stringMatching(
-  /^tok-[a-f0-9]{8}$/
-);
+const clientRequestTokenArb = fc.stringMatching(/^tok-[a-f0-9]{8}$/);
 
-function makeAppSyncEvent(fieldName: string, args: Record<string, unknown>): HandlerEvent {
+/**
+ * Builds an AppSync event whose caller identity carries a
+ * `custom:organization` claim. Property tests generate/pass an `orgId`
+ * for the row(s) under test — the identity's org must match so the
+ * fetch-then-verify org-scoping gate (finding ca76d041; assertRowOrg in
+ * auth-event.ts) lets the same-org caller through, exactly as a real
+ * caller acting on their own org's data store would. Defaults to
+ * 'org-test1234' for property cases that hard-code that orgId in their
+ * fixtures (optimistic-locking tests below) rather than generating one.
+ */
+function makeAppSyncEvent(
+  fieldName: string,
+  args: Record<string, unknown>,
+  callerOrgId = "org-test1234",
+): HandlerEvent {
   return {
     info: { fieldName },
     arguments: args,
-    identity: { username: 'test-user' },
+    identity: { username: "test-user", "custom:organization": callerOrgId },
   } as unknown as HandlerEvent;
 }
 
@@ -133,23 +187,33 @@ function makeAppSyncEvent(fieldName: string, args: Record<string, unknown>): Han
 beforeEach(() => {
   jest.clearAllMocks();
   mockAdapter.requiredPolicies.mockReturnValue({ provision: [], connect: [] });
-  mockAdapter.provision.mockResolvedValue({ resourceArn: 'arn:aws:s3:::test-bucket' });
+  mockAdapter.provision.mockResolvedValue({
+    resourceArn: "arn:aws:s3:::test-bucket",
+  });
   mockAdapter.connect.mockResolvedValue(undefined);
   mockAdapter.disconnect.mockResolvedValue(undefined);
-  mockAdapter.testConnection.mockResolvedValue({ success: true, message: 'OK' });
-  mockAdapter.getMetrics.mockResolvedValue({ size: '0 MB', records: 0 });
-  mockPolicyManager.getAccountContext.mockResolvedValue({ accountId: '123456789012', region: 'us-east-1' });
+  mockAdapter.testConnection.mockResolvedValue({
+    success: true,
+    message: "OK",
+  });
+  mockAdapter.getMetrics.mockResolvedValue({ size: "0 MB", records: 0 });
+  mockPolicyManager.getAccountContext.mockResolvedValue({
+    accountId: "123456789012",
+    region: "us-east-1",
+  });
   mockPolicyManager.ensureRole.mockResolvedValue(undefined);
   mockPolicyManager.assumeScopedRole.mockResolvedValue({
-    accessKeyId: 'AKID', secretAccessKey: 'SECRET', sessionToken: 'TOKEN',
+    accessKeyId: "AKID",
+    secretAccessKey: "SECRET",
+    sessionToken: "TOKEN",
   });
   mockPolicyManager.deleteRole.mockResolvedValue(undefined);
 });
 
 // Feature: datastore-adapter-pattern, Property 13: Resolver cleans up failed entry on mutation failure
 // Validates: Requirements 10.5
-describe('Property 13: Resolver cleans up failed entry on mutation failure', () => {
-  it('for any adapter error during createDataStore, the resolver deletes the failed record before re-throwing', () => {
+describe("Property 13: Resolver cleans up failed entry on mutation failure", () => {
+  it("for any adapter error during createDataStore, the resolver deletes the failed record before re-throwing", () => {
     return fc.assert(
       fc.asyncProperty(
         nameArb,
@@ -166,16 +230,16 @@ describe('Property 13: Resolver cleans up failed entry on mutation failure', () 
           const deleteInputs: FakeCommand["input"][] = [];
 
           mockDynamoSend.mockImplementation((cmd: FakeCommand) => {
-            if (cmd._type === 'Query') {
+            if (cmd._type === "Query") {
               return Promise.resolve({ Items: [] });
             }
-            if (cmd._type === 'Put') {
+            if (cmd._type === "Put") {
               return Promise.resolve({});
             }
-            if (cmd._type === 'Update') {
+            if (cmd._type === "Update") {
               return Promise.resolve({ Attributes: {} });
             }
-            if (cmd._type === 'Delete') {
+            if (cmd._type === "Delete") {
               deleteInputs.push(cmd.input);
               return Promise.resolve({});
             }
@@ -184,43 +248,47 @@ describe('Property 13: Resolver cleans up failed entry on mutation failure', () 
 
           // Make the adapter throw during provision/connect
           const adapterError = new Error(errorMsg);
-          if (provisionMode === 'CREATE_NEW') {
+          if (provisionMode === "CREATE_NEW") {
             mockAdapter.provision.mockRejectedValue(adapterError);
           } else {
             mockAdapter.connect.mockRejectedValue(adapterError);
           }
 
-          const event = makeAppSyncEvent('createDataStore', {
-            input: {
-              name,
-              type,
-              category,
-              provisionMode,
-              orgId,
-              config: JSON.stringify({ bucketName: 'test' }),
-              clientRequestToken: 'tok-12345678',
+          const event = makeAppSyncEvent(
+            "createDataStore",
+            {
+              input: {
+                name,
+                type,
+                category,
+                provisionMode,
+                orgId,
+                config: JSON.stringify({ bucketName: "test" }),
+                clientRequestToken: "tok-12345678",
+              },
             },
-          });
+            orgId,
+          );
 
           await expect(handler(event)).rejects.toThrow(errorMsg);
 
           // Verify that a DeleteCommand was sent to clean up the failed entry
           expect(deleteInputs.length).toBeGreaterThanOrEqual(1);
           const cleanupDelete = deleteInputs.find(
-            (d) => d?.Key?.dataStoreId !== undefined
+            (d) => d?.Key?.dataStoreId !== undefined,
           );
           expect(cleanupDelete).toBeDefined();
-        }
+        },
       ),
-      { numRuns: 20 }
+      { numRuns: 20 },
     );
   });
 });
 
 // Feature: datastore-adapter-pattern, Property 14: Idempotent creation via clientRequestToken
 // Validates: Requirements 11.1
-describe('Property 14: Idempotent creation via clientRequestToken', () => {
-  it('calling createDataStore twice with the same clientRequestToken returns the same record without creating a duplicate', () => {
+describe("Property 14: Idempotent creation via clientRequestToken", () => {
+  it("calling createDataStore twice with the same clientRequestToken returns the same record without creating a duplicate", () => {
     return fc.assert(
       fc.asyncProperty(
         nameArb,
@@ -232,11 +300,11 @@ describe('Property 14: Idempotent creation via clientRequestToken', () => {
           mockDynamoSend.mockReset();
 
           const existingItem = {
-            dataStoreId: 'existing-id-1234',
+            dataStoreId: "existing-id-1234",
             name,
             type,
             category,
-            status: 'CONNECTED',
+            status: "CONNECTED",
             orgId,
             clientRequestToken: token,
             version: 1,
@@ -244,46 +312,50 @@ describe('Property 14: Idempotent creation via clientRequestToken', () => {
 
           // The QueryCommand for idempotency check returns the existing item
           mockDynamoSend.mockImplementation((cmd: FakeCommand) => {
-            if (cmd._type === 'Query') {
+            if (cmd._type === "Query") {
               return Promise.resolve({ Items: [existingItem] });
             }
             return Promise.resolve({});
           });
 
-          const event = makeAppSyncEvent('createDataStore', {
-            input: {
-              name,
-              type,
-              category,
-              provisionMode: 'CONNECT_EXISTING',
-              orgId,
-              config: JSON.stringify({}),
-              clientRequestToken: token,
+          const event = makeAppSyncEvent(
+            "createDataStore",
+            {
+              input: {
+                name,
+                type,
+                category,
+                provisionMode: "CONNECT_EXISTING",
+                orgId,
+                config: JSON.stringify({}),
+                clientRequestToken: token,
+              },
             },
-          });
+            orgId,
+          );
 
-          const result = await handler(event) as DataStoreResult;
+          const result = (await handler(event)) as DataStoreResult;
 
           // Should return the existing item
           expect(result).toEqual(existingItem);
-          expect(result.dataStoreId).toBe('existing-id-1234');
+          expect(result.dataStoreId).toBe("existing-id-1234");
 
           // Should NOT have called PutCommand (no new item created)
           const putCalls = mockDynamoSend.mock.calls.filter(
-            ([cmd]: [FakeCommand]) => cmd._type === "Put"
+            ([cmd]: [FakeCommand]) => cmd._type === "Put",
           );
           expect(putCalls).toHaveLength(0);
-        }
+        },
       ),
-      { numRuns: 20 }
+      { numRuns: 20 },
     );
   });
 });
 
 // Feature: datastore-adapter-pattern, Property 15: Optimistic locking rejects stale versions
 // Validates: Requirements 11.2
-describe('Property 15: Optimistic locking rejects stale versions', () => {
-  it('connectDataStore with a stale version throws ConflictError after retries', () => {
+describe("Property 15: Optimistic locking rejects stale versions", () => {
+  it("connectDataStore with a stale version throws ConflictError after retries", () => {
     return fc.assert(
       fc.asyncProperty(
         fc.integer({ min: 2, max: 100 }),
@@ -291,13 +363,13 @@ describe('Property 15: Optimistic locking rejects stale versions', () => {
           mockDynamoSend.mockReset();
 
           const existingItem = {
-            dataStoreId: 'ds-lock-test',
-            name: 'Test Store',
-            type: 'S3',
-            category: 'S3_STORAGE',
-            status: 'DISCONNECTED',
-            orgId: 'org-test1234',
-            config: JSON.stringify({ bucketName: 'test' }),
+            dataStoreId: "ds-lock-test",
+            name: "Test Store",
+            type: "S3",
+            category: "S3_STORAGE",
+            status: "DISCONNECTED",
+            orgId: "org-test1234",
+            config: JSON.stringify({ bucketName: "test" }),
             version: currentVersion,
           };
 
@@ -305,31 +377,29 @@ describe('Property 15: Optimistic locking rejects stale versions', () => {
           // UpdateCommand always fails with ConditionalCheckFailedException
           // (simulating another process bumping the version)
           mockDynamoSend.mockImplementation((cmd: FakeCommand) => {
-            if (cmd._type === 'Get') {
+            if (cmd._type === "Get") {
               return Promise.resolve({ Item: existingItem });
             }
-            if (cmd._type === 'Update') {
+            if (cmd._type === "Update") {
               const err = new Error("Conditional check failed");
-              err.name = 'ConditionalCheckFailedException';
+              err.name = "ConditionalCheckFailedException";
               return Promise.reject(err);
             }
             return Promise.resolve({});
           });
 
-          const event = makeAppSyncEvent('connectDataStore', {
-            dataStoreId: 'ds-lock-test',
+          const event = makeAppSyncEvent("connectDataStore", {
+            dataStoreId: "ds-lock-test",
           });
 
-          await expect(handler(event)).rejects.toThrow(
-            /[Vv]ersion conflict/
-          );
-        }
+          await expect(handler(event)).rejects.toThrow(/[Vv]ersion conflict/);
+        },
       ),
-      { numRuns: 20 }
+      { numRuns: 20 },
     );
   });
 
-  it('disconnectDataStore with a stale version throws ConflictError after retries', () => {
+  it("disconnectDataStore with a stale version throws ConflictError after retries", () => {
     return fc.assert(
       fc.asyncProperty(
         fc.integer({ min: 2, max: 100 }),
@@ -337,49 +407,50 @@ describe('Property 15: Optimistic locking rejects stale versions', () => {
           mockDynamoSend.mockReset();
 
           const existingItem = {
-            dataStoreId: 'ds-lock-test-2',
-            name: 'Test Store 2',
-            type: 'DYNAMODB',
-            category: 'NOSQL_DATABASE',
-            status: 'CONNECTED',
-            orgId: 'org-test5678',
-            config: JSON.stringify({ tableName: 'test' }),
+            dataStoreId: "ds-lock-test-2",
+            name: "Test Store 2",
+            type: "DYNAMODB",
+            category: "NOSQL_DATABASE",
+            status: "CONNECTED",
+            orgId: "org-test5678",
+            config: JSON.stringify({ tableName: "test" }),
             version: currentVersion,
           };
 
           mockDynamoSend.mockImplementation((cmd: FakeCommand) => {
-            if (cmd._type === 'Get') {
+            if (cmd._type === "Get") {
               return Promise.resolve({ Item: existingItem });
             }
-            if (cmd._type === 'Update') {
+            if (cmd._type === "Update") {
               const err = new Error("Conditional check failed");
-              err.name = 'ConditionalCheckFailedException';
+              err.name = "ConditionalCheckFailedException";
               return Promise.reject(err);
             }
             return Promise.resolve({});
           });
 
-          const event = makeAppSyncEvent('disconnectDataStore', {
-            dataStoreId: 'ds-lock-test-2',
-          });
-
-          await expect(handler(event)).rejects.toThrow(
-            /[Vv]ersion conflict/
+          const event = makeAppSyncEvent(
+            "disconnectDataStore",
+            {
+              dataStoreId: "ds-lock-test-2",
+            },
+            "org-test5678",
           );
-        }
+
+          await expect(handler(event)).rejects.toThrow(/[Vv]ersion conflict/);
+        },
       ),
-      { numRuns: 20 }
+      { numRuns: 20 },
     );
   });
 });
 
-
 // Feature: datastore-integration-pipeline, Property 1: Usage Field Round-Trip
 // Validates: Requirements 1.1, 1.3, 1.5, 1.6
-describe('Property 1: Usage Field Round-Trip', () => {
-  const usageArb = fc.constantFrom('KNOWLEDGE', 'OPERATIONAL', 'BOTH');
+describe("Property 1: Usage Field Round-Trip", () => {
+  const usageArb = fc.constantFrom("KNOWLEDGE", "OPERATIONAL", "BOTH");
 
-  it('createDataStore followed by getDataStore returns usage as uppercase GraphQL enum value', () => {
+  it("createDataStore followed by getDataStore returns usage as uppercase GraphQL enum value", () => {
     return fc.assert(
       fc.asyncProperty(
         nameArb,
@@ -394,20 +465,20 @@ describe('Property 1: Usage Field Round-Trip', () => {
           let persistedItem: Record<string, unknown> | null = null;
 
           mockDynamoSend.mockImplementation((cmd: FakeCommand) => {
-            if (cmd._type === 'Query') {
+            if (cmd._type === "Query") {
               // Idempotency check — no existing item
               return Promise.resolve({ Items: [] });
             }
-            if (cmd._type === 'Put') {
+            if (cmd._type === "Put") {
               persistedItem = cmd.input.Item ?? null;
               return Promise.resolve({});
             }
-            if (cmd._type === 'Update') {
+            if (cmd._type === "Update") {
               // Final status update — merge into persisted item and return
-              const updated = { ...persistedItem, status: 'CONNECTED' };
+              const updated = { ...persistedItem, status: "CONNECTED" };
               return Promise.resolve({ Attributes: updated });
             }
-            if (cmd._type === 'Get') {
+            if (cmd._type === "Get") {
               // Return the persisted item
               return Promise.resolve({ Item: persistedItem });
             }
@@ -415,31 +486,39 @@ describe('Property 1: Usage Field Round-Trip', () => {
           });
 
           // Create with usage
-          const createEvent = makeAppSyncEvent('createDataStore', {
-            input: {
-              name,
-              type,
-              category,
-              provisionMode: 'CONNECT_EXISTING',
-              orgId,
-              config: JSON.stringify({ bucketName: 'test' }),
-              clientRequestToken: 'tok-roundtrip',
-              usage,
+          const createEvent = makeAppSyncEvent(
+            "createDataStore",
+            {
+              input: {
+                name,
+                type,
+                category,
+                provisionMode: "CONNECT_EXISTING",
+                orgId,
+                config: JSON.stringify({ bucketName: "test" }),
+                clientRequestToken: "tok-roundtrip",
+                usage,
+              },
             },
-          });
+            orgId,
+          );
 
           await handler(createEvent);
 
           // Now getDataStore should return the same usage
-          const getEvent = makeAppSyncEvent('getDataStore', {
-            dataStoreId: persistedItem!.dataStoreId,
-          });
+          const getEvent = makeAppSyncEvent(
+            "getDataStore",
+            {
+              dataStoreId: persistedItem!.dataStoreId,
+            },
+            orgId,
+          );
 
-          const result = await handler(getEvent) as DataStoreResult;
+          const result = (await handler(getEvent)) as DataStoreResult;
           expect(result.usage).toBe(usage);
-        }
+        },
       ),
-      { numRuns: 100 }
+      { numRuns: 100 },
     );
   });
 
@@ -456,51 +535,59 @@ describe('Property 1: Usage Field Round-Trip', () => {
           let persistedItem: Record<string, unknown> | null = null;
 
           mockDynamoSend.mockImplementation((cmd: FakeCommand) => {
-            if (cmd._type === 'Query') {
+            if (cmd._type === "Query") {
               return Promise.resolve({ Items: [] });
             }
-            if (cmd._type === 'Put') {
+            if (cmd._type === "Put") {
               persistedItem = cmd.input.Item ?? null;
               return Promise.resolve({});
             }
-            if (cmd._type === 'Update') {
-              const updated = { ...persistedItem, status: 'CONNECTED' };
+            if (cmd._type === "Update") {
+              const updated = { ...persistedItem, status: "CONNECTED" };
               return Promise.resolve({ Attributes: updated });
             }
-            if (cmd._type === 'Get') {
+            if (cmd._type === "Get") {
               return Promise.resolve({ Item: persistedItem });
             }
             return Promise.resolve({});
           });
 
           // Create WITHOUT usage field
-          const createEvent = makeAppSyncEvent('createDataStore', {
-            input: {
-              name,
-              type,
-              category,
-              provisionMode: 'CONNECT_EXISTING',
-              orgId,
-              config: JSON.stringify({ bucketName: 'test' }),
-              clientRequestToken: 'tok-nodefault',
+          const createEvent = makeAppSyncEvent(
+            "createDataStore",
+            {
+              input: {
+                name,
+                type,
+                category,
+                provisionMode: "CONNECT_EXISTING",
+                orgId,
+                config: JSON.stringify({ bucketName: "test" }),
+                clientRequestToken: "tok-nodefault",
+              },
             },
-          });
+            orgId,
+          );
 
           await handler(createEvent);
 
-          const getEvent = makeAppSyncEvent('getDataStore', {
-            dataStoreId: persistedItem!.dataStoreId,
-          });
+          const getEvent = makeAppSyncEvent(
+            "getDataStore",
+            {
+              dataStoreId: persistedItem!.dataStoreId,
+            },
+            orgId,
+          );
 
-          const result = await handler(getEvent) as DataStoreResult;
-          expect(result.usage).toBe('BOTH');
-        }
+          const result = (await handler(getEvent)) as DataStoreResult;
+          expect(result.usage).toBe("BOTH");
+        },
       ),
-      { numRuns: 100 }
+      { numRuns: 100 },
     );
   });
 
-  it('updateDataStore with a new usage value followed by getDataStore returns the updated value', () => {
+  it("updateDataStore with a new usage value followed by getDataStore returns the updated value", () => {
     return fc.assert(
       fc.asyncProperty(
         usageArb,
@@ -510,26 +597,30 @@ describe('Property 1: Usage Field Round-Trip', () => {
 
           // Simulate an existing item with initialUsage
           let storedItem: Record<string, unknown> = {
-            dataStoreId: 'ds-update-usage',
-            name: 'Test Store',
-            type: 'S3',
-            category: 'S3_STORAGE',
-            status: 'CONNECTED',
-            orgId: 'org-test0001',
+            dataStoreId: "ds-update-usage",
+            name: "Test Store",
+            type: "S3",
+            category: "S3_STORAGE",
+            status: "CONNECTED",
+            orgId: "org-test0001",
             usage: initialUsage,
             version: 1,
-            config: JSON.stringify({ bucketName: 'test' }),
+            config: JSON.stringify({ bucketName: "test" }),
           };
 
           mockDynamoSend.mockImplementation((cmd: FakeCommand) => {
-            if (cmd._type === 'Get') {
+            if (cmd._type === "Get") {
               return Promise.resolve({ Item: { ...storedItem } });
             }
-            if (cmd._type === 'Update') {
+            if (cmd._type === "Update") {
               // Apply the update to storedItem
               const exprValues = cmd.input.ExpressionAttributeValues || {};
-              if (exprValues[':usage'] !== undefined) {
-                storedItem = { ...storedItem, usage: exprValues[':usage'], version: storedItem.version + 1 };
+              if (exprValues[":usage"] !== undefined) {
+                storedItem = {
+                  ...storedItem,
+                  usage: exprValues[":usage"],
+                  version: storedItem.version + 1,
+                };
               } else {
                 storedItem = { ...storedItem, version: storedItem.version + 1 };
               }
@@ -539,34 +630,41 @@ describe('Property 1: Usage Field Round-Trip', () => {
           });
 
           // Update with new usage
-          const updateEvent = makeAppSyncEvent('updateDataStore', {
-            input: {
-              dataStoreId: 'ds-update-usage',
-              usage: newUsage,
-              version: 1,
+          const updateEvent = makeAppSyncEvent(
+            "updateDataStore",
+            {
+              input: {
+                dataStoreId: "ds-update-usage",
+                usage: newUsage,
+                version: 1,
+              },
             },
-          });
+            "org-test0001",
+          );
 
           await handler(updateEvent);
 
           // Get should return the new usage
-          const getEvent = makeAppSyncEvent('getDataStore', {
-            dataStoreId: 'ds-update-usage',
-          });
+          const getEvent = makeAppSyncEvent(
+            "getDataStore",
+            {
+              dataStoreId: "ds-update-usage",
+            },
+            "org-test0001",
+          );
 
-          const result = await handler(getEvent) as DataStoreResult;
+          const result = (await handler(getEvent)) as DataStoreResult;
           expect(result.usage).toBe(newUsage);
-        }
+        },
       ),
-      { numRuns: 100 }
+      { numRuns: 100 },
     );
   });
 });
 
-
 // Feature: datastore-integration-pipeline, Property 2: Usage Field Backward Compatibility
 // Validates: Requirements 1.5, 1.10
-describe('Property 2: Usage Field Backward Compatibility', () => {
+describe("Property 2: Usage Field Backward Compatibility", () => {
   it('getDataStore returns usage "both" for legacy items that lack a usage field', () => {
     return fc.assert(
       fc.asyncProperty(
@@ -579,34 +677,38 @@ describe('Property 2: Usage Field Backward Compatibility', () => {
 
           // Legacy item — no usage field
           const legacyItem: Record<string, unknown> = {
-            dataStoreId: 'ds-legacy-compat',
+            dataStoreId: "ds-legacy-compat",
             name,
             type,
             category,
-            status: 'CONNECTED',
+            status: "CONNECTED",
             orgId,
             version: 1,
-            config: JSON.stringify({ bucketName: 'test' }),
+            config: JSON.stringify({ bucketName: "test" }),
           };
           // Explicitly ensure no usage field
           delete legacyItem.usage;
 
           mockDynamoSend.mockImplementation((cmd: FakeCommand) => {
-            if (cmd._type === 'Get') {
+            if (cmd._type === "Get") {
               return Promise.resolve({ Item: { ...legacyItem } });
             }
             return Promise.resolve({});
           });
 
-          const getEvent = makeAppSyncEvent('getDataStore', {
-            dataStoreId: 'ds-legacy-compat',
-          });
+          const getEvent = makeAppSyncEvent(
+            "getDataStore",
+            {
+              dataStoreId: "ds-legacy-compat",
+            },
+            orgId,
+          );
 
-          const result = await handler(getEvent) as DataStoreResult;
-          expect(result.usage).toBe('BOTH');
-        }
+          const result = (await handler(getEvent)) as DataStoreResult;
+          expect(result.usage).toBe("BOTH");
+        },
       ),
-      { numRuns: 100 }
+      { numRuns: 100 },
     );
   });
 
@@ -620,7 +722,7 @@ describe('Property 2: Usage Field Backward Compatibility', () => {
             type: dataStoreTypeArb,
             category: categoryArb,
           }),
-          { minLength: 1, maxLength: 5 }
+          { minLength: 1, maxLength: 5 },
         ),
         async (orgId, items) => {
           mockDynamoSend.mockReset();
@@ -631,43 +733,50 @@ describe('Property 2: Usage Field Backward Compatibility', () => {
             name: item.name,
             type: item.type,
             category: item.category,
-            status: 'CONNECTED',
+            status: "CONNECTED",
             orgId,
             version: 1,
             config: JSON.stringify({}),
           }));
 
           mockDynamoSend.mockImplementation((cmd: FakeCommand) => {
-            if (cmd._type === 'Query') {
+            if (cmd._type === "Query") {
               return Promise.resolve({ Items: legacyItems });
             }
             return Promise.resolve({});
           });
 
-          const listEvent = makeAppSyncEvent('listDataStores', {
+          const listEvent = makeAppSyncEvent("listDataStores", {
             orgId,
           });
 
-          const result = await handler(listEvent) as DataStoreResult[];
+          const result = (await handler(listEvent)) as DataStoreResult[];
           for (const item of result) {
-            expect(item.usage).toBe('BOTH');
+            expect(item.usage).toBe("BOTH");
           }
-        }
+        },
       ),
-      { numRuns: 100 }
+      { numRuns: 100 },
     );
   });
 });
 
-
 // Feature: datastore-integration-pipeline, Property 5: Discovery API Returns Only CONNECTED Stores with Correct Capabilities
 // **Validates: Requirements 3.3, 3.5, 3.6, 3.7**
-describe('Property 5: Discovery API Returns Only CONNECTED Stores with Correct Capabilities', () => {
+describe("Property 5: Discovery API Returns Only CONNECTED Stores with Correct Capabilities", () => {
   // Import the real getDataStoreOperations for capability assertions
-  const { getDataStoreOperations } = jest.requireActual('../../utils/operations-registry') as typeof import('../../utils/operations-registry');
+  const { getDataStoreOperations } = jest.requireActual(
+    "../../utils/operations-registry",
+  ) as typeof import("../../utils/operations-registry");
 
-  const usageArb = fc.constantFrom('knowledge', 'operational', 'both');
-  const statusArb = fc.constantFrom('CONNECTED', 'ERROR', 'PROVISIONING', 'DELETING', 'CREATED');
+  const usageArb = fc.constantFrom("knowledge", "operational", "both");
+  const statusArb = fc.constantFrom(
+    "CONNECTED",
+    "ERROR",
+    "PROVISIONING",
+    "DELETING",
+    "CREATED",
+  );
 
   const dataStoreItemArb = fc.record({
     dataStoreId: fc.stringMatching(/^ds-[a-z0-9]{8}$/),
@@ -676,13 +785,13 @@ describe('Property 5: Discovery API Returns Only CONNECTED Stores with Correct C
     category: categoryArb,
     status: statusArb,
     usage: usageArb,
-    provider: fc.constantFrom('Amazon Web Services', 'External'),
+    provider: fc.constantFrom("Amazon Web Services", "External"),
     orgId: orgIdArb,
     version: fc.integer({ min: 1, max: 10 }),
-    config: fc.constant(JSON.stringify({ bucketName: 'test' })),
+    config: fc.constant(JSON.stringify({ bucketName: "test" })),
   });
 
-  it('returns only stores with status CONNECTED', () => {
+  it("returns only stores with status CONNECTED", () => {
     return fc.assert(
       fc.asyncProperty(
         orgIdArb,
@@ -695,74 +804,80 @@ describe('Property 5: Discovery API Returns Only CONNECTED Stores with Correct C
 
           // Mock DynamoDB query to return all org stores
           mockDynamoSend.mockImplementation((cmd: FakeCommand) => {
-            if (cmd._type === 'Query') {
+            if (cmd._type === "Query") {
               return Promise.resolve({ Items: orgStores });
             }
             return Promise.resolve({});
           });
 
-          const event = makeAppSyncEvent('listAvailableDataSources', {
+          const event = makeAppSyncEvent("listAvailableDataSources", {
             orgId,
           });
 
-          const result = await handler(event) as DataStoreResult[];
+          const result = (await handler(event)) as DataStoreResult[];
 
           // Assert only CONNECTED stores are returned
-          const connectedStores = orgStores.filter((s) => s.status === 'CONNECTED');
+          const connectedStores = orgStores.filter(
+            (s) => s.status === "CONNECTED",
+          );
           expect(result.length).toBe(connectedStores.length);
           for (const item of result) {
-            expect(item.status).toBe('CONNECTED');
+            expect(item.status).toBe("CONNECTED");
           }
-        }
+        },
       ),
-      { numRuns: 100 }
+      { numRuns: 100 },
     );
   });
 
-  it('filters by usage parameter correctly (both matches either knowledge or operational)', () => {
+  it("filters by usage parameter correctly (both matches either knowledge or operational)", () => {
     return fc.assert(
       fc.asyncProperty(
         orgIdArb,
         fc.array(dataStoreItemArb, { minLength: 1, maxLength: 10 }),
-        fc.constantFrom('KNOWLEDGE', 'OPERATIONAL', 'BOTH'),
+        fc.constantFrom("KNOWLEDGE", "OPERATIONAL", "BOTH"),
         async (orgId, stores, usageFilter) => {
           mockDynamoSend.mockReset();
 
           // All stores CONNECTED so we only test usage filtering
-          const orgStores = stores.map((s) => ({ ...s, orgId, status: 'CONNECTED' }));
+          const orgStores = stores.map((s) => ({
+            ...s,
+            orgId,
+            status: "CONNECTED",
+          }));
 
           mockDynamoSend.mockImplementation((cmd: FakeCommand) => {
-            if (cmd._type === 'Query') {
+            if (cmd._type === "Query") {
               return Promise.resolve({ Items: orgStores });
             }
             return Promise.resolve({});
           });
 
-          const event = makeAppSyncEvent('listAvailableDataSources', {
+          const event = makeAppSyncEvent("listAvailableDataSources", {
             orgId,
             usage: usageFilter,
           });
 
-          const result = await handler(event) as DataStoreResult[];
+          const result = (await handler(event)) as DataStoreResult[];
 
           // Compute expected filtered stores
           const filterUpper = usageFilter.toUpperCase();
           const expectedStores = orgStores.filter((s) => {
-            const storeUsage = (s.usage || 'BOTH').toUpperCase();
-            if (filterUpper === 'BOTH') {
+            const storeUsage = (s.usage || "BOTH").toUpperCase();
+            if (filterUpper === "BOTH") {
               return true;
             }
-            return storeUsage === filterUpper || storeUsage === 'BOTH';
+            return storeUsage === filterUpper || storeUsage === "BOTH";
           });
 
           expect(result.length).toBe(expectedStores.length);
-        }
+        },
       ),
-      { numRuns: 100 }
+      { numRuns: 100 },
     );
   });
 
-  it('each returned store has capabilities matching getDataStoreOperations(store.type)', () => {
+  it("each returned store has capabilities matching getDataStoreOperations(store.type)", () => {
     return fc.assert(
       fc.asyncProperty(
         orgIdArb,
@@ -771,61 +886,74 @@ describe('Property 5: Discovery API Returns Only CONNECTED Stores with Correct C
           mockDynamoSend.mockReset();
 
           // All stores CONNECTED
-          const orgStores = stores.map((s) => ({ ...s, orgId, status: 'CONNECTED' }));
+          const orgStores = stores.map((s) => ({
+            ...s,
+            orgId,
+            status: "CONNECTED",
+          }));
 
           mockDynamoSend.mockImplementation((cmd: FakeCommand) => {
-            if (cmd._type === 'Query') {
+            if (cmd._type === "Query") {
               return Promise.resolve({ Items: orgStores });
             }
             return Promise.resolve({});
           });
 
-          const event = makeAppSyncEvent('listAvailableDataSources', {
+          const event = makeAppSyncEvent("listAvailableDataSources", {
             orgId,
           });
 
-          const result = await handler(event) as DataStoreResult[];
+          const result = (await handler(event)) as DataStoreResult[];
 
           // Assert capabilities match the operations registry
           for (const item of result) {
             const expectedCapabilities = getDataStoreOperations(item.type!);
             expect(item.capabilities).toEqual(expectedCapabilities);
           }
-        }
+        },
       ),
-      { numRuns: 100 }
+      { numRuns: 100 },
     );
   });
 
-  it('returns empty array for orgs with no connected stores', () => {
+  it("returns empty array for orgs with no connected stores", () => {
     return fc.assert(
-      fc.asyncProperty(
-        orgIdArb,
-        async (orgId) => {
-          mockDynamoSend.mockReset();
+      fc.asyncProperty(orgIdArb, async (orgId) => {
+        mockDynamoSend.mockReset();
 
-          // Return stores that are all non-CONNECTED
-          const nonConnectedStores = [
-            { dataStoreId: 'ds-err00001', status: 'ERROR', orgId, type: 'S3', usage: 'both' },
-            { dataStoreId: 'ds-prov0001', status: 'PROVISIONING', orgId, type: 'DYNAMODB', usage: 'operational' },
-          ];
-
-          mockDynamoSend.mockImplementation((cmd: FakeCommand) => {
-            if (cmd._type === 'Query') {
-              return Promise.resolve({ Items: nonConnectedStores });
-            }
-            return Promise.resolve({});
-          });
-
-          const event = makeAppSyncEvent('listAvailableDataSources', {
+        // Return stores that are all non-CONNECTED
+        const nonConnectedStores = [
+          {
+            dataStoreId: "ds-err00001",
+            status: "ERROR",
             orgId,
-          });
+            type: "S3",
+            usage: "both",
+          },
+          {
+            dataStoreId: "ds-prov0001",
+            status: "PROVISIONING",
+            orgId,
+            type: "DYNAMODB",
+            usage: "operational",
+          },
+        ];
 
-          const result = await handler(event) as DataStoreResult[];
-          expect(result).toEqual([]);
-        }
-      ),
-      { numRuns: 100 }
+        mockDynamoSend.mockImplementation((cmd: FakeCommand) => {
+          if (cmd._type === "Query") {
+            return Promise.resolve({ Items: nonConnectedStores });
+          }
+          return Promise.resolve({});
+        });
+
+        const event = makeAppSyncEvent("listAvailableDataSources", {
+          orgId,
+        });
+
+        const result = (await handler(event)) as DataStoreResult[];
+        expect(result).toEqual([]);
+      }),
+      { numRuns: 100 },
     );
   });
 });

--- a/backend/src/lambda/datastore-resolver.ts
+++ b/backend/src/lambda/datastore-resolver.ts
@@ -18,9 +18,14 @@ import { v4 as uuidv4 } from "uuid";
 import { getAdapter } from "./adapters/registry";
 import { PolicyManager, type ScopedCredentials } from "../utils/policy-manager";
 import { getDataStoreOperations } from "../utils/operations-registry";
-import { extractOrgFromEvent, isAdminFromEvent } from "../utils/auth-event";
+import {
+  extractOrgFromEvent,
+  isAdminFromEvent,
+  assertRowOrg,
+} from "../utils/auth-event";
 import {
   ConflictError,
+  PermissionError,
   ResourceNotFoundError,
   ValidationError,
 } from "./adapters/errors";
@@ -104,6 +109,7 @@ interface DataStoreRecord {
   secretArn?: string;
   status?: string;
   usage?: string;
+  orgId?: string;
   [key: string]: unknown;
 }
 
@@ -155,7 +161,7 @@ export async function handler(event: AppSyncEvent) {
         return await listDataStores(effectiveOrgId, event.arguments.category);
       }
       case "getDataStore":
-        return await getDataStore(event.arguments.dataStoreId);
+        return await getDataStoreGuarded(event.arguments.dataStoreId, event);
       case "getDataStoreStats": {
         // Org scoping (sweep finding 615aa5bb, filed as the getDataStoreStats
         // defect): same coerce-not-reject read-path gate as listDataStores
@@ -170,17 +176,21 @@ export async function handler(event: AppSyncEvent) {
         return await createDataStore(
           event.arguments.input,
           event.identity?.username || "system",
+          event,
         );
       case "updateDataStore":
-        return await updateDataStore(event.arguments.input);
+        return await updateDataStore(event.arguments.input, event);
       case "deleteDataStore":
-        return await deleteDataStore(event.arguments.dataStoreId);
+        return await deleteDataStore(event.arguments.dataStoreId, event);
       case "connectDataStore":
-        return await connectDataStore(event.arguments.dataStoreId);
+        return await connectDataStore(event.arguments.dataStoreId, event);
       case "disconnectDataStore":
-        return await disconnectDataStore(event.arguments.dataStoreId);
+        return await disconnectDataStore(event.arguments.dataStoreId, event);
       case "testDataStoreConnection":
-        return await testDataStoreConnection(event.arguments.dataStoreId);
+        return await testDataStoreConnection(
+          event.arguments.dataStoreId,
+          event,
+        );
       case "listAvailableDataSources": {
         // Org scoping (sweep finding 615aa5bb): same coerce-not-reject
         // read-path gate as listDataStores/getDataStoreStats above.
@@ -302,6 +312,24 @@ async function getDataStore(dataStoreId: string): Promise<DataStoreRecord> {
   return item as DataStoreRecord;
 }
 
+/**
+ * Fetch-then-verify gate for the `getDataStore` GraphQL field itself
+ * (finding ca76d041, datastore half; CRE item 2). Unlike the collection
+ * reads above (listDataStores/getDataStoreStats/listAvailableDataSources),
+ * a single by-ID read has no orgId argument to coerce against — there is
+ * nothing to fall back to, so an unresolvable/mismatched caller org is a
+ * hard denial via the shared `assertRowOrg` gate, same as every mutation
+ * below. Admins bypass (assertRowOrg honours isAdminFromEvent).
+ */
+async function getDataStoreGuarded(
+  dataStoreId: string,
+  event: unknown,
+): Promise<DataStoreRecord> {
+  const item = await getDataStore(dataStoreId);
+  await assertRowOrg(item, event);
+  return item;
+}
+
 async function getDataStoreStats(orgId: string) {
   const result = await dynamodb.send(
     new QueryCommand({
@@ -389,7 +417,27 @@ async function listAvailableDataSources(orgId: string, usage?: string) {
 
 // --- Mutations ---
 
-async function createDataStore(input: CreateDataStoreInput, createdBy: string) {
+async function createDataStore(
+  input: CreateDataStoreInput,
+  createdBy: string,
+  event: unknown,
+) {
+  // Org scoping (finding ca76d041, datastore half; CRE item 2): createDataStore
+  // trusted a client-supplied input.orgId outright. Mutation convention is
+  // reject-not-coerce (unlike the read-path collection queries above): derive
+  // the caller's org server-side and refuse a mismatched client value BEFORE
+  // any DynamoDB write, Secrets Manager call, or IAM change. Admins may still
+  // create on behalf of any org (same bypass every other operation honours).
+  const admin = isAdminFromEvent(event);
+  if (!admin) {
+    const callerOrgId = await extractOrgFromEvent(event);
+    if (!callerOrgId || callerOrgId !== input.orgId) {
+      throw new PermissionError(
+        "Access denied: orgId does not match caller's organization",
+      );
+    }
+  }
+
   const dataStoreId = uuidv4();
   const timestamp = new Date().toISOString();
 
@@ -598,9 +646,14 @@ async function createDataStore(input: CreateDataStoreInput, createdBy: string) {
   }
 }
 
-async function updateDataStore(input: UpdateDataStoreInput) {
+async function updateDataStore(input: UpdateDataStoreInput, event: unknown) {
   const dataStoreId = input.dataStoreId;
   const existing = await getDataStore(dataStoreId);
+
+  // Org scoping (finding ca76d041): reconcile BEFORE the optimistic-lock
+  // check or any write — a cross-org caller must never learn version info
+  // via a ConflictError side channel either.
+  await assertRowOrg(existing, event);
 
   // Optimistic locking
   if (existing.version !== input.version) {
@@ -676,7 +729,7 @@ async function updateDataStore(input: UpdateDataStoreInput) {
   }
 }
 
-async function deleteDataStore(dataStoreId: string) {
+async function deleteDataStore(dataStoreId: string, event: unknown) {
   let existing: DataStoreRecord | undefined;
 
   try {
@@ -690,6 +743,13 @@ async function deleteDataStore(dataStoreId: string) {
     }
     throw error;
   }
+
+  // Org scoping (finding ca76d041): reconcile BEFORE disconnect, deprovision,
+  // secret deletion, IAM role deletion, or the DynamoDB delete — this is the
+  // worst-case operation (it deprovisions infrastructure, force-deletes the
+  // secret, and deletes the citadel-ds IAM role), so the gate must run before
+  // any of that, not just before the final DynamoDB delete.
+  await assertRowOrg(existing, event);
 
   const adapter = getAdapter(existing.type);
   const config =
@@ -758,9 +818,14 @@ async function deleteDataStore(dataStoreId: string) {
   return { success: true, message: "Data store deleted successfully" };
 }
 
-async function connectDataStore(dataStoreId: string) {
+async function connectDataStore(dataStoreId: string, event: unknown) {
   return retryOptimisticLock(async () => {
     const existing = await getDataStore(dataStoreId);
+
+    // Org scoping (finding ca76d041): reconcile BEFORE assuming any scoped
+    // role, retrieving credentials, or calling adapter.connect.
+    await assertRowOrg(existing, event);
+
     const currentVersion = existing.version;
 
     const adapter = getAdapter(existing.type);
@@ -854,9 +919,13 @@ async function connectDataStore(dataStoreId: string) {
   });
 }
 
-async function disconnectDataStore(dataStoreId: string) {
+async function disconnectDataStore(dataStoreId: string, event: unknown) {
   return retryOptimisticLock(async () => {
     const existing = await getDataStore(dataStoreId);
+
+    // Org scoping (finding ca76d041): reconcile BEFORE adapter.disconnect.
+    await assertRowOrg(existing, event);
+
     const currentVersion = existing.version;
 
     const adapter = getAdapter(existing.type);
@@ -908,8 +977,13 @@ async function disconnectDataStore(dataStoreId: string) {
   });
 }
 
-async function testDataStoreConnection(dataStoreId: string) {
+async function testDataStoreConnection(dataStoreId: string, event: unknown) {
   const existing = await getDataStore(dataStoreId);
+
+  // Org scoping (finding ca76d041): reconcile BEFORE retrieving credentials
+  // from Secrets Manager or calling adapter.testConnection.
+  await assertRowOrg(existing, event);
+
   const adapter = getAdapter(existing.type);
   const config =
     typeof existing.config === "string"

--- a/backend/src/utils/__tests__/auth-event.test.ts
+++ b/backend/src/utils/__tests__/auth-event.test.ts
@@ -6,18 +6,24 @@
  * path is asserted never to trigger when a claim is present — that
  * guarantee is the reason this helper exists.
  */
-import { mockClient } from 'aws-sdk-client-mock';
+import { mockClient } from "aws-sdk-client-mock";
 import {
   CognitoIdentityProviderClient,
   AdminGetUserCommand,
-} from '@aws-sdk/client-cognito-identity-provider';
-import { extractOrgFromEvent, isAdminFromEvent, hasRoleFromEvent } from '../auth-event';
+} from "@aws-sdk/client-cognito-identity-provider";
+import {
+  extractOrgFromEvent,
+  isAdminFromEvent,
+  hasRoleFromEvent,
+  assertRowOrg,
+  CrossOrgAccessError,
+} from "../auth-event";
 
 const cognitoMock = mockClient(CognitoIdentityProviderClient);
 
-describe('auth-event', () => {
+describe("auth-event", () => {
   beforeAll(() => {
-    process.env.USER_POOL_ID = 'us-east-1_test';
+    process.env.USER_POOL_ID = "us-east-1_test";
   });
 
   beforeEach(() => {
@@ -28,76 +34,76 @@ describe('auth-event', () => {
     delete process.env.USER_POOL_ID;
   });
 
-  describe('extractOrgFromEvent', () => {
+  describe("extractOrgFromEvent", () => {
     test('returns orgId from identity["custom:organization"] without calling Cognito', async () => {
       const event = {
         identity: {
-          sub: 'user-123',
-          'custom:organization': 'org-claim-a',
+          sub: "user-123",
+          "custom:organization": "org-claim-a",
         },
       };
 
       const result = await extractOrgFromEvent(event);
 
-      expect(result).toBe('org-claim-a');
+      expect(result).toBe("org-claim-a");
       expect(cognitoMock.commandCalls(AdminGetUserCommand).length).toBe(0);
     });
 
     test('returns orgId from identity.claims["custom:organization"] without calling Cognito', async () => {
       const event = {
         identity: {
-          sub: 'user-123',
+          sub: "user-123",
           claims: {
-            'custom:organization': 'org-claim-b',
+            "custom:organization": "org-claim-b",
           },
         },
       };
 
       const result = await extractOrgFromEvent(event);
 
-      expect(result).toBe('org-claim-b');
+      expect(result).toBe("org-claim-b");
       expect(cognitoMock.commandCalls(AdminGetUserCommand).length).toBe(0);
     });
 
-    test('falls back to Cognito AdminGetUser and returns attribute value when no claim is present', async () => {
+    test("falls back to Cognito AdminGetUser and returns attribute value when no claim is present", async () => {
       cognitoMock.on(AdminGetUserCommand).resolves({
-        Username: 'user-123',
+        Username: "user-123",
         UserAttributes: [
-          { Name: 'sub', Value: 'user-123' },
-          { Name: 'custom:organization', Value: 'org-cognito-c' },
+          { Name: "sub", Value: "user-123" },
+          { Name: "custom:organization", Value: "org-cognito-c" },
         ],
       });
 
-      const event = { identity: { sub: 'user-123' } };
+      const event = { identity: { sub: "user-123" } };
 
       const result = await extractOrgFromEvent(event);
 
-      expect(result).toBe('org-cognito-c');
+      expect(result).toBe("org-cognito-c");
       expect(cognitoMock.commandCalls(AdminGetUserCommand).length).toBe(1);
     });
 
-    test('returns null (without throwing) when Cognito fallback errors', async () => {
-      cognitoMock.on(AdminGetUserCommand).rejects(new Error('boom'));
+    test("returns null (without throwing) when Cognito fallback errors", async () => {
+      cognitoMock.on(AdminGetUserCommand).rejects(new Error("boom"));
 
-      const event = { identity: { sub: 'user-123' } };
+      const event = { identity: { sub: "user-123" } };
 
       const result = await extractOrgFromEvent(event);
 
       expect(result).toBeNull();
     });
 
-    test('returns null when event has no identity', async () => {
+    test("returns null when event has no identity", async () => {
       const result = await extractOrgFromEvent({});
       expect(result).toBeNull();
       expect(cognitoMock.commandCalls(AdminGetUserCommand).length).toBe(0);
     });
 
-    test('returns null when USER_POOL_ID is unset (no Cognito call)', async () => {
+    test("returns null when USER_POOL_ID is unset (no Cognito call)", async () => {
       const originalPoolId = process.env.USER_POOL_ID;
       delete process.env.USER_POOL_ID;
 
       try {
-        const event = { identity: { sub: 'user-123' } };
+        const event = { identity: { sub: "user-123" } };
         const result = await extractOrgFromEvent(event);
         expect(result).toBeNull();
         expect(cognitoMock.commandCalls(AdminGetUserCommand).length).toBe(0);
@@ -106,145 +112,202 @@ describe('auth-event', () => {
       }
     });
 
-    test('falls back to Cognito using identity.username when sub is absent', async () => {
+    test("falls back to Cognito using identity.username when sub is absent", async () => {
       cognitoMock.on(AdminGetUserCommand).resolves({
-        Username: 'name-only-user',
+        Username: "name-only-user",
         UserAttributes: [
-          { Name: 'custom:organization', Value: 'org-from-username' },
+          { Name: "custom:organization", Value: "org-from-username" },
         ],
       });
 
-      const event = { identity: { username: 'name-only-user' } };
+      const event = { identity: { username: "name-only-user" } };
 
       const result = await extractOrgFromEvent(event);
-      expect(result).toBe('org-from-username');
+      expect(result).toBe("org-from-username");
       expect(cognitoMock.commandCalls(AdminGetUserCommand).length).toBe(1);
     });
   });
 
-  describe('isAdminFromEvent', () => {
+  describe("isAdminFromEvent", () => {
     test('returns true when identity["custom:role"] is "admin"', () => {
-      const event = { identity: { 'custom:role': 'admin' } };
+      const event = { identity: { "custom:role": "admin" } };
       expect(isAdminFromEvent(event)).toBe(true);
     });
 
     test('returns true when identity.claims["custom:role"] is "admin"', () => {
-      const event = { identity: { claims: { 'custom:role': 'admin' } } };
+      const event = { identity: { claims: { "custom:role": "admin" } } };
       expect(isAdminFromEvent(event)).toBe(true);
     });
 
     test('returns false when role is "project_manager"', () => {
-      const event = { identity: { 'custom:role': 'project_manager' } };
+      const event = { identity: { "custom:role": "project_manager" } };
       expect(isAdminFromEvent(event)).toBe(false);
     });
 
-    test('returns false when role claim is absent', () => {
-      const event = { identity: { sub: 'user-123' } };
+    test("returns false when role claim is absent", () => {
+      const event = { identity: { sub: "user-123" } };
       expect(isAdminFromEvent(event)).toBe(false);
     });
 
-    test('returns false when event has no identity', () => {
+    test("returns false when event has no identity", () => {
       expect(isAdminFromEvent({})).toBe(false);
     });
 
     test('returns true when cognito:groups is an array containing "admin"', () => {
       const event = {
-        identity: { 'cognito:groups': ['admin', 'user'] },
+        identity: { "cognito:groups": ["admin", "user"] },
       };
       expect(isAdminFromEvent(event)).toBe(true);
     });
 
-    test('returns false when cognito:groups array contains only non-admin groups', () => {
+    test("returns false when cognito:groups array contains only non-admin groups", () => {
       const event = {
-        identity: { 'cognito:groups': ['user', 'project_manager'] },
+        identity: { "cognito:groups": ["user", "project_manager"] },
       };
       expect(isAdminFromEvent(event)).toBe(false);
     });
 
     test('returns true when cognito:groups is the comma-separated string "admin,user"', () => {
       const event = {
-        identity: { 'cognito:groups': 'admin,user' },
+        identity: { "cognito:groups": "admin,user" },
       };
       expect(isAdminFromEvent(event)).toBe(true);
     });
 
     test('returns false when cognito:groups is the string "user,project_manager"', () => {
       const event = {
-        identity: { 'cognito:groups': 'user,project_manager' },
+        identity: { "cognito:groups": "user,project_manager" },
       };
       expect(isAdminFromEvent(event)).toBe(false);
     });
 
-    test('returns false when both cognito:groups and custom:role are missing', () => {
-      const event = { identity: { sub: 'user-123' } };
+    test("returns false when both cognito:groups and custom:role are missing", () => {
+      const event = { identity: { sub: "user-123" } };
       expect(isAdminFromEvent(event)).toBe(false);
     });
 
     test('honours cognito:groups at identity["cognito:groups"] (Cognito user pool auth mode)', () => {
       const event = {
-        identity: { 'cognito:groups': ['admin'] },
+        identity: { "cognito:groups": ["admin"] },
       };
       expect(isAdminFromEvent(event)).toBe(true);
     });
 
     test('honours cognito:groups at identity.claims["cognito:groups"] (proxy/IAM mode)', () => {
       const event = {
-        identity: { claims: { 'cognito:groups': ['admin'] } },
+        identity: { claims: { "cognito:groups": ["admin"] } },
       };
       expect(isAdminFromEvent(event)).toBe(true);
     });
 
     test('custom:role "admin" wins even when cognito:groups is empty/absent', () => {
       const event = {
-        identity: { 'custom:role': 'admin', 'cognito:groups': [] },
+        identity: { "custom:role": "admin", "cognito:groups": [] },
       };
       expect(isAdminFromEvent(event)).toBe(true);
     });
   });
 
-  describe('hasRoleFromEvent', () => {
+  describe("hasRoleFromEvent", () => {
     test('returns true when identity["custom:role"] equals the requested role', () => {
-      const event = { identity: { 'custom:role': 'architect' } };
-      expect(hasRoleFromEvent(event, 'architect')).toBe(true);
+      const event = { identity: { "custom:role": "architect" } };
+      expect(hasRoleFromEvent(event, "architect")).toBe(true);
     });
 
     test('returns true when identity.claims["custom:role"] equals the requested role', () => {
-      const event = { identity: { claims: { 'custom:role': 'architect' } } };
-      expect(hasRoleFromEvent(event, 'architect')).toBe(true);
+      const event = { identity: { claims: { "custom:role": "architect" } } };
+      expect(hasRoleFromEvent(event, "architect")).toBe(true);
     });
 
-    test('returns false when custom:role is a different role', () => {
-      const event = { identity: { 'custom:role': 'developer' } };
-      expect(hasRoleFromEvent(event, 'architect')).toBe(false);
+    test("returns false when custom:role is a different role", () => {
+      const event = { identity: { "custom:role": "developer" } };
+      expect(hasRoleFromEvent(event, "architect")).toBe(false);
     });
 
-    test('returns true when cognito:groups array contains the requested role', () => {
-      const event = { identity: { 'cognito:groups': ['architect', 'user'] } };
-      expect(hasRoleFromEvent(event, 'architect')).toBe(true);
+    test("returns true when cognito:groups array contains the requested role", () => {
+      const event = { identity: { "cognito:groups": ["architect", "user"] } };
+      expect(hasRoleFromEvent(event, "architect")).toBe(true);
     });
 
-    test('returns true when cognito:groups is a comma-separated string containing the role', () => {
-      const event = { identity: { 'cognito:groups': 'user,architect' } };
-      expect(hasRoleFromEvent(event, 'architect')).toBe(true);
+    test("returns true when cognito:groups is a comma-separated string containing the role", () => {
+      const event = { identity: { "cognito:groups": "user,architect" } };
+      expect(hasRoleFromEvent(event, "architect")).toBe(true);
     });
 
     test('honours cognito:groups at identity.claims["cognito:groups"] (proxy/IAM mode)', () => {
-      const event = { identity: { claims: { 'cognito:groups': ['architect'] } } };
-      expect(hasRoleFromEvent(event, 'architect')).toBe(true);
+      const event = {
+        identity: { claims: { "cognito:groups": ["architect"] } },
+      };
+      expect(hasRoleFromEvent(event, "architect")).toBe(true);
     });
 
-    test('returns false when neither custom:role nor cognito:groups include the role', () => {
-      const event = { identity: { 'cognito:groups': ['user', 'developer'] } };
-      expect(hasRoleFromEvent(event, 'architect')).toBe(false);
+    test("returns false when neither custom:role nor cognito:groups include the role", () => {
+      const event = { identity: { "cognito:groups": ["user", "developer"] } };
+      expect(hasRoleFromEvent(event, "architect")).toBe(false);
     });
 
-    test('returns false when event has no identity', () => {
-      expect(hasRoleFromEvent({}, 'architect')).toBe(false);
+    test("returns false when event has no identity", () => {
+      expect(hasRoleFromEvent({}, "architect")).toBe(false);
     });
 
-    test('does not treat an admin caller as holding other roles', () => {
-      const event = { identity: { 'custom:role': 'admin' } };
-      expect(hasRoleFromEvent(event, 'architect')).toBe(false);
+    test("does not treat an admin caller as holding other roles", () => {
+      const event = { identity: { "custom:role": "admin" } };
+      expect(hasRoleFromEvent(event, "architect")).toBe(false);
+    });
+  });
+
+  describe("assertRowOrg", () => {
+    test("resolves when the row orgId matches the caller server-derived org", async () => {
+      const event = { identity: { sub: "u1", "custom:organization": "org-a" } };
+      await expect(
+        assertRowOrg({ orgId: "org-a" }, event),
+      ).resolves.toBeUndefined();
+    });
+
+    test("throws CrossOrgAccessError when the row orgId differs from the caller org", async () => {
+      const event = { identity: { sub: "u1", "custom:organization": "org-a" } };
+      await expect(
+        assertRowOrg({ orgId: "org-b" }, event),
+      ).rejects.toBeInstanceOf(CrossOrgAccessError);
+    });
+
+    test("throws when the row has no orgId (fail closed, never silently allow)", async () => {
+      const event = { identity: { sub: "u1", "custom:organization": "org-a" } };
+      await expect(assertRowOrg({}, event)).rejects.toBeInstanceOf(
+        CrossOrgAccessError,
+      );
+    });
+
+    test("throws when the row is null/undefined (fail closed)", async () => {
+      const event = { identity: { sub: "u1", "custom:organization": "org-a" } };
+      await expect(assertRowOrg(undefined, event)).rejects.toBeInstanceOf(
+        CrossOrgAccessError,
+      );
+      await expect(assertRowOrg(null, event)).rejects.toBeInstanceOf(
+        CrossOrgAccessError,
+      );
+    });
+
+    test("throws when the caller org is unresolvable, even if the row has an orgId (fail closed)", async () => {
+      const event = { identity: { sub: "u1" } }; // no org claim, no USER_POOL_ID Cognito fallback match
+      cognitoMock.rejects(new Error("user not found"));
+      await expect(
+        assertRowOrg({ orgId: "org-a" }, event),
+      ).rejects.toBeInstanceOf(CrossOrgAccessError);
+    });
+
+    test("admin bypasses the org check entirely, even for a cross-org row", async () => {
+      const event = { identity: { sub: "admin-1", "custom:role": "admin" } };
+      await expect(
+        assertRowOrg({ orgId: "org-completely-different" }, event),
+      ).resolves.toBeUndefined();
+    });
+
+    test('CrossOrgAccessError carries the "Access denied" message used by resolvers', async () => {
+      const event = { identity: { sub: "u1", "custom:organization": "org-a" } };
+      await expect(assertRowOrg({ orgId: "org-b" }, event)).rejects.toThrow(
+        "Access denied",
+      );
     });
   });
 });

--- a/backend/src/utils/auth-event.ts
+++ b/backend/src/utils/auth-event.ts
@@ -1,13 +1,30 @@
-import { CognitoIdentityProviderClient, AdminGetUserCommand } from '@aws-sdk/client-cognito-identity-provider';
+import {
+  CognitoIdentityProviderClient,
+  AdminGetUserCommand,
+} from "@aws-sdk/client-cognito-identity-provider";
 
 const cognitoClient = new CognitoIdentityProviderClient({});
+
+/**
+ * Thrown by {@link assertRowOrg} when a loaded row's org does not match the
+ * caller's server-derived org. Callers should let this propagate (fail
+ * closed) rather than catching and continuing.
+ */
+export class CrossOrgAccessError extends Error {
+  constructor(message = "Access denied") {
+    super(message);
+    this.name = "CrossOrgAccessError";
+  }
+}
 
 /**
  * Reads a claim from the AppSync identity, tolerating both shapes:
  *  - `identity['custom:organization']` (Cognito user pool auth mode)
  *  - `identity.claims['custom:organization']` (some proxy/IAM modes)
  */
-type IdentityBag = Record<string, unknown> & { claims?: Record<string, unknown> | null };
+type IdentityBag = Record<string, unknown> & {
+  claims?: Record<string, unknown> | null;
+};
 type EventWithIdentity = { identity?: IdentityBag | null } | null | undefined;
 
 function readClaim(event: unknown, name: string): string | undefined {
@@ -26,7 +43,9 @@ function readClaim(event: unknown, name: string): string | undefined {
  * intake-orchestration resolver (project-owner fallback for org-less
  * project rows created before the pre-token-generation trigger existed).
  */
-export async function lookupUserOrganization(username: string): Promise<string | null> {
+export async function lookupUserOrganization(
+  username: string,
+): Promise<string | null> {
   const userPoolId = process.env.USER_POOL_ID;
   if (!userPoolId) return null;
 
@@ -34,10 +53,12 @@ export async function lookupUserOrganization(username: string): Promise<string |
     const response = await cognitoClient.send(
       new AdminGetUserCommand({ UserPoolId: userPoolId, Username: username }),
     );
-    const attr = response.UserAttributes?.find((a) => a.Name === 'custom:organization');
+    const attr = response.UserAttributes?.find(
+      (a) => a.Name === "custom:organization",
+    );
     return attr?.Value || null;
   } catch (err) {
-    console.warn('lookupUserOrganization: Cognito lookup failed', {
+    console.warn("lookupUserOrganization: Cognito lookup failed", {
       userId: username,
       err: String(err),
     });
@@ -57,8 +78,10 @@ export async function lookupUserOrganization(username: string): Promise<string |
  * api-key auth). Callers are responsible for deciding whether null means
  * "deny" or "allow through".
  */
-export async function extractOrgFromEvent(event: unknown): Promise<string | null> {
-  const claimOrg = readClaim(event, 'custom:organization');
+export async function extractOrgFromEvent(
+  event: unknown,
+): Promise<string | null> {
+  const claimOrg = readClaim(event, "custom:organization");
   if (claimOrg) return claimOrg;
 
   const identity: IdentityBag = (event as EventWithIdentity)?.identity || {};
@@ -79,20 +102,20 @@ export async function extractOrgFromEvent(event: unknown): Promise<string | null
  */
 export function isAdminFromEvent(event: unknown): boolean {
   // Path 1: explicit custom:role claim equals 'admin'.
-  if (readClaim(event, 'custom:role') === 'admin') return true;
+  if (readClaim(event, "custom:role") === "admin") return true;
 
   // Path 2: cognito:groups membership includes 'admin'. Cognito issues this
   // claim as an array in standard JWT, but some AppSync auth modes flatten
   // it to a comma-separated string. Tolerate both.
-  const groups = readClaim(event, 'cognito:groups');
+  const groups = readClaim(event, "cognito:groups");
   if (Array.isArray(groups)) {
-    return groups.some((g) => typeof g === 'string' && g === 'admin');
+    return groups.some((g) => typeof g === "string" && g === "admin");
   }
-  if (typeof groups === 'string') {
+  if (typeof groups === "string") {
     return groups
-      .split(',')
+      .split(",")
       .map((s) => s.trim())
-      .includes('admin');
+      .includes("admin");
   }
 
   return false;
@@ -115,20 +138,51 @@ export function isAdminFromEvent(event: unknown): boolean {
  */
 export function hasRoleFromEvent(event: unknown, role: string): boolean {
   // Path 1: explicit custom:role claim equals the requested role.
-  if (readClaim(event, 'custom:role') === role) return true;
+  if (readClaim(event, "custom:role") === role) return true;
 
   // Path 2: cognito:groups membership includes the requested role. Tolerate
   // both the array and comma-separated-string shapes (see isAdminFromEvent).
-  const groups = readClaim(event, 'cognito:groups');
+  const groups = readClaim(event, "cognito:groups");
   if (Array.isArray(groups)) {
-    return groups.some((g) => typeof g === 'string' && g === role);
+    return groups.some((g) => typeof g === "string" && g === role);
   }
-  if (typeof groups === 'string') {
+  if (typeof groups === "string") {
     return groups
-      .split(',')
+      .split(",")
       .map((s) => s.trim())
       .includes(role);
   }
 
   return false;
+}
+
+/**
+ * Fetch-then-verify row-org reconciliation gate. Shared by every resolver
+ * that loads a client-supplied-ID row and must refuse a cross-org caller
+ * BEFORE any mutation/side-effect (finding ca76d041). Mirrors the
+ * already-correct `getExecution` gate in execution-resolver.ts and the
+ * `assertRowOrg`/`CrossOrgRowError` pattern duplicated in
+ * eval-comparison-resolver.ts and replay-package-builder.ts — this is the
+ * ONE shared version new callers should use instead of inlining another
+ * copy.
+ *
+ * Admins bypass (mirrors isAdminFromEvent usage elsewhere in this file).
+ * Otherwise: the caller's server-derived org (extractOrgFromEvent) must
+ * equal the row's `orgId`. Fail closed — a row with no orgId, or a caller
+ * with no resolvable org, is denied rather than silently allowed.
+ *
+ * Throws {@link CrossOrgAccessError} on denial.
+ */
+export async function assertRowOrg(
+  row: { orgId?: unknown } | null | undefined,
+  event: unknown,
+): Promise<void> {
+  if (isAdminFromEvent(event)) return;
+
+  const rowOrgId = typeof row?.orgId === "string" ? row.orgId : undefined;
+  const callerOrgId = await extractOrgFromEvent(event);
+
+  if (!rowOrgId || !callerOrgId || rowOrgId !== callerOrgId) {
+    throw new CrossOrgAccessError();
+  }
 }


### PR DESCRIPTION
## Summary

Every by-id datastore operation acted on a client-supplied `dataStoreId` without reconciling it against the caller's organization. An earlier sweep fixed only the collection reads, so the item-level operations - including the destructive ones - remained exposed to any authenticated user of any organization.

`deleteDataStore` is the severe case: it deprovisions infrastructure, force-deletes the secret and deletes the 'citadel-ds' IAM role. Against another tenant's id, that is unauthenticated-in-effect destruction of their resources. `updateDataStore`, `connectataStore`, `disconnectDataStore` and `testDataStoreConnection` allowed tampering and provider calls; `getDataStore` allowed disclosure; `createDataStore` trusted a client-supplied `input.orgId`.

## Fix

One shared helper, `assertRowOrg(row, event)` in `utils/auth-event.ts`: admin bypass via `isAdminFromEvent`, otherwise the server-derived caller org must equal the row's `orgId`, failing closed when the org is unresolvable or the row carries none. Used by all six by-id operations rather than six inline variants, called immediately after write. `createDataStore` now rejects imatched `orgId` (mutations reject, reads coerce, per the existing convention).

All ten operations in the resolver are enumerated in the tests, so none is left implicitly unconsidered.

## Testing

- Per operation, a cross-org caller is refused **and** the mocks record zero Secrets Manager deletes, zero IAM role deletions, zero provider/deprovision calls and zero DynamoDB writes - an error thrown after a side effect would fail these
- Fail-closed cases: absent identity, unresolvable org, missing row, and a row with no `orgId` attribute
- Admin bypass confirmed deliberate and unreachable by non-admins
- Bite-proven: reverting the guard makes a cross-org call succeed; restored byte-identically
- tsc, lint, `cdk synth` exit 0; 12 new scoping tests plus 7 helper tests; full backend
jest 7066

## Worth reviewers' attention

Three pre-existing test fixtures were invoking these mutations with **no identity or org context at all** - the suite had been exercising the vulnerable path and passing. They now carry matching identity. That is part of why this class survived: the tests encoded the gap rather than catching it.

## Notes

- Second of four remediations for the external security report; remaining are the integration by-id operations and the app-access owner gate
- `DataStoreRecord` gained an optional `orgId` to satisfy the type checker