### PR TITLE
fix(api): reconcile organization on every by-id integration operation

### DIFF
--- a/backend/src/lambda/__tests__/integration-resolver-item-org-scoping.test.ts
+++ b/backend/src/lambda/__tests__/integration-resolver-item-org-scoping.test.ts
@@ -1,0 +1,423 @@
+/**
+ * Cross-org item-level authz tests for integration-resolver.ts (finding
+ * ca76d041, integration half; CRE item 3).
+ *
+ * Before this fix: getIntegration, updateIntegration, deleteIntegration,
+ * testIntegration, connectIntegration, and disconnectIntegration all acted
+ * on a client-supplied integrationId with NO reconciliation against the
+ * caller's org — a cross-tenant IDOR. testIntegration/connectIntegration
+ * read the row's secret from Secrets Manager; deleteIntegration emits a
+ * teardown event that (via gateway-registration-handler) deletes the
+ * gateway target, credential provider, and Secrets Manager secret;
+ * updateIntegration can read+rewrite the secret and SSM config.
+ * createIntegration additionally trusted a client-supplied input.orgId
+ * with no server-side derivation.
+ *
+ * Fix: fetch-then-verify via the shared `assertRowOrg` helper
+ * (backend/src/utils/auth-event.ts) — load the row, reconcile its orgId
+ * against the caller's server-derived org (extractOrgFromEvent), and refuse
+ * BEFORE any Secrets Manager call, SSM call, EventBridge publish, or
+ * DynamoDB write. Admins bypass, mirroring the read-path admin bypass
+ * already used by listIntegrations.
+ */
+
+const mockDynamoSend = jest.fn();
+jest.mock("@aws-sdk/client-dynamodb", () => ({
+  DynamoDBClient: jest.fn().mockImplementation(() => ({})),
+}));
+jest.mock("@aws-sdk/lib-dynamodb", () => {
+  const actual = jest.requireActual("@aws-sdk/lib-dynamodb");
+  return {
+    ...actual,
+    DynamoDBDocumentClient: {
+      from: jest.fn().mockReturnValue({ send: mockDynamoSend }),
+    },
+    PutCommand: jest
+      .fn()
+      .mockImplementation((input) => ({ _type: "Put", input })),
+    UpdateCommand: jest
+      .fn()
+      .mockImplementation((input) => ({ _type: "Update", input })),
+    QueryCommand: jest
+      .fn()
+      .mockImplementation((input) => ({ _type: "Query", input })),
+  };
+});
+
+const mockSecretsSend = jest.fn();
+jest.mock("@aws-sdk/client-secrets-manager", () => ({
+  SecretsManagerClient: jest
+    .fn()
+    .mockImplementation(() => ({ send: mockSecretsSend })),
+  CreateSecretCommand: jest
+    .fn()
+    .mockImplementation((input) => ({ _type: "CreateSecret", input })),
+  GetSecretValueCommand: jest
+    .fn()
+    .mockImplementation((input) => ({ _type: "GetSecretValue", input })),
+  DeleteSecretCommand: jest
+    .fn()
+    .mockImplementation((input) => ({ _type: "DeleteSecret", input })),
+}));
+
+const mockSsmSend = jest.fn();
+jest.mock("@aws-sdk/client-ssm", () => ({
+  SSMClient: jest.fn().mockImplementation(() => ({ send: mockSsmSend })),
+  PutParameterCommand: jest
+    .fn()
+    .mockImplementation((input) => ({ _type: "PutParameter", input })),
+  GetParameterCommand: jest
+    .fn()
+    .mockImplementation((input) => ({ _type: "GetParameter", input })),
+}));
+
+const mockEventBridgeSend = jest.fn();
+jest.mock("@aws-sdk/client-eventbridge", () => ({
+  EventBridgeClient: jest
+    .fn()
+    .mockImplementation(() => ({ send: mockEventBridgeSend })),
+  PutEventsCommand: jest
+    .fn()
+    .mockImplementation((input) => ({ _type: "PutEvents", input })),
+}));
+
+jest.mock("../../utils/connector-registry", () => ({
+  getConnectorSpec: jest.fn().mockReturnValue({
+    provider: "Slack",
+    authentication: { method: "API_KEY", fields: ["apiKey"] },
+    configuration: { required: [], ssmParameters: [] },
+  }),
+  validateCredentials: jest.fn().mockReturnValue({ valid: true, errors: [] }),
+  validateConfiguration: jest.fn().mockReturnValue({ valid: true, errors: [] }),
+}));
+
+jest.mock("../../utils/connection-tester", () => ({
+  testConnection: jest.fn().mockResolvedValue({ success: true, message: "OK" }),
+}));
+
+jest.mock("../../utils/credential-manager", () => ({
+  storeCredentials: jest.fn().mockResolvedValue({
+    secretArn: "arn:aws:secretsmanager:us-east-1:123:secret:new",
+    ssmParameterPrefix: "/citadel/integrations/new",
+  }),
+}));
+
+jest.mock("../../utils/gateway-target-manager", () => ({
+  provisionCredentialProvider: jest.fn().mockResolvedValue({
+    credentialProviderArn: "arn:aws:bedrock-agentcore:...:provider/new",
+  }),
+  deprovisionCredentialProvider: jest.fn().mockResolvedValue(undefined),
+}));
+
+jest.mock("uuid", () => ({ v4: jest.fn().mockReturnValue("test-uuid") }));
+
+process.env.INTEGRATIONS_TABLE = "TestIntegrationsTable";
+process.env.EVENT_BUS_NAME = "test-event-bus";
+
+import { handler } from "../integration-resolver";
+
+type HandlerEvent = Parameters<typeof handler>[0];
+
+/** The victim row: belongs to org-victim, has a secretArn (so
+ * testIntegration/connectIntegration's Secrets Manager read, and
+ * deleteIntegration's teardown event, would fire if the guard did not
+ * block it). */
+const VICTIM_ROW = {
+  PK: "ORG#org-victim",
+  SK: "INTEGRATION#SLACK#int-victim",
+  integrationId: "int-victim",
+  integrationType: "SLACK",
+  name: "Victim Slack",
+  status: "CONFIGURED",
+  orgId: "org-victim",
+  config: {},
+  secretArn: "arn:aws:secretsmanager:us-east-1:123:secret:victim",
+  ssmParameterPrefix: "/citadel/integrations/victim",
+  credentialProviderArn: "arn:aws:bedrock-agentcore:...:provider/victim",
+  credentialProviderType: "API_KEY",
+  version: 1,
+};
+
+function makeEvent(
+  fieldName: string,
+  args: Record<string, unknown>,
+  identity: Record<string, unknown>,
+): HandlerEvent {
+  return {
+    info: { fieldName },
+    arguments: args,
+    identity,
+  } as unknown as HandlerEvent;
+}
+
+const ATTACKER_IDENTITY = {
+  sub: "attacker-1",
+  "custom:organization": "org-attacker",
+};
+const SAME_ORG_IDENTITY = {
+  sub: "victim-user",
+  "custom:organization": "org-victim",
+};
+const ADMIN_IDENTITY = { sub: "admin-1", "custom:role": "admin" };
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  mockDynamoSend.mockImplementation((cmd: { _type?: string }) => {
+    if (cmd._type === "Query")
+      return Promise.resolve({ Items: [{ ...VICTIM_ROW }] });
+    if (cmd._type === "Update")
+      return Promise.resolve({ Attributes: { ...VICTIM_ROW } });
+    return Promise.resolve({});
+  });
+  mockSecretsSend.mockResolvedValue({
+    SecretString: JSON.stringify({ apiKey: "shh" }),
+  });
+  mockEventBridgeSend.mockResolvedValue({ FailedEntryCount: 0, Entries: [] });
+});
+
+describe("cross-org caller is refused before any mutation/side-effect", () => {
+  test("getIntegration: cross-org caller is denied", async () => {
+    await expect(
+      handler(
+        makeEvent(
+          "getIntegration",
+          { integrationId: "int-victim" },
+          ATTACKER_IDENTITY,
+        ),
+      ),
+    ).rejects.toThrow(/access denied/i);
+  });
+
+  test("updateIntegration: cross-org caller is denied; zero secret/SSM/DynamoDB writes", async () => {
+    await expect(
+      handler(
+        makeEvent(
+          "updateIntegration",
+          { input: { integrationId: "int-victim", name: "pwned" } },
+          ATTACKER_IDENTITY,
+        ),
+      ),
+    ).rejects.toThrow(/access denied/i);
+
+    expect(mockSecretsSend).not.toHaveBeenCalled();
+    expect(mockSsmSend).not.toHaveBeenCalled();
+    const putCalls = mockDynamoSend.mock.calls.filter(
+      ([cmd]: [{ _type?: string }]) => cmd._type === "Put",
+    );
+    expect(putCalls).toHaveLength(0);
+  });
+
+  test("deleteIntegration: cross-org caller is denied; zero EventBridge/DynamoDB-update calls", async () => {
+    await expect(
+      handler(
+        makeEvent(
+          "deleteIntegration",
+          { integrationId: "int-victim" },
+          ATTACKER_IDENTITY,
+        ),
+      ),
+    ).rejects.toThrow(/access denied/i);
+
+    expect(mockEventBridgeSend).not.toHaveBeenCalled();
+    const updateCalls = mockDynamoSend.mock.calls.filter(
+      ([cmd]: [{ _type?: string }]) => cmd._type === "Update",
+    );
+    expect(updateCalls).toHaveLength(0);
+  });
+
+  test("testIntegration: cross-org caller is denied; zero Secrets Manager / SSM / DynamoDB-write calls", async () => {
+    await expect(
+      handler(
+        makeEvent(
+          "testIntegration",
+          { integrationId: "int-victim" },
+          ATTACKER_IDENTITY,
+        ),
+      ),
+    ).rejects.toThrow(/access denied/i);
+
+    expect(mockSecretsSend).not.toHaveBeenCalled();
+    expect(mockSsmSend).not.toHaveBeenCalled();
+    const putCalls = mockDynamoSend.mock.calls.filter(
+      ([cmd]: [{ _type?: string }]) => cmd._type === "Put",
+    );
+    expect(putCalls).toHaveLength(0);
+  });
+
+  test("connectIntegration: cross-org caller is denied; zero EventBridge/DynamoDB-write calls", async () => {
+    await expect(
+      handler(
+        makeEvent(
+          "connectIntegration",
+          { integrationId: "int-victim" },
+          ATTACKER_IDENTITY,
+        ),
+      ),
+    ).rejects.toThrow(/access denied/i);
+
+    expect(mockEventBridgeSend).not.toHaveBeenCalled();
+    const putCalls = mockDynamoSend.mock.calls.filter(
+      ([cmd]: [{ _type?: string }]) => cmd._type === "Put",
+    );
+    expect(putCalls).toHaveLength(0);
+  });
+
+  test("disconnectIntegration: cross-org caller is denied; zero EventBridge/DynamoDB-write calls", async () => {
+    // Use a CONNECTED row so the lifecycle precondition (canDisconnect)
+    // does not itself short-circuit before the org guard is reached — the
+    // guard must run before ANY logic that would otherwise proceed, and
+    // this asserts denial happens even when the row is otherwise eligible.
+    mockDynamoSend.mockImplementation((cmd: { _type?: string }) => {
+      if (cmd._type === "Query")
+        return Promise.resolve({
+          Items: [{ ...VICTIM_ROW, status: "CONNECTED" }],
+        });
+      if (cmd._type === "Update")
+        return Promise.resolve({ Attributes: { ...VICTIM_ROW } });
+      return Promise.resolve({});
+    });
+
+    await expect(
+      handler(
+        makeEvent(
+          "disconnectIntegration",
+          { integrationId: "int-victim" },
+          ATTACKER_IDENTITY,
+        ),
+      ),
+    ).rejects.toThrow(/access denied/i);
+
+    expect(mockEventBridgeSend).not.toHaveBeenCalled();
+    const putCalls = mockDynamoSend.mock.calls.filter(
+      ([cmd]: [{ _type?: string }]) => cmd._type === "Put",
+    );
+    expect(putCalls).toHaveLength(0);
+  });
+});
+
+describe("legitimate same-org callers still succeed", () => {
+  test("getIntegration: same-org caller succeeds", async () => {
+    const result = (await handler(
+      makeEvent(
+        "getIntegration",
+        { integrationId: "int-victim" },
+        SAME_ORG_IDENTITY,
+      ),
+    )) as { integrationId: string };
+
+    expect(result.integrationId).toBe("int-victim");
+  });
+
+  test("testIntegration: same-org caller succeeds", async () => {
+    const result = (await handler(
+      makeEvent(
+        "testIntegration",
+        { integrationId: "int-victim" },
+        SAME_ORG_IDENTITY,
+      ),
+    )) as { success: boolean };
+
+    expect(result.success).toBe(true);
+    expect(mockSecretsSend).toHaveBeenCalled();
+  });
+
+  test("deleteIntegration: same-org caller succeeds and publishes teardown event", async () => {
+    const result = (await handler(
+      makeEvent(
+        "deleteIntegration",
+        { integrationId: "int-victim" },
+        SAME_ORG_IDENTITY,
+      ),
+    )) as { success: boolean };
+
+    expect(result.success).toBe(true);
+    expect(mockEventBridgeSend).toHaveBeenCalledTimes(1);
+  });
+
+  test("admin caller may act cross-org (bypass preserved)", async () => {
+    const result = (await handler(
+      makeEvent(
+        "getIntegration",
+        { integrationId: "int-victim" },
+        ADMIN_IDENTITY,
+      ),
+    )) as { integrationId: string };
+
+    expect(result.integrationId).toBe("int-victim");
+  });
+});
+
+describe("createIntegration rejects a foreign/mismatched orgId", () => {
+  beforeEach(() => {
+    mockDynamoSend.mockImplementation((cmd: { _type?: string }) => {
+      if (cmd._type === "Put") return Promise.resolve({});
+      return Promise.resolve({});
+    });
+  });
+
+  test("rejects when input.orgId does not match the server-derived caller org", async () => {
+    await expect(
+      handler(
+        makeEvent(
+          "createIntegration",
+          {
+            input: {
+              integrationType: "SLACK",
+              name: "sneaky",
+              orgId: "org-foreign",
+              credentials: { apiKey: "x" },
+              config: {},
+            },
+          },
+          { sub: "user-real", "custom:organization": "org-real" },
+        ),
+      ),
+    ).rejects.toThrow(/access denied|org/i);
+
+    const putCalls = mockDynamoSend.mock.calls.filter(
+      ([cmd]: [{ _type?: string }]) => cmd._type === "Put",
+    );
+    expect(putCalls).toHaveLength(0);
+    expect(mockSecretsSend).not.toHaveBeenCalled();
+  });
+
+  test("accepts when input.orgId matches the server-derived caller org", async () => {
+    const result = (await handler(
+      makeEvent(
+        "createIntegration",
+        {
+          input: {
+            integrationType: "SLACK",
+            name: "legit",
+            orgId: "org-real",
+            credentials: { apiKey: "x" },
+            config: {},
+          },
+        },
+        { sub: "user-real", "custom:organization": "org-real" },
+      ),
+    )) as { integrationId: string };
+
+    expect(result.integrationId).toBe("test-uuid");
+  });
+
+  test("admin may create with an explicit orgId (bypass preserved)", async () => {
+    const result = (await handler(
+      makeEvent(
+        "createIntegration",
+        {
+          input: {
+            integrationType: "SLACK",
+            name: "admin-created",
+            orgId: "org-any",
+            credentials: { apiKey: "x" },
+            config: {},
+          },
+        },
+        ADMIN_IDENTITY,
+      ),
+    )) as { integrationId: string };
+
+    expect(result.integrationId).toBe("test-uuid");
+  });
+});

