### PR TITLE
fix(api): owner-gate app access grants and revocations

### DIFF
--- a/backend/src/lambda/__tests__/fixtures/registry-service-mock.ts
+++ b/backend/src/lambda/__tests__/fixtures/registry-service-mock.ts
@@ -34,6 +34,7 @@ export function resetMockRegistry(): void {
   records.clear();
   listResourceSummariesCallCount = 0;
   getResourceCallCounts.clear();
+  updateResourceCallCount = 0;
 }
 
 /** Test-visible call counter: how many times listResourceSummaries() ran. */
@@ -49,6 +50,18 @@ export function getGetResourceCallCount(
   id: string,
 ): number {
   return getResourceCallCounts.get(`${type}:${id}`) ?? 0;
+}
+
+/**
+ * Test-visible call counter: total updateResource() invocations across all
+ * records, this test run. Used to assert "zero writes on refused access"
+ * (finding 8b0e32a7) without needing to spy on a per-call service instance,
+ * since `getMockRegistryService()` returns a fresh object per call but all
+ * instances share this module-level counter.
+ */
+let updateResourceCallCount = 0;
+export function getUpdateResourceCallCount(): number {
+  return updateResourceCallCount;
 }
 
 export function getMockRegistryService() {
@@ -181,6 +194,7 @@ export function getMockRegistryService() {
       id: string,
       input: UpdateResourceInput,
     ): Promise<RegistryRecord> {
+      updateResourceCallCount += 1;
       const existing = records.get(`${type}:${id}`);
       if (!existing) throw new Error(`Record not found: ${type}:${id}`);
       const updated: MockRegistryRecord = {

--- a/backend/src/lambda/__tests__/registry-agent-record-resolver-access-owner-gate.test.ts
+++ b/backend/src/lambda/__tests__/registry-agent-record-resolver-access-owner-gate.test.ts
@@ -1,0 +1,328 @@
+/**
+ * RED-first tests for finding 8b0e32a7 (CRE item 4): grantAppAccess and
+ * revokeAppAccess must enforce an owner-role gate before writing, using the
+ * manifest `access` map as the canonical authorization store — the same
+ * store the write path (writeManifestMutation) actually updates. The
+ * previously-defined checkOperationAccess/checkAppAccess (app-access-control.ts)
+ * read a SEPARATE DynamoDB ACCESS# store that the grant/revoke write path
+ * never updates (confirmed zero production writers) — wiring the gate to
+ * that store instead would authorize against stale/absent data, which is
+ * why this test suite gates against the manifest, not app-access-control.ts.
+ *
+ * Threat model asserted here:
+ *   - same-org NON-OWNER (the case org scoping alone would miss) → refused
+ *   - cross-org caller → refused
+ *   - owner → succeeds
+ *   - admin group → bypasses (consistent with getApp/checkAppAccess convention)
+ *   - refusal happens BEFORE any manifest write (assert zero updateResource calls)
+ *   - split-brain check: grant, then re-authorize through the SAME gate in
+ *     the same test, proving the gate reads what the write just updated.
+ */
+
+process.env.REGISTRY_ID = "test-registry-id";
+process.env.APPS_TABLE = "citadel-apps-test";
+process.env.WORKFLOWS_TABLE = "citadel-workflows-test";
+process.env.AGENT_CONFIG_TABLE = "citadel-agents-test";
+process.env.EVENT_BUS_NAME = "citadel-agents-test";
+process.env.USER_POOL_ID = "us-east-1_test";
+process.env.AUTHORITY_UNITS_TABLE = "test-authority-units";
+process.env.AWS_REGION = "us-east-1";
+
+import {
+  EventBridgeClient,
+  PutEventsCommand,
+} from "@aws-sdk/client-eventbridge";
+import { mockClient } from "aws-sdk-client-mock";
+
+const ebMock = mockClient(EventBridgeClient);
+
+import {
+  seedMockRegistry,
+  resetMockRegistry,
+  getUpdateResourceCallCount,
+} from "./fixtures/registry-service-mock";
+
+jest.mock("../../services/registry-service", () => {
+  const { getMockRegistryService } = jest.requireActual(
+    "./fixtures/registry-service-mock",
+  );
+  const actual = jest.requireActual("../../services/registry-service");
+  return {
+    RegistryService: jest
+      .fn()
+      .mockImplementation(() => getMockRegistryService()),
+    getRegistryService: jest.fn(() => getMockRegistryService()),
+    _resetRegistryService: jest.fn(),
+    isRegistryEnabled: jest.fn(() => true),
+    TypeMismatchError: actual.TypeMismatchError,
+    RegistryLifecycleError: actual.RegistryLifecycleError,
+  };
+});
+
+// Cognito lookups are used by extractOrgFromEvent's fallback path; these
+// tests always supply custom:organization directly on the event so no
+// network call is made, but we still mock the client defensively.
+jest.mock("@aws-sdk/client-cognito-identity-provider", () => ({
+  CognitoIdentityProviderClient: jest.fn().mockImplementation(() => ({
+    send: jest
+      .fn()
+      .mockRejectedValue(new Error("Cognito not reachable in test")),
+  })),
+  AdminGetUserCommand: jest.fn(),
+}));
+
+import { handler } from "../registry-agent-record-resolver";
+
+type HandlerEvent = Parameters<typeof handler>[0];
+const invokeHandler = handler as (event: HandlerEvent) => Promise<unknown>;
+
+function makeEvent(
+  fieldName: string,
+  args: Record<string, unknown>,
+  opts: { userId: string; orgId?: string; groups?: string[] },
+) {
+  const claims: Record<string, unknown> = {
+    sub: opts.userId,
+  };
+  if (opts.orgId !== undefined) claims["custom:organization"] = opts.orgId;
+  if (opts.groups !== undefined) claims["cognito:groups"] = opts.groups;
+  return {
+    info: { fieldName },
+    arguments: args,
+    identity: { sub: opts.userId, claims },
+  } as unknown as HandlerEvent;
+}
+
+const APP_ID = "app-1";
+const OWNER_ID = "owner-user";
+const APP_ORG = "org-1";
+
+function seedAppWithAccess(
+  access: Record<
+    string,
+    { role: string; grantedAt: string; grantedBy: string }
+  > = {},
+) {
+  seedMockRegistry("agent", APP_ID, {
+    name: "Test App",
+    description: "Test",
+    status: "DRAFT",
+    customDescriptorContent: JSON.stringify({
+      appId: APP_ID,
+      manifest: {
+        orgId: APP_ORG,
+        version: 1,
+        status: "DRAFT",
+        workflowIds: [],
+        agentBindings: [],
+        permissions: [],
+        configSchema: null,
+        configValues: null,
+        authConfig: null,
+        access: {
+          [OWNER_ID]: {
+            role: "owner",
+            grantedAt: "2024-01-01T00:00:00Z",
+            grantedBy: "system",
+          },
+          ...access,
+        },
+        routingConfig: null,
+      },
+    }),
+  });
+}
+
+describe("registry-agent-record-resolver — grantAppAccess/revokeAppAccess owner gate (finding 8b0e32a7)", () => {
+  beforeEach(() => {
+    resetMockRegistry();
+    ebMock.reset();
+    ebMock.on(PutEventsCommand).resolves({});
+  });
+
+  describe("grantAppAccess", () => {
+    test("refuses a same-org NON-OWNER (the case org scoping alone would miss)", async () => {
+      seedAppWithAccess({
+        "non-owner-user": {
+          role: "editor",
+          grantedAt: "2024-01-01T00:00:00Z",
+          grantedBy: OWNER_ID,
+        },
+      });
+
+      await expect(
+        invokeHandler(
+          makeEvent(
+            "grantAppAccess",
+            { appId: APP_ID, userId: "attacker", role: "owner" },
+            { userId: "non-owner-user", orgId: APP_ORG },
+          ),
+        ),
+      ).rejects.toThrow(/Access denied|owner/i);
+
+      expect(getUpdateResourceCallCount()).toBe(0);
+    });
+
+    test("refuses a cross-org caller", async () => {
+      seedAppWithAccess();
+
+      await expect(
+        invokeHandler(
+          makeEvent(
+            "grantAppAccess",
+            { appId: APP_ID, userId: "attacker", role: "owner" },
+            { userId: "cross-org-user", orgId: "org-2" },
+          ),
+        ),
+      ).rejects.toThrow(/Access denied|owner/i);
+
+      expect(getUpdateResourceCallCount()).toBe(0);
+    });
+
+    test("refuses when caller identity/org cannot be resolved (fail closed)", async () => {
+      seedAppWithAccess();
+
+      await expect(
+        invokeHandler(
+          makeEvent(
+            "grantAppAccess",
+            { appId: APP_ID, userId: "attacker", role: "owner" },
+            { userId: "no-org-claim-user" }, // no custom:organization, Cognito lookup rejects
+          ),
+        ),
+      ).rejects.toThrow(/Access denied|owner/i);
+
+      expect(getUpdateResourceCallCount()).toBe(0);
+    });
+
+    test("allows the owner to grant access", async () => {
+      seedAppWithAccess();
+
+      const result = await invokeHandler(
+        makeEvent(
+          "grantAppAccess",
+          { appId: APP_ID, userId: "target-user", role: "editor" },
+          { userId: OWNER_ID, orgId: APP_ORG },
+        ),
+      );
+
+      expect(result).toBeDefined();
+      expect(getUpdateResourceCallCount()).toBe(1);
+
+      const entries = ebMock
+        .commandCalls(PutEventsCommand)
+        .flatMap((c) => c.args[0].input.Entries ?? []);
+      expect(
+        entries.find((e) => e?.DetailType === "app.access.granted"),
+      ).toBeDefined();
+    });
+
+    test("admin group bypasses the owner check", async () => {
+      seedAppWithAccess();
+
+      const result = await invokeHandler(
+        makeEvent(
+          "grantAppAccess",
+          { appId: APP_ID, userId: "target-user", role: "viewer" },
+          { userId: "admin-user", orgId: "unrelated-org", groups: ["admin"] },
+        ),
+      );
+
+      expect(result).toBeDefined();
+      expect(getUpdateResourceCallCount()).toBe(1);
+    });
+
+    test("split-brain: after granting owner to a second user, the gate immediately recognizes them as owner", async () => {
+      seedAppWithAccess();
+
+      // Original owner grants owner role to a second user.
+      await invokeHandler(
+        makeEvent(
+          "grantAppAccess",
+          { appId: APP_ID, userId: "second-owner", role: "owner" },
+          { userId: OWNER_ID, orgId: APP_ORG },
+        ),
+      );
+
+      // The newly-granted owner immediately re-authorizes through the SAME
+      // gate, in the same test/process, by performing another owner-gated
+      // grant — proving the gate reads the store the FIRST grant write just
+      // updated (the manifest `access` map), not a stale/separate ACCESS#
+      // DynamoDB table the write never touches. If the gate instead read
+      // that separate store, second-owner would have no entry there and
+      // this call would be refused with "Access denied".
+      await expect(
+        invokeHandler(
+          makeEvent(
+            "grantAppAccess",
+            { appId: APP_ID, userId: "target-user-2", role: "viewer" },
+            { userId: "second-owner", orgId: APP_ORG },
+          ),
+        ),
+      ).resolves.toBeDefined();
+
+      expect(getUpdateResourceCallCount()).toBe(2);
+    });
+  });
+
+  describe("revokeAppAccess", () => {
+    test("refuses a same-org NON-OWNER", async () => {
+      seedAppWithAccess({
+        "non-owner-user": {
+          role: "editor",
+          grantedAt: "2024-01-01T00:00:00Z",
+          grantedBy: OWNER_ID,
+        },
+      });
+
+      await expect(
+        invokeHandler(
+          makeEvent(
+            "revokeAppAccess",
+            { appId: APP_ID, userId: OWNER_ID },
+            { userId: "non-owner-user", orgId: APP_ORG },
+          ),
+        ),
+      ).rejects.toThrow(/Access denied|owner/i);
+
+      expect(getUpdateResourceCallCount()).toBe(0);
+    });
+
+    test("refuses a cross-org caller", async () => {
+      seedAppWithAccess();
+
+      await expect(
+        invokeHandler(
+          makeEvent(
+            "revokeAppAccess",
+            { appId: APP_ID, userId: OWNER_ID },
+            { userId: "cross-org-user", orgId: "org-2" },
+          ),
+        ),
+      ).rejects.toThrow(/Access denied|owner/i);
+
+      expect(getUpdateResourceCallCount()).toBe(0);
+    });
+
+    test("allows the owner to revoke access", async () => {
+      seedAppWithAccess({
+        "target-user": {
+          role: "editor",
+          grantedAt: "2024-01-01T00:00:00Z",
+          grantedBy: OWNER_ID,
+        },
+      });
+
+      const result = await invokeHandler(
+        makeEvent(
+          "revokeAppAccess",
+          { appId: APP_ID, userId: "target-user" },
+          { userId: OWNER_ID, orgId: APP_ORG },
+        ),
+      );
+
+      expect(result).toBeDefined();
+      expect(getUpdateResourceCallCount()).toBe(1);
+    });
+  });
+});

--- a/backend/src/lambda/__tests__/registry-agent-record-resolver-access.test.ts
+++ b/backend/src/lambda/__tests__/registry-agent-record-resolver-access.test.ts
@@ -7,30 +7,37 @@
  * wrapper from its storage backing.
  */
 
-process.env.REGISTRY_ID = 'test-registry-id';
-process.env.APPS_TABLE = 'citadel-apps-test';
-process.env.WORKFLOWS_TABLE = 'citadel-workflows-test';
-process.env.AGENT_CONFIG_TABLE = 'citadel-agents-test';
-process.env.EVENT_BUS_NAME = 'citadel-agents-test';
-process.env.USER_POOL_ID = 'us-east-1_test';
-process.env.AUTHORITY_UNITS_TABLE = 'test-authority-units';
-process.env.AWS_REGION = 'us-east-1';
+process.env.REGISTRY_ID = "test-registry-id";
+process.env.APPS_TABLE = "citadel-apps-test";
+process.env.WORKFLOWS_TABLE = "citadel-workflows-test";
+process.env.AGENT_CONFIG_TABLE = "citadel-agents-test";
+process.env.EVENT_BUS_NAME = "citadel-agents-test";
+process.env.USER_POOL_ID = "us-east-1_test";
+process.env.AUTHORITY_UNITS_TABLE = "test-authority-units";
+process.env.AWS_REGION = "us-east-1";
 
-import { EventBridgeClient, PutEventsCommand } from '@aws-sdk/client-eventbridge';
-import { mockClient } from 'aws-sdk-client-mock';
+import {
+  EventBridgeClient,
+  PutEventsCommand,
+} from "@aws-sdk/client-eventbridge";
+import { mockClient } from "aws-sdk-client-mock";
 
 const ebMock = mockClient(EventBridgeClient);
 
 import {
   seedMockRegistry,
   resetMockRegistry,
-} from './fixtures/registry-service-mock';
+} from "./fixtures/registry-service-mock";
 
-jest.mock('../../services/registry-service', () => {
-  const { getMockRegistryService } = jest.requireActual('./fixtures/registry-service-mock');
-  const actual = jest.requireActual('../../services/registry-service');
+jest.mock("../../services/registry-service", () => {
+  const { getMockRegistryService } = jest.requireActual(
+    "./fixtures/registry-service-mock",
+  );
+  const actual = jest.requireActual("../../services/registry-service");
   return {
-    RegistryService: jest.fn().mockImplementation(() => getMockRegistryService()),
+    RegistryService: jest
+      .fn()
+      .mockImplementation(() => getMockRegistryService()),
     getRegistryService: jest.fn(() => getMockRegistryService()),
     _resetRegistryService: jest.fn(),
     isRegistryEnabled: jest.fn(() => true),
@@ -39,16 +46,17 @@ jest.mock('../../services/registry-service', () => {
   };
 });
 
-jest.mock('../../utils/appsync', () => ({
-  getUserId: jest.fn().mockReturnValue('user-123'),
+jest.mock("../../utils/appsync", () => ({
+  getUserId: jest.fn().mockReturnValue("user-123"),
 }));
 
 const mockListAppAccessEntriesImpl = jest.fn();
-jest.mock('../app-access-control', () => ({
-  listAppAccessEntries: (...args: unknown[]) => mockListAppAccessEntriesImpl(...args),
+jest.mock("../app-access-control", () => ({
+  listAppAccessEntries: (...args: unknown[]) =>
+    mockListAppAccessEntriesImpl(...args),
 }));
 
-import { handler } from '../registry-agent-record-resolver';
+import { handler } from "../registry-agent-record-resolver";
 
 type HandlerEvent = Parameters<typeof handler>[0];
 
@@ -62,35 +70,51 @@ function makeEvent(fieldName: string, args: Record<string, unknown>) {
   return {
     info: { fieldName },
     arguments: args,
-    identity: { sub: 'user-123', claims: { sub: 'user-123' } },
+    identity: {
+      sub: "user-123",
+      claims: { sub: "user-123", "custom:organization": "org-1" },
+    },
   } as unknown as HandlerEvent;
 }
 
 function seedApp(): void {
-  seedMockRegistry('agent', 'app-1', {
-    name: 'Test App',
-    description: 'Test',
-    status: 'DRAFT',
+  seedMockRegistry("agent", "app-1", {
+    name: "Test App",
+    description: "Test",
+    status: "DRAFT",
     customDescriptorContent: JSON.stringify({
-      appId: 'app-1',
+      appId: "app-1",
       manifest: {
-        orgId: 'org-1',
+        orgId: "org-1",
         version: 1,
-        status: 'DRAFT',
+        status: "DRAFT",
+        createdBy: "user-123",
         workflowIds: [],
         agentBindings: [],
         permissions: [],
         configSchema: null,
         configValues: null,
         authConfig: null,
-        access: {},
+        // user-123 is the caller used by every test in this file (see
+        // makeEvent) and is seeded here as an explicit owner so the
+        // grantAppAccess/revokeAppAccess owner gate (finding 8b0e32a7)
+        // does not refuse these pre-existing success-path tests. The
+        // owner-gate's own refusal paths are covered separately in
+        // registry-agent-record-resolver-access-owner-gate.test.ts.
+        access: {
+          "user-123": {
+            role: "owner",
+            grantedAt: "2024-01-01T00:00:00Z",
+            grantedBy: "system",
+          },
+        },
         routingConfig: null,
       },
     }),
   });
 }
 
-describe('registry-agent-record-resolver — access / auth surfaces', () => {
+describe("registry-agent-record-resolver — access / auth surfaces", () => {
   beforeEach(() => {
     resetMockRegistry();
     ebMock.reset();
@@ -100,143 +124,160 @@ describe('registry-agent-record-resolver — access / auth surfaces', () => {
 
   // ─── setAppAuthConfig ────────────────────────────────────────
 
-  describe('setAppAuthConfig', () => {
-    test('succeeds and emits app.auth.config.set event', async () => {
+  describe("setAppAuthConfig", () => {
+    test("succeeds and emits app.auth.config.set event", async () => {
       seedApp();
 
       await invokeHandler(
-        makeEvent('setAppAuthConfig', {
-          appId: 'app-1',
-          authConfig: JSON.stringify({ provider: 'cognito', userPoolId: 'up-1' }),
+        makeEvent("setAppAuthConfig", {
+          appId: "app-1",
+          authConfig: JSON.stringify({
+            provider: "cognito",
+            userPoolId: "up-1",
+          }),
         }),
       );
 
       const entries = ebMock
         .commandCalls(PutEventsCommand)
         .flatMap((c) => c.args[0].input.Entries ?? []);
-      const set = entries.find((e) => e?.DetailType === 'app.auth.config.set');
+      const set = entries.find((e) => e?.DetailType === "app.auth.config.set");
       expect(set).toBeDefined();
-      expect(set!.Source).toBe('citadel.apps');
+      expect(set!.Source).toBe("citadel.apps");
     });
 
-    test('throws when app not found', async () => {
+    test("throws when app not found", async () => {
       await expect(
         invokeHandler(
-          makeEvent('setAppAuthConfig', {
-            appId: 'nonexistent',
-            authConfig: JSON.stringify({ provider: 'cognito' }),
+          makeEvent("setAppAuthConfig", {
+            appId: "nonexistent",
+            authConfig: JSON.stringify({ provider: "cognito" }),
           }),
         ),
-      ).rejects.toThrow('App not found');
+      ).rejects.toThrow("App not found");
     });
   });
 
   // ─── grantAppAccess ───────────────────────────────────────────
 
-  describe('grantAppAccess', () => {
-    test('succeeds and emits app.access.granted event with grantedBy user id', async () => {
+  describe("grantAppAccess", () => {
+    test("succeeds and emits app.access.granted event with grantedBy user id", async () => {
       seedApp();
 
       await invokeHandler(
-        makeEvent('grantAppAccess', {
-          appId: 'app-1',
-          userId: 'target-user',
-          role: 'editor',
+        makeEvent("grantAppAccess", {
+          appId: "app-1",
+          userId: "target-user",
+          role: "editor",
         }),
       );
 
       const entries = ebMock
         .commandCalls(PutEventsCommand)
         .flatMap((c) => c.args[0].input.Entries ?? []);
-      const granted = entries.find((e) => e?.DetailType === 'app.access.granted');
+      const granted = entries.find(
+        (e) => e?.DetailType === "app.access.granted",
+      );
       expect(granted).toBeDefined();
 
       const detail = JSON.parse(granted!.Detail!);
-      expect(detail.appId).toBe('app-1');
-      expect(detail.userId).toBe('target-user');
-      expect(detail.role).toBe('editor');
-      expect(detail.grantedBy).toBe('user-123');
+      expect(detail.appId).toBe("app-1");
+      expect(detail.userId).toBe("target-user");
+      expect(detail.role).toBe("editor");
+      expect(detail.grantedBy).toBe("user-123");
     });
 
-    test('throws when app not found', async () => {
+    test("throws when app not found", async () => {
       await expect(
         invokeHandler(
-          makeEvent('grantAppAccess', {
-            appId: 'nonexistent',
-            userId: 'target-user',
-            role: 'editor',
+          makeEvent("grantAppAccess", {
+            appId: "nonexistent",
+            userId: "target-user",
+            role: "editor",
           }),
         ),
-      ).rejects.toThrow('App not found');
+      ).rejects.toThrow("App not found");
     });
   });
 
   // ─── revokeAppAccess ──────────────────────────────────────────
 
-  describe('revokeAppAccess', () => {
-    test('succeeds and emits app.access.revoked event with revokedBy user id', async () => {
+  describe("revokeAppAccess", () => {
+    test("succeeds and emits app.access.revoked event with revokedBy user id", async () => {
       seedApp();
 
       await invokeHandler(
-        makeEvent('revokeAppAccess', {
-          appId: 'app-1',
-          userId: 'target-user',
+        makeEvent("revokeAppAccess", {
+          appId: "app-1",
+          userId: "target-user",
         }),
       );
 
       const entries = ebMock
         .commandCalls(PutEventsCommand)
         .flatMap((c) => c.args[0].input.Entries ?? []);
-      const revoked = entries.find((e) => e?.DetailType === 'app.access.revoked');
+      const revoked = entries.find(
+        (e) => e?.DetailType === "app.access.revoked",
+      );
       expect(revoked).toBeDefined();
 
       const detail = JSON.parse(revoked!.Detail!);
-      expect(detail.appId).toBe('app-1');
-      expect(detail.userId).toBe('target-user');
-      expect(detail.revokedBy).toBe('user-123');
+      expect(detail.appId).toBe("app-1");
+      expect(detail.userId).toBe("target-user");
+      expect(detail.revokedBy).toBe("user-123");
     });
 
-    test('throws when app not found', async () => {
+    test("throws when app not found", async () => {
       await expect(
         invokeHandler(
-          makeEvent('revokeAppAccess', {
-            appId: 'nonexistent',
-            userId: 'target-user',
+          makeEvent("revokeAppAccess", {
+            appId: "nonexistent",
+            userId: "target-user",
           }),
         ),
-      ).rejects.toThrow('App not found');
+      ).rejects.toThrow("App not found");
     });
   });
 
   // ─── listAppAccessEntries ────────────────────────────────────
 
-  describe('listAppAccessEntries', () => {
-    test('delegates to app-access-control#listAppAccessEntries with the deps struct', async () => {
+  describe("listAppAccessEntries", () => {
+    test("delegates to app-access-control#listAppAccessEntries with the deps struct", async () => {
       const entries = [
-        { userId: 'u1', role: 'editor', grantedBy: 'admin', grantedAt: '2024-01-01T00:00:00Z' },
-        { userId: 'u2', role: 'viewer', grantedBy: 'admin', grantedAt: '2024-01-02T00:00:00Z' },
+        {
+          userId: "u1",
+          role: "editor",
+          grantedBy: "admin",
+          grantedAt: "2024-01-01T00:00:00Z",
+        },
+        {
+          userId: "u2",
+          role: "viewer",
+          grantedBy: "admin",
+          grantedAt: "2024-01-02T00:00:00Z",
+        },
       ];
       mockListAppAccessEntriesImpl.mockResolvedValueOnce(entries);
 
       const result = await invokeHandler(
-        makeEvent('listAppAccessEntries', { appId: 'app-1' }),
+        makeEvent("listAppAccessEntries", { appId: "app-1" }),
       );
 
       expect(result).toEqual(entries);
       expect(mockListAppAccessEntriesImpl).toHaveBeenCalledTimes(1);
       const call = mockListAppAccessEntriesImpl.mock.calls[0];
-      expect(call[0]).toBe('app-1');
+      expect(call[0]).toBe("app-1");
       // Second arg is the shared deps struct containing docClient + appsTable.
       expect(call[1]).toEqual(
-        expect.objectContaining({ appsTable: 'citadel-apps-test' }),
+        expect.objectContaining({ appsTable: "citadel-apps-test" }),
       );
     });
 
-    test('returns empty array when no access entries exist', async () => {
+    test("returns empty array when no access entries exist", async () => {
       mockListAppAccessEntriesImpl.mockResolvedValueOnce([]);
 
       const result = await invokeHandler(
-        makeEvent('listAppAccessEntries', { appId: 'app-empty' }),
+        makeEvent("listAppAccessEntries", { appId: "app-empty" }),
       );
 
       expect(result).toEqual([]);

--- a/backend/src/lambda/__tests__/registry-agent-record-resolver-identity.test.ts
+++ b/backend/src/lambda/__tests__/registry-agent-record-resolver-identity.test.ts
@@ -23,34 +23,37 @@
  */
 // Env vars MUST be set BEFORE importing the resolver — module captures them
 // at load time (see crud.test.ts).
-process.env.REGISTRY_ID = 'test-registry-id';
-process.env.APPS_TABLE = 'citadel-apps-test';
-process.env.WORKFLOWS_TABLE = 'citadel-workflows-test';
-process.env.AGENT_CONFIG_TABLE = 'citadel-agents-test';
-process.env.EVENT_BUS_NAME = 'citadel-agents-test';
-process.env.USER_POOL_ID = 'us-east-1_test';
-process.env.AWS_REGION = 'us-east-1';
+process.env.REGISTRY_ID = "test-registry-id";
+process.env.APPS_TABLE = "citadel-apps-test";
+process.env.WORKFLOWS_TABLE = "citadel-workflows-test";
+process.env.AGENT_CONFIG_TABLE = "citadel-agents-test";
+process.env.EVENT_BUS_NAME = "citadel-agents-test";
+process.env.USER_POOL_ID = "us-east-1_test";
+process.env.AWS_REGION = "us-east-1";
 // Keep authority grant/revoke as no-ops (no DDB mock needed for that path).
 delete process.env.AUTHORITY_UNITS_TABLE;
 
-import { EventBridgeClient, PutEventsCommand } from '@aws-sdk/client-eventbridge';
+import {
+  EventBridgeClient,
+  PutEventsCommand,
+} from "@aws-sdk/client-eventbridge";
 import {
   DynamoDBDocumentClient,
   GetCommand,
   UpdateCommand,
   DeleteCommand,
-} from '@aws-sdk/lib-dynamodb';
-import { mockClient } from 'aws-sdk-client-mock';
+} from "@aws-sdk/lib-dynamodb";
+import { mockClient } from "aws-sdk-client-mock";
 
 const ebMock = mockClient(EventBridgeClient);
 const ddbMock = mockClient(DynamoDBDocumentClient);
 
 /** The 12-char id the (mocked) registry assigns, ignoring the caller's uuid. */
-const REGISTRY_ASSIGNED_ID = 'rec123456789';
+const REGISTRY_ASSIGNED_ID = "rec123456789";
 /** Stale client-side UUID embedded in seeded descriptors for sweep tests. */
-const STALE_UUID = 'aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee';
+const STALE_UUID = "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee";
 
-jest.mock('../../services/registry-service', () => {
+jest.mock("../../services/registry-service", () => {
   interface MockRegistryRecord {
     recordId: string;
     name?: string;
@@ -73,10 +76,10 @@ jest.mock('../../services/registry-service', () => {
       // Mimic the real registry: the caller-supplied id is DISCARDED and a
       // registry-assigned 12-char recordId is used instead.
       const record = {
-        recordId: 'rec123456789',
+        recordId: "rec123456789",
         name: input.name,
         description: input.description,
-        status: 'DRAFT',
+        status: "DRAFT",
         customDescriptorContent: input.customMetadata,
         createdAt: new Date(),
         updatedAt: new Date(),
@@ -94,7 +97,9 @@ jest.mock('../../services/registry-service', () => {
       const updated = {
         ...existing,
         ...(input.name !== undefined && { name: input.name }),
-        ...(input.description !== undefined && { description: input.description }),
+        ...(input.description !== undefined && {
+          description: input.description,
+        }),
         ...(input.customMetadata !== undefined && {
           customDescriptorContent: input.customMetadata,
         }),
@@ -132,23 +137,24 @@ jest.mock('../../services/registry-service', () => {
     isRegistryEnabled: jest.fn(() => true),
     TypeMismatchError,
     RegistryLifecycleError,
-    __seed: (type: string, id: string, rec: MockRegistryRecord) => records.set(`${type}:${id}`, rec),
+    __seed: (type: string, id: string, rec: MockRegistryRecord) =>
+      records.set(`${type}:${id}`, rec),
     __get: (type: string, id: string) => records.get(`${type}:${id}`),
     __reset: () => records.clear(),
   };
 });
 
-jest.mock('../../utils/appsync', () => ({
-  getUserId: jest.fn().mockReturnValue('user-123'),
+jest.mock("../../utils/appsync", () => ({
+  getUserId: jest.fn().mockReturnValue("user-123"),
 }));
 
-jest.mock('../../utils/appsync-publish', () => ({
+jest.mock("../../utils/appsync-publish", () => ({
   publishAppStatusEvent: jest.fn().mockResolvedValue(undefined),
 }));
 
-import { handler } from '../registry-agent-record-resolver';
+import { handler } from "../registry-agent-record-resolver";
 
-import * as registryServiceMockedModule from '../../services/registry-service';
+import * as registryServiceMockedModule from "../../services/registry-service";
 
 interface SeededRegistryRecord {
   recordId: string;
@@ -177,11 +183,15 @@ type HandlerEvent = Parameters<typeof handler>[0];
 // (single cast here) so calls don't pass superfluous arguments.
 const invokeHandler = handler as (event: HandlerEvent) => Promise<unknown>;
 
-function makeEvent(fieldName: string, args: Record<string, unknown>, sub = 'user-123'): HandlerEvent {
+function makeEvent(
+  fieldName: string,
+  args: Record<string, unknown>,
+  sub = "user-123",
+): HandlerEvent {
   return {
     info: { fieldName },
     arguments: args,
-    identity: { sub, claims: { sub } },
+    identity: { sub, claims: { sub, "custom:organization": "org-1" } },
   } as unknown as HandlerEvent;
 }
 
@@ -190,27 +200,40 @@ function makeEvent(fieldName: string, args: Record<string, unknown>, sub = 'user
  * in its customDescriptorContent (a stale UUID) — the exact persisted state
  * a real createApp leaves behind.
  */
-function seedAppWithStaleDescriptorId(manifest: Record<string, unknown> = {}): void {
-  registryMock.__seed('agent', 'app-1', {
-    recordId: 'app-1',
-    name: 'Test App',
-    description: 'Test',
-    status: 'DRAFT',
+function seedAppWithStaleDescriptorId(
+  manifest: Record<string, unknown> = {},
+): void {
+  registryMock.__seed("agent", "app-1", {
+    recordId: "app-1",
+    name: "Test App",
+    description: "Test",
+    status: "DRAFT",
     createdAt: new Date(),
     updatedAt: new Date(),
     customDescriptorContent: JSON.stringify({
       appId: STALE_UUID,
       manifest: {
-        orgId: 'org-1',
+        orgId: "org-1",
         version: 1,
-        status: 'DRAFT',
+        status: "DRAFT",
         workflowIds: [],
         agentBindings: [],
         permissions: [],
         configSchema: null,
         configValues: null,
         authConfig: null,
-        access: {},
+        // user-123 is makeEvent's default caller — seeded as owner here so
+        // the grantAppAccess/revokeAppAccess owner gate (finding 8b0e32a7)
+        // does not refuse these identity-chain tests, which are unrelated
+        // to access control. Gate refusal paths are covered separately in
+        // registry-agent-record-resolver-access-owner-gate.test.ts.
+        access: {
+          "user-123": {
+            role: "owner",
+            grantedAt: "2024-01-01T00:00:00Z",
+            grantedBy: "system",
+          },
+        },
         routingConfig: null,
         ...manifest,
       },
@@ -222,10 +245,14 @@ function seedAppWithStaleDescriptorId(manifest: Record<string, unknown> = {}): v
 function metaUpdateCalls() {
   return ddbMock
     .commandCalls(UpdateCommand)
-    .filter((c) => (c.args[0].input as { TableName?: string }).TableName === 'citadel-apps-test');
+    .filter(
+      (c) =>
+        (c.args[0].input as { TableName?: string }).TableName ===
+        "citadel-apps-test",
+    );
 }
 
-describe('registry-agent-record-resolver — appId identity chain', () => {
+describe("registry-agent-record-resolver — appId identity chain", () => {
   beforeEach(() => {
     registryMock.__reset();
     ebMock.reset();
@@ -245,16 +272,16 @@ describe('registry-agent-record-resolver — appId identity chain', () => {
     delete process.env.REGISTRY_ID;
   });
 
-  describe('createApp', () => {
-    test('returns the registry-assigned recordId as appId, not the original UUID from customDescriptorContent', async () => {
+  describe("createApp", () => {
+    test("returns the registry-assigned recordId as appId, not the original UUID from customDescriptorContent", async () => {
       const result = (await invokeHandler(
-        makeEvent('createApp', {
-          input: { name: 'New App', description: 'A test app', orgId: 'org-1' },
+        makeEvent("createApp", {
+          input: { name: "New App", description: "A test app", orgId: "org-1" },
         }),
       )) as Record<string, unknown>;
 
       // The persisted record's descriptor still embeds the original UUID.
-      const persisted = registryMock.__get('agent', REGISTRY_ASSIGNED_ID);
+      const persisted = registryMock.__get("agent", REGISTRY_ASSIGNED_ID);
       expect(persisted).toBeDefined();
       const descriptor = JSON.parse(persisted.customDescriptorContent);
       expect(descriptor.appId).not.toBe(REGISTRY_ASSIGNED_ID); // uuid, discarded by registry
@@ -265,43 +292,52 @@ describe('registry-agent-record-resolver — appId identity chain', () => {
       expect(result.appId).not.toBe(descriptor.appId);
     });
 
-    test('returned appId agrees with the AppsTable #META mirror key', async () => {
+    test("returned appId agrees with the AppsTable #META mirror key", async () => {
       const result = (await invokeHandler(
-        makeEvent('createApp', {
-          input: { name: 'New App', description: 'A test app', orgId: 'org-1' },
+        makeEvent("createApp", {
+          input: { name: "New App", description: "A test app", orgId: "org-1" },
         }),
       )) as Record<string, unknown>;
 
       const calls = metaUpdateCalls();
       expect(calls).toHaveLength(1);
-      const mirrorKey = (calls[0].args[0].input as { Key: { appId?: string } }).Key.appId;
+      const mirrorKey = (calls[0].args[0].input as { Key: { appId?: string } })
+        .Key.appId;
       expect(mirrorKey).toBe(REGISTRY_ASSIGNED_ID);
       // Create-then-import identity chain: the id handed back to the caller
       // must be the same id the mirror row is keyed by.
       expect(result.appId).toBe(mirrorKey);
     });
 
-    test('logs an error with appId and tableName when the #META mirror write fails', async () => {
-      ddbMock.on(UpdateCommand).rejects(new Error('provisioning boom'));
-      const errorSpy = jest.spyOn(console, 'error').mockImplementation(() => undefined);
-      const warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => undefined);
+    test("logs an error with appId and tableName when the #META mirror write fails", async () => {
+      ddbMock.on(UpdateCommand).rejects(new Error("provisioning boom"));
+      const errorSpy = jest
+        .spyOn(console, "error")
+        .mockImplementation(() => undefined);
+      const warnSpy = jest
+        .spyOn(console, "warn")
+        .mockImplementation(() => undefined);
       try {
         await invokeHandler(
-          makeEvent('createApp', {
-            input: { name: 'New App', description: 'A test app', orgId: 'org-1' },
+          makeEvent("createApp", {
+            input: {
+              name: "New App",
+              description: "A test app",
+              orgId: "org-1",
+            },
           }),
         );
 
         const mirrorFailureLogs = errorSpy.mock.calls.filter(
           (call) =>
-            typeof call[0] === 'string' &&
-            call[0].includes('#META mirror write failed'),
+            typeof call[0] === "string" &&
+            call[0].includes("#META mirror write failed"),
         );
         expect(mirrorFailureLogs).toHaveLength(1);
         expect(mirrorFailureLogs[0][1]).toEqual(
           expect.objectContaining({
             appId: REGISTRY_ASSIGNED_ID,
-            tableName: 'citadel-apps-test',
+            tableName: "citadel-apps-test",
           }),
         );
       } finally {
@@ -311,127 +347,148 @@ describe('registry-agent-record-resolver — appId identity chain', () => {
     });
   });
 
-  describe('sibling mutation paths return recordId when the descriptor embeds a stale UUID', () => {
-    test('updateApp', async () => {
+  describe("sibling mutation paths return recordId when the descriptor embeds a stale UUID", () => {
+    test("updateApp", async () => {
       seedAppWithStaleDescriptorId();
       const result = (await invokeHandler(
-        makeEvent('updateApp', { input: { appId: 'app-1', name: 'Renamed' } }),
+        makeEvent("updateApp", { input: { appId: "app-1", name: "Renamed" } }),
       )) as Record<string, unknown>;
-      expect(result.appId).toBe('app-1');
+      expect(result.appId).toBe("app-1");
     });
 
-    test('bindWorkflowToApp (new binding)', async () => {
+    test("bindWorkflowToApp (new binding)", async () => {
       seedAppWithStaleDescriptorId();
       const result = (await invokeHandler(
-        makeEvent('bindWorkflowToApp', { appId: 'app-1', workflowId: 'wf-1' }),
+        makeEvent("bindWorkflowToApp", { appId: "app-1", workflowId: "wf-1" }),
       )) as Record<string, unknown>;
-      expect(result.appId).toBe('app-1');
+      expect(result.appId).toBe("app-1");
     });
 
-    test('bindWorkflowToApp (idempotent early return)', async () => {
-      seedAppWithStaleDescriptorId({ workflowIds: ['wf-1'] });
+    test("bindWorkflowToApp (idempotent early return)", async () => {
+      seedAppWithStaleDescriptorId({ workflowIds: ["wf-1"] });
       const result = (await invokeHandler(
-        makeEvent('bindWorkflowToApp', { appId: 'app-1', workflowId: 'wf-1' }),
+        makeEvent("bindWorkflowToApp", { appId: "app-1", workflowId: "wf-1" }),
       )) as Record<string, unknown>;
-      expect(result.appId).toBe('app-1');
+      expect(result.appId).toBe("app-1");
     });
 
-    test('unbindWorkflowFromApp', async () => {
-      seedAppWithStaleDescriptorId({ workflowIds: ['wf-1'] });
+    test("unbindWorkflowFromApp", async () => {
+      seedAppWithStaleDescriptorId({ workflowIds: ["wf-1"] });
       const result = (await invokeHandler(
-        makeEvent('unbindWorkflowFromApp', { appId: 'app-1', workflowId: 'wf-1' }),
+        makeEvent("unbindWorkflowFromApp", {
+          appId: "app-1",
+          workflowId: "wf-1",
+        }),
       )) as Record<string, unknown>;
-      expect(result.appId).toBe('app-1');
+      expect(result.appId).toBe("app-1");
     });
 
-    test('updateAgentBinding', async () => {
+    test("updateAgentBinding", async () => {
       seedAppWithStaleDescriptorId({
-        agentBindings: [{ agentId: 'agent-x', status: 'DESIGN' }],
+        agentBindings: [{ agentId: "agent-x", status: "DESIGN" }],
       });
       const result = (await invokeHandler(
-        makeEvent('updateAgentBinding', {
-          input: { appId: 'app-1', agentId: 'agent-x', systemPromptAddition: 'hi' },
+        makeEvent("updateAgentBinding", {
+          input: {
+            appId: "app-1",
+            agentId: "agent-x",
+            systemPromptAddition: "hi",
+          },
         }),
       )) as Record<string, unknown>;
-      expect(result.appId).toBe('app-1');
+      expect(result.appId).toBe("app-1");
     });
 
-    test('addAppComponent', async () => {
+    test("addAppComponent", async () => {
       seedAppWithStaleDescriptorId();
       const result = (await invokeHandler(
-        makeEvent('addAppComponent', {
-          appId: 'app-1',
-          component: { type: 'agent', data: JSON.stringify({ agentId: 'agent-y' }) },
+        makeEvent("addAppComponent", {
+          appId: "app-1",
+          component: {
+            type: "agent",
+            data: JSON.stringify({ agentId: "agent-y" }),
+          },
         }),
       )) as Record<string, unknown>;
-      expect(result.appId).toBe('app-1');
+      expect(result.appId).toBe("app-1");
     });
 
-    test('removeAppComponent', async () => {
+    test("removeAppComponent", async () => {
       seedAppWithStaleDescriptorId({
-        agentBindings: [{ agentId: 'agent-x', status: 'DESIGN' }],
+        agentBindings: [{ agentId: "agent-x", status: "DESIGN" }],
       });
       const result = (await invokeHandler(
-        makeEvent('removeAppComponent', {
-          appId: 'app-1',
-          componentType: 'agent',
-          componentId: 'agent-x',
+        makeEvent("removeAppComponent", {
+          appId: "app-1",
+          componentType: "agent",
+          componentId: "agent-x",
         }),
       )) as Record<string, unknown>;
-      expect(result.appId).toBe('app-1');
+      expect(result.appId).toBe("app-1");
     });
 
-    test('setAppConfigSchema', async () => {
+    test("setAppConfigSchema", async () => {
       seedAppWithStaleDescriptorId();
       const result = (await invokeHandler(
-        makeEvent('setAppConfigSchema', {
-          appId: 'app-1',
-          schema: JSON.stringify({ type: 'object' }),
+        makeEvent("setAppConfigSchema", {
+          appId: "app-1",
+          schema: JSON.stringify({ type: "object" }),
           version: 1,
         }),
       )) as Record<string, unknown>;
-      expect(result.appId).toBe('app-1');
+      expect(result.appId).toBe("app-1");
     });
 
-    test('setAppConfigValues', async () => {
+    test("setAppConfigValues", async () => {
       seedAppWithStaleDescriptorId();
       const result = (await invokeHandler(
-        makeEvent('setAppConfigValues', {
-          appId: 'app-1',
+        makeEvent("setAppConfigValues", {
+          appId: "app-1",
           values: JSON.stringify({}),
           version: 1,
         }),
       )) as Record<string, unknown>;
-      expect(result.appId).toBe('app-1');
+      expect(result.appId).toBe("app-1");
     });
 
-    test('setAppAuthConfig', async () => {
+    test("setAppAuthConfig", async () => {
       seedAppWithStaleDescriptorId();
       const result = (await invokeHandler(
-        makeEvent('setAppAuthConfig', {
-          appId: 'app-1',
-          authConfig: JSON.stringify({ mode: 'NONE' }),
+        makeEvent("setAppAuthConfig", {
+          appId: "app-1",
+          authConfig: JSON.stringify({ mode: "NONE" }),
         }),
       )) as Record<string, unknown>;
-      expect(result.appId).toBe('app-1');
+      expect(result.appId).toBe("app-1");
     });
 
-    test('grantAppAccess', async () => {
+    test("grantAppAccess", async () => {
       seedAppWithStaleDescriptorId();
       const result = (await invokeHandler(
-        makeEvent('grantAppAccess', { appId: 'app-1', userId: 'user-2', role: 'viewer' }),
+        makeEvent("grantAppAccess", {
+          appId: "app-1",
+          userId: "user-2",
+          role: "viewer",
+        }),
       )) as Record<string, unknown>;
-      expect(result.appId).toBe('app-1');
+      expect(result.appId).toBe("app-1");
     });
 
-    test('revokeAppAccess', async () => {
+    test("revokeAppAccess", async () => {
       seedAppWithStaleDescriptorId({
-        access: { 'user-2': { role: 'viewer', grantedAt: 'x', grantedBy: 'y' } },
+        access: {
+          "user-123": {
+            role: "owner",
+            grantedAt: "2024-01-01T00:00:00Z",
+            grantedBy: "system",
+          },
+          "user-2": { role: "viewer", grantedAt: "x", grantedBy: "y" },
+        },
       });
       const result = (await invokeHandler(
-        makeEvent('revokeAppAccess', { appId: 'app-1', userId: 'user-2' }),
+        makeEvent("revokeAppAccess", { appId: "app-1", userId: "user-2" }),
       )) as Record<string, unknown>;
-      expect(result.appId).toBe('app-1');
+      expect(result.appId).toBe("app-1");
     });
   });
 });

--- a/backend/src/lambda/registry-agent-record-resolver.ts
+++ b/backend/src/lambda/registry-agent-record-resolver.ts
@@ -1088,9 +1088,15 @@ export const handler: AppSyncResolverHandler<
       case "setAppAuthConfig":
         return await setAppAuthConfig(args.appId, args.authConfig, userId);
       case "grantAppAccess":
-        return await grantAppAccess(args.appId, args.userId, args.role, userId);
+        return await grantAppAccess(
+          args.appId,
+          args.userId,
+          args.role,
+          userId,
+          event,
+        );
       case "revokeAppAccess":
-        return await revokeAppAccess(args.appId, args.userId, userId);
+        return await revokeAppAccess(args.appId, args.userId, userId, event);
 
       // Non-AgentApp queries (preserved DDB / subscription paths)
       case "listAppApiKeys":
@@ -1445,7 +1451,18 @@ export async function createApp(
     configSchema: null,
     configValues: null,
     authConfig: null,
-    access: {},
+    // Seed the creator as an explicit owner entry (finding 8b0e32a7 / CRE
+    // item 4). Apps created BEFORE this change have no entry here at all —
+    // assertManifestOwnerAccess falls back to manifest.createdBy for those,
+    // since createdBy has always been stamped and cannot be spoofed by a
+    // caller (server-derived at createApp time).
+    access: {
+      [userId]: {
+        role: "owner",
+        grantedAt: now,
+        grantedBy: "system",
+      },
+    },
     routingConfig: null,
     ...(input.sourceProjectId !== undefined && {
       sourceProjectId: input.sourceProjectId,
@@ -2352,16 +2369,91 @@ async function setAppAuthConfig(
   return projectAgentAppNormalized(updated);
 }
 
+/**
+ * Owner-gate for grantAppAccess/revokeAppAccess (finding 8b0e32a7, CRE item
+ * 4). checkOperationAccess/checkAppAccess (app-access-control.ts) reserve
+ * both operations at 'owner' but read a SEPARATE DynamoDB ACCESS# store
+ * (appsTable GroupIndex) that this resolver's writes never update — that
+ * store has ZERO production writers (autoAssignOwner/grantAppAccess/
+ * revokeAppAccess in app-access-control.ts are exercised only by tests).
+ * The canonical, write-consistent store is the Registry record MANIFEST's
+ * `access` map: it is the ONLY store this resolver's grant/revoke actually
+ * mutate (via writeManifestMutation), and it is read here the same way
+ * getApp's own tenant gate reads the manifest's `orgId` — so a grant is
+ * immediately visible to the next authorization check in-process (the
+ * split-brain requirement).
+ *
+ * Fails closed: any missing identity, missing app, or Cognito lookup
+ * failure (via extractOrgFromEvent) results in a thrown "Access denied"
+ * BEFORE any manifest read is used to authorize a write. Admin group
+ * bypasses, matching checkAppAccess's own convention. Same-org membership
+ * alone is NOT sufficient — the caller must hold 'owner' in the manifest's
+ * `access` map, or (for apps created before this fix, whose manifests never
+ * had an owner entry populated) be the app's recorded `createdBy` — see the
+ * fallback below.
+ */
+async function assertManifestOwnerAccess(
+  appId: string,
+  record: RegistryRecord,
+  event: unknown,
+): Promise<void> {
+  if (isAdminFromEvent(event)) {
+    return;
+  }
+
+  const callerId = getUserId(
+    (event as { identity?: Parameters<typeof getUserId>[0] })?.identity,
+  );
+  if (!callerId || callerId === "anonymous") {
+    throw new Error(`Access denied: requires owner role for app ${appId}`);
+  }
+
+  const callerOrgId = await extractOrgFromEvent(event);
+  const manifest = readManifest(record);
+  if (!callerOrgId || callerOrgId !== manifest.orgId) {
+    throw new Error(`Access denied: requires owner role for app ${appId}`);
+  }
+
+  const callerEntry = manifest.access?.[callerId];
+  const isExplicitOwner = callerEntry?.role === "owner";
+
+  // Backward-compat fallback: apps created BEFORE this fix have `access: {}`
+  // in their manifest (the field existed but nothing ever populated an
+  // owner entry into it) — with no fallback, existing app creators would be
+  // locked out of granting/revoking on their own apps. `createdBy` has
+  // always been stamped server-side at createApp time from the caller's
+  // verified identity, never client-suppliable, so treating the creator as
+  // an implicit owner when NO owner entry exists yet is safe and does not
+  // reopen the vulnerability: it only recognizes the one identity the
+  // system itself recorded as having created the app, and stops applying
+  // the instant a real owner entry exists (including the one seeded by
+  // createApp going forward).
+  const hasAnyOwnerEntry = Object.values(manifest.access ?? {}).some(
+    (entry) => entry?.role === "owner",
+  );
+  const isImplicitCreatorOwner =
+    !hasAnyOwnerEntry &&
+    !!manifest.createdBy &&
+    manifest.createdBy === callerId;
+
+  if (!isExplicitOwner && !isImplicitCreatorOwner) {
+    throw new Error(`Access denied: requires owner role for app ${appId}`);
+  }
+}
+
 async function grantAppAccess(
   appId: string,
   targetUserId: string,
   role: string,
   grantingUserId: string,
+  event: unknown,
 ): Promise<unknown> {
   const record = await getRegistryService().getResource("agent", appId);
   if (!record) {
     throw new Error("App not found");
   }
+
+  await assertManifestOwnerAccess(appId, record, event);
 
   const now = new Date().toISOString();
   const mutatedContent = writeManifestMutation(record, (m) => {
@@ -2393,11 +2485,14 @@ async function revokeAppAccess(
   appId: string,
   targetUserId: string,
   revokingUserId: string,
+  event: unknown,
 ): Promise<unknown> {
   const record = await getRegistryService().getResource("agent", appId);
   if (!record) {
     throw new Error("App not found");
   }
+
+  await assertManifestOwnerAccess(appId, record, event);
 
   const mutatedContent = writeManifestMutation(record, (m) => {
     const access = m.access || {};


### PR DESCRIPTION
## Summary

`grantAppAccess` and `revokeAppAccess` performed a privileged access-control write behind only an existence check, and the AppSync event was never passed to them, so no caller identity was available. Organization scoping alone would not have fixed this: a same-organization non-owner could grant themselves owner on another user's app.

- The event is now threaded into both functions
- An owner gate runs before any write, failing closed on missing identity, unresolvable organization or absent owner entry, with an admin bypass consistent with the existing `checkAppAccess` convention

## The substantive part: which store is authoritative

The report suggested wiring `checkOperationAccess` whose operation map already reserves grant and revoke at owner. Investigating that surfaced a split-brain: the resolver writes access into the **Registry record manifest**, while `checkOperationAccess` / `checkAppAccess` read a **separate DynamoB `ACCESS#` store** - and that store has **zero production writers** (its helpers are exercised only by tests).

Gating on it would therefore have authorized against a source the write never updates: the gate would pass while the effective ACL diverged, which is worse than the current state because it looks protected. The manifest is consequently treated as canonical and the gate reads it. Proven end-to-end in a single test - an owner grants access and the grantee immediately passes the same gate.

## No owner lockout, no migration

The abandoned store holds no data, so no backfill is required. Pre-existing apps carry `access: {}`, so the gate falls back to the server-stamped `createdBy`, and `createApp` now seeds the creator as an explicit owner going forward.

## Testing

- The reported escalation - same-org non-owner granting themselves owner - is refused with zero manifest writes and zero DynamoDB writes; cross-org refused likewise
- Fail-closed on absent identity, unresolvable role, missing app and missing access entries; owner and admin paths still succeed
- Bite-proven: removing the gate lets the non-owner grant succeed; restored byte-identically
- tsc, lint, `cdk synth` exit 0; targeted 59; full backend jest 7113
- Post-merge spot-check confirms this gate and the datastore/integration `assertRowOrg` guards coexist - no guard dropped by the merge

## Notes

`checkOperationAccess` still has no other call sites. Filed separately: `publishApp` and `unpublishApp` have no access checks at all (separate Lambda), and the editor-reserved lifecycle operations - `updateApp`, component add/remove, agent binding, config and auth setters, and the API-key lifecycle - are likewise ungated. 