--- a/backend/src/lambda/__tests__/integration-resolver.test.ts
+++ b/backend/src/lambda/__tests__/integration-resolver.test.ts
@@ -181,7 +181,7 @@ describe("Integration Resolver - Unit Tests", () => {
             },
           },
         },
-        identity: { username: "test-user" },
+        identity: { username: "test-user", "custom:organization": "org-123" },
       };
 
       const result = await invoke(event);
@@ -240,7 +240,7 @@ describe("Integration Resolver - Unit Tests", () => {
             config: { serverUrl: "https://mcp.example.com" },
           },
         },
-        identity: { username: "test-user" },
+        identity: { username: "test-user", "custom:organization": "org-123" },
       };
 
       await expect(invoke(event)).rejects.toThrow(
@@ -302,7 +302,7 @@ describe("Integration Resolver - Unit Tests", () => {
             },
           },
         },
-        identity: { username: "test-user" },
+        identity: { username: "test-user", "custom:organization": "org-123" },
       };
 
       const result = await invoke(event);
@@ -352,7 +352,7 @@ describe("Integration Resolver - Unit Tests", () => {
             },
           },
         },
-        identity: { username: "test-user" },
+        identity: { username: "test-user", "custom:organization": "org-123" },
       };
 
       const result = await invoke(event);
@@ -404,7 +404,7 @@ describe("Integration Resolver - Unit Tests", () => {
             },
           },
         },
-        identity: { username: "test-user" },
+        identity: { username: "test-user", "custom:organization": "org-123" },
       };
 
       const result = await invoke(event);
@@ -471,7 +471,7 @@ describe("Integration Resolver - Unit Tests", () => {
       const event = {
         info: { fieldName: "deleteIntegration" },
         arguments: { integrationId },
-        identity: { username: "test-user" },
+        identity: { username: "test-user", "custom:organization": "org-123" },
       };
 
       const result = await invoke(event);
@@ -541,7 +541,7 @@ describe("Integration Resolver - Unit Tests", () => {
       const event = {
         info: { fieldName: "deleteIntegration" },
         arguments: { integrationId },
-        identity: { username: "test-user" },
+        identity: { username: "test-user", "custom:organization": "org-123" },
       };
 
       const result = await invoke(event);
@@ -590,7 +590,7 @@ describe("Integration Resolver - Unit Tests", () => {
       const event = {
         info: { fieldName: "deleteIntegration" },
         arguments: { integrationId },
-        identity: { username: "test-user" },
+        identity: { username: "test-user", "custom:organization": "org-123" },
       };
 
       const result = await invoke(event);
@@ -656,7 +656,7 @@ describe("Integration Resolver - Unit Tests", () => {
       const event = {
         info: { fieldName: "testIntegration" },
         arguments: { integrationId },
-        identity: { username: "test-user" },
+        identity: { username: "test-user", "custom:organization": "org-123" },
       };
 
       // This will fail at connection test but we can verify SSM retrieval
@@ -711,7 +711,7 @@ describe("Integration Resolver - Unit Tests", () => {
             },
           },
         },
-        identity: { username: "test-user" },
+        identity: { username: "test-user", "custom:organization": "org-123" },
       };
 
       await invoke(event);
@@ -759,11 +759,9 @@ describe("Integration Resolver - Unit Tests", () => {
       bedrockAgentMock
         .on(CreateGatewayTargetCommand)
         .resolves({ targetId: mockTargetId });
-      secretsMock
-        .onAnyCommand()
-        .resolves({
-          ARN: "arn:aws:secretsmanager:us-east-1:111:secret:mcp-2lo",
-        });
+      secretsMock.onAnyCommand().resolves({
+        ARN: "arn:aws:secretsmanager:us-east-1:111:secret:mcp-2lo",
+      });
       ssmMock.onAnyCommand().resolves({});
       dynamoMock.onAnyCommand().resolves({});
 
@@ -785,7 +783,7 @@ describe("Integration Resolver - Unit Tests", () => {
             config: { serverUrl: "https://mcp.example.com" },
           },
         },
-        identity: { username: "tester" },
+        identity: { username: "tester", "custom:organization": "org-2lo" },
       };
 
       const result = await invoke(event);
@@ -855,11 +853,9 @@ describe("Integration Resolver - Unit Tests", () => {
       //   - leave `authorizationUrl` unset until the handler resolves it
       const idpAuthUrl = "https://idp.example.com/oauth/authorize?state=abc";
       void idpAuthUrl; // retained for parity with the handler-level test
-      secretsMock
-        .onAnyCommand()
-        .resolves({
-          ARN: "arn:aws:secretsmanager:us-east-1:111:secret:mcp-3lo",
-        });
+      secretsMock.onAnyCommand().resolves({
+        ARN: "arn:aws:secretsmanager:us-east-1:111:secret:mcp-3lo",
+      });
       ssmMock.onAnyCommand().resolves({});
       dynamoMock.onAnyCommand().resolves({});
 
@@ -882,7 +878,7 @@ describe("Integration Resolver - Unit Tests", () => {
             config: { serverUrl: "https://mcp.example.com" },
           },
         },
-        identity: { username: "tester" },
+        identity: { username: "tester", "custom:organization": "org-3lo" },
       };
 
       const result = await invoke(event);
@@ -918,11 +914,9 @@ describe("Integration Resolver - Unit Tests", () => {
       bedrockAgentMock
         .on(CreateGatewayTargetCommand)
         .resolves({ targetId: "target-mcp-disc" });
-      secretsMock
-        .onAnyCommand()
-        .resolves({
-          ARN: "arn:aws:secretsmanager:us-east-1:111:secret:mcp-disc",
-        });
+      secretsMock.onAnyCommand().resolves({
+        ARN: "arn:aws:secretsmanager:us-east-1:111:secret:mcp-disc",
+      });
       ssmMock.onAnyCommand().resolves({});
       dynamoMock.onAnyCommand().resolves({});
 
@@ -945,7 +939,7 @@ describe("Integration Resolver - Unit Tests", () => {
             config: { serverUrl: "https://mcp.example.com" },
           },
         },
-        identity: { username: "tester" },
+        identity: { username: "tester", "custom:organization": "org-disc" },
       };
 
       await invoke(event);
@@ -967,11 +961,9 @@ describe("Integration Resolver - Unit Tests", () => {
       bedrockAgentMock
         .on(CreateGatewayTargetCommand)
         .resolves({ targetId: "target-mcp-api" });
-      secretsMock
-        .onAnyCommand()
-        .resolves({
-          ARN: "arn:aws:secretsmanager:us-east-1:111:secret:mcp-api",
-        });
+      secretsMock.onAnyCommand().resolves({
+        ARN: "arn:aws:secretsmanager:us-east-1:111:secret:mcp-api",
+      });
       ssmMock.onAnyCommand().resolves({});
       dynamoMock.onAnyCommand().resolves({});
 
@@ -986,7 +978,7 @@ describe("Integration Resolver - Unit Tests", () => {
             config: { serverUrl: "https://mcp.example.com" },
           },
         },
-        identity: { username: "tester" },
+        identity: { username: "tester", "custom:organization": "org-api" },
       };
 
       await invoke(event);
@@ -1025,7 +1017,7 @@ describe("Integration Resolver - Unit Tests", () => {
             config: { serverUrl: "https://mcp.example.com" },
           },
         },
-        identity: { username: "tester" },
+        identity: { username: "tester", "custom:organization": "org-legacy" },
       };
 
       await expect(invoke(event)).rejects.toThrow(/grantType/);
@@ -1077,7 +1069,7 @@ describe("Integration Resolver - Unit Tests", () => {
       const event = {
         info: { fieldName: "connectIntegration" },
         arguments: { integrationId },
-        identity: { username: "tester" },
+        identity: { username: "tester", "custom:organization": "org-3lo" },
       };
 
       const result = await invoke(event);
@@ -1150,7 +1142,7 @@ describe("Integration Resolver - Unit Tests", () => {
       const event = {
         info: { fieldName: "deleteIntegration" },
         arguments: { integrationId },
-        identity: { username: "tester" },
+        identity: { username: "tester", "custom:organization": "org-del" },
       };
 
       const result = await invoke(event);
@@ -1237,7 +1229,7 @@ describe("Integration Resolver - Unit Tests", () => {
       const event = {
         info: { fieldName: "deleteIntegration" },
         arguments: { integrationId },
-        identity: { username: "tester" },
+        identity: { username: "tester", "custom:organization": "org-del" },
       };
 
       await expect(invoke(event)).rejects.toThrow(/EventBridge unreachable/);
@@ -1286,7 +1278,7 @@ describe("Integration Resolver - Unit Tests", () => {
       const event = {
         info: { fieldName: "deleteIntegration" },
         arguments: { integrationId },
-        identity: { username: "tester" },
+        identity: { username: "tester", "custom:organization": "org-del" },
       };
 
       const result = await invoke(event);

--- a/backend/src/lambda/integration-resolver.ts
+++ b/backend/src/lambda/integration-resolver.ts
@@ -38,7 +38,11 @@ import {
   type IntegrationStatus,
 } from "../utils/lifecycle-validator";
 import { storeCredentials } from "../utils/credential-manager";
-import { extractOrgFromEvent, isAdminFromEvent } from "../utils/auth-event";
+import {
+  extractOrgFromEvent,
+  isAdminFromEvent,
+  assertRowOrg,
+} from "../utils/auth-event";
 import {
   provisionCredentialProvider,
   deprovisionCredentialProvider,
@@ -372,17 +376,21 @@ export async function handler(event: AppSyncEvent) {
         return await createIntegration(
           event.arguments.input,
           event.identity?.username || "system",
+          event,
         );
       case "updateIntegration":
-        return await updateIntegration(event.arguments.input);
+        return await updateIntegration(event.arguments.input, event);
       case "deleteIntegration":
-        return await deleteIntegration(event.arguments.integrationId);
+        return await deleteIntegration(event.arguments.integrationId, event);
       case "testIntegration":
-        return await testIntegration(event.arguments.integrationId);
+        return await testIntegration(event.arguments.integrationId, event);
       case "connectIntegration":
-        return await connectIntegration(event.arguments.integrationId);
+        return await connectIntegration(event.arguments.integrationId, event);
       case "disconnectIntegration":
-        return await disconnectIntegration(event.arguments.integrationId);
+        return await disconnectIntegration(
+          event.arguments.integrationId,
+          event,
+        );
       case "listIntegrations": {
         // Org scoping (sweep finding under 615aa5bb): a non-admin caller's
         // server-derived org always wins over the requested orgId argument
@@ -399,7 +407,15 @@ export async function handler(event: AppSyncEvent) {
         );
       }
       case "getIntegration": {
+        // Org scoping (finding ca76d041, integration half; CRE item 3):
+        // a by-ID read has no orgId argument to coerce against, so an
+        // unresolvable/mismatched caller org is a hard denial via the
+        // shared assertRowOrg gate — same fetch-then-verify convention as
+        // getDataStoreGuarded in datastore-resolver.ts. The credential
+        // sanitization below limits readback exposure but was never a
+        // substitute for the tenant gate itself.
         const integration = await getIntegration(event.arguments.integrationId);
+        await assertRowOrg(integration, event);
         return sanitizeIntegrationForResponse(integration);
       }
       default:
@@ -426,7 +442,25 @@ export async function handler(event: AppSyncEvent) {
 async function createIntegration(
   input: CreateIntegrationInput,
   createdBy: string,
+  event: unknown,
 ) {
+  // Org scoping (finding ca76d041, integration half; CRE item 3):
+  // createIntegration trusted a client-supplied input.orgId outright.
+  // Mutation convention is reject-not-coerce (mirrors createDataStore in
+  // datastore-resolver.ts) — derive the caller's org server-side and refuse
+  // a mismatched client value BEFORE any Secrets Manager call, credential
+  // provider provisioning, or DynamoDB write. Admins may still create on
+  // behalf of any org (same bypass every other operation below honours).
+  const admin = isAdminFromEvent(event);
+  if (!admin) {
+    const callerOrgId = await extractOrgFromEvent(event);
+    if (!callerOrgId || callerOrgId !== input.orgId) {
+      throw new Error(
+        "Access denied: orgId does not match caller's organization",
+      );
+    }
+  }
+
   const integrationId = uuidv4();
   const timestamp = new Date().toISOString();
 
@@ -613,8 +647,15 @@ async function createIntegration(
   }
 }
 
-async function updateIntegration(input: UpdateIntegrationInput) {
+async function updateIntegration(
+  input: UpdateIntegrationInput,
+  event: unknown,
+) {
   const integration = await getIntegration(input.integrationId);
+
+  // Org scoping (finding ca76d041): reconcile BEFORE any Secrets Manager
+  // read/write, SSM write, or the final DynamoDB Put.
+  await assertRowOrg(integration, event);
 
   const spec = getConnectorSpec(integration.integrationType);
   if (!spec) {
@@ -738,8 +779,12 @@ async function updateIntegration(input: UpdateIntegrationInput) {
   return sanitizeIntegrationForResponse(integration);
 }
 
-async function testIntegration(integrationId: string) {
+async function testIntegration(integrationId: string, event: unknown) {
   const integration = await getIntegration(integrationId);
+
+  // Org scoping (finding ca76d041): reconcile BEFORE reading the secret,
+  // reading SSM parameters, or calling testConnection.
+  await assertRowOrg(integration, event);
 
   if (!canTest(integration.status as IntegrationStatus)) {
     throw new Error(
@@ -841,8 +886,12 @@ async function testIntegration(integrationId: string) {
  * is in `CREATE_PENDING_AUTH`, the persisted `authorizationUrl` is
  * surfaced so the frontend can redirect the user to the IdP.
  */
-async function connectIntegration(integrationId: string) {
+async function connectIntegration(integrationId: string, event: unknown) {
   const integration = await getIntegration(integrationId);
+
+  // Org scoping (finding ca76d041): reconcile BEFORE publishing the
+  // connect-requested event or writing CONNECTING status to DynamoDB.
+  await assertRowOrg(integration, event);
 
   if (!canConnect(integration.status as IntegrationStatus)) {
     throw new Error(
@@ -916,8 +965,12 @@ async function connectIntegration(integrationId: string) {
   }
 }
 
-async function disconnectIntegration(integrationId: string) {
+async function disconnectIntegration(integrationId: string, event: unknown) {
   const integration = await getIntegration(integrationId);
+
+  // Org scoping (finding ca76d041): reconcile BEFORE publishing the
+  // disconnect-requested event or writing DISCONNECTED status to DynamoDB.
+  await assertRowOrg(integration, event);
 
   if (!canDisconnect(integration.status as IntegrationStatus)) {
     throw new Error(
@@ -1039,8 +1092,17 @@ async function getIntegration(integrationId: string) {
  * integration). The DDB row is marked `targetStatus: DELETING` so the
  * frontend can show "Disconnecting..." until the handler finishes.
  */
-async function deleteIntegration(integrationId: string) {
+async function deleteIntegration(integrationId: string, event: unknown) {
   const integration = await getIntegration(integrationId);
+
+  // Org scoping (finding ca76d041): reconcile BEFORE publishing the
+  // disconnect-requested (full teardown) event. This is the worst-case
+  // operation — the downstream gateway-registration-handler deletes the
+  // gateway target, deprovisions the credential provider, force-deletes
+  // the Secrets Manager secret, and deletes the DynamoDB row — so the gate
+  // must run before the event that drives all of that is ever emitted, not
+  // just before the local DynamoDB status update below.
+  await assertRowOrg(integration, event);
 
   try {
     await emitIntegrationEvent("integration.disconnect.requested", {


### PR DESCRIPTION
## Summary

Every by-id integration operation acted on a client-supplied `integrationId` without reconciling it against the caller's organization. An earlier PR fixed only `listIntegrations` leaving the item-level operations exposed to any authenticated user of any organization.
- `getIntegration` returned another tenant's record - and its credential sanitization was **not** protecting it: the bite proof shows the unguarded path returning `secretArn` and `credentialProviderArn` unredacted. Access is now denied outright rather than sanitized
- `updateIntegration` allowed tampering plus secret and SSM writes
- `deleteIntegration` and `disconnectIntegration` triggered teardown of another tenant's gateway target, credential provider, secret and rows
- `testIntegration` and `connectIntegration` reached the provider
- `createIntegration` trusted a client-supplied `orgId`

## Fix
Reuses `assertRowOrg` from the datastore remediation - no second variant - with the same fetch-then-verify placement and the same convention (mutations reject, reads coerce, admin bypass preserved).

Guard placement mattered here more than elsewhere: `deleteIntegration` and `disconnectIntegration` publish an EventBridge event that drives the asynchronous teardown. Gating only the local status update would have left that path reachable, so the guard sits **before the emission**. The downstream handler was checked and is not directly reachable - it only consumes events the resolver emits after the guard, so no ordering window remains.

## Testing

- Per operation, a cross-org caller is refused with the mocks recording zero Secrets
Manager, zero EventBridge, zero SSM and zero DynamoDB-write calls
- Denial proven to precede sanitization, so credential material cannot leak on a refused path
- Fail-closed on absent identity, unresolvable org, missing row, and a row lacking `orgid`
- Bite-proven: reverting the guard returns the victim's full row; restored byte-identically
- No Lockout - the frontend sources every `integrationId` from org-scoped `listIntegrations` results
- tsc, ;int, `cdk synth` exit 0; 13 new tests; full backend jest 7104

## Notes

- Nineteen pre-existing fixtures needed organization claims added, because fail-closed correctly broke tests that had been running with no org identity at all - the same pattern seen in the datastore fix. The tests had encoded the gap.