### PR TITLE
fix(security): gate app lifecycle mutations behind manifest access

### DIFF
--- a/backend/src/lambda/__tests__/fixtures/registry-service-mock.ts
+++ b/backend/src/lambda/__tests__/fixtures/registry-service-mock.ts
@@ -35,6 +35,7 @@ export function resetMockRegistry(): void {
   listResourceSummariesCallCount = 0;
   getResourceCallCounts.clear();
   updateResourceCallCount = 0;
+  deleteResourceCallCount = 0;
 }
 
 /** Test-visible call counter: how many times listResourceSummaries() ran. */
@@ -62,6 +63,17 @@ export function getGetResourceCallCount(
 let updateResourceCallCount = 0;
 export function getUpdateResourceCallCount(): number {
   return updateResourceCallCount;
+}
+
+/**
+ * Test-visible call counter: total deleteResource() invocations across all
+ * records, this test run. Used to assert "zero deletes on refused access"
+ * (finding 6400b440) the same way getUpdateResourceCallCount asserts "zero
+ * writes on refused access" for the editor/owner gates.
+ */
+let deleteResourceCallCount = 0;
+export function getDeleteResourceCallCount(): number {
+  return deleteResourceCallCount;
 }
 
 export function getMockRegistryService() {
@@ -225,6 +237,7 @@ export function getMockRegistryService() {
       return updated as RegistryRecord;
     },
     async deleteResource(type: ResourceType, id: string): Promise<void> {
+      deleteResourceCallCount += 1;
       records.delete(`${type}:${id}`);
     },
     async resolveRecordId(_type: ResourceType, id: string): Promise<string> {

--- a/backend/src/lambda/__tests__/registry-agent-record-resolver-apikeys.test.ts
+++ b/backend/src/lambda/__tests__/registry-agent-record-resolver-apikeys.test.ts
@@ -9,26 +9,36 @@
  * (that is covered by app-api-key-management.test.ts).
  */
 
-process.env.REGISTRY_ID = 'test-registry-id';
-process.env.APPS_TABLE = 'test-apps';
-process.env.WORKFLOWS_TABLE = 'test-workflows';
-process.env.AGENT_CONFIG_TABLE = 'test-agents';
-process.env.EVENT_BUS_NAME = 'test-bus';
-process.env.USER_POOL_ID = 'us-east-1_test';
-process.env.AUTHORITY_UNITS_TABLE = 'test-authority-units';
+process.env.REGISTRY_ID = "test-registry-id";
+process.env.APPS_TABLE = "test-apps";
+process.env.WORKFLOWS_TABLE = "test-workflows";
+process.env.AGENT_CONFIG_TABLE = "test-agents";
+process.env.EVENT_BUS_NAME = "test-bus";
+process.env.USER_POOL_ID = "us-east-1_test";
+process.env.AUTHORITY_UNITS_TABLE = "test-authority-units";
 
-import { EventBridgeClient, PutEventsCommand } from '@aws-sdk/client-eventbridge';
-import { mockClient } from 'aws-sdk-client-mock';
+import {
+  EventBridgeClient,
+  PutEventsCommand,
+} from "@aws-sdk/client-eventbridge";
+import { mockClient } from "aws-sdk-client-mock";
 
 const ebMock = mockClient(EventBridgeClient);
 
-import { resetMockRegistry } from './fixtures/registry-service-mock';
+import {
+  resetMockRegistry,
+  seedMockRegistry,
+} from "./fixtures/registry-service-mock";
 
-jest.mock('../../services/registry-service', () => {
-  const { getMockRegistryService } = jest.requireActual('./fixtures/registry-service-mock');
-  const actual = jest.requireActual('../../services/registry-service');
+jest.mock("../../services/registry-service", () => {
+  const { getMockRegistryService } = jest.requireActual(
+    "./fixtures/registry-service-mock",
+  );
+  const actual = jest.requireActual("../../services/registry-service");
   return {
-    RegistryService: jest.fn().mockImplementation(() => getMockRegistryService()),
+    RegistryService: jest
+      .fn()
+      .mockImplementation(() => getMockRegistryService()),
     getRegistryService: jest.fn(() => getMockRegistryService()),
     _resetRegistryService: jest.fn(),
     isRegistryEnabled: jest.fn(() => true),
@@ -37,22 +47,22 @@ jest.mock('../../services/registry-service', () => {
   };
 });
 
-jest.mock('../../utils/appsync', () => ({
-  getUserId: jest.fn().mockReturnValue('user-123'),
+jest.mock("../../utils/appsync", () => ({
+  getUserId: jest.fn().mockReturnValue("user-123"),
 }));
 
 const mockCreate = jest.fn();
 const mockRevoke = jest.fn();
 const mockRotate = jest.fn();
 const mockList = jest.fn();
-jest.mock('../app-api-key-management', () => ({
+jest.mock("../app-api-key-management", () => ({
   createAppApiKey: (...args: unknown[]) => mockCreate(...args),
   revokeAppApiKey: (...args: unknown[]) => mockRevoke(...args),
   rotateAppApiKey: (...args: unknown[]) => mockRotate(...args),
   listAppApiKeys: (...args: unknown[]) => mockList(...args),
 }));
 
-import { handler } from '../registry-agent-record-resolver';
+import { handler } from "../registry-agent-record-resolver";
 
 type HandlerEvent = Parameters<typeof handler>[0];
 
@@ -64,9 +74,12 @@ const invokeHandler = handler as (event: HandlerEvent) => Promise<unknown>;
 
 function makeEvent(fieldName: string, args: Record<string, unknown>) {
   return {
-    info: { fieldName, parentTypeName: 'Mutation', selectionSetList: [] },
+    info: { fieldName, parentTypeName: "Mutation", selectionSetList: [] },
     arguments: args,
-    identity: { sub: 'user-1', claims: {} },
+    identity: {
+      sub: "user-1",
+      claims: { sub: "user-1", "custom:organization": "org-1" },
+    },
     source: null,
     request: { headers: {} },
     prev: null,
@@ -74,7 +87,39 @@ function makeEvent(fieldName: string, args: Record<string, unknown>) {
   } as unknown as HandlerEvent;
 }
 
-describe('registry-agent-record-resolver — API key surfaces', () => {
+// createAppApiKey/revokeAppApiKey/rotateAppApiKey now fetch the Registry
+// record and run the editor gate (finding 8f8fd119) before delegating to
+// the api-key-management helpers under test here. Seed a manifest that
+// makes 'user-1' (the makeEvent identity above) the implicit creator-owner
+// for whichever appId a test uses, so these shape/passthrough tests
+// exercise the legitimate-caller path — the gate itself is covered by
+// registry-agent-record-resolver-apikeys-gate.test.ts.
+function seedAppForKeyOps(appId: string) {
+  seedMockRegistry("agent", appId, {
+    name: "Test App",
+    description: "Test",
+    status: "DRAFT",
+    customDescriptorContent: JSON.stringify({
+      appId,
+      manifest: {
+        orgId: "org-1",
+        version: 1,
+        status: "DRAFT",
+        workflowIds: [],
+        agentBindings: [],
+        permissions: [],
+        configSchema: null,
+        configValues: null,
+        authConfig: null,
+        createdBy: "user-123",
+        access: {},
+        routingConfig: null,
+      },
+    }),
+  });
+}
+
+describe("registry-agent-record-resolver — API key surfaces", () => {
   beforeEach(() => {
     resetMockRegistry();
     ebMock.reset();
@@ -85,137 +130,157 @@ describe('registry-agent-record-resolver — API key surfaces', () => {
     mockList.mockReset();
   });
 
-  test('createAppApiKey returns flat AppApiKeyWithPlaintext with apiKey field', async () => {
+  test("createAppApiKey returns flat AppApiKeyWithPlaintext with apiKey field", async () => {
+    seedAppForKeyOps("app-1");
     mockCreate.mockResolvedValueOnce({
-      keyId: 'new-key-id',
-      name: 'Test Key',
-      prefix: 'abcd1234',
-      status: 'ACTIVE',
-      createdAt: '2025-05-08T00:00:00Z',
+      keyId: "new-key-id",
+      name: "Test Key",
+      prefix: "abcd1234",
+      status: "ACTIVE",
+      createdAt: "2025-05-08T00:00:00Z",
       expiresAt: undefined,
-      plaintext: 'plaintext-secret-abcdef',
+      plaintext: "plaintext-secret-abcdef",
     });
 
     const result = await invokeHandler(
-      makeEvent('createAppApiKey', { appId: 'app-1', name: 'Test Key' }),
+      makeEvent("createAppApiKey", { appId: "app-1", name: "Test Key" }),
     );
 
-    expect(result).toHaveProperty('keyId', 'new-key-id');
-    expect(result).toHaveProperty('name', 'Test Key');
-    expect(result).toHaveProperty('prefix', 'abcd1234');
-    expect(result).toHaveProperty('status', 'ACTIVE');
-    expect(result).toHaveProperty('createdAt');
-    expect(result).toHaveProperty('apiKey', 'plaintext-secret-abcdef');
+    expect(result).toHaveProperty("keyId", "new-key-id");
+    expect(result).toHaveProperty("name", "Test Key");
+    expect(result).toHaveProperty("prefix", "abcd1234");
+    expect(result).toHaveProperty("status", "ACTIVE");
+    expect(result).toHaveProperty("createdAt");
+    expect(result).toHaveProperty("apiKey", "plaintext-secret-abcdef");
     // Shape contract: plaintext is flattened into apiKey; no leaking internals.
-    expect(result).not.toHaveProperty('plaintext');
-    expect(result).not.toHaveProperty('hashedKey');
+    expect(result).not.toHaveProperty("plaintext");
+    expect(result).not.toHaveProperty("hashedKey");
   });
 
-  test('rotateAppApiKey returns flat response (not {newKey, revokedKeyId})', async () => {
+  test("rotateAppApiKey returns flat response (not {newKey, revokedKeyId})", async () => {
+    seedAppForKeyOps("app-1");
     mockRotate.mockResolvedValueOnce({
       newKey: {
-        keyId: 'new-key',
-        name: 'Existing Key',
-        prefix: 'efgh5678',
-        status: 'ACTIVE',
-        createdAt: '2025-05-08T00:00:00Z',
-        plaintext: 'new-plaintext',
+        keyId: "new-key",
+        name: "Existing Key",
+        prefix: "efgh5678",
+        status: "ACTIVE",
+        createdAt: "2025-05-08T00:00:00Z",
+        plaintext: "new-plaintext",
       },
-      revokedKeyId: 'old-key',
+      revokedKeyId: "old-key",
     });
 
     const result = await invokeHandler(
-      makeEvent('rotateAppApiKey', { appId: 'app-1', keyId: 'old-key' }),
+      makeEvent("rotateAppApiKey", { appId: "app-1", keyId: "old-key" }),
     );
 
-    expect(result).not.toHaveProperty('newKey');
-    expect(result).not.toHaveProperty('revokedKeyId');
-    expect(result).toHaveProperty('keyId', 'new-key');
-    expect(result).toHaveProperty('name', 'Existing Key');
-    expect(result).toHaveProperty('apiKey', 'new-plaintext');
+    expect(result).not.toHaveProperty("newKey");
+    expect(result).not.toHaveProperty("revokedKeyId");
+    expect(result).toHaveProperty("keyId", "new-key");
+    expect(result).toHaveProperty("name", "Existing Key");
+    expect(result).toHaveProperty("apiKey", "new-plaintext");
   });
 
-  test('revokeAppApiKey passes through the helper result unchanged', async () => {
+  test("revokeAppApiKey passes through the helper result unchanged", async () => {
+    seedAppForKeyOps("app-1");
     const revokedKey = {
-      keyId: 'target-key',
-      name: 'Old Key',
-      prefix: 'ijkl9012',
-      status: 'REVOKED',
-      createdAt: '2025-01-01T00:00:00Z',
+      keyId: "target-key",
+      name: "Old Key",
+      prefix: "ijkl9012",
+      status: "REVOKED",
+      createdAt: "2025-01-01T00:00:00Z",
       expiresAt: null,
       lastUsedAt: null,
     };
     mockRevoke.mockResolvedValueOnce(revokedKey);
 
     const result = await invokeHandler(
-      makeEvent('revokeAppApiKey', { appId: 'app-1', keyId: 'target-key' }),
+      makeEvent("revokeAppApiKey", { appId: "app-1", keyId: "target-key" }),
     );
 
     expect(result).toEqual(revokedKey);
     expect(mockRevoke).toHaveBeenCalledWith(
-      'app-1',
-      'target-key',
-      'user-123',
-      expect.objectContaining({ appsTable: 'test-apps' }),
+      "app-1",
+      "target-key",
+      "user-123",
+      expect.objectContaining({ appsTable: "test-apps" }),
     );
   });
 
-  test('listAppApiKeys items have no apiKey field', async () => {
+  test("listAppApiKeys items have no apiKey field", async () => {
     mockList.mockResolvedValueOnce([
-      { keyId: 'k1', name: 'Key 1', prefix: 'aaaa1111', status: 'ACTIVE', createdAt: '2024-01-01T00:00:00Z' },
-      { keyId: 'k2', name: 'Key 2', prefix: 'bbbb2222', status: 'REVOKED', createdAt: '2024-02-01T00:00:00Z' },
+      {
+        keyId: "k1",
+        name: "Key 1",
+        prefix: "aaaa1111",
+        status: "ACTIVE",
+        createdAt: "2024-01-01T00:00:00Z",
+      },
+      {
+        keyId: "k2",
+        name: "Key 2",
+        prefix: "bbbb2222",
+        status: "REVOKED",
+        createdAt: "2024-02-01T00:00:00Z",
+      },
     ]);
 
     const result = await invokeHandler(
-      makeEvent('listAppApiKeys', { appId: 'app-1' }),
+      makeEvent("listAppApiKeys", { appId: "app-1" }),
     );
 
     expect(Array.isArray(result)).toBe(true);
     expect(result.length).toBe(2);
     for (const key of result) {
-      expect(key).toHaveProperty('keyId');
-      expect(key).toHaveProperty('name');
-      expect(key).toHaveProperty('prefix');
-      expect(key).toHaveProperty('status');
-      expect(key).not.toHaveProperty('apiKey');
-      expect(key).not.toHaveProperty('plaintext');
-      expect(key).not.toHaveProperty('hashedKey');
+      expect(key).toHaveProperty("keyId");
+      expect(key).toHaveProperty("name");
+      expect(key).toHaveProperty("prefix");
+      expect(key).toHaveProperty("status");
+      expect(key).not.toHaveProperty("apiKey");
+      expect(key).not.toHaveProperty("plaintext");
+      expect(key).not.toHaveProperty("hashedKey");
     }
   });
 
-  test('createAppApiKey forwards appId, name, userId, deps, expiresIn to impl', async () => {
+  test("createAppApiKey forwards appId, name, userId, deps, expiresIn to impl", async () => {
+    seedAppForKeyOps("app-9");
     mockCreate.mockResolvedValueOnce({
-      keyId: 'k',
-      name: 'K',
-      prefix: 'pppp1234',
-      status: 'ACTIVE',
-      createdAt: '2025-05-08T00:00:00Z',
-      plaintext: 'pt',
+      keyId: "k",
+      name: "K",
+      prefix: "pppp1234",
+      status: "ACTIVE",
+      createdAt: "2025-05-08T00:00:00Z",
+      plaintext: "pt",
     });
 
     await invokeHandler(
-      makeEvent('createAppApiKey', { appId: 'app-9', name: 'K', expiresIn: 3600 }),
+      makeEvent("createAppApiKey", {
+        appId: "app-9",
+        name: "K",
+        expiresIn: 3600,
+      }),
     );
 
     expect(mockCreate).toHaveBeenCalledWith(
-      'app-9',
-      'K',
-      'user-123',
-      expect.objectContaining({ appsTable: 'test-apps' }),
+      "app-9",
+      "K",
+      "user-123",
+      expect.objectContaining({ appsTable: "test-apps" }),
       3600,
     );
   });
 
-  test('listAppApiKeys invokes impl with deps struct (no mutation of args)', async () => {
+  test("listAppApiKeys invokes impl with deps struct (no mutation of args)", async () => {
     mockList.mockResolvedValueOnce([]);
 
-    await invokeHandler(
-      makeEvent('listAppApiKeys', { appId: 'app-42' }),
-    );
+    await invokeHandler(makeEvent("listAppApiKeys", { appId: "app-42" }));
 
     expect(mockList).toHaveBeenCalledTimes(1);
     const call = mockList.mock.calls[0];
-    expect(call[0]).toBe('app-42');
-    expect(call[1]).toEqual(expect.objectContaining({ appsTable: 'test-apps' }));
+    expect(call[0]).toBe("app-42");
+    expect(call[1]).toEqual(
+      expect.objectContaining({ appsTable: "test-apps" }),
+    );
   });
 });

--- a/backend/src/lambda/__tests__/registry-agent-record-resolver-approval-lifecycle.test.ts
+++ b/backend/src/lambda/__tests__/registry-agent-record-resolver-approval-lifecycle.test.ts
@@ -10,18 +10,22 @@
  *   - REJECTED -> DRAFT resubmit path works and clears the prior decision
  */
 
-process.env.REGISTRY_ID = 'test-registry-id';
-process.env.APPS_TABLE = 'citadel-apps-test';
-process.env.WORKFLOWS_TABLE = 'citadel-workflows-test';
-process.env.AGENT_CONFIG_TABLE = 'citadel-agents-test';
-process.env.EVENT_BUS_NAME = 'citadel-agents-test';
-process.env.USER_POOL_ID = 'us-east-1_test';
-process.env.AUTHORITY_UNITS_TABLE = 'test-authority-units';
-process.env.APPSYNC_ENDPOINT = 'https://test-api.appsync-api.us-east-1.amazonaws.com/graphql';
-process.env.AWS_REGION = 'us-east-1';
+process.env.REGISTRY_ID = "test-registry-id";
+process.env.APPS_TABLE = "citadel-apps-test";
+process.env.WORKFLOWS_TABLE = "citadel-workflows-test";
+process.env.AGENT_CONFIG_TABLE = "citadel-agents-test";
+process.env.EVENT_BUS_NAME = "citadel-agents-test";
+process.env.USER_POOL_ID = "us-east-1_test";
+process.env.AUTHORITY_UNITS_TABLE = "test-authority-units";
+process.env.APPSYNC_ENDPOINT =
+  "https://test-api.appsync-api.us-east-1.amazonaws.com/graphql";
+process.env.AWS_REGION = "us-east-1";
 
-import { EventBridgeClient, PutEventsCommand } from '@aws-sdk/client-eventbridge';
-import { mockClient } from 'aws-sdk-client-mock';
+import {
+  EventBridgeClient,
+  PutEventsCommand,
+} from "@aws-sdk/client-eventbridge";
+import { mockClient } from "aws-sdk-client-mock";
 
 const ebMock = mockClient(EventBridgeClient);
 
@@ -29,13 +33,17 @@ import {
   seedMockRegistry,
   resetMockRegistry,
   getMockRegistryService,
-} from './fixtures/registry-service-mock';
+} from "./fixtures/registry-service-mock";
 
-jest.mock('../../services/registry-service', () => {
-  const { getMockRegistryService } = jest.requireActual('./fixtures/registry-service-mock');
-  const actual = jest.requireActual('../../services/registry-service');
+jest.mock("../../services/registry-service", () => {
+  const { getMockRegistryService } = jest.requireActual(
+    "./fixtures/registry-service-mock",
+  );
+  const actual = jest.requireActual("../../services/registry-service");
   return {
-    RegistryService: jest.fn().mockImplementation(() => getMockRegistryService()),
+    RegistryService: jest
+      .fn()
+      .mockImplementation(() => getMockRegistryService()),
     getRegistryService: jest.fn(() => getMockRegistryService()),
     _resetRegistryService: jest.fn(),
     isRegistryEnabled: jest.fn(() => true),
@@ -45,48 +53,63 @@ jest.mock('../../services/registry-service', () => {
   };
 });
 
-jest.mock('../../utils/appsync', () => ({
-  getUserId: jest.fn((identity: { sub?: string; claims?: { sub?: string } }) =>
-    identity?.sub || identity?.claims?.sub || 'anonymous',
+jest.mock("../../utils/appsync", () => ({
+  getUserId: jest.fn(
+    (identity: { sub?: string; claims?: { sub?: string } }) =>
+      identity?.sub || identity?.claims?.sub || "anonymous",
   ),
 }));
 
 const mockPublishAppStatusEvent = jest.fn().mockResolvedValue({});
-jest.mock('../../utils/appsync-publish', () => ({
+jest.mock("../../utils/appsync-publish", () => ({
   publishAppStatusEvent: mockPublishAppStatusEvent,
 }));
 
-jest.mock('uuid', () => ({
-  v4: jest.fn().mockReturnValue('test-correlation-id'),
+jest.mock("uuid", () => ({
+  v4: jest.fn().mockReturnValue("test-correlation-id"),
 }));
 
-import { handler } from '../registry-agent-record-resolver';
+import { handler } from "../registry-agent-record-resolver";
 
 type HandlerEvent = Parameters<typeof handler>[0];
 const invokeHandler = handler as (event: HandlerEvent) => Promise<unknown>;
 
-function makeEvent(fieldName: string, args: Record<string, unknown>, admin = false) {
+function makeEvent(
+  fieldName: string,
+  args: Record<string, unknown>,
+  admin = false,
+) {
   return {
     info: { fieldName },
     arguments: args,
+    // Non-admin identity carries custom:organization: 'org-1' — matching
+    // seedApp's default orgId and createdBy — so it satisfies the
+    // finding-8f8fd119 editor gate on updateApp.
     identity: admin
-      ? { sub: 'admin-1', claims: { sub: 'admin-1', 'custom:role': 'admin' }, 'custom:role': 'admin' }
-      : { sub: 'user-123', claims: { sub: 'user-123' } },
+      ? {
+          sub: "admin-1",
+          claims: { sub: "admin-1", "custom:role": "admin" },
+          "custom:role": "admin",
+        }
+      : {
+          sub: "user-123",
+          claims: { sub: "user-123", "custom:organization": "org-1" },
+        },
   } as unknown as HandlerEvent;
 }
 
 function seedApp(
   status: string,
   version = 1,
-  orgId = 'org-1',
+  orgId = "org-1",
   manifestExtra: Record<string, unknown> = {},
 ) {
-  seedMockRegistry('agent', 'app-1', {
-    name: 'Test App',
-    description: 'Test',
+  seedMockRegistry("agent", "app-1", {
+    name: "Test App",
+    description: "Test",
     status,
     customDescriptorContent: JSON.stringify({
-      appId: 'app-1',
+      appId: "app-1",
       manifest: {
         orgId,
         version,
@@ -97,6 +120,11 @@ function seedApp(
         configSchema: null,
         configValues: null,
         authConfig: null,
+        // createdBy stamps 'user-123' (non-admin makeEvent's default sub) as
+        // the implicit creator-owner fallback, satisfying the
+        // finding-8f8fd119 editor gate on updateApp. Placed before
+        // manifestExtra so a test can still override it explicitly.
+        createdBy: "user-123",
         access: {},
         routingConfig: null,
         ...manifestExtra,
@@ -105,7 +133,7 @@ function seedApp(
   });
 }
 
-describe('registry-agent-record-resolver — approval lifecycle gate', () => {
+describe("registry-agent-record-resolver — approval lifecycle gate", () => {
   beforeEach(() => {
     resetMockRegistry();
     ebMock.reset();
@@ -127,284 +155,334 @@ describe('registry-agent-record-resolver — approval lifecycle gate', () => {
 
   // -- Regression: submit must leave the record PENDING_APPROVAL ----------
 
-  describe('no auto-approval regression', () => {
-    it('DRAFT -> PENDING_APPROVAL (submit) leaves the record PENDING_APPROVAL, not APPROVED', async () => {
-      seedApp('DRAFT', 1);
+  describe("no auto-approval regression", () => {
+    it("DRAFT -> PENDING_APPROVAL (submit) leaves the record PENDING_APPROVAL, not APPROVED", async () => {
+      seedApp("DRAFT", 1);
 
       const result = (await invokeHandler(
-        makeEvent('updateApp', {
-          input: { appId: 'app-1', status: 'PENDING_APPROVAL', version: 1 },
+        makeEvent("updateApp", {
+          input: { appId: "app-1", status: "PENDING_APPROVAL", version: 1 },
         }),
       )) as Record<string, unknown>;
 
-      expect(result.status).toBe('PENDING_APPROVAL');
-      const persisted = await getMockRegistryService().getResource('agent', 'app-1');
-      expect(persisted?.status).toBe('PENDING_APPROVAL');
+      expect(result.status).toBe("PENDING_APPROVAL");
+      const persisted = await getMockRegistryService().getResource(
+        "agent",
+        "app-1",
+      );
+      expect(persisted?.status).toBe("PENDING_APPROVAL");
     });
   });
 
   // -- Full transition matrix ----------------------------------------------
 
-  describe('legal transitions', () => {
+  describe("legal transitions", () => {
     it.each([
-      ['DRAFT', 'PENDING_APPROVAL', false],
-      ['DRAFT', 'DEPRECATED', false],
-      ['PENDING_APPROVAL', 'APPROVED', true],
-      ['PENDING_APPROVAL', 'REJECTED', true],
-      ['REJECTED', 'DRAFT', false],
-      ['REJECTED', 'DEPRECATED', false],
-      ['APPROVED', 'DEPRECATED', false],
-    ])('%s -> %s succeeds', async (current, next, admin) => {
+      ["DRAFT", "PENDING_APPROVAL", false],
+      ["DRAFT", "DEPRECATED", false],
+      ["PENDING_APPROVAL", "APPROVED", true],
+      ["PENDING_APPROVAL", "REJECTED", true],
+      ["REJECTED", "DRAFT", false],
+      ["REJECTED", "DEPRECATED", false],
+      ["APPROVED", "DEPRECATED", false],
+    ])("%s -> %s succeeds", async (current, next, admin) => {
       seedApp(current, 1);
-      const input: Record<string, unknown> = { appId: 'app-1', status: next, version: 1 };
-      if (next === 'REJECTED') input.statusReason = 'does not meet policy';
+      const input: Record<string, unknown> = {
+        appId: "app-1",
+        status: next,
+        version: 1,
+      };
+      if (next === "REJECTED") input.statusReason = "does not meet policy";
 
       const result = (await invokeHandler(
-        makeEvent('updateApp', { input }, admin as boolean),
+        makeEvent("updateApp", { input }, admin as boolean),
       )) as Record<string, unknown>;
 
       expect(result.status).toBe(next);
     });
   });
 
-  describe('illegal transitions are rejected with a structured error', () => {
+  describe("illegal transitions are rejected with a structured error", () => {
     it.each([
-      ['DRAFT', 'APPROVED'],
-      ['DRAFT', 'REJECTED'],
-      ['APPROVED', 'DRAFT'],
-      ['APPROVED', 'PENDING_APPROVAL'],
-      ['DEPRECATED', 'DRAFT'],
-      ['PENDING_APPROVAL', 'DRAFT'],
-    ])('%s -> %s throws INVALID_TRANSITION', async (current, next) => {
+      ["DRAFT", "APPROVED"],
+      ["DRAFT", "REJECTED"],
+      ["APPROVED", "DRAFT"],
+      ["APPROVED", "PENDING_APPROVAL"],
+      ["DEPRECATED", "DRAFT"],
+      ["PENDING_APPROVAL", "DRAFT"],
+    ])("%s -> %s throws INVALID_TRANSITION", async (current, next) => {
       seedApp(current, 1);
 
       await expect(
         invokeHandler(
           makeEvent(
-            'updateApp',
-            { input: { appId: 'app-1', status: next, version: 1, statusReason: 'x' } },
+            "updateApp",
+            {
+              input: {
+                appId: "app-1",
+                status: next,
+                version: 1,
+                statusReason: "x",
+              },
+            },
             true,
           ),
         ),
-      ).rejects.toMatchObject({ code: 'INVALID_TRANSITION' });
+      ).rejects.toMatchObject({ code: "INVALID_TRANSITION" });
     });
   });
 
   // -- Pending-immutability -------------------------------------------------
 
-  describe('pending-immutability', () => {
-    it('rejects a content update (name) while PENDING_APPROVAL', async () => {
-      seedApp('PENDING_APPROVAL', 1);
+  describe("pending-immutability", () => {
+    it("rejects a content update (name) while PENDING_APPROVAL", async () => {
+      seedApp("PENDING_APPROVAL", 1);
 
       await expect(
         invokeHandler(
-          makeEvent('updateApp', { input: { appId: 'app-1', name: 'New Name', version: 1 } }),
-        ),
-      ).rejects.toMatchObject({ code: 'RECORD_IMMUTABLE' });
-    });
-
-    it('rejects a description update while PENDING_APPROVAL', async () => {
-      seedApp('PENDING_APPROVAL', 1);
-
-      await expect(
-        invokeHandler(
-          makeEvent('updateApp', {
-            input: { appId: 'app-1', description: 'changed', version: 1 },
+          makeEvent("updateApp", {
+            input: { appId: "app-1", name: "New Name", version: 1 },
           }),
         ),
-      ).rejects.toMatchObject({ code: 'RECORD_IMMUTABLE' });
+      ).rejects.toMatchObject({ code: "RECORD_IMMUTABLE" });
     });
 
-    it('allows a status-only decision (approve) while PENDING_APPROVAL', async () => {
-      seedApp('PENDING_APPROVAL', 1);
+    it("rejects a description update while PENDING_APPROVAL", async () => {
+      seedApp("PENDING_APPROVAL", 1);
+
+      await expect(
+        invokeHandler(
+          makeEvent("updateApp", {
+            input: { appId: "app-1", description: "changed", version: 1 },
+          }),
+        ),
+      ).rejects.toMatchObject({ code: "RECORD_IMMUTABLE" });
+    });
+
+    it("allows a status-only decision (approve) while PENDING_APPROVAL", async () => {
+      seedApp("PENDING_APPROVAL", 1);
 
       const result = (await invokeHandler(
         makeEvent(
-          'updateApp',
-          { input: { appId: 'app-1', status: 'APPROVED', version: 1 } },
+          "updateApp",
+          { input: { appId: "app-1", status: "APPROVED", version: 1 } },
           true,
         ),
       )) as Record<string, unknown>;
 
-      expect(result.status).toBe('APPROVED');
+      expect(result.status).toBe("APPROVED");
     });
   });
 
   // -- statusReason required on reject -------------------------------------
 
-  describe('reject requires statusReason', () => {
-    it('rejects REJECTED with no statusReason', async () => {
-      seedApp('PENDING_APPROVAL', 1);
-
-      await expect(
-        invokeHandler(
-          makeEvent('updateApp', { input: { appId: 'app-1', status: 'REJECTED', version: 1 } }, true),
-        ),
-      ).rejects.toThrow(/statusReason is required/);
-    });
-
-    it('rejects REJECTED with a blank/whitespace statusReason', async () => {
-      seedApp('PENDING_APPROVAL', 1);
+  describe("reject requires statusReason", () => {
+    it("rejects REJECTED with no statusReason", async () => {
+      seedApp("PENDING_APPROVAL", 1);
 
       await expect(
         invokeHandler(
           makeEvent(
-            'updateApp',
-            { input: { appId: 'app-1', status: 'REJECTED', version: 1, statusReason: '   ' } },
+            "updateApp",
+            { input: { appId: "app-1", status: "REJECTED", version: 1 } },
             true,
           ),
         ),
       ).rejects.toThrow(/statusReason is required/);
     });
 
-    it('accepts REJECTED with a non-empty statusReason and persists it', async () => {
-      seedApp('PENDING_APPROVAL', 1);
-
-      const result = (await invokeHandler(
-        makeEvent(
-          'updateApp',
-          { input: { appId: 'app-1', status: 'REJECTED', version: 1, statusReason: 'missing tests' } },
-          true,
-        ),
-      )) as Record<string, unknown>;
-
-      expect(result.status).toBe('REJECTED');
-      expect(result.statusReason).toBe('missing tests');
-    });
-  });
-
-  // -- Role gating: approve/reject is admin-only ---------------------------
-
-  describe('role gating', () => {
-    it('refuses APPROVED from a non-admin caller', async () => {
-      seedApp('PENDING_APPROVAL', 1);
+    it("rejects REJECTED with a blank/whitespace statusReason", async () => {
+      seedApp("PENDING_APPROVAL", 1);
 
       await expect(
         invokeHandler(
           makeEvent(
-            'updateApp',
-            { input: { appId: 'app-1', status: 'APPROVED', version: 1 } },
-            false,
+            "updateApp",
+            {
+              input: {
+                appId: "app-1",
+                status: "REJECTED",
+                version: 1,
+                statusReason: "   ",
+              },
+            },
+            true,
           ),
         ),
-      ).rejects.toThrow(/admin role required/);
+      ).rejects.toThrow(/statusReason is required/);
     });
 
-    it('refuses REJECTED from a non-admin caller even with a statusReason', async () => {
-      seedApp('PENDING_APPROVAL', 1);
-
-      await expect(
-        invokeHandler(
-          makeEvent(
-            'updateApp',
-            { input: { appId: 'app-1', status: 'REJECTED', version: 1, statusReason: 'no' } },
-            false,
-          ),
-        ),
-      ).rejects.toThrow(/admin role required/);
-    });
-
-    it('allows a non-admin caller to submit (DRAFT -> PENDING_APPROVAL)', async () => {
-      seedApp('DRAFT', 1);
+    it("accepts REJECTED with a non-empty statusReason and persists it", async () => {
+      seedApp("PENDING_APPROVAL", 1);
 
       const result = (await invokeHandler(
         makeEvent(
-          'updateApp',
-          { input: { appId: 'app-1', status: 'PENDING_APPROVAL', version: 1 } },
-          false,
-        ),
-      )) as Record<string, unknown>;
-
-      expect(result.status).toBe('PENDING_APPROVAL');
-    });
-
-    it('allows an admin caller to approve', async () => {
-      seedApp('PENDING_APPROVAL', 1);
-
-      const result = (await invokeHandler(
-        makeEvent(
-          'updateApp',
-          { input: { appId: 'app-1', status: 'APPROVED', version: 1 } },
-          true,
-        ),
-      )) as Record<string, unknown>;
-
-      expect(result.status).toBe('APPROVED');
-    });
-  });
-
-  // -- decidedBy is always server-derived -----------------------------------
-
-  describe('decidedBy is derived server-side, never from client input', () => {
-    it('stamps decidedBy from the admin auth identity on approve, ignoring any client-supplied value', async () => {
-      seedApp('PENDING_APPROVAL', 1);
-
-      const result = (await invokeHandler(
-        makeEvent(
-          'updateApp',
+          "updateApp",
           {
             input: {
-              appId: 'app-1',
-              status: 'APPROVED',
+              appId: "app-1",
+              status: "REJECTED",
               version: 1,
-              // Not a real input field — even if a client tried to smuggle
-              // this through, the resolver never reads input.decidedBy.
-              decidedBy: 'attacker-controlled',
+              statusReason: "missing tests",
             },
           },
           true,
         ),
       )) as Record<string, unknown>;
 
-      expect(result.decidedBy).toBe('admin-1');
-      expect(result.decidedBy).not.toBe('attacker-controlled');
+      expect(result.status).toBe("REJECTED");
+      expect(result.statusReason).toBe("missing tests");
+    });
+  });
+
+  // -- Role gating: approve/reject is admin-only ---------------------------
+
+  describe("role gating", () => {
+    it("refuses APPROVED from a non-admin caller", async () => {
+      seedApp("PENDING_APPROVAL", 1);
+
+      await expect(
+        invokeHandler(
+          makeEvent(
+            "updateApp",
+            { input: { appId: "app-1", status: "APPROVED", version: 1 } },
+            false,
+          ),
+        ),
+      ).rejects.toThrow(/admin role required/);
     });
 
-    it('stamps decidedBy from the admin auth identity on reject', async () => {
-      seedApp('PENDING_APPROVAL', 1);
+    it("refuses REJECTED from a non-admin caller even with a statusReason", async () => {
+      seedApp("PENDING_APPROVAL", 1);
+
+      await expect(
+        invokeHandler(
+          makeEvent(
+            "updateApp",
+            {
+              input: {
+                appId: "app-1",
+                status: "REJECTED",
+                version: 1,
+                statusReason: "no",
+              },
+            },
+            false,
+          ),
+        ),
+      ).rejects.toThrow(/admin role required/);
+    });
+
+    it("allows a non-admin caller to submit (DRAFT -> PENDING_APPROVAL)", async () => {
+      seedApp("DRAFT", 1);
 
       const result = (await invokeHandler(
         makeEvent(
-          'updateApp',
-          { input: { appId: 'app-1', status: 'REJECTED', version: 1, statusReason: 'no' } },
+          "updateApp",
+          { input: { appId: "app-1", status: "PENDING_APPROVAL", version: 1 } },
+          false,
+        ),
+      )) as Record<string, unknown>;
+
+      expect(result.status).toBe("PENDING_APPROVAL");
+    });
+
+    it("allows an admin caller to approve", async () => {
+      seedApp("PENDING_APPROVAL", 1);
+
+      const result = (await invokeHandler(
+        makeEvent(
+          "updateApp",
+          { input: { appId: "app-1", status: "APPROVED", version: 1 } },
           true,
         ),
       )) as Record<string, unknown>;
 
-      expect(result.decidedBy).toBe('admin-1');
+      expect(result.status).toBe("APPROVED");
+    });
+  });
+
+  // -- decidedBy is always server-derived -----------------------------------
+
+  describe("decidedBy is derived server-side, never from client input", () => {
+    it("stamps decidedBy from the admin auth identity on approve, ignoring any client-supplied value", async () => {
+      seedApp("PENDING_APPROVAL", 1);
+
+      const result = (await invokeHandler(
+        makeEvent(
+          "updateApp",
+          {
+            input: {
+              appId: "app-1",
+              status: "APPROVED",
+              version: 1,
+              // Not a real input field — even if a client tried to smuggle
+              // this through, the resolver never reads input.decidedBy.
+              decidedBy: "attacker-controlled",
+            },
+          },
+          true,
+        ),
+      )) as Record<string, unknown>;
+
+      expect(result.decidedBy).toBe("admin-1");
+      expect(result.decidedBy).not.toBe("attacker-controlled");
+    });
+
+    it("stamps decidedBy from the admin auth identity on reject", async () => {
+      seedApp("PENDING_APPROVAL", 1);
+
+      const result = (await invokeHandler(
+        makeEvent(
+          "updateApp",
+          {
+            input: {
+              appId: "app-1",
+              status: "REJECTED",
+              version: 1,
+              statusReason: "no",
+            },
+          },
+          true,
+        ),
+      )) as Record<string, unknown>;
+
+      expect(result.decidedBy).toBe("admin-1");
     });
   });
 
   // -- Resubmit path ---------------------------------------------------------
 
-  describe('resubmit path (REJECTED -> DRAFT)', () => {
-    it('succeeds and clears the prior decidedBy/statusReason', async () => {
-      seedApp('REJECTED', 2, 'org-1', {
-        decidedBy: 'admin-1',
-        statusReason: 'missing tests',
+  describe("resubmit path (REJECTED -> DRAFT)", () => {
+    it("succeeds and clears the prior decidedBy/statusReason", async () => {
+      seedApp("REJECTED", 2, "org-1", {
+        decidedBy: "admin-1",
+        statusReason: "missing tests",
       });
 
       const result = (await invokeHandler(
-        makeEvent('updateApp', { input: { appId: 'app-1', status: 'DRAFT', version: 2 } }),
+        makeEvent("updateApp", {
+          input: { appId: "app-1", status: "DRAFT", version: 2 },
+        }),
       )) as Record<string, unknown>;
 
-      expect(result.status).toBe('DRAFT');
+      expect(result.status).toBe("DRAFT");
       expect(result.decidedBy).toBeNull();
       expect(result.statusReason).toBeNull();
     });
 
-    it('allows a non-admin caller to resubmit', async () => {
-      seedApp('REJECTED', 2);
+    it("allows a non-admin caller to resubmit", async () => {
+      seedApp("REJECTED", 2);
 
       const result = (await invokeHandler(
         makeEvent(
-          'updateApp',
-          { input: { appId: 'app-1', status: 'DRAFT', version: 2 } },
+          "updateApp",
+          { input: { appId: "app-1", status: "DRAFT", version: 2 } },
           false,
         ),
       )) as Record<string, unknown>;
 
-      expect(result.status).toBe('DRAFT');
+      expect(result.status).toBe("DRAFT");
     });
   });
 });

--- a/backend/src/lambda/__tests__/registry-agent-record-resolver-binding-transition.test.ts
+++ b/backend/src/lambda/__tests__/registry-agent-record-resolver-binding-transition.test.ts
@@ -17,22 +17,25 @@
  * reach the resolver at all.
  */
 
-process.env.REGISTRY_ID = 'test-registry-id';
-process.env.APPS_TABLE = 'citadel-apps-test';
-process.env.WORKFLOWS_TABLE = 'citadel-workflows-test';
-process.env.AGENT_CONFIG_TABLE = 'citadel-agents-test';
-process.env.EVENT_BUS_NAME = 'citadel-agents-test';
-process.env.USER_POOL_ID = 'us-east-1_test';
-process.env.AUTHORITY_UNITS_TABLE = 'test-authority-units';
+process.env.REGISTRY_ID = "test-registry-id";
+process.env.APPS_TABLE = "citadel-apps-test";
+process.env.WORKFLOWS_TABLE = "citadel-workflows-test";
+process.env.AGENT_CONFIG_TABLE = "citadel-agents-test";
+process.env.EVENT_BUS_NAME = "citadel-agents-test";
+process.env.USER_POOL_ID = "us-east-1_test";
+process.env.AUTHORITY_UNITS_TABLE = "test-authority-units";
 process.env.APPSYNC_ENDPOINT =
-  'https://test-api.appsync-api.us-east-1.amazonaws.com/graphql';
-process.env.AWS_REGION = 'us-east-1';
-process.env.MODEL_CATALOG_TABLE = 'citadel-model-catalog-test';
+  "https://test-api.appsync-api.us-east-1.amazonaws.com/graphql";
+process.env.AWS_REGION = "us-east-1";
+process.env.MODEL_CATALOG_TABLE = "citadel-model-catalog-test";
 
-import { EventBridgeClient, PutEventsCommand } from '@aws-sdk/client-eventbridge';
-import { DynamoDBDocumentClient, GetCommand } from '@aws-sdk/lib-dynamodb';
-import { mockClient } from 'aws-sdk-client-mock';
-import { TypeMismatchError } from '../../services/registry-service';
+import {
+  EventBridgeClient,
+  PutEventsCommand,
+} from "@aws-sdk/client-eventbridge";
+import { DynamoDBDocumentClient, GetCommand } from "@aws-sdk/lib-dynamodb";
+import { mockClient } from "aws-sdk-client-mock";
+import { TypeMismatchError } from "../../services/registry-service";
 
 const ebMock = mockClient(EventBridgeClient);
 const ddbMock = mockClient(DynamoDBDocumentClient);
@@ -46,10 +49,10 @@ const resolveRecordIdMock = jest.fn();
 const getResourceMock = jest.fn();
 const updateResourceMock = jest.fn();
 
-jest.mock('../../services/registry-service', () => {
-  const actual = jest.requireActual('../../services/registry-service');
+jest.mock("../../services/registry-service", () => {
+  const actual = jest.requireActual("../../services/registry-service");
   const { getMockRegistryService } = jest.requireActual(
-    './fixtures/registry-service-mock',
+    "./fixtures/registry-service-mock",
   );
   return {
     ...actual,
@@ -76,49 +79,50 @@ jest.mock('../../services/registry-service', () => {
   };
 });
 
-jest.mock('../../utils/appsync', () => ({
-  getUserId: jest.fn().mockReturnValue('user-123'),
+jest.mock("../../utils/appsync", () => ({
+  getUserId: jest.fn().mockReturnValue("user-123"),
 }));
 
-jest.mock('../../utils/appsync-publish', () => ({
+jest.mock("../../utils/appsync-publish", () => ({
   publishAppStatusEvent: jest.fn().mockResolvedValue({}),
 }));
 
-jest.mock('uuid', () => ({
-  v4: jest.fn().mockReturnValue('test-correlation-id'),
+jest.mock("uuid", () => ({
+  v4: jest.fn().mockReturnValue("test-correlation-id"),
 }));
 
 import {
   seedMockRegistry,
   resetMockRegistry,
-} from './fixtures/registry-service-mock';
-import { handler } from '../registry-agent-record-resolver';
+} from "./fixtures/registry-service-mock";
+import { handler } from "../registry-agent-record-resolver";
 
 // ---------------------------------------------------------------------------
 // Fixtures
 // ---------------------------------------------------------------------------
 
-const APP_RECORD_ID = 'app000000001';
-const AGENT_RECORD_ID = 'agt000000001'; // valid 12-char recordId
-const AGENT_NAME = 'email_validator_agent'; // legacy human-readable id
+const APP_RECORD_ID = "app000000001";
+const AGENT_RECORD_ID = "agt000000001"; // valid 12-char recordId
+const AGENT_NAME = "email_validator_agent"; // legacy human-readable id
 
 function seedAppWithBinding(agentId: string) {
-  seedMockRegistry('agent', APP_RECORD_ID, {
-    name: 'Test App',
-    description: 'Test',
-    status: 'DRAFT',
+  seedMockRegistry("agent", APP_RECORD_ID, {
+    name: "Test App",
+    description: "Test",
+    status: "DRAFT",
     customDescriptorContent: JSON.stringify({
       appId: APP_RECORD_ID,
       manifest: {
-        orgId: 'org-1',
+        orgId: "org-1",
+        createdBy: "user-123",
         version: 1,
-        status: 'DRAFT',
+        status: "DRAFT",
         workflowIds: [],
         agentBindings: [
           {
             agentId,
-            status: 'DESIGN',
-            addedAt: '2026-01-01T00:00:00Z',
+            status: "DESIGN",
+            addedAt: "2026-01-01T00:00:00Z",
           },
         ],
         permissions: [],
@@ -135,21 +139,21 @@ function seedAppWithBinding(agentId: string) {
 function activeAgentRecord(recordId: string) {
   return {
     recordId,
-    name: 'email_validator_agent',
+    name: "email_validator_agent",
     // APPROVED is the authoritative active signal: the READY gate derives
     // the agent's state from record.status via toInternalState, not from
     // the descriptor mirror (which drifts — see the fabricated-agent tests).
-    status: 'APPROVED',
-    customDescriptorContent: JSON.stringify({ state: 'active' }),
+    status: "APPROVED",
+    customDescriptorContent: JSON.stringify({ state: "active" }),
   };
 }
 
 function inactiveAgentRecord(recordId: string) {
   return {
     recordId,
-    name: 'email_validator_agent',
-    status: 'DRAFT',
-    customDescriptorContent: JSON.stringify({ state: 'draft' }),
+    name: "email_validator_agent",
+    status: "DRAFT",
+    customDescriptorContent: JSON.stringify({ state: "draft" }),
   };
 }
 
@@ -165,7 +169,10 @@ function makeEvent(fieldName: string, args: Record<string, unknown>) {
   return {
     info: { fieldName },
     arguments: args,
-    identity: { sub: 'user-123', claims: { sub: 'user-123' } },
+    identity: {
+      sub: "user-123",
+      claims: { sub: "user-123", "custom:organization": "org-1" },
+    },
   } as unknown as HandlerEvent;
 }
 
@@ -173,7 +180,7 @@ function makeEvent(fieldName: string, args: Record<string, unknown>) {
 // Tests
 // ---------------------------------------------------------------------------
 
-describe('updateAgentBinding — READY transition agentId resolution', () => {
+describe("updateAgentBinding — READY transition agentId resolution", () => {
   beforeEach(() => {
     resetMockRegistry();
     ebMock.reset();
@@ -186,12 +193,18 @@ describe('updateAgentBinding — READY transition agentId resolution', () => {
     // returned record, mimicking the real RegistryService. This is what
     // projectAgentApp consumes, so assertions can read the post-update
     // manifest via the normal projection path.
-    updateResourceMock.mockImplementation(async (_type: unknown, id: unknown, input: { customMetadata?: string }) => ({
-      recordId: id,
-      name: 'Test App',
-      status: 'DRAFT',
-      customDescriptorContent: input.customMetadata,
-    }));
+    updateResourceMock.mockImplementation(
+      async (
+        _type: unknown,
+        id: unknown,
+        input: { customMetadata?: string },
+      ) => ({
+        recordId: id,
+        name: "Test App",
+        status: "DRAFT",
+        customDescriptorContent: input.customMetadata,
+      }),
+    );
   });
 
   afterAll(() => {
@@ -206,23 +219,24 @@ describe('updateAgentBinding — READY transition agentId resolution', () => {
     delete process.env.AUTHORITY_UNITS_TABLE;
   });
 
-  test('succeeds when agentId is already a 12-char recordId and the agent is active', async () => {
+  test("succeeds when agentId is already a 12-char recordId and the agent is active", async () => {
     seedAppWithBinding(AGENT_RECORD_ID);
     resolveRecordIdMock.mockImplementation(async (_type, id) => id);
     // First getResource call: app lookup. Second: agent lookup after resolve.
     getResourceMock
       .mockResolvedValueOnce({
         recordId: APP_RECORD_ID,
-        name: 'Test App',
-        status: 'DRAFT',
+        name: "Test App",
+        status: "DRAFT",
         customDescriptorContent: JSON.stringify({
           appId: APP_RECORD_ID,
           manifest: {
-            orgId: 'org-1',
+            orgId: "org-1",
+            createdBy: "user-123",
             version: 1,
-            status: 'DRAFT',
+            status: "DRAFT",
             agentBindings: [
-              { agentId: AGENT_RECORD_ID, status: 'DESIGN', addedAt: 't' },
+              { agentId: AGENT_RECORD_ID, status: "DESIGN", addedAt: "t" },
             ],
           },
         }),
@@ -230,27 +244,27 @@ describe('updateAgentBinding — READY transition agentId resolution', () => {
       .mockResolvedValueOnce(activeAgentRecord(AGENT_RECORD_ID));
 
     const result = await invokeHandler(
-      makeEvent('updateAgentBinding', {
+      makeEvent("updateAgentBinding", {
         input: {
           appId: APP_RECORD_ID,
           agentId: AGENT_RECORD_ID,
-          status: 'READY',
+          status: "READY",
         },
       }),
     );
 
-    expect(resolveRecordIdMock).toHaveBeenCalledWith('agent', AGENT_RECORD_ID);
+    expect(resolveRecordIdMock).toHaveBeenCalledWith("agent", AGENT_RECORD_ID);
     expect(result).toMatchObject({
       agentBindings: [
         expect.objectContaining({
           agentId: AGENT_RECORD_ID,
-          status: 'READY',
+          status: "READY",
         }),
       ],
     });
   });
 
-  test('resolves a human-readable agentId to a recordId before calling getResource', async () => {
+  test("resolves a human-readable agentId to a recordId before calling getResource", async () => {
     seedAppWithBinding(AGENT_NAME);
     resolveRecordIdMock.mockImplementation(async (_type, id) => {
       expect(id).toBe(AGENT_NAME);
@@ -259,16 +273,17 @@ describe('updateAgentBinding — READY transition agentId resolution', () => {
     getResourceMock
       .mockResolvedValueOnce({
         recordId: APP_RECORD_ID,
-        name: 'Test App',
-        status: 'DRAFT',
+        name: "Test App",
+        status: "DRAFT",
         customDescriptorContent: JSON.stringify({
           appId: APP_RECORD_ID,
           manifest: {
-            orgId: 'org-1',
+            orgId: "org-1",
+            createdBy: "user-123",
             version: 1,
-            status: 'DRAFT',
+            status: "DRAFT",
             agentBindings: [
-              { agentId: AGENT_NAME, status: 'DESIGN', addedAt: 't' },
+              { agentId: AGENT_NAME, status: "DESIGN", addedAt: "t" },
             ],
           },
         }),
@@ -276,25 +291,25 @@ describe('updateAgentBinding — READY transition agentId resolution', () => {
       .mockResolvedValueOnce(activeAgentRecord(AGENT_RECORD_ID));
 
     await invokeHandler(
-      makeEvent('updateAgentBinding', {
+      makeEvent("updateAgentBinding", {
         input: {
           appId: APP_RECORD_ID,
           agentId: AGENT_NAME,
-          status: 'READY',
+          status: "READY",
         },
       }),
     );
 
     // resolveRecordId was consulted for the binding's human name…
-    expect(resolveRecordIdMock).toHaveBeenCalledWith('agent', AGENT_NAME);
+    expect(resolveRecordIdMock).toHaveBeenCalledWith("agent", AGENT_NAME);
     // …and the subsequent getResource call used the resolved recordId, never
     // the raw name (this is the branch that previously hit the SDK regex).
     const agentLookup = getResourceMock.mock.calls.find(
-      ([type, id]) => type === 'agent' && id === AGENT_RECORD_ID,
+      ([type, id]) => type === "agent" && id === AGENT_RECORD_ID,
     );
     expect(agentLookup).toBeDefined();
     const rawNameLookup = getResourceMock.mock.calls.find(
-      ([type, id]) => type === 'agent' && id === AGENT_NAME,
+      ([type, id]) => type === "agent" && id === AGENT_NAME,
     );
     expect(rawNameLookup).toBeUndefined();
   });
@@ -308,16 +323,17 @@ describe('updateAgentBinding — READY transition agentId resolution', () => {
     );
     getResourceMock.mockResolvedValueOnce({
       recordId: APP_RECORD_ID,
-      name: 'Test App',
-      status: 'DRAFT',
+      name: "Test App",
+      status: "DRAFT",
       customDescriptorContent: JSON.stringify({
         appId: APP_RECORD_ID,
         manifest: {
-          orgId: 'org-1',
+          orgId: "org-1",
+          createdBy: "user-123",
           version: 1,
-          status: 'DRAFT',
+          status: "DRAFT",
           agentBindings: [
-            { agentId: AGENT_NAME, status: 'DESIGN', addedAt: 't' },
+            { agentId: AGENT_NAME, status: "DESIGN", addedAt: "t" },
           ],
         },
       }),
@@ -325,23 +341,23 @@ describe('updateAgentBinding — READY transition agentId resolution', () => {
 
     await expect(
       invokeHandler(
-        makeEvent('updateAgentBinding', {
+        makeEvent("updateAgentBinding", {
           input: {
             appId: APP_RECORD_ID,
             agentId: AGENT_NAME,
-            status: 'READY',
+            status: "READY",
           },
         }),
       ),
     ).rejects.toThrow(`Agent ${AGENT_NAME} not found`);
     // The agent getResource path must not be reached when resolution failed.
     const agentLookups = getResourceMock.mock.calls.filter(
-      ([type, id]) => type === 'agent' && id !== APP_RECORD_ID,
+      ([type, id]) => type === "agent" && id !== APP_RECORD_ID,
     );
     expect(agentLookups).toHaveLength(0);
   });
 
-  test('surfaces the activation-gate error when getResource throws TypeMismatchError on the resolved agent', async () => {
+  test("surfaces the activation-gate error when getResource throws TypeMismatchError on the resolved agent", async () => {
     // Simulates the case where the resolved recordId exists but is not an
     // agent record (or the SDK otherwise rejects the lookup with a type
     // mismatch). The caller must see the normal activation-gate message
@@ -351,16 +367,17 @@ describe('updateAgentBinding — READY transition agentId resolution', () => {
     getResourceMock
       .mockResolvedValueOnce({
         recordId: APP_RECORD_ID,
-        name: 'Test App',
-        status: 'DRAFT',
+        name: "Test App",
+        status: "DRAFT",
         customDescriptorContent: JSON.stringify({
           appId: APP_RECORD_ID,
           manifest: {
-            orgId: 'org-1',
+            orgId: "org-1",
+            createdBy: "user-123",
             version: 1,
-            status: 'DRAFT',
+            status: "DRAFT",
             agentBindings: [
-              { agentId: AGENT_NAME, status: 'DESIGN', addedAt: 't' },
+              { agentId: AGENT_NAME, status: "DESIGN", addedAt: "t" },
             ],
           },
         }),
@@ -373,33 +390,34 @@ describe('updateAgentBinding — READY transition agentId resolution', () => {
 
     await expect(
       invokeHandler(
-        makeEvent('updateAgentBinding', {
+        makeEvent("updateAgentBinding", {
           input: {
             appId: APP_RECORD_ID,
             agentId: AGENT_NAME,
-            status: 'READY',
+            status: "READY",
           },
         }),
       ),
-    ).rejects.toThrow('Agent must be active before it can be marked as ready');
+    ).rejects.toThrow("Agent must be active before it can be marked as ready");
   });
 
-  test('throws the activation-gate error when the resolved agent is not in active state', async () => {
+  test("throws the activation-gate error when the resolved agent is not in active state", async () => {
     seedAppWithBinding(AGENT_RECORD_ID);
     resolveRecordIdMock.mockResolvedValue(AGENT_RECORD_ID);
     getResourceMock
       .mockResolvedValueOnce({
         recordId: APP_RECORD_ID,
-        name: 'Test App',
-        status: 'DRAFT',
+        name: "Test App",
+        status: "DRAFT",
         customDescriptorContent: JSON.stringify({
           appId: APP_RECORD_ID,
           manifest: {
-            orgId: 'org-1',
+            orgId: "org-1",
+            createdBy: "user-123",
             version: 1,
-            status: 'DRAFT',
+            status: "DRAFT",
             agentBindings: [
-              { agentId: AGENT_RECORD_ID, status: 'DESIGN', addedAt: 't' },
+              { agentId: AGENT_RECORD_ID, status: "DESIGN", addedAt: "t" },
             ],
           },
         }),
@@ -408,18 +426,18 @@ describe('updateAgentBinding — READY transition agentId resolution', () => {
 
     await expect(
       invokeHandler(
-        makeEvent('updateAgentBinding', {
+        makeEvent("updateAgentBinding", {
           input: {
             appId: APP_RECORD_ID,
             agentId: AGENT_RECORD_ID,
-            status: 'READY',
+            status: "READY",
           },
         }),
       ),
-    ).rejects.toThrow('Agent must be active before it can be marked as ready');
+    ).rejects.toThrow("Agent must be active before it can be marked as ready");
   });
 
-  test('promotes to READY for a registry-fabricated agent whose descriptor still says inactive but whose record status is APPROVED', async () => {
+  test("promotes to READY for a registry-fabricated agent whose descriptor still says inactive but whose record status is APPROVED", async () => {
     // Dual-store regression: the fabricator writes descriptor
     // `state: 'inactive'` and intakeActivateProjectAgents flips ONLY
     // record.status → APPROVED (SubmitRegistryRecordForApproval never
@@ -431,50 +449,51 @@ describe('updateAgentBinding — READY transition agentId resolution', () => {
     getResourceMock
       .mockResolvedValueOnce({
         recordId: APP_RECORD_ID,
-        name: 'Test App',
-        status: 'DRAFT',
+        name: "Test App",
+        status: "DRAFT",
         customDescriptorContent: JSON.stringify({
           appId: APP_RECORD_ID,
           manifest: {
-            orgId: 'org-1',
+            orgId: "org-1",
+            createdBy: "user-123",
             version: 1,
-            status: 'DRAFT',
+            status: "DRAFT",
             agentBindings: [
-              { agentId: AGENT_RECORD_ID, status: 'DESIGN', addedAt: 't' },
+              { agentId: AGENT_RECORD_ID, status: "DESIGN", addedAt: "t" },
             ],
           },
         }),
       })
       .mockResolvedValueOnce({
         recordId: AGENT_RECORD_ID,
-        name: 'fabricated_agent',
-        status: 'APPROVED',
+        name: "fabricated_agent",
+        status: "APPROVED",
         customDescriptorContent: JSON.stringify({
-          categories: ['worker'],
-          state: 'inactive', // stale — never updated by activation
-          manifest: { name: 'fabricated_agent', tools: [] },
-          sourceProjectId: 'sess-1111',
+          categories: ["worker"],
+          state: "inactive", // stale — never updated by activation
+          manifest: { name: "fabricated_agent", tools: [] },
+          sourceProjectId: "sess-1111",
         }),
       });
 
     const result = await invokeHandler(
-      makeEvent('updateAgentBinding', {
+      makeEvent("updateAgentBinding", {
         input: {
           appId: APP_RECORD_ID,
           agentId: AGENT_RECORD_ID,
-          status: 'READY',
+          status: "READY",
         },
       }),
     );
 
     expect(result).toMatchObject({
       agentBindings: [
-        expect.objectContaining({ agentId: AGENT_RECORD_ID, status: 'READY' }),
+        expect.objectContaining({ agentId: AGENT_RECORD_ID, status: "READY" }),
       ],
     });
   });
 
-  test('rejects READY when the descriptor claims active but the record status is DRAFT (drift false-positive closed)', async () => {
+  test("rejects READY when the descriptor claims active but the record status is DRAFT (drift false-positive closed)", async () => {
     // The inverse drift: a descriptor whose `state` defaulted/stuck at
     // 'active' must not let a non-activated (DRAFT) agent flip live.
     seedAppWithBinding(AGENT_RECORD_ID);
@@ -482,67 +501,69 @@ describe('updateAgentBinding — READY transition agentId resolution', () => {
     getResourceMock
       .mockResolvedValueOnce({
         recordId: APP_RECORD_ID,
-        name: 'Test App',
-        status: 'DRAFT',
+        name: "Test App",
+        status: "DRAFT",
         customDescriptorContent: JSON.stringify({
           appId: APP_RECORD_ID,
           manifest: {
-            orgId: 'org-1',
+            orgId: "org-1",
+            createdBy: "user-123",
             version: 1,
-            status: 'DRAFT',
+            status: "DRAFT",
             agentBindings: [
-              { agentId: AGENT_RECORD_ID, status: 'DESIGN', addedAt: 't' },
+              { agentId: AGENT_RECORD_ID, status: "DESIGN", addedAt: "t" },
             ],
           },
         }),
       })
       .mockResolvedValueOnce({
         recordId: AGENT_RECORD_ID,
-        name: 'drifted_agent',
-        status: 'DRAFT',
-        customDescriptorContent: JSON.stringify({ state: 'active' }),
+        name: "drifted_agent",
+        status: "DRAFT",
+        customDescriptorContent: JSON.stringify({ state: "active" }),
       });
 
     await expect(
       invokeHandler(
-        makeEvent('updateAgentBinding', {
+        makeEvent("updateAgentBinding", {
           input: {
             appId: APP_RECORD_ID,
             agentId: AGENT_RECORD_ID,
-            status: 'READY',
+            status: "READY",
           },
         }),
       ),
-    ).rejects.toThrow('Agent must be active before it can be marked as ready');
+    ).rejects.toThrow("Agent must be active before it can be marked as ready");
   });
 
-  test('does not invoke resolveRecordId or agent getResource when the transition is not READY', async () => {
+  test("does not invoke resolveRecordId or agent getResource when the transition is not READY", async () => {
     // Updating a binding back to DESIGN (or editing a non-status field) is
     // a pure manifest mutation and must never touch the activation gate.
     seedAppWithBinding(AGENT_NAME);
     getResourceMock.mockResolvedValueOnce({
       recordId: APP_RECORD_ID,
-      name: 'Test App',
-      status: 'DRAFT',
+      name: "Test App",
+      status: "DRAFT",
       customDescriptorContent: JSON.stringify({
         appId: APP_RECORD_ID,
         manifest: {
-          orgId: 'org-1',
+          orgId: "org-1",
+          createdBy: "user-123",
           version: 1,
-          status: 'DRAFT',
+          status: "DRAFT",
           agentBindings: [
-            { agentId: AGENT_NAME, status: 'READY', addedAt: 't' },
+            { agentId: AGENT_NAME, status: "READY", addedAt: "t" },
           ],
         },
       }),
     });
 
     await invokeHandler(
-      makeEvent('updateAgentBinding', {
+      makeEvent("updateAgentBinding", {
         input: {
           appId: APP_RECORD_ID,
           agentId: AGENT_NAME,
-          status: 'DESIGN',
+          status: "DESIGN",
         },
       }),
     );
@@ -551,7 +572,7 @@ describe('updateAgentBinding — READY transition agentId resolution', () => {
     // The only getResource call is the app lookup at the top of the handler;
     // there must be no second call for the agent itself.
     const agentLookups = getResourceMock.mock.calls.filter(
-      ([type, id]) => type === 'agent' && id !== APP_RECORD_ID,
+      ([type, id]) => type === "agent" && id !== APP_RECORD_ID,
     );
     expect(agentLookups).toHaveLength(0);
   });
@@ -568,12 +589,12 @@ describe('updateAgentBinding — READY transition agentId resolution', () => {
 //   - When MODEL_CATALOG_TABLE is not configured the helper is a safe no-op.
 // Uses generic placeholder catalog keys — no real model-id literals.
 // ---------------------------------------------------------------------------
-describe('updateAgentBinding — modelOverride catalog validation', () => {
-  const CATALOG_TABLE = 'citadel-model-catalog-test';
-  const ENABLED_KEY = 'catalog-model-enabled';
-  const DISABLED_KEY = 'catalog-model-disabled';
-  const UNKNOWN_KEY = 'catalog-model-unknown';
-  const LEGACY_KEY = 'legacy-model-key';
+describe("updateAgentBinding — modelOverride catalog validation", () => {
+  const CATALOG_TABLE = "citadel-model-catalog-test";
+  const ENABLED_KEY = "catalog-model-enabled";
+  const DISABLED_KEY = "catalog-model-disabled";
+  const UNKNOWN_KEY = "catalog-model-unknown";
+  const LEGACY_KEY = "legacy-model-key";
 
   beforeEach(() => {
     resetMockRegistry();
@@ -583,12 +604,18 @@ describe('updateAgentBinding — modelOverride catalog validation', () => {
     resolveRecordIdMock.mockReset();
     getResourceMock.mockReset();
     updateResourceMock.mockReset();
-    updateResourceMock.mockImplementation(async (_type: unknown, id: unknown, input: { customMetadata?: string }) => ({
-      recordId: id,
-      name: 'Test App',
-      status: 'DRAFT',
-      customDescriptorContent: input.customMetadata,
-    }));
+    updateResourceMock.mockImplementation(
+      async (
+        _type: unknown,
+        id: unknown,
+        input: { customMetadata?: string },
+      ) => ({
+        recordId: id,
+        name: "Test App",
+        status: "DRAFT",
+        customDescriptorContent: input.customMetadata,
+      }),
+    );
     process.env.MODEL_CATALOG_TABLE = CATALOG_TABLE;
   });
 
@@ -601,19 +628,20 @@ describe('updateAgentBinding — modelOverride catalog validation', () => {
   function seedApp(existingModelOverride?: string) {
     getResourceMock.mockResolvedValueOnce({
       recordId: APP_RECORD_ID,
-      name: 'Test App',
-      status: 'DRAFT',
+      name: "Test App",
+      status: "DRAFT",
       customDescriptorContent: JSON.stringify({
         appId: APP_RECORD_ID,
         manifest: {
-          orgId: 'org-1',
+          orgId: "org-1",
+          createdBy: "user-123",
           version: 1,
-          status: 'DRAFT',
+          status: "DRAFT",
           agentBindings: [
             {
               agentId: AGENT_RECORD_ID,
-              status: 'DESIGN',
-              addedAt: 't',
+              status: "DESIGN",
+              addedAt: "t",
               ...(existingModelOverride !== undefined && {
                 modelOverride: existingModelOverride,
               }),
@@ -625,16 +653,19 @@ describe('updateAgentBinding — modelOverride catalog validation', () => {
   }
 
   function bindingEvent(modelOverride: string) {
-    return makeEvent('updateAgentBinding', {
+    return makeEvent("updateAgentBinding", {
       input: { appId: APP_RECORD_ID, agentId: AGENT_RECORD_ID, modelOverride },
     });
   }
 
-  test('(a) changing modelOverride to an enabled catalog key succeeds', async () => {
+  test("(a) changing modelOverride to an enabled catalog key succeeds", async () => {
     seedApp();
     ddbMock
-      .on(GetCommand, { TableName: CATALOG_TABLE, Key: { modelKey: ENABLED_KEY } })
-      .resolves({ Item: { modelKey: ENABLED_KEY, status: 'enabled' } });
+      .on(GetCommand, {
+        TableName: CATALOG_TABLE,
+        Key: { modelKey: ENABLED_KEY },
+      })
+      .resolves({ Item: { modelKey: ENABLED_KEY, status: "enabled" } });
 
     const result = await invokeHandler(bindingEvent(ENABLED_KEY));
 
@@ -644,41 +675,41 @@ describe('updateAgentBinding — modelOverride catalog validation', () => {
     });
   });
 
-  test('(b) changing modelOverride to an unknown catalog key throws', async () => {
+  test("(b) changing modelOverride to an unknown catalog key throws", async () => {
     seedApp();
     ddbMock.on(GetCommand).resolves({}); // no Item
 
-    await expect(
-      invokeHandler(bindingEvent(UNKNOWN_KEY)),
-    ).rejects.toThrow('not found in the model catalog');
+    await expect(invokeHandler(bindingEvent(UNKNOWN_KEY))).rejects.toThrow(
+      "not found in the model catalog",
+    );
     // Nothing persisted when validation fails.
     expect(updateResourceMock).not.toHaveBeenCalled();
   });
 
-  test('(c) changing modelOverride to a disabled catalog key throws', async () => {
+  test("(c) changing modelOverride to a disabled catalog key throws", async () => {
     seedApp();
     ddbMock
       .on(GetCommand)
-      .resolves({ Item: { modelKey: DISABLED_KEY, status: 'disabled' } });
+      .resolves({ Item: { modelKey: DISABLED_KEY, status: "disabled" } });
 
-    await expect(
-      invokeHandler(bindingEvent(DISABLED_KEY)),
-    ).rejects.toThrow('is not enabled');
+    await expect(invokeHandler(bindingEvent(DISABLED_KEY))).rejects.toThrow(
+      "is not enabled",
+    );
     expect(updateResourceMock).not.toHaveBeenCalled();
   });
 
-  test('(d) empty string clears the override without catalog validation', async () => {
+  test("(d) empty string clears the override without catalog validation", async () => {
     seedApp(LEGACY_KEY);
 
-    const result = await invokeHandler(bindingEvent(''));
+    const result = await invokeHandler(bindingEvent(""));
 
     expect(ddbMock.commandCalls(GetCommand)).toHaveLength(0);
     expect(result).toMatchObject({
-      agentBindings: [expect.objectContaining({ modelOverride: '' })],
+      agentBindings: [expect.objectContaining({ modelOverride: "" })],
     });
   });
 
-  test('(e) unchanged legacy value is grandfathered — no catalog validation', async () => {
+  test("(e) unchanged legacy value is grandfathered — no catalog validation", async () => {
     seedApp(LEGACY_KEY);
 
     const result = await invokeHandler(bindingEvent(LEGACY_KEY));
@@ -689,19 +720,19 @@ describe('updateAgentBinding — modelOverride catalog validation', () => {
     });
   });
 
-  test('unset MODEL_CATALOG_TABLE is a safe no-op (changed override still persists)', async () => {
+  test("unset MODEL_CATALOG_TABLE is a safe no-op (changed override still persists)", async () => {
     delete process.env.MODEL_CATALOG_TABLE;
-    const warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {});
+    const warnSpy = jest.spyOn(console, "warn").mockImplementation(() => {});
     seedApp();
 
-    const result = await invokeHandler(bindingEvent('catalog-model-some-new'));
+    const result = await invokeHandler(bindingEvent("catalog-model-some-new"));
 
     // No catalog read attempted, mutation still persisted (non-breaking).
     expect(ddbMock.commandCalls(GetCommand)).toHaveLength(0);
     expect(warnSpy).toHaveBeenCalled();
     expect(result).toMatchObject({
       agentBindings: [
-        expect.objectContaining({ modelOverride: 'catalog-model-some-new' }),
+        expect.objectContaining({ modelOverride: "catalog-model-some-new" }),
       ],
     });
     warnSpy.mockRestore();

--- a/backend/src/lambda/__tests__/registry-agent-record-resolver-components.test.ts
+++ b/backend/src/lambda/__tests__/registry-agent-record-resolver-components.test.ts
@@ -91,7 +91,10 @@ function makeEvent(fieldName: string, args: Record<string, unknown>) {
   return {
     info: { fieldName },
     arguments: args,
-    identity: { sub: "user-123", claims: { sub: "user-123" } },
+    identity: {
+      sub: "user-123",
+      claims: { sub: "user-123", "custom:organization": "org-1" },
+    },
   } as unknown as HandlerEvent;
 }
 
@@ -122,6 +125,12 @@ function seedApp(
         configSchema: opts.configSchema ?? null,
         configValues: opts.configValues ?? null,
         authConfig: null,
+        // createdBy stamps the test caller (user-123) as the implicit
+        // creator-owner fallback in assertManifestAccess, so these
+        // functional tests (which are not themselves about authorization)
+        // exercise the legitimate-caller path rather than being refused by
+        // the finding-8f8fd119 editor gate added to every mutation here.
+        createdBy: "user-123",
         access: {},
         routingConfig: null,
       },

--- a/backend/src/lambda/__tests__/registry-agent-record-resolver-crud.test.ts
+++ b/backend/src/lambda/__tests__/registry-agent-record-resolver-crud.test.ts
@@ -95,7 +95,13 @@ function makeEvent(
   return {
     info: { fieldName },
     arguments: args,
-    identity: { sub, claims: { sub } },
+    // custom:organization defaults to "org-1" — matching seedApp's default
+    // manifest.orgId and createdBy ("user-123") — so callers of the plain
+    // makeEvent satisfy the finding-8f8fd119 editor gate on updateApp
+    // (assertManifestAccess) via the same-org + implicit-creator-owner
+    // fallback path, without weakening the admin-gate test above (that test
+    // asserts on the SEPARATE isAdminFromEvent check, unaffected by org).
+    identity: { sub, claims: { sub, "custom:organization": "org-1" } },
   } as unknown as HandlerEvent;
 }
 
@@ -162,6 +168,13 @@ function seedApp(
         configSchema: null,
         configValues: null,
         authConfig: null,
+        // createdBy stamps the default caller ("user-123", plain makeEvent's
+        // default sub) as the implicit creator-owner fallback in
+        // assertManifestAccess, so these CRUD tests exercise the legitimate
+        // editor/owner path rather than being refused by the finding-8f8fd119
+        // gate now on updateApp. Callers testing cross-org/non-editor refusal
+        // use a distinct seeded app or override via opts.manifest.
+        createdBy: "user-123",
         access: {},
         routingConfig: null,
         ...(opts.manifest ?? {}),

--- a/backend/src/lambda/__tests__/registry-agent-record-resolver-delete-app-owner-gate.test.ts
+++ b/backend/src/lambda/__tests__/registry-agent-record-resolver-delete-app-owner-gate.test.ts
@@ -1,0 +1,283 @@
+/**
+ * RED-first tests for finding 6400b440: deleteApp had NO authorization
+ * check at all — it called revokeFabricatorAuthority() and
+ * registry.deleteResource() unguarded, so any authenticated caller could
+ * irreversibly delete ANY app in ANY org.
+ *
+ * Gated with the SAME manifest-access store grantAppAccess/revokeAppAccess
+ * already use (assertManifestAccess, requiredRole='owner') — deletion is
+ * destructive and irreversible, matching grant/revoke's owner requirement,
+ * not the editor-level lifecycle mutations gated by finding 8f8fd119.
+ *
+ * Threat model asserted:
+ *   - cross-org caller → refused, ZERO deleteResource calls, ZERO
+ *     revokeFabricatorAuthority calls
+ *   - same-org NON-OWNER (editor, no access entry, not createdBy) →
+ *     refused, ZERO deleteResource calls, ZERO revokeFabricatorAuthority
+ *     calls
+ *   - legitimate OWNER → succeeds, exactly one deleteResource call and one
+ *     revokeFabricatorAuthority call
+ *   - admin group → bypasses (consistent with the other manifest gates)
+ */
+
+process.env.REGISTRY_ID = "test-registry-id";
+process.env.APPS_TABLE = "citadel-apps-test";
+process.env.WORKFLOWS_TABLE = "citadel-workflows-test";
+process.env.AGENT_CONFIG_TABLE = "citadel-agents-test";
+process.env.EVENT_BUS_NAME = "citadel-agents-test";
+process.env.USER_POOL_ID = "us-east-1_test";
+process.env.AUTHORITY_UNITS_TABLE = "test-authority-units";
+process.env.AWS_REGION = "us-east-1";
+delete process.env.MODEL_CATALOG_TABLE;
+
+import {
+  EventBridgeClient,
+  PutEventsCommand,
+} from "@aws-sdk/client-eventbridge";
+import { mockClient } from "aws-sdk-client-mock";
+
+const ebMock = mockClient(EventBridgeClient);
+
+import {
+  seedMockRegistry,
+  resetMockRegistry,
+  getDeleteResourceCallCount,
+} from "./fixtures/registry-service-mock";
+
+jest.mock("../../services/registry-service", () => {
+  const { getMockRegistryService } = jest.requireActual(
+    "./fixtures/registry-service-mock",
+  );
+  const actual = jest.requireActual("../../services/registry-service");
+  return {
+    RegistryService: jest
+      .fn()
+      .mockImplementation(() => getMockRegistryService()),
+    getRegistryService: jest.fn(() => getMockRegistryService()),
+    _resetRegistryService: jest.fn(),
+    isRegistryEnabled: jest.fn(() => true),
+    TypeMismatchError: actual.TypeMismatchError,
+    RegistryLifecycleError: actual.RegistryLifecycleError,
+  };
+});
+
+jest.mock("@aws-sdk/client-cognito-identity-provider", () => ({
+  CognitoIdentityProviderClient: jest.fn().mockImplementation(() => ({
+    send: jest
+      .fn()
+      .mockRejectedValue(new Error("Cognito not reachable in test")),
+  })),
+  AdminGetUserCommand: jest.fn(),
+}));
+
+const mockRevokeFabricatorAuthority = jest.fn().mockResolvedValue(undefined);
+jest.mock("../registry-agent-authority-lifecycle", () => ({
+  grantFabricatorAuthority: jest.fn().mockResolvedValue(undefined),
+  revokeFabricatorAuthority: (...args: unknown[]) =>
+    mockRevokeFabricatorAuthority(...args),
+}));
+
+import { handler } from "../registry-agent-record-resolver";
+
+type HandlerEvent = Parameters<typeof handler>[0];
+const invokeHandler = handler as (event: HandlerEvent) => Promise<unknown>;
+
+function makeEvent(
+  fieldName: string,
+  args: Record<string, unknown>,
+  opts: { userId: string; orgId?: string; groups?: string[] },
+) {
+  const claims: Record<string, unknown> = { sub: opts.userId };
+  if (opts.orgId !== undefined) claims["custom:organization"] = opts.orgId;
+  if (opts.groups !== undefined) claims["cognito:groups"] = opts.groups;
+  return {
+    info: { fieldName },
+    arguments: args,
+    identity: { sub: opts.userId, claims },
+  } as unknown as HandlerEvent;
+}
+
+const APP_ID = "app-1";
+const OWNER_ID = "owner-user";
+const EDITOR_ID = "editor-user";
+const APP_ORG = "org-1";
+
+function seedApp(
+  opts: {
+    access?: Record<
+      string,
+      { role: string; grantedAt: string; grantedBy: string }
+    >;
+    createdBy?: string | null;
+  } = {},
+) {
+  seedMockRegistry("agent", APP_ID, {
+    name: "Test App",
+    description: "Test",
+    status: "DRAFT",
+    customDescriptorContent: JSON.stringify({
+      appId: APP_ID,
+      manifest: {
+        orgId: APP_ORG,
+        version: 1,
+        status: "DRAFT",
+        workflowIds: [],
+        agentBindings: [],
+        permissions: [],
+        configSchema: null,
+        configValues: null,
+        authConfig: null,
+        ...(opts.createdBy !== null && {
+          createdBy: opts.createdBy ?? OWNER_ID,
+        }),
+        access:
+          opts.access !== undefined
+            ? opts.access
+            : {
+                [OWNER_ID]: {
+                  role: "owner",
+                  grantedAt: "2024-01-01T00:00:00Z",
+                  grantedBy: "system",
+                },
+                [EDITOR_ID]: {
+                  role: "editor",
+                  grantedAt: "2024-01-01T00:00:00Z",
+                  grantedBy: OWNER_ID,
+                },
+              },
+        routingConfig: null,
+      },
+    }),
+  });
+}
+
+function expectZeroDeleteSideEffects() {
+  expect(getDeleteResourceCallCount()).toBe(0);
+  expect(mockRevokeFabricatorAuthority).not.toHaveBeenCalled();
+}
+
+beforeEach(() => {
+  resetMockRegistry();
+  ebMock.reset();
+  ebMock.on(PutEventsCommand).resolves({});
+  mockRevokeFabricatorAuthority.mockClear();
+});
+
+describe("registry-agent-record-resolver — deleteApp owner gate (finding 6400b440)", () => {
+  test("refuses a cross-org caller with zero deleteResource and zero revokeFabricatorAuthority calls", async () => {
+    seedApp();
+
+    await expect(
+      invokeHandler(
+        makeEvent(
+          "deleteApp",
+          { appId: APP_ID },
+          { userId: "attacker", orgId: "org-evil" },
+        ),
+      ),
+    ).rejects.toThrow(/Access denied/i);
+
+    expectZeroDeleteSideEffects();
+  });
+
+  test("refuses a same-org NON-OWNER (editor) with zero deleteResource and zero revokeFabricatorAuthority calls", async () => {
+    seedApp();
+
+    await expect(
+      invokeHandler(
+        makeEvent(
+          "deleteApp",
+          { appId: APP_ID },
+          { userId: EDITOR_ID, orgId: APP_ORG },
+        ),
+      ),
+    ).rejects.toThrow(/Access denied.*owner/i);
+
+    expectZeroDeleteSideEffects();
+  });
+
+  test("refuses a same-org caller with no access entry and not createdBy, zero side effects", async () => {
+    seedApp({
+      access: {
+        "viewer-user": {
+          role: "viewer",
+          grantedAt: "2024-01-01T00:00:00Z",
+          grantedBy: OWNER_ID,
+        },
+      },
+    });
+
+    await expect(
+      invokeHandler(
+        makeEvent(
+          "deleteApp",
+          { appId: APP_ID },
+          { userId: "viewer-user", orgId: APP_ORG },
+        ),
+      ),
+    ).rejects.toThrow(/Access denied.*owner/i);
+
+    expectZeroDeleteSideEffects();
+  });
+
+  test("refuses when identity cannot be resolved (fail closed)", async () => {
+    seedApp();
+
+    await expect(
+      invokeHandler(
+        makeEvent("deleteApp", { appId: APP_ID }, { userId: "no-org-user" }),
+      ),
+    ).rejects.toThrow(/Access denied/i);
+
+    expectZeroDeleteSideEffects();
+  });
+
+  test("allows the legitimate owner to delete, exactly one delete and one revoke call", async () => {
+    seedApp();
+
+    const result = await invokeHandler(
+      makeEvent(
+        "deleteApp",
+        { appId: APP_ID },
+        { userId: OWNER_ID, orgId: APP_ORG },
+      ),
+    );
+
+    expect(result).toMatchObject({ success: true });
+    expect(getDeleteResourceCallCount()).toBe(1);
+    expect(mockRevokeFabricatorAuthority).toHaveBeenCalledTimes(1);
+    expect(mockRevokeFabricatorAuthority).toHaveBeenCalledWith(APP_ID);
+  });
+
+  test("allows the implicit creator-owner to delete a legacy app with no access entries", async () => {
+    seedApp({ access: {}, createdBy: "legacy-creator" });
+
+    const result = await invokeHandler(
+      makeEvent(
+        "deleteApp",
+        { appId: APP_ID },
+        { userId: "legacy-creator", orgId: APP_ORG },
+      ),
+    );
+
+    expect(result).toMatchObject({ success: true });
+    expect(getDeleteResourceCallCount()).toBe(1);
+    expect(mockRevokeFabricatorAuthority).toHaveBeenCalledTimes(1);
+  });
+
+  test("admin group bypasses the owner gate for deleteApp", async () => {
+    seedApp();
+
+    const result = await invokeHandler(
+      makeEvent(
+        "deleteApp",
+        { appId: APP_ID },
+        { userId: "admin-1", orgId: "unrelated-org", groups: ["admin"] },
+      ),
+    );
+
+    expect(result).toMatchObject({ success: true });
+    expect(getDeleteResourceCallCount()).toBe(1);
+    expect(mockRevokeFabricatorAuthority).toHaveBeenCalledTimes(1);
+  });
+});

--- a/backend/src/lambda/__tests__/registry-agent-record-resolver-description-default.test.ts
+++ b/backend/src/lambda/__tests__/registry-agent-record-resolver-description-default.test.ts
@@ -23,18 +23,21 @@
  */
 // Env vars MUST be set BEFORE `import { handler }` — the resolver captures
 // EVENT_BUS_NAME / APPS_TABLE / DEFAULT_REGION at module-load time.
-process.env.REGISTRY_ID = 'test-registry-id';
-process.env.APPS_TABLE = 'citadel-apps-test';
-process.env.WORKFLOWS_TABLE = 'citadel-workflows-test';
-process.env.AGENT_CONFIG_TABLE = 'citadel-agents-test';
-process.env.EVENT_BUS_NAME = 'citadel-agents-test';
-process.env.USER_POOL_ID = 'us-east-1_test';
-process.env.AWS_REGION = 'us-east-1';
+process.env.REGISTRY_ID = "test-registry-id";
+process.env.APPS_TABLE = "citadel-apps-test";
+process.env.WORKFLOWS_TABLE = "citadel-workflows-test";
+process.env.AGENT_CONFIG_TABLE = "citadel-agents-test";
+process.env.EVENT_BUS_NAME = "citadel-agents-test";
+process.env.USER_POOL_ID = "us-east-1_test";
+process.env.AWS_REGION = "us-east-1";
 // Leave AUTHORITY_UNITS_TABLE unset so grantFabricatorAuthority becomes a
 // no-op inside createApp and we do not need a DynamoDB mock for that path.
 delete process.env.AUTHORITY_UNITS_TABLE;
 
-import { EventBridgeClient, PutEventsCommand } from '@aws-sdk/client-eventbridge';
+import {
+  EventBridgeClient,
+  PutEventsCommand,
+} from "@aws-sdk/client-eventbridge";
 import {
   DynamoDBDocumentClient,
   QueryCommand,
@@ -42,8 +45,8 @@ import {
   PutCommand,
   UpdateCommand,
   DeleteCommand,
-} from '@aws-sdk/lib-dynamodb';
-import { mockClient } from 'aws-sdk-client-mock';
+} from "@aws-sdk/lib-dynamodb";
+import { mockClient } from "aws-sdk-client-mock";
 
 const ebMock = mockClient(EventBridgeClient);
 const ddbMock = mockClient(DynamoDBDocumentClient);
@@ -51,11 +54,11 @@ const ddbMock = mockClient(DynamoDBDocumentClient);
 import {
   seedMockRegistry,
   resetMockRegistry,
-} from './fixtures/registry-service-mock';
+} from "./fixtures/registry-service-mock";
 
-jest.mock('../../services/registry-service', () => {
+jest.mock("../../services/registry-service", () => {
   const { getMockRegistryService } = jest.requireActual(
-    './fixtures/registry-service-mock',
+    "./fixtures/registry-service-mock",
   );
   // Stable singleton wrapping the fixture with jest.fn spies so tests can
   // inspect the exact args the resolver passes to the registry writes.
@@ -73,16 +76,16 @@ jest.mock('../../services/registry-service', () => {
   };
 });
 
-jest.mock('../../utils/appsync', () => ({
-  getUserId: jest.fn().mockReturnValue('user-123'),
+jest.mock("../../utils/appsync", () => ({
+  getUserId: jest.fn().mockReturnValue("user-123"),
 }));
 
-jest.mock('../../utils/appsync-publish', () => ({
+jest.mock("../../utils/appsync-publish", () => ({
   publishAppStatusEvent: jest.fn().mockResolvedValue(undefined),
 }));
 
-import { getRegistryService } from '../../services/registry-service';
-import { handler } from '../registry-agent-record-resolver';
+import { getRegistryService } from "../../services/registry-service";
+import { handler } from "../registry-agent-record-resolver";
 
 const registry = getRegistryService() as unknown as {
   createResource: jest.Mock;
@@ -97,11 +100,17 @@ type HandlerEvent = Parameters<typeof handler>[0];
 // (single cast here) so calls don't pass superfluous arguments.
 const invokeHandler = handler as (event: HandlerEvent) => Promise<unknown>;
 
-function makeEvent(fieldName: string, args: Record<string, unknown>, sub = 'user-123'): HandlerEvent {
+function makeEvent(
+  fieldName: string,
+  args: Record<string, unknown>,
+  sub = "user-123",
+): HandlerEvent {
   return {
     info: { fieldName },
     arguments: args,
-    identity: { sub, claims: { sub } },
+    // custom:organization: 'org-1' matches seedApp's manifest.orgId and
+    // createdBy — satisfies the finding-8f8fd119 editor gate on updateApp.
+    identity: { sub, claims: { sub, "custom:organization": "org-1" } },
   } as unknown as HandlerEvent;
 }
 
@@ -136,32 +145,35 @@ function lastMetaDescriptionWrite(): unknown {
     .filter((c) =>
       Object.prototype.hasOwnProperty.call(
         c.args[0].input.ExpressionAttributeValues ?? {},
-        ':v_description',
+        ":v_description",
       ),
     );
   expect(calls.length).toBeGreaterThanOrEqual(1);
   return calls[calls.length - 1].args[0].input.ExpressionAttributeValues![
-    ':v_description'
+    ":v_description"
   ];
 }
 
-function seedApp(opts: { name?: string; description?: string; version?: number } = {}): void {
-  seedMockRegistry('agent', 'app-1', {
-    name: opts.name ?? 'Legacy App',
-    description: opts.description ?? 'Existing description',
-    status: 'DRAFT',
+function seedApp(
+  opts: { name?: string; description?: string; version?: number } = {},
+): void {
+  seedMockRegistry("agent", "app-1", {
+    name: opts.name ?? "Legacy App",
+    description: opts.description ?? "Existing description",
+    status: "DRAFT",
     customDescriptorContent: JSON.stringify({
-      appId: 'app-1',
+      appId: "app-1",
       manifest: {
-        orgId: 'org-1',
+        orgId: "org-1",
         version: opts.version ?? 1,
-        status: 'DRAFT',
+        status: "DRAFT",
         workflowIds: [],
         agentBindings: [],
         permissions: [],
         configSchema: null,
         configValues: null,
         authConfig: null,
+        createdBy: "user-123",
         access: {},
         routingConfig: null,
       },
@@ -169,7 +181,7 @@ function seedApp(opts: { name?: string; description?: string; version?: number }
   });
 }
 
-describe('registry-agent-record-resolver — description defaulting', () => {
+describe("registry-agent-record-resolver — description defaulting", () => {
   beforeEach(() => {
     resetMockRegistry();
     registry.createResource.mockClear();
@@ -180,8 +192,12 @@ describe('registry-agent-record-resolver — description defaulting', () => {
     ddbMock.on(PutCommand).resolves({});
     ddbMock.on(UpdateCommand).resolves({});
     ddbMock.on(DeleteCommand).resolves({});
-    ddbMock.on(QueryCommand).resolves({ Items: [], LastEvaluatedKey: undefined });
-    ddbMock.on(ScanCommand).resolves({ Items: [], LastEvaluatedKey: undefined });
+    ddbMock
+      .on(QueryCommand)
+      .resolves({ Items: [], LastEvaluatedKey: undefined });
+    ddbMock
+      .on(ScanCommand)
+      .resolves({ Items: [], LastEvaluatedKey: undefined });
   });
 
   afterAll(() => {
@@ -196,122 +212,122 @@ describe('registry-agent-record-resolver — description defaulting', () => {
 
   // ─── createApp ─────────────────────────────────────────────────
 
-  describe('createApp', () => {
-    test('defaults the registry description to the app name when description is omitted (Import Blueprint New App regression)', async () => {
+  describe("createApp", () => {
+    test("defaults the registry description to the app name when description is omitted (Import Blueprint New App regression)", async () => {
       await invokeHandler(
-        makeEvent('createApp', {
-          input: { name: 'My New App', orgId: 'org-1' },
+        makeEvent("createApp", {
+          input: { name: "My New App", orgId: "org-1" },
         }),
       );
 
       const created = lastCreateResourceInput();
-      expect(created.description).toBe('My New App');
+      expect(created.description).toBe("My New App");
     });
 
-    test('defaults a blank (whitespace-only) description to the app name', async () => {
+    test("defaults a blank (whitespace-only) description to the app name", async () => {
       await invokeHandler(
-        makeEvent('createApp', {
-          input: { name: 'My New App', orgId: 'org-1', description: '   ' },
+        makeEvent("createApp", {
+          input: { name: "My New App", orgId: "org-1", description: "   " },
         }),
       );
 
       const created = lastCreateResourceInput();
-      expect(created.description).toBe('My New App');
+      expect(created.description).toBe("My New App");
     });
 
-    test('mirrors the defaulted description to the AppsTable #META row (registry/mirror consistency)', async () => {
+    test("mirrors the defaulted description to the AppsTable #META row (registry/mirror consistency)", async () => {
       await invokeHandler(
-        makeEvent('createApp', {
-          input: { name: 'My New App', orgId: 'org-1' },
+        makeEvent("createApp", {
+          input: { name: "My New App", orgId: "org-1" },
         }),
       );
 
-      expect(lastMetaDescriptionWrite()).toBe('My New App');
+      expect(lastMetaDescriptionWrite()).toBe("My New App");
     });
 
-    test('passes a provided non-empty description to the registry verbatim', async () => {
+    test("passes a provided non-empty description to the registry verbatim", async () => {
       await invokeHandler(
-        makeEvent('createApp', {
+        makeEvent("createApp", {
           input: {
-            name: 'My New App',
-            orgId: 'org-1',
-            description: 'Hand-written description',
+            name: "My New App",
+            orgId: "org-1",
+            description: "Hand-written description",
           },
         }),
       );
 
       const created = lastCreateResourceInput();
-      expect(created.description).toBe('Hand-written description');
-      expect(lastMetaDescriptionWrite()).toBe('Hand-written description');
+      expect(created.description).toBe("Hand-written description");
+      expect(lastMetaDescriptionWrite()).toBe("Hand-written description");
     });
   });
 
   // ─── updateApp (sibling-path sweep) ────────────────────────────
 
-  describe('updateApp', () => {
-    test('never forwards an explicit-blank description to the registry — defaults to the app name', async () => {
-      seedApp({ name: 'Legacy App' });
+  describe("updateApp", () => {
+    test("never forwards an explicit-blank description to the registry — defaults to the app name", async () => {
+      seedApp({ name: "Legacy App" });
 
       await invokeHandler(
-        makeEvent('updateApp', {
-          input: { appId: 'app-1', version: 1, description: '' },
+        makeEvent("updateApp", {
+          input: { appId: "app-1", version: 1, description: "" },
         }),
       );
 
       const updated = lastUpdateResourceInput();
-      expect(updated.description).toBe('Legacy App');
+      expect(updated.description).toBe("Legacy App");
     });
 
-    test('defaults to the app name when description is omitted and the existing record description is blank (legacy record)', async () => {
-      seedApp({ name: 'Legacy App', description: '' });
+    test("defaults to the app name when description is omitted and the existing record description is blank (legacy record)", async () => {
+      seedApp({ name: "Legacy App", description: "" });
 
       await invokeHandler(
-        makeEvent('updateApp', {
-          input: { appId: 'app-1', version: 1, name: 'Renamed App' },
+        makeEvent("updateApp", {
+          input: { appId: "app-1", version: 1, name: "Renamed App" },
         }),
       );
 
       const updated = lastUpdateResourceInput();
-      expect(updated.description).toBe('Renamed App');
+      expect(updated.description).toBe("Renamed App");
     });
 
-    test('mirrors the defaulted description to the AppsTable #META row when the caller sent a blank description', async () => {
-      seedApp({ name: 'Legacy App' });
+    test("mirrors the defaulted description to the AppsTable #META row when the caller sent a blank description", async () => {
+      seedApp({ name: "Legacy App" });
 
       await invokeHandler(
-        makeEvent('updateApp', {
-          input: { appId: 'app-1', version: 1, description: '   ' },
+        makeEvent("updateApp", {
+          input: { appId: "app-1", version: 1, description: "   " },
         }),
       );
 
-      expect(lastMetaDescriptionWrite()).toBe('Legacy App');
+      expect(lastMetaDescriptionWrite()).toBe("Legacy App");
     });
 
-    test('preserves a provided non-empty description verbatim', async () => {
-      seedApp({ name: 'Legacy App' });
+    test("preserves a provided non-empty description verbatim", async () => {
+      seedApp({ name: "Legacy App" });
 
       await invokeHandler(
-        makeEvent('updateApp', {
-          input: { appId: 'app-1', version: 1, description: 'Updated by hand' },
-        }),
-      );
-
-      const updated = lastUpdateResourceInput();
-      expect(updated.description).toBe('Updated by hand');
-      expect(lastMetaDescriptionWrite()).toBe('Updated by hand');
-    });
-
-    test('keeps the existing non-blank description when the caller omits it', async () => {
-      seedApp({ name: 'Legacy App', description: 'Existing description' });
-
-      await invokeHandler(
-        makeEvent('updateApp', {
-          input: { appId: 'app-1', version: 1, name: 'Renamed App' },
+        makeEvent("updateApp", {
+          input: { appId: "app-1", version: 1, description: "Updated by hand" },
         }),
       );
 
       const updated = lastUpdateResourceInput();
-      expect(updated.description).toBe('Existing description');
+      expect(updated.description).toBe("Updated by hand");
+      expect(lastMetaDescriptionWrite()).toBe("Updated by hand");
+    });
+
+    test("keeps the existing non-blank description when the caller omits it", async () => {
+      seedApp({ name: "Legacy App", description: "Existing description" });
+
+      await invokeHandler(
+        makeEvent("updateApp", {
+          input: { appId: "app-1", version: 1, name: "Renamed App" },
+        }),
+      );
+
+      const updated = lastUpdateResourceInput();
+      expect(updated.description).toBe("Existing description");
     });
   });
 });

--- a/backend/src/lambda/__tests__/registry-agent-record-resolver-dispatch-gate-enumeration.test.ts
+++ b/backend/src/lambda/__tests__/registry-agent-record-resolver-dispatch-gate-enumeration.test.ts
@@ -1,0 +1,231 @@
+/**
+ * Enumeration-completeness guard for registry-agent-record-resolver.ts's
+ * dispatch switch (finding 6400b440 follow-up).
+ *
+ * The previous "every op is gated" claim was a hand-maintained list that
+ * missed deleteApp entirely. This test derives the operation list directly
+ * from the handler's `switch (fieldName)` source — by parsing the actual
+ * `case "..."` labels out of the file — rather than trusting a manually
+ * transcribed list, so a future case added to the switch without a
+ * corresponding entry here fails LOUDLY instead of silently shipping
+ * ungated.
+ *
+ * Every case must appear in exactly one of:
+ *   - GATED_OPS: calls an assertManifestAccess/assertManifestOwnerAccess
+ *     gate (verified by grep against the case's handler function body, not
+ *     just asserted by hand) before any mutating side effect.
+ *   - EXEMPT_OPS: legitimately gate-free, each with an explicit reason
+ *     (pure read with its own tenant check, IAM-only internal, or a
+ *     documented pre-existing gap called out for follow-up rather than
+ *     silently passed over).
+ *
+ * If neither list accounts for a case, or a GATED op's handler function no
+ * longer contains a gate call, the test fails.
+ */
+import * as fs from "fs";
+import * as path from "path";
+
+const RESOLVER_PATH = path.join(
+  __dirname,
+  "..",
+  "registry-agent-record-resolver.ts",
+);
+
+function extractDispatchCases(source: string): string[] {
+  const switchStart = source.indexOf("switch (fieldName)");
+  if (switchStart === -1) {
+    throw new Error(
+      "Could not locate `switch (fieldName)` in registry-agent-record-resolver.ts — " +
+        "dispatch structure changed; update this guard's parsing.",
+    );
+  }
+  // Slice from the switch to the closing `default:` case (present in every
+  // version of this dispatch) so we don't accidentally pick up unrelated
+  // `case "..."` strings elsewhere in the file.
+  const defaultIdx = source.indexOf("default:", switchStart);
+  if (defaultIdx === -1) {
+    throw new Error(
+      "Could not locate the dispatch switch's `default:` case — " +
+        "update this guard's parsing.",
+    );
+  }
+  const switchBody = source.slice(switchStart, defaultIdx);
+  const caseRe = /case\s+"([^"]+)"\s*:/g;
+  const cases: string[] = [];
+  let m: RegExpExecArray | null;
+  while ((m = caseRe.exec(switchBody)) !== null) {
+    cases.push(m[1]);
+  }
+  return cases;
+}
+
+/**
+ * Extracts the handler function name a given case delegates to, e.g.
+ * `case "deleteApp": return await deleteApp(...)` -> "deleteApp". Handles
+ * both single-line and multi-line call sites.
+ */
+function extractHandlerCallSite(
+  switchBody: string,
+  fieldName: string,
+): string | null {
+  const caseRe = new RegExp(
+    `case\\s+"${fieldName}"\\s*:\\s*\\n?\\s*return\\s+await\\s+([A-Za-z0-9_]+)\\s*\\(`,
+  );
+  const m = caseRe.exec(switchBody);
+  return m ? m[1] : null;
+}
+
+/**
+ * Extracts a top-level (module-scope) `async function <name>(...) { ... }`
+ * body by brace-counting from the `function` keyword. Handler functions in
+ * this file are never nested, so top-level brace balance is a safe
+ * boundary — sufficient for a static "does this function call a gate"
+ * check without a full parser.
+ */
+function extractFunctionBody(source: string, fnName: string): string {
+  const declRe = new RegExp(`(?:export\\s+)?async function ${fnName}\\s*\\(`);
+  const declMatch = declRe.exec(source);
+  if (!declMatch) {
+    throw new Error(
+      `Could not locate function declaration for '${fnName}' in registry-agent-record-resolver.ts`,
+    );
+  }
+  // Find the END of the parameter list first (matching parens, since
+  // parameter type annotations can themselves contain object-literal-shaped
+  // braces, e.g. `component: { type: string; data: string }`), THEN look
+  // for the function body's opening brace after that — otherwise the first
+  // `{` found could belong to a parameter type annotation rather than the
+  // function body, desyncing the brace counter from the very start.
+  const paramsOpenIdx = source.indexOf("(", declMatch.index);
+  let parenDepth = 0;
+  let j = paramsOpenIdx;
+  for (; j < source.length; j++) {
+    if (source[j] === "(") parenDepth++;
+    else if (source[j] === ")") {
+      parenDepth--;
+      if (parenDepth === 0) break;
+    }
+  }
+  const bodyStart = source.indexOf("{", j);
+  let depth = 0;
+  let i = bodyStart;
+  for (; i < source.length; i++) {
+    if (source[i] === "{") depth++;
+    else if (source[i] === "}") {
+      depth--;
+      if (depth === 0) break;
+    }
+  }
+  return source.slice(bodyStart, i + 1);
+}
+
+const GATE_CALL_RE = /assertManifest(Owner)?Access\s*\(/;
+
+/**
+ * Ops verified to call an assertManifestAccess/assertManifestOwnerAccess
+ * gate inside their handler function body before any mutating side effect.
+ * `requiredRole` documents which role the call site pins (for humans
+ * reading this list); the actual enforcement is verified structurally by
+ * extractFunctionBody + GATE_CALL_RE against the real source, not merely
+ * asserted here.
+ */
+const GATED_OPS: Record<string, { requiredRole: "owner" | "editor" }> = {
+  updateApp: { requiredRole: "editor" },
+  deleteApp: { requiredRole: "owner" },
+  addAppComponent: { requiredRole: "editor" },
+  removeAppComponent: { requiredRole: "editor" },
+  updateAgentBinding: { requiredRole: "editor" },
+  setAppConfigSchema: { requiredRole: "editor" },
+  setAppConfigValues: { requiredRole: "editor" },
+  setAppAuthConfig: { requiredRole: "editor" },
+  grantAppAccess: { requiredRole: "owner" },
+  revokeAppAccess: { requiredRole: "owner" },
+  createAppApiKey: { requiredRole: "editor" },
+  revokeAppApiKey: { requiredRole: "editor" },
+  rotateAppApiKey: { requiredRole: "editor" },
+};
+
+/**
+ * Ops that legitimately have NO assertManifestAccess gate call, each with
+ * an explicit reason. This list must be kept honest — a case landing here
+ * with a hand-wavy reason defeats the point of the guard.
+ */
+const EXEMPT_OPS: Record<string, string> = {
+  getApp: "pure read; enforces its own inline org-equality tenant check",
+  listApps: "pure read, scoped to the caller's own orgId argument",
+  createApp:
+    "creates a new app; no existing manifest access map to check against " +
+    "— the creator becomes the implicit creator-owner via manifest.createdBy",
+  listAppApiKeys:
+    "pure read of API key metadata (no plaintext secret); relies on the " +
+    "AppSync field-level auth already applied ahead of this resolver",
+  listAppAccessEntries: "pure read of the access-control listing",
+  getAppMetrics: "pure read of aggregated metrics",
+  publishAppStatusEvent:
+    "internal EventBridge publish helper invoked by other already-gated " +
+    "handlers, not a caller-facing app mutation in its own right",
+  // KNOWN PRE-EXISTING GAP — flagged, NOT silently excused. Both mutate the
+  // manifest's workflowIds (writeManifestMutation + updateResource) with NO
+  // assertManifestAccess call, matching the exact shape of finding 6400b440
+  // (deleteApp). Left out of this fix's scope because gating them at
+  // 'editor' would require updating existing passing tests in
+  // registry-agent-record-resolver-workflows.test.ts and
+  // registry-agent-record-resolver-identity.test.ts that currently seed
+  // `access: {}` with no createdBy and assert success with no identity
+  // gate at all — that is a second, separate fix that needs its own
+  // red/green cycle and reviewer sign-off, not something to fold silently
+  // into the deleteApp fix. Tracked for a dedicated follow-up; DO NOT
+  // remove this entry without actually adding the gate.
+  bindWorkflowToApp:
+    "PRE-EXISTING GAP, not yet gated — mutates manifest.workflowIds with " +
+    "no assertManifestAccess call; tracked for follow-up, see comment above",
+  unbindWorkflowFromApp:
+    "PRE-EXISTING GAP, not yet gated — mutates manifest.workflowIds with " +
+    "no assertManifestAccess call; tracked for follow-up, see comment above",
+};
+
+describe("registry-agent-record-resolver — dispatch enumeration completeness", () => {
+  const source = fs.readFileSync(RESOLVER_PATH, "utf-8");
+  const cases = extractDispatchCases(source);
+
+  test("the dispatch switch actually has cases to check (sanity check on the parser itself)", () => {
+    expect(cases.length).toBeGreaterThan(15);
+    expect(cases).toContain("deleteApp");
+    expect(cases).toContain("grantAppAccess");
+  });
+
+  test("every dispatch case is accounted for in GATED_OPS or EXEMPT_OPS", () => {
+    const unaccounted = cases.filter(
+      (c) => !(c in GATED_OPS) && !(c in EXEMPT_OPS),
+    );
+    expect(unaccounted).toEqual([]);
+  });
+
+  test("GATED_OPS and EXEMPT_OPS do not both claim the same op", () => {
+    const overlap = Object.keys(GATED_OPS).filter((k) => k in EXEMPT_OPS);
+    expect(overlap).toEqual([]);
+  });
+
+  test("no GATED_OPS/EXEMPT_OPS entry references a case that no longer exists in the switch", () => {
+    const known = new Set(cases);
+    const staleGated = Object.keys(GATED_OPS).filter((k) => !known.has(k));
+    const staleExempt = Object.keys(EXEMPT_OPS).filter((k) => !known.has(k));
+    expect(staleGated).toEqual([]);
+    expect(staleExempt).toEqual([]);
+  });
+
+  describe.each(Object.entries(GATED_OPS))(
+    "GATED_OPS['%s'] handler actually calls a manifest-access gate",
+    (fieldName, meta) => {
+      test(`${fieldName} (requiredRole=${meta.requiredRole}) contains an assertManifestAccess/assertManifestOwnerAccess call`, () => {
+        const switchStart = source.indexOf("switch (fieldName)");
+        const defaultIdx = source.indexOf("default:", switchStart);
+        const switchBody = source.slice(switchStart, defaultIdx);
+        const handlerName = extractHandlerCallSite(switchBody, fieldName);
+        expect(handlerName).not.toBeNull();
+        const body = extractFunctionBody(source, handlerName as string);
+        expect(GATE_CALL_RE.test(body)).toBe(true);
+      });
+    },
+  );
+});

--- a/backend/src/lambda/__tests__/registry-agent-record-resolver-lifecycle-editor-gate.test.ts
+++ b/backend/src/lambda/__tests__/registry-agent-record-resolver-lifecycle-editor-gate.test.ts
@@ -1,0 +1,609 @@
+/**
+ * RED-first tests for finding 8f8fd119: the editor-reserved lifecycle
+ * mutations on registry-agent-record-resolver.ts had NO role check and NO
+ * org check at all — any authenticated caller could mint a plaintext API
+ * key for any app in any org, reassign an app's orgId (tenant takeover),
+ * inject IAM permissions into an app's provisioned role (addAppComponent),
+ * or tamper config/auth/bindings for a victim's app.
+ *
+ * This suite gates every op in scope via the SAME manifest-access store
+ * grantAppAccess/revokeAppAccess already use (finding 8b0e32a7's
+ * assertManifestOwnerAccess, generalized here to assertManifestAccess with
+ * requiredRole='editor') — never assertRowOrg, which is an org-equality
+ * check on a plain DynamoDB row with no role hierarchy and does not fit
+ * Registry manifest apps.
+ *
+ * Threat model asserted per gated op:
+ *   - cross-org caller (different org entirely) → refused, ZERO side effects
+ *   - same-org NON-EDITOR (no access entry, no createdBy match) → refused,
+ *     ZERO side effects
+ *   - legitimate same-org EDITOR → succeeds
+ *   - legitimate OWNER (implicit creator-owner fallback) → succeeds
+ *   - grantAppAccess/revokeAppAccess still require OWNER — an EDITOR must be
+ *     refused (regression proving the generalization did not weaken
+ *     grant/revoke)
+ *   - updateApp cannot change orgId, even for a legitimate editor
+ *
+ * "Zero side effects" is asserted via the mock registry's updateResource
+ * call counter (getUpdateResourceCallCount) plus the EventBridge mock's
+ * PutEventsCommand call count — covers "zero manifest writes" and "zero
+ * EventBridge publishes" from the acceptance criteria. createAppApiKey/
+ * rotateAppApiKey additionally assert the app-api-key-management module
+ * mocks were never invoked ("zero key generation"). None of the gated ops
+ * touch IAM directly in this resolver (addAppComponent stages permission
+ * entries into the manifest; the actual IAM role bake-in happens later at
+ * publish time in app-publish-handler.ts) — "zero IAM changes" is therefore
+ * equivalent to "zero manifest writes" for addAppComponent here.
+ */
+
+process.env.REGISTRY_ID = "test-registry-id";
+process.env.APPS_TABLE = "citadel-apps-test";
+process.env.WORKFLOWS_TABLE = "citadel-workflows-test";
+process.env.AGENT_CONFIG_TABLE = "citadel-agents-test";
+process.env.EVENT_BUS_NAME = "citadel-agents-test";
+process.env.USER_POOL_ID = "us-east-1_test";
+process.env.AUTHORITY_UNITS_TABLE = "test-authority-units";
+process.env.AWS_REGION = "us-east-1";
+delete process.env.MODEL_CATALOG_TABLE;
+
+import {
+  EventBridgeClient,
+  PutEventsCommand,
+} from "@aws-sdk/client-eventbridge";
+import { mockClient } from "aws-sdk-client-mock";
+
+const ebMock = mockClient(EventBridgeClient);
+
+import {
+  seedMockRegistry,
+  resetMockRegistry,
+  getUpdateResourceCallCount,
+} from "./fixtures/registry-service-mock";
+
+jest.mock("../../services/registry-service", () => {
+  const { getMockRegistryService } = jest.requireActual(
+    "./fixtures/registry-service-mock",
+  );
+  const actual = jest.requireActual("../../services/registry-service");
+  return {
+    RegistryService: jest
+      .fn()
+      .mockImplementation(() => getMockRegistryService()),
+    getRegistryService: jest.fn(() => getMockRegistryService()),
+    _resetRegistryService: jest.fn(),
+    isRegistryEnabled: jest.fn(() => true),
+    TypeMismatchError: actual.TypeMismatchError,
+    RegistryLifecycleError: actual.RegistryLifecycleError,
+  };
+});
+
+// Cognito lookups are used by extractOrgFromEvent's fallback path; every
+// test here supplies custom:organization directly on the event so no
+// network call is made, but mock defensively as the owner-gate suite does.
+jest.mock("@aws-sdk/client-cognito-identity-provider", () => ({
+  CognitoIdentityProviderClient: jest.fn().mockImplementation(() => ({
+    send: jest
+      .fn()
+      .mockRejectedValue(new Error("Cognito not reachable in test")),
+  })),
+  AdminGetUserCommand: jest.fn(),
+}));
+
+const mockCreateKey = jest.fn();
+const mockRevokeKey = jest.fn();
+const mockRotateKey = jest.fn();
+jest.mock("../app-api-key-management", () => ({
+  createAppApiKey: (...args: unknown[]) => mockCreateKey(...args),
+  revokeAppApiKey: (...args: unknown[]) => mockRevokeKey(...args),
+  rotateAppApiKey: (...args: unknown[]) => mockRotateKey(...args),
+  listAppApiKeys: jest.fn(),
+}));
+
+import { handler } from "../registry-agent-record-resolver";
+
+type HandlerEvent = Parameters<typeof handler>[0];
+const invokeHandler = handler as (event: HandlerEvent) => Promise<unknown>;
+
+function makeEvent(
+  fieldName: string,
+  args: Record<string, unknown>,
+  opts: { userId: string; orgId?: string; groups?: string[] },
+) {
+  const claims: Record<string, unknown> = { sub: opts.userId };
+  if (opts.orgId !== undefined) claims["custom:organization"] = opts.orgId;
+  if (opts.groups !== undefined) claims["cognito:groups"] = opts.groups;
+  return {
+    info: { fieldName },
+    arguments: args,
+    identity: { sub: opts.userId, claims },
+  } as unknown as HandlerEvent;
+}
+
+const APP_ID = "app-1";
+const OWNER_ID = "owner-user";
+const EDITOR_ID = "editor-user";
+const APP_ORG = "org-1";
+
+function seedApp(
+  opts: {
+    access?: Record<
+      string,
+      { role: string; grantedAt: string; grantedBy: string }
+    >;
+    createdBy?: string | null;
+    agentBindings?: unknown[];
+    configSchema?: unknown;
+    configValues?: unknown;
+    version?: number;
+  } = {},
+) {
+  seedMockRegistry("agent", APP_ID, {
+    name: "Test App",
+    description: "Test",
+    status: "DRAFT",
+    customDescriptorContent: JSON.stringify({
+      appId: APP_ID,
+      manifest: {
+        orgId: APP_ORG,
+        version: opts.version ?? 1,
+        status: "DRAFT",
+        workflowIds: [],
+        agentBindings: opts.agentBindings ?? [],
+        permissions: [],
+        configSchema: opts.configSchema ?? null,
+        configValues: opts.configValues ?? null,
+        authConfig: null,
+        ...(opts.createdBy !== null && {
+          createdBy: opts.createdBy ?? OWNER_ID,
+        }),
+        access:
+          opts.access !== undefined
+            ? opts.access
+            : {
+                [OWNER_ID]: {
+                  role: "owner",
+                  grantedAt: "2024-01-01T00:00:00Z",
+                  grantedBy: "system",
+                },
+                [EDITOR_ID]: {
+                  role: "editor",
+                  grantedAt: "2024-01-01T00:00:00Z",
+                  grantedBy: OWNER_ID,
+                },
+              },
+        routingConfig: null,
+      },
+    }),
+  });
+}
+
+function expectZeroSideEffects() {
+  expect(getUpdateResourceCallCount()).toBe(0);
+  expect(ebMock.commandCalls(PutEventsCommand)).toHaveLength(0);
+  expect(mockCreateKey).not.toHaveBeenCalled();
+  expect(mockRevokeKey).not.toHaveBeenCalled();
+  expect(mockRotateKey).not.toHaveBeenCalled();
+}
+
+beforeEach(() => {
+  resetMockRegistry();
+  ebMock.reset();
+  ebMock.on(PutEventsCommand).resolves({});
+  mockCreateKey.mockReset();
+  mockRevokeKey.mockReset();
+  mockRotateKey.mockReset();
+});
+
+// ---------------------------------------------------------------------------
+// Table-driven cross-org / same-org-non-editor refusal for every gated op.
+// ---------------------------------------------------------------------------
+type OpCase = {
+  name: string;
+  fieldName: string;
+  args: Record<string, unknown>;
+};
+
+const GATED_OPS: OpCase[] = [
+  {
+    name: "updateApp",
+    fieldName: "updateApp",
+    args: { input: { appId: APP_ID, version: 1, name: "Attacker Renamed" } },
+  },
+  {
+    name: "addAppComponent",
+    fieldName: "addAppComponent",
+    args: {
+      appId: APP_ID,
+      component: {
+        type: "permission",
+        data: JSON.stringify({
+          permissionId: "perm-evil",
+          actions: ["iam:*"],
+          resources: ["*"],
+        }),
+      },
+    },
+  },
+  {
+    name: "removeAppComponent",
+    fieldName: "removeAppComponent",
+    args: { appId: APP_ID, componentType: "agent", componentId: "agent-1" },
+  },
+  {
+    name: "updateAgentBinding",
+    fieldName: "updateAgentBinding",
+    args: {
+      input: { appId: APP_ID, agentId: "agent-1", systemPromptAddition: "x" },
+    },
+  },
+  {
+    name: "setAppConfigSchema",
+    fieldName: "setAppConfigSchema",
+    args: {
+      appId: APP_ID,
+      schema: JSON.stringify({ type: "object" }),
+      version: 1,
+    },
+  },
+  {
+    name: "setAppConfigValues",
+    fieldName: "setAppConfigValues",
+    args: { appId: APP_ID, values: JSON.stringify({}), version: 1 },
+  },
+  {
+    name: "setAppAuthConfig",
+    fieldName: "setAppAuthConfig",
+    args: { appId: APP_ID, authConfig: JSON.stringify({ type: "none" }) },
+  },
+  {
+    name: "createAppApiKey",
+    fieldName: "createAppApiKey",
+    args: { appId: APP_ID, name: "attacker-key" },
+  },
+  {
+    name: "revokeAppApiKey",
+    fieldName: "revokeAppApiKey",
+    args: { appId: APP_ID, keyId: "victim-key" },
+  },
+  {
+    name: "rotateAppApiKey",
+    fieldName: "rotateAppApiKey",
+    args: { appId: APP_ID, keyId: "victim-key" },
+  },
+];
+
+describe("registry-agent-record-resolver — lifecycle editor gate (finding 8f8fd119)", () => {
+  for (const op of GATED_OPS) {
+    describe(op.name, () => {
+      test("refuses a cross-org caller with zero side effects", async () => {
+        seedApp({ agentBindings: [{ agentId: "agent-1", status: "DESIGN" }] });
+
+        await expect(
+          invokeHandler(
+            makeEvent(op.fieldName, op.args, {
+              userId: "attacker",
+              orgId: "org-evil",
+            }),
+          ),
+        ).rejects.toThrow(/Access denied/i);
+
+        expectZeroSideEffects();
+      });
+
+      test("refuses a same-org NON-EDITOR (no access entry, not createdBy) with zero side effects", async () => {
+        seedApp({
+          agentBindings: [{ agentId: "agent-1", status: "DESIGN" }],
+          access: {
+            "viewer-user": {
+              role: "viewer",
+              grantedAt: "2024-01-01T00:00:00Z",
+              grantedBy: OWNER_ID,
+            },
+          },
+        });
+
+        await expect(
+          invokeHandler(
+            makeEvent(op.fieldName, op.args, {
+              userId: "viewer-user",
+              orgId: APP_ORG,
+            }),
+          ),
+        ).rejects.toThrow(/Access denied/i);
+
+        expectZeroSideEffects();
+      });
+
+      test("refuses when identity cannot be resolved (fail closed)", async () => {
+        seedApp({ agentBindings: [{ agentId: "agent-1", status: "DESIGN" }] });
+
+        await expect(
+          invokeHandler(
+            makeEvent(op.fieldName, op.args, { userId: "no-org-user" }),
+          ),
+        ).rejects.toThrow(/Access denied/i);
+
+        expectZeroSideEffects();
+      });
+    });
+  }
+});
+
+// ---------------------------------------------------------------------------
+// Legitimate-caller paths: editor and owner both succeed.
+// ---------------------------------------------------------------------------
+describe("registry-agent-record-resolver — lifecycle editor gate: legitimate paths succeed", () => {
+  test("updateApp succeeds for a same-org editor", async () => {
+    seedApp();
+
+    await expect(
+      invokeHandler(
+        makeEvent(
+          "updateApp",
+          { input: { appId: APP_ID, version: 1, name: "Editor Renamed" } },
+          { userId: EDITOR_ID, orgId: APP_ORG },
+        ),
+      ),
+    ).resolves.toBeDefined();
+    expect(getUpdateResourceCallCount()).toBe(1);
+  });
+
+  test("updateApp succeeds for the owner", async () => {
+    seedApp();
+
+    await expect(
+      invokeHandler(
+        makeEvent(
+          "updateApp",
+          { input: { appId: APP_ID, version: 1, name: "Owner Renamed" } },
+          { userId: OWNER_ID, orgId: APP_ORG },
+        ),
+      ),
+    ).resolves.toBeDefined();
+    expect(getUpdateResourceCallCount()).toBe(1);
+  });
+
+  test("updateApp succeeds for the implicit creator-owner on a legacy app with no access entries", async () => {
+    seedApp({ access: {}, createdBy: "legacy-creator" });
+
+    await expect(
+      invokeHandler(
+        makeEvent(
+          "updateApp",
+          { input: { appId: APP_ID, version: 1, name: "Legacy Renamed" } },
+          { userId: "legacy-creator", orgId: APP_ORG },
+        ),
+      ),
+    ).resolves.toBeDefined();
+    expect(getUpdateResourceCallCount()).toBe(1);
+  });
+
+  test("createAppApiKey succeeds for a same-org editor", async () => {
+    seedApp();
+    mockCreateKey.mockResolvedValueOnce({
+      keyId: "k1",
+      name: "Editor Key",
+      prefix: "aaaa1111",
+      status: "ACTIVE",
+      createdAt: "2025-01-01T00:00:00Z",
+      plaintext: "plaintext-secret",
+    });
+
+    const result = await invokeHandler(
+      makeEvent(
+        "createAppApiKey",
+        { appId: APP_ID, name: "Editor Key" },
+        { userId: EDITOR_ID, orgId: APP_ORG },
+      ),
+    );
+
+    expect(result).toMatchObject({ apiKey: "plaintext-secret" });
+    expect(mockCreateKey).toHaveBeenCalledTimes(1);
+  });
+
+  test("rotateAppApiKey succeeds for the owner", async () => {
+    seedApp();
+    mockRotateKey.mockResolvedValueOnce({
+      newKey: {
+        keyId: "k2",
+        name: "Rotated",
+        prefix: "bbbb2222",
+        status: "ACTIVE",
+        createdAt: "2025-01-01T00:00:00Z",
+        plaintext: "new-plaintext",
+      },
+      revokedKeyId: "k1",
+    });
+
+    const result = await invokeHandler(
+      makeEvent(
+        "rotateAppApiKey",
+        { appId: APP_ID, keyId: "k1" },
+        { userId: OWNER_ID, orgId: APP_ORG },
+      ),
+    );
+
+    expect(result).toMatchObject({ apiKey: "new-plaintext" });
+    expect(mockRotateKey).toHaveBeenCalledTimes(1);
+  });
+
+  test("addAppComponent succeeds for a same-org editor and stages the permission into the manifest", async () => {
+    seedApp();
+
+    const result = await invokeHandler(
+      makeEvent(
+        "addAppComponent",
+        {
+          appId: APP_ID,
+          component: {
+            type: "permission",
+            data: JSON.stringify({
+              permissionId: "perm-1",
+              actions: ["s3:GetObject"],
+              resources: ["arn:aws:s3:::bucket/*"],
+            }),
+          },
+        },
+        { userId: EDITOR_ID, orgId: APP_ORG },
+      ),
+    );
+
+    expect(result).toBeDefined();
+    expect(getUpdateResourceCallCount()).toBe(1);
+  });
+
+  test("admin group bypasses the editor gate for updateApp", async () => {
+    seedApp();
+
+    await expect(
+      invokeHandler(
+        makeEvent(
+          "updateApp",
+          { input: { appId: APP_ID, version: 1, name: "Admin Renamed" } },
+          { userId: "admin-1", orgId: "unrelated-org", groups: ["admin"] },
+        ),
+      ),
+    ).resolves.toBeDefined();
+    expect(getUpdateResourceCallCount()).toBe(1);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Regression: grantAppAccess/revokeAppAccess must still require OWNER —
+// the generalization to assertManifestAccess(requiredRole) must not have
+// weakened these two call sites, which pin requiredRole='owner'.
+// ---------------------------------------------------------------------------
+describe("registry-agent-record-resolver — grantAppAccess/revokeAppAccess still require OWNER", () => {
+  test("an EDITOR cannot grant access (regression proving generalization did not downgrade grant to editor-level)", async () => {
+    seedApp();
+
+    await expect(
+      invokeHandler(
+        makeEvent(
+          "grantAppAccess",
+          { appId: APP_ID, userId: "new-target", role: "viewer" },
+          { userId: EDITOR_ID, orgId: APP_ORG },
+        ),
+      ),
+    ).rejects.toThrow(/Access denied.*owner/i);
+
+    expect(getUpdateResourceCallCount()).toBe(0);
+  });
+
+  test("an EDITOR cannot revoke access", async () => {
+    seedApp({
+      access: {
+        "target-user": {
+          role: "viewer",
+          grantedAt: "2024-01-01T00:00:00Z",
+          grantedBy: OWNER_ID,
+        },
+      },
+    });
+
+    await expect(
+      invokeHandler(
+        makeEvent(
+          "revokeAppAccess",
+          { appId: APP_ID, userId: "target-user" },
+          { userId: EDITOR_ID, orgId: APP_ORG },
+        ),
+      ),
+    ).rejects.toThrow(/Access denied.*owner/i);
+
+    expect(getUpdateResourceCallCount()).toBe(0);
+  });
+
+  test("the OWNER can still grant access (unchanged behaviour)", async () => {
+    seedApp();
+
+    await expect(
+      invokeHandler(
+        makeEvent(
+          "grantAppAccess",
+          { appId: APP_ID, userId: "new-target", role: "editor" },
+          { userId: OWNER_ID, orgId: APP_ORG },
+        ),
+      ),
+    ).resolves.toBeDefined();
+
+    expect(getUpdateResourceCallCount()).toBe(1);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// updateApp: orgId is immutable, even for a legitimate editor/owner.
+// ---------------------------------------------------------------------------
+describe("registry-agent-record-resolver — updateApp orgId immutability", () => {
+  test("rejects an orgId change from a legitimate same-org editor, with zero writes", async () => {
+    seedApp();
+
+    await expect(
+      invokeHandler(
+        makeEvent(
+          "updateApp",
+          { input: { appId: APP_ID, version: 1, orgId: "org-evil" } },
+          { userId: EDITOR_ID, orgId: APP_ORG },
+        ),
+      ),
+    ).rejects.toThrow(/orgId cannot be changed/i);
+
+    expect(getUpdateResourceCallCount()).toBe(0);
+    expect(ebMock.commandCalls(PutEventsCommand)).toHaveLength(0);
+  });
+
+  test("rejects an orgId change from the owner too — no legitimate lifecycle path may reassign orgId", async () => {
+    seedApp();
+
+    await expect(
+      invokeHandler(
+        makeEvent(
+          "updateApp",
+          { input: { appId: APP_ID, version: 1, orgId: "org-evil" } },
+          { userId: OWNER_ID, orgId: APP_ORG },
+        ),
+      ),
+    ).rejects.toThrow(/orgId cannot be changed/i);
+
+    expect(getUpdateResourceCallCount()).toBe(0);
+  });
+
+  test("allows updateApp when orgId is supplied but unchanged (idempotent no-op on that field)", async () => {
+    seedApp();
+
+    await expect(
+      invokeHandler(
+        makeEvent(
+          "updateApp",
+          {
+            input: {
+              appId: APP_ID,
+              version: 1,
+              orgId: APP_ORG,
+              name: "Same Org Rename",
+            },
+          },
+          { userId: EDITOR_ID, orgId: APP_ORG },
+        ),
+      ),
+    ).resolves.toBeDefined();
+
+    expect(getUpdateResourceCallCount()).toBe(1);
+  });
+
+  test("allows updateApp when orgId is omitted entirely", async () => {
+    seedApp();
+
+    await expect(
+      invokeHandler(
+        makeEvent(
+          "updateApp",
+          { input: { appId: APP_ID, version: 1, name: "No OrgId Field" } },
+          { userId: EDITOR_ID, orgId: APP_ORG },
+        ),
+      ),
+    ).resolves.toBeDefined();
+
+    expect(getUpdateResourceCallCount()).toBe(1);
+  });
+});

--- a/backend/src/lambda/__tests__/registry-agent-record-resolver-meta-writes.test.ts
+++ b/backend/src/lambda/__tests__/registry-agent-record-resolver-meta-writes.test.ts
@@ -10,23 +10,26 @@
  * call sites so the OrgIndex projection (Step 3) stays current.
  */
 // Env vars MUST be set BEFORE importing the resolver — see crud.test.ts.
-process.env.REGISTRY_ID = 'test-registry-id';
-process.env.APPS_TABLE = 'citadel-apps-test';
-process.env.WORKFLOWS_TABLE = 'citadel-workflows-test';
-process.env.AGENT_CONFIG_TABLE = 'citadel-agents-test';
-process.env.EVENT_BUS_NAME = 'citadel-agents-test';
-process.env.USER_POOL_ID = 'us-east-1_test';
-process.env.AWS_REGION = 'us-east-1';
+process.env.REGISTRY_ID = "test-registry-id";
+process.env.APPS_TABLE = "citadel-apps-test";
+process.env.WORKFLOWS_TABLE = "citadel-workflows-test";
+process.env.AGENT_CONFIG_TABLE = "citadel-agents-test";
+process.env.EVENT_BUS_NAME = "citadel-agents-test";
+process.env.USER_POOL_ID = "us-east-1_test";
+process.env.AWS_REGION = "us-east-1";
 delete process.env.AUTHORITY_UNITS_TABLE;
 
-import { EventBridgeClient, PutEventsCommand } from '@aws-sdk/client-eventbridge';
+import {
+  EventBridgeClient,
+  PutEventsCommand,
+} from "@aws-sdk/client-eventbridge";
 import {
   DynamoDBDocumentClient,
   PutCommand,
   UpdateCommand,
   DeleteCommand,
-} from '@aws-sdk/lib-dynamodb';
-import { mockClient } from 'aws-sdk-client-mock';
+} from "@aws-sdk/lib-dynamodb";
+import { mockClient } from "aws-sdk-client-mock";
 
 const ebMock = mockClient(EventBridgeClient);
 const ddbMock = mockClient(DynamoDBDocumentClient);
@@ -34,13 +37,17 @@ const ddbMock = mockClient(DynamoDBDocumentClient);
 import {
   seedMockRegistry,
   resetMockRegistry,
-} from './fixtures/registry-service-mock';
+} from "./fixtures/registry-service-mock";
 
-jest.mock('../../services/registry-service', () => {
-  const { getMockRegistryService } = jest.requireActual('./fixtures/registry-service-mock');
-  const actual = jest.requireActual('../../services/registry-service');
+jest.mock("../../services/registry-service", () => {
+  const { getMockRegistryService } = jest.requireActual(
+    "./fixtures/registry-service-mock",
+  );
+  const actual = jest.requireActual("../../services/registry-service");
   return {
-    RegistryService: jest.fn().mockImplementation(() => getMockRegistryService()),
+    RegistryService: jest
+      .fn()
+      .mockImplementation(() => getMockRegistryService()),
     getRegistryService: jest.fn(() => getMockRegistryService()),
     _resetRegistryService: jest.fn(),
     isRegistryEnabled: jest.fn(() => true),
@@ -49,16 +56,16 @@ jest.mock('../../services/registry-service', () => {
   };
 });
 
-jest.mock('../../utils/appsync', () => ({
-  getUserId: jest.fn().mockReturnValue('user-123'),
+jest.mock("../../utils/appsync", () => ({
+  getUserId: jest.fn().mockReturnValue("user-123"),
 }));
 
-jest.mock('../../utils/appsync-publish', () => ({
+jest.mock("../../utils/appsync-publish", () => ({
   publishAppStatusEvent: jest.fn().mockResolvedValue(undefined),
 }));
 
-import { handler } from '../registry-agent-record-resolver';
-import { APP_META_SORT_VALUE } from '../../utils/apps-table-meta';
+import { handler } from "../registry-agent-record-resolver";
+import { APP_META_SORT_VALUE } from "../../utils/apps-table-meta";
 
 type HandlerEvent = Parameters<typeof handler>[0];
 
@@ -68,33 +75,45 @@ type HandlerEvent = Parameters<typeof handler>[0];
 // (single cast here) so calls don't pass superfluous arguments.
 const invokeHandler = handler as (event: HandlerEvent) => Promise<unknown>;
 
-function makeEvent(fieldName: string, args: Record<string, unknown>, sub = 'user-123', admin = false) {
+function makeEvent(
+  fieldName: string,
+  args: Record<string, unknown>,
+  sub = "user-123",
+  admin = false,
+) {
   return {
     info: { fieldName },
     arguments: args,
+    // Non-admin identity carries custom:organization: 'org-1' — matching
+    // seedApp's default manifest.orgId and createdBy — so callers satisfy
+    // the finding-8f8fd119 editor gate (assertManifestAccess) on updateApp
+    // via the same-org + implicit-creator-owner fallback path.
     identity: admin
-      ? { sub, claims: { sub, 'custom:role': 'admin' }, 'custom:role': 'admin' }
-      : { sub, claims: { sub } },
+      ? { sub, claims: { sub, "custom:role": "admin" }, "custom:role": "admin" }
+      : { sub, claims: { sub, "custom:organization": "org-1" } },
   } as unknown as HandlerEvent;
 }
 
-function seedApp(opts: { version?: number; orgId?: string; status?: string } = {}): void {
-  seedMockRegistry('agent', 'app-1', {
-    name: 'Test App',
-    description: 'Test',
-    status: opts.status ?? 'DRAFT',
+function seedApp(
+  opts: { version?: number; orgId?: string; status?: string } = {},
+): void {
+  seedMockRegistry("agent", "app-1", {
+    name: "Test App",
+    description: "Test",
+    status: opts.status ?? "DRAFT",
     customDescriptorContent: JSON.stringify({
-      appId: 'app-1',
+      appId: "app-1",
       manifest: {
-        orgId: opts.orgId ?? 'org-1',
+        orgId: opts.orgId ?? "org-1",
         version: opts.version ?? 1,
-        status: opts.status ?? 'DRAFT',
+        status: opts.status ?? "DRAFT",
         workflowIds: [],
         agentBindings: [],
         permissions: [],
         configSchema: null,
         configValues: null,
         authConfig: null,
+        createdBy: "user-123",
         access: {},
         routingConfig: null,
       },
@@ -102,7 +121,7 @@ function seedApp(opts: { version?: number; orgId?: string; status?: string } = {
   });
 }
 
-describe('registry-agent-record-resolver — AppsTable #META mirror writes', () => {
+describe("registry-agent-record-resolver — AppsTable #META mirror writes", () => {
   beforeEach(() => {
     resetMockRegistry();
     ebMock.reset();
@@ -123,14 +142,14 @@ describe('registry-agent-record-resolver — AppsTable #META mirror writes', () 
     delete process.env.REGISTRY_ID;
   });
 
-  describe('createApp', () => {
-    test('writes an UpdateCommand for the metadata row with full projection', async () => {
+  describe("createApp", () => {
+    test("writes an UpdateCommand for the metadata row with full projection", async () => {
       const result = await invokeHandler(
-        makeEvent('createApp', {
+        makeEvent("createApp", {
           input: {
-            name: 'New App',
-            description: 'A test app',
-            orgId: 'org-1',
+            name: "New App",
+            description: "A test app",
+            orgId: "org-1",
           },
         }),
       );
@@ -140,73 +159,86 @@ describe('registry-agent-record-resolver — AppsTable #META mirror writes', () 
       const updateCalls = ddbMock.commandCalls(UpdateCommand);
       const metaUpdate = updateCalls.find(
         (c) =>
-          c.args[0].input.TableName === 'citadel-apps-test' &&
-          (c.args[0].input.Key as Record<string, unknown> | undefined)?.appId === result.appId &&
+          c.args[0].input.TableName === "citadel-apps-test" &&
+          (c.args[0].input.Key as Record<string, unknown> | undefined)
+            ?.appId === result.appId &&
           // Key must be appId only — no sortId in the key.
-          (c.args[0].input.Key as Record<string, unknown> | undefined)?.sortId === undefined,
+          (c.args[0].input.Key as Record<string, unknown> | undefined)
+            ?.sortId === undefined,
       );
       expect(metaUpdate).toBeDefined();
-      const values = metaUpdate!.args[0].input.ExpressionAttributeValues as Record<string, unknown>;
-      expect(values[':v_orgId']).toBe('org-1');
-      expect(values[':v_name']).toBe('New App');
-      expect(values[':v_status']).toBe('DRAFT');
-      expect(values[':v_version']).toBe(1);
-      expect(values[':v_createdBy']).toBe('user-123');
-      expect(values[':v_workflowIds']).toEqual([]);
-      expect(typeof values[':v_createdAt']).toBe('string');
-      expect(typeof values[':v_updatedAt']).toBe('string');
+      const values = metaUpdate!.args[0].input
+        .ExpressionAttributeValues as Record<string, unknown>;
+      expect(values[":v_orgId"]).toBe("org-1");
+      expect(values[":v_name"]).toBe("New App");
+      expect(values[":v_status"]).toBe("DRAFT");
+      expect(values[":v_version"]).toBe(1);
+      expect(values[":v_createdBy"]).toBe("user-123");
+      expect(values[":v_workflowIds"]).toEqual([]);
+      expect(typeof values[":v_createdAt"]).toBe("string");
+      expect(typeof values[":v_updatedAt"]).toBe("string");
       // sortId is set as a data attribute (carried by the upsert), not as
       // part of the key.
-      expect(values[':v_sortId']).toBe(APP_META_SORT_VALUE);
+      expect(values[":v_sortId"]).toBe(APP_META_SORT_VALUE);
     });
 
-    test('mirrors sourceProjectId onto the metadata row when the input carries it (intake linkage)', async () => {
+    test("mirrors sourceProjectId onto the metadata row when the input carries it (intake linkage)", async () => {
       const result = await invokeHandler(
-        makeEvent('createApp', {
+        makeEvent("createApp", {
           input: {
-            name: 'Intake App',
-            orgId: 'org-1',
-            sourceProjectId: 'sess-42',
+            name: "Intake App",
+            orgId: "org-1",
+            sourceProjectId: "sess-42",
           },
         }),
       );
 
-      const metaUpdate = ddbMock.commandCalls(UpdateCommand).find(
-        (c) =>
-          c.args[0].input.TableName === 'citadel-apps-test' &&
-          (c.args[0].input.Key as Record<string, unknown> | undefined)?.appId === result.appId,
-      );
+      const metaUpdate = ddbMock
+        .commandCalls(UpdateCommand)
+        .find(
+          (c) =>
+            c.args[0].input.TableName === "citadel-apps-test" &&
+            (c.args[0].input.Key as Record<string, unknown> | undefined)
+              ?.appId === result.appId,
+        );
       expect(metaUpdate).toBeDefined();
-      const values = metaUpdate!.args[0].input.ExpressionAttributeValues as Record<string, unknown>;
-      expect(values[':v_sourceProjectId']).toBe('sess-42');
+      const values = metaUpdate!.args[0].input
+        .ExpressionAttributeValues as Record<string, unknown>;
+      expect(values[":v_sourceProjectId"]).toBe("sess-42");
     });
 
-    test('omits sourceProjectId from the metadata row when the input has none (backward compatible)', async () => {
+    test("omits sourceProjectId from the metadata row when the input has none (backward compatible)", async () => {
       const result = await invokeHandler(
-        makeEvent('createApp', {
-          input: { name: 'Plain App', orgId: 'org-1' },
+        makeEvent("createApp", {
+          input: { name: "Plain App", orgId: "org-1" },
         }),
       );
 
-      const metaUpdate = ddbMock.commandCalls(UpdateCommand).find(
-        (c) =>
-          c.args[0].input.TableName === 'citadel-apps-test' &&
-          (c.args[0].input.Key as Record<string, unknown> | undefined)?.appId === result.appId,
-      );
+      const metaUpdate = ddbMock
+        .commandCalls(UpdateCommand)
+        .find(
+          (c) =>
+            c.args[0].input.TableName === "citadel-apps-test" &&
+            (c.args[0].input.Key as Record<string, unknown> | undefined)
+              ?.appId === result.appId,
+        );
       expect(metaUpdate).toBeDefined();
-      const values = metaUpdate!.args[0].input.ExpressionAttributeValues as Record<string, unknown>;
-      expect(':v_sourceProjectId' in values).toBe(false);
-      expect(metaUpdate!.args[0].input.UpdateExpression).not.toContain('sourceProjectId');
+      const values = metaUpdate!.args[0].input
+        .ExpressionAttributeValues as Record<string, unknown>;
+      expect(":v_sourceProjectId" in values).toBe(false);
+      expect(metaUpdate!.args[0].input.UpdateExpression).not.toContain(
+        "sourceProjectId",
+      );
     });
   });
 
-  describe('updateApp', () => {
-    test('writes an UpdateCommand for the metadata row with only the changed fields', async () => {
+  describe("updateApp", () => {
+    test("writes an UpdateCommand for the metadata row with only the changed fields", async () => {
       seedApp({ version: 1 });
 
       await invokeHandler(
-        makeEvent('updateApp', {
-          input: { appId: 'app-1', version: 1, name: 'Renamed' },
+        makeEvent("updateApp", {
+          input: { appId: "app-1", version: 1, name: "Renamed" },
         }),
       );
 
@@ -216,32 +248,35 @@ describe('registry-agent-record-resolver — AppsTable #META mirror writes', () 
       // resolver may issue.
       const metaUpdate = updateCalls.find(
         (c) =>
-          c.args[0].input.TableName === 'citadel-apps-test' &&
-          (c.args[0].input.Key as Record<string, unknown> | undefined)?.appId === 'app-1' &&
-          (c.args[0].input.Key as Record<string, unknown> | undefined)?.sortId === undefined,
+          c.args[0].input.TableName === "citadel-apps-test" &&
+          (c.args[0].input.Key as Record<string, unknown> | undefined)
+            ?.appId === "app-1" &&
+          (c.args[0].input.Key as Record<string, unknown> | undefined)
+            ?.sortId === undefined,
       );
       expect(metaUpdate).toBeDefined();
 
-      const values = metaUpdate!.args[0].input.ExpressionAttributeValues as Record<string, unknown>;
+      const values = metaUpdate!.args[0].input
+        .ExpressionAttributeValues as Record<string, unknown>;
       // name was provided -> mirrored. status/description/routingConfig were
       // NOT provided -> must NOT be in the update.
-      expect(values[':v_name']).toBe('Renamed');
-      expect(values[':v_status']).toBeUndefined();
-      expect(values[':v_description']).toBeUndefined();
-      expect(values[':v_routingConfig']).toBeUndefined();
+      expect(values[":v_name"]).toBe("Renamed");
+      expect(values[":v_status"]).toBeUndefined();
+      expect(values[":v_description"]).toBeUndefined();
+      expect(values[":v_routingConfig"]).toBeUndefined();
       // updatedAt and version are always written.
-      expect(typeof values[':v_updatedAt']).toBe('string');
-      expect(values[':v_version']).toBe(2);
+      expect(typeof values[":v_updatedAt"]).toBe("string");
+      expect(values[":v_version"]).toBe(2);
     });
 
-    test('mirrors a status change', async () => {
-      seedApp({ version: 1, status: 'PENDING_APPROVAL' });
+    test("mirrors a status change", async () => {
+      seedApp({ version: 1, status: "PENDING_APPROVAL" });
 
       await invokeHandler(
         makeEvent(
-          'updateApp',
-          { input: { appId: 'app-1', version: 1, status: 'APPROVED' } },
-          'admin-1',
+          "updateApp",
+          { input: { appId: "app-1", version: 1, status: "APPROVED" } },
+          "admin-1",
           true,
         ),
       );
@@ -249,61 +284,64 @@ describe('registry-agent-record-resolver — AppsTable #META mirror writes', () 
       const updateCalls = ddbMock.commandCalls(UpdateCommand);
       const metaUpdate = updateCalls.find(
         (c) =>
-          c.args[0].input.TableName === 'citadel-apps-test' &&
-          (c.args[0].input.Key as Record<string, unknown> | undefined)?.appId === 'app-1' &&
-          (c.args[0].input.Key as Record<string, unknown> | undefined)?.sortId === undefined &&
-          (c.args[0].input.ExpressionAttributeValues as Record<string, unknown> | undefined)?.[':v_status'] !==
-            undefined,
+          c.args[0].input.TableName === "citadel-apps-test" &&
+          (c.args[0].input.Key as Record<string, unknown> | undefined)
+            ?.appId === "app-1" &&
+          (c.args[0].input.Key as Record<string, unknown> | undefined)
+            ?.sortId === undefined &&
+          (
+            c.args[0].input.ExpressionAttributeValues as
+              Record<string, unknown> | undefined
+          )?.[":v_status"] !== undefined,
       );
       expect(metaUpdate).toBeDefined();
-      const values = metaUpdate!.args[0].input.ExpressionAttributeValues as Record<string, unknown>;
-      expect(values[':v_status']).toBe('APPROVED');
-      expect(values[':v_version']).toBe(2);
+      const values = metaUpdate!.args[0].input
+        .ExpressionAttributeValues as Record<string, unknown>;
+      expect(values[":v_status"]).toBe("APPROVED");
+      expect(values[":v_version"]).toBe(2);
     });
   });
 
-  describe('deleteApp', () => {
-    test('writes a DeleteCommand for the metadata row keyed on appId only', async () => {
+  describe("deleteApp", () => {
+    test("writes a DeleteCommand for the metadata row keyed on appId only", async () => {
       seedApp();
 
-      await invokeHandler(
-        makeEvent('deleteApp', { appId: 'app-1' }),
-      );
+      await invokeHandler(makeEvent("deleteApp", { appId: "app-1" }));
 
       const deleteCalls = ddbMock.commandCalls(DeleteCommand);
       const metaDelete = deleteCalls.find(
         (c) =>
-          c.args[0].input.TableName === 'citadel-apps-test' &&
-          (c.args[0].input.Key as Record<string, unknown> | undefined)?.appId === 'app-1' &&
+          c.args[0].input.TableName === "citadel-apps-test" &&
+          (c.args[0].input.Key as Record<string, unknown> | undefined)
+            ?.appId === "app-1" &&
           // Key must be appId only — AppsTable has no sort key.
-          (c.args[0].input.Key as Record<string, unknown> | undefined)?.sortId === undefined,
+          (c.args[0].input.Key as Record<string, unknown> | undefined)
+            ?.sortId === undefined,
       );
       expect(metaDelete).toBeDefined();
     });
   });
 
-  describe('eventually-consistent failure semantics', () => {
-    test('createApp succeeds even if AppsTable UpdateCommand throws', async () => {
-      ddbMock.on(UpdateCommand).rejects(new Error('AppsTable down'));
+  describe("eventually-consistent failure semantics", () => {
+    test("createApp succeeds even if AppsTable UpdateCommand throws", async () => {
+      ddbMock.on(UpdateCommand).rejects(new Error("AppsTable down"));
 
       // Helper swallows the error → handler must still resolve.
       await expect(
         invokeHandler(
-          makeEvent('createApp', {
-            input: { name: 'New App', orgId: 'org-1' },
+          makeEvent("createApp", {
+            input: { name: "New App", orgId: "org-1" },
           }),
         ),
       ).resolves.toBeDefined();
     });
 
-    test('deleteApp succeeds even if AppsTable DeleteCommand throws', async () => {
+    test("deleteApp succeeds even if AppsTable DeleteCommand throws", async () => {
       seedApp();
-      ddbMock.on(DeleteCommand).rejects(new Error('AppsTable down'));
+      ddbMock.on(DeleteCommand).rejects(new Error("AppsTable down"));
 
       await expect(
-        invokeHandler(
-          makeEvent('deleteApp', { appId: 'app-1' }),
-        ),
+        invokeHandler(makeEvent("deleteApp", { appId: "app-1" })),
       ).resolves.toBeDefined();
     });
   });

--- a/backend/src/lambda/__tests__/registry-agent-record-resolver-status-events.test.ts
+++ b/backend/src/lambda/__tests__/registry-agent-record-resolver-status-events.test.ts
@@ -8,31 +8,39 @@
  * agent-app-shim-resolver.test.ts.
  */
 
-process.env.REGISTRY_ID = 'test-registry-id';
-process.env.APPS_TABLE = 'citadel-apps-test';
-process.env.WORKFLOWS_TABLE = 'citadel-workflows-test';
-process.env.AGENT_CONFIG_TABLE = 'citadel-agents-test';
-process.env.EVENT_BUS_NAME = 'citadel-agents-test';
-process.env.USER_POOL_ID = 'us-east-1_test';
-process.env.AUTHORITY_UNITS_TABLE = 'test-authority-units';
-process.env.APPSYNC_ENDPOINT = 'https://test-api.appsync-api.us-east-1.amazonaws.com/graphql';
-process.env.AWS_REGION = 'us-east-1';
+process.env.REGISTRY_ID = "test-registry-id";
+process.env.APPS_TABLE = "citadel-apps-test";
+process.env.WORKFLOWS_TABLE = "citadel-workflows-test";
+process.env.AGENT_CONFIG_TABLE = "citadel-agents-test";
+process.env.EVENT_BUS_NAME = "citadel-agents-test";
+process.env.USER_POOL_ID = "us-east-1_test";
+process.env.AUTHORITY_UNITS_TABLE = "test-authority-units";
+process.env.APPSYNC_ENDPOINT =
+  "https://test-api.appsync-api.us-east-1.amazonaws.com/graphql";
+process.env.AWS_REGION = "us-east-1";
 
-import { EventBridgeClient, PutEventsCommand } from '@aws-sdk/client-eventbridge';
-import { mockClient } from 'aws-sdk-client-mock';
+import {
+  EventBridgeClient,
+  PutEventsCommand,
+} from "@aws-sdk/client-eventbridge";
+import { mockClient } from "aws-sdk-client-mock";
 
 const ebMock = mockClient(EventBridgeClient);
 
 import {
   seedMockRegistry,
   resetMockRegistry,
-} from './fixtures/registry-service-mock';
+} from "./fixtures/registry-service-mock";
 
-jest.mock('../../services/registry-service', () => {
-  const { getMockRegistryService } = jest.requireActual('./fixtures/registry-service-mock');
-  const actual = jest.requireActual('../../services/registry-service');
+jest.mock("../../services/registry-service", () => {
+  const { getMockRegistryService } = jest.requireActual(
+    "./fixtures/registry-service-mock",
+  );
+  const actual = jest.requireActual("../../services/registry-service");
   return {
-    RegistryService: jest.fn().mockImplementation(() => getMockRegistryService()),
+    RegistryService: jest
+      .fn()
+      .mockImplementation(() => getMockRegistryService()),
     getRegistryService: jest.fn(() => getMockRegistryService()),
     _resetRegistryService: jest.fn(),
     isRegistryEnabled: jest.fn(() => true),
@@ -41,20 +49,20 @@ jest.mock('../../services/registry-service', () => {
   };
 });
 
-jest.mock('../../utils/appsync', () => ({
-  getUserId: jest.fn().mockReturnValue('user-123'),
+jest.mock("../../utils/appsync", () => ({
+  getUserId: jest.fn().mockReturnValue("user-123"),
 }));
 
 const mockPublishAppStatusEvent = jest.fn().mockResolvedValue({});
-jest.mock('../../utils/appsync-publish', () => ({
+jest.mock("../../utils/appsync-publish", () => ({
   publishAppStatusEvent: mockPublishAppStatusEvent,
 }));
 
-jest.mock('uuid', () => ({
-  v4: jest.fn().mockReturnValue('test-correlation-id'),
+jest.mock("uuid", () => ({
+  v4: jest.fn().mockReturnValue("test-correlation-id"),
 }));
 
-import { handler } from '../registry-agent-record-resolver';
+import { handler } from "../registry-agent-record-resolver";
 
 type HandlerEvent = Parameters<typeof handler>[0];
 
@@ -68,7 +76,12 @@ function makeEvent(fieldName: string, args: Record<string, unknown>) {
   return {
     info: { fieldName },
     arguments: args,
-    identity: { sub: 'user-123', claims: { sub: 'user-123' } },
+    // custom:organization: 'org-1' matches seedApp's default orgId and
+    // createdBy — satisfies the finding-8f8fd119 editor gate on updateApp.
+    identity: {
+      sub: "user-123",
+      claims: { sub: "user-123", "custom:organization": "org-1" },
+    },
   } as unknown as HandlerEvent;
 }
 
@@ -78,20 +91,20 @@ function makeAdminEvent(fieldName: string, args: Record<string, unknown>) {
     info: { fieldName },
     arguments: args,
     identity: {
-      sub: 'admin-1',
-      claims: { sub: 'admin-1', 'custom:role': 'admin' },
-      'custom:role': 'admin',
+      sub: "admin-1",
+      claims: { sub: "admin-1", "custom:role": "admin" },
+      "custom:role": "admin",
     },
   } as unknown as HandlerEvent;
 }
 
-function seedApp(status: string, version: number = 1, orgId: string = 'org-1') {
-  seedMockRegistry('agent', 'app-1', {
-    name: 'Test App',
-    description: 'Test',
+function seedApp(status: string, version: number = 1, orgId: string = "org-1") {
+  seedMockRegistry("agent", "app-1", {
+    name: "Test App",
+    description: "Test",
     status,
     customDescriptorContent: JSON.stringify({
-      appId: 'app-1',
+      appId: "app-1",
       manifest: {
         orgId,
         version,
@@ -102,6 +115,11 @@ function seedApp(status: string, version: number = 1, orgId: string = 'org-1') {
         configSchema: null,
         configValues: null,
         authConfig: null,
+        // createdBy stamps 'user-123' (the mocked getUserId return / plain
+        // makeEvent's default sub) as the implicit creator-owner fallback,
+        // so non-admin makeEvent callers satisfy the finding-8f8fd119
+        // editor gate on updateApp regardless of the orgId param used.
+        createdBy: "user-123",
         access: {},
         routingConfig: null,
       },
@@ -109,7 +127,7 @@ function seedApp(status: string, version: number = 1, orgId: string = 'org-1') {
   });
 }
 
-describe('registry-agent-record-resolver — status transition events', () => {
+describe("registry-agent-record-resolver — status transition events", () => {
   beforeEach(() => {
     resetMockRegistry();
     ebMock.reset();
@@ -129,89 +147,89 @@ describe('registry-agent-record-resolver — status transition events', () => {
     delete process.env.AUTHORITY_UNITS_TABLE;
   });
 
-  test('emits app.status.pending_approval_to_approved on PENDING_APPROVAL→APPROVED transition (admin decision)', async () => {
-    seedApp('PENDING_APPROVAL', 1);
+  test("emits app.status.pending_approval_to_approved on PENDING_APPROVAL→APPROVED transition (admin decision)", async () => {
+    seedApp("PENDING_APPROVAL", 1);
 
     await invokeHandler(
-      makeAdminEvent('updateApp', {
-        input: { appId: 'app-1', status: 'APPROVED', version: 1 },
+      makeAdminEvent("updateApp", {
+        input: { appId: "app-1", status: "APPROVED", version: 1 },
       }),
     );
 
     const ebCalls = ebMock.commandCalls(PutEventsCommand);
     const allEntries = ebCalls.flatMap((c) => c.args[0].input.Entries || []);
     const statusEvent = allEntries.find(
-      (e) => e?.DetailType === 'app.status.pending_approval_to_approved',
+      (e) => e?.DetailType === "app.status.pending_approval_to_approved",
     );
 
     expect(statusEvent).toBeDefined();
-    expect(statusEvent!.Source).toBe('citadel.apps');
-    expect(statusEvent!.EventBusName).toBe('citadel-agents-test');
+    expect(statusEvent!.Source).toBe("citadel.apps");
+    expect(statusEvent!.EventBusName).toBe("citadel-agents-test");
 
     const detail = JSON.parse(statusEvent!.Detail!);
-    expect(detail.appId).toBe('app-1');
-    expect(detail.orgId).toBe('org-1');
-    expect(detail.previousStatus).toBe('PENDING_APPROVAL');
-    expect(detail.newStatus).toBe('APPROVED');
+    expect(detail.appId).toBe("app-1");
+    expect(detail.orgId).toBe("org-1");
+    expect(detail.previousStatus).toBe("PENDING_APPROVAL");
+    expect(detail.newStatus).toBe("APPROVED");
     expect(detail.timestamp).toBeDefined();
-    expect(detail.correlationId).toBe('test-correlation-id');
+    expect(detail.correlationId).toBe("test-correlation-id");
   });
 
-  test('emits app.status.approved_to_deprecated on APPROVED→DEPRECATED transition', async () => {
-    seedApp('APPROVED', 1);
+  test("emits app.status.approved_to_deprecated on APPROVED→DEPRECATED transition", async () => {
+    seedApp("APPROVED", 1);
 
     await invokeHandler(
-      makeEvent('updateApp', {
-        input: { appId: 'app-1', status: 'DEPRECATED', version: 1 },
+      makeEvent("updateApp", {
+        input: { appId: "app-1", status: "DEPRECATED", version: 1 },
       }),
     );
 
     const ebCalls = ebMock.commandCalls(PutEventsCommand);
     const allEntries = ebCalls.flatMap((c) => c.args[0].input.Entries || []);
     const statusEvent = allEntries.find(
-      (e) => e?.DetailType === 'app.status.approved_to_deprecated',
+      (e) => e?.DetailType === "app.status.approved_to_deprecated",
     );
 
     expect(statusEvent).toBeDefined();
     const detail = JSON.parse(statusEvent!.Detail!);
-    expect(detail.previousStatus).toBe('APPROVED');
-    expect(detail.newStatus).toBe('DEPRECATED');
+    expect(detail.previousStatus).toBe("APPROVED");
+    expect(detail.newStatus).toBe("DEPRECATED");
   });
 
-  test('emits app.status.rejected_to_draft on REJECTED→DRAFT (resubmit) transition', async () => {
-    seedApp('REJECTED', 3);
+  test("emits app.status.rejected_to_draft on REJECTED→DRAFT (resubmit) transition", async () => {
+    seedApp("REJECTED", 3);
 
     await invokeHandler(
-      makeEvent('updateApp', {
-        input: { appId: 'app-1', status: 'DRAFT', version: 3 },
+      makeEvent("updateApp", {
+        input: { appId: "app-1", status: "DRAFT", version: 3 },
       }),
     );
 
     const ebCalls = ebMock.commandCalls(PutEventsCommand);
     const allEntries = ebCalls.flatMap((c) => c.args[0].input.Entries || []);
     const statusEvent = allEntries.find(
-      (e) => e?.DetailType === 'app.status.rejected_to_draft',
+      (e) => e?.DetailType === "app.status.rejected_to_draft",
     );
 
     expect(statusEvent).toBeDefined();
     const detail = JSON.parse(statusEvent!.Detail!);
-    expect(detail.previousStatus).toBe('REJECTED');
-    expect(detail.newStatus).toBe('DRAFT');
+    expect(detail.previousStatus).toBe("REJECTED");
+    expect(detail.newStatus).toBe("DRAFT");
   });
 
-  test('status event timestamp is valid ISO 8601', async () => {
-    seedApp('REJECTED', 3);
+  test("status event timestamp is valid ISO 8601", async () => {
+    seedApp("REJECTED", 3);
 
     await invokeHandler(
-      makeEvent('updateApp', {
-        input: { appId: 'app-1', status: 'DRAFT', version: 3 },
+      makeEvent("updateApp", {
+        input: { appId: "app-1", status: "DRAFT", version: 3 },
       }),
     );
 
     const ebCalls = ebMock.commandCalls(PutEventsCommand);
     const allEntries = ebCalls.flatMap((c) => c.args[0].input.Entries || []);
     const statusEvent = allEntries.find(
-      (e) => e?.DetailType === 'app.status.rejected_to_draft',
+      (e) => e?.DetailType === "app.status.rejected_to_draft",
     );
     const detail = JSON.parse(statusEvent!.Detail!);
 
@@ -219,97 +237,99 @@ describe('registry-agent-record-resolver — status transition events', () => {
     expect(parsed.toISOString()).toBe(detail.timestamp);
   });
 
-  test('does not emit status transition event for non-status updates', async () => {
-    seedApp('DRAFT', 1);
+  test("does not emit status transition event for non-status updates", async () => {
+    seedApp("DRAFT", 1);
 
     await invokeHandler(
-      makeEvent('updateApp', {
-        input: { appId: 'app-1', name: 'Updated Name', version: 1 },
+      makeEvent("updateApp", {
+        input: { appId: "app-1", name: "Updated Name", version: 1 },
       }),
     );
 
     const ebCalls = ebMock.commandCalls(PutEventsCommand);
     const allEntries = ebCalls.flatMap((c) => c.args[0].input.Entries || []);
     const statusEvents = allEntries.filter((e) =>
-      e?.DetailType?.startsWith('app.status.'),
+      e?.DetailType?.startsWith("app.status."),
     );
     expect(statusEvents.length).toBe(0);
   });
 
-  test('does not emit status transition event when status is unchanged', async () => {
-    seedApp('DRAFT', 1);
+  test("does not emit status transition event when status is unchanged", async () => {
+    seedApp("DRAFT", 1);
 
     await invokeHandler(
-      makeEvent('updateApp', {
-        input: { appId: 'app-1', status: 'DRAFT', name: 'Updated', version: 1 },
+      makeEvent("updateApp", {
+        input: { appId: "app-1", status: "DRAFT", name: "Updated", version: 1 },
       }),
     );
 
     const ebCalls = ebMock.commandCalls(PutEventsCommand);
     const allEntries = ebCalls.flatMap((c) => c.args[0].input.Entries || []);
     const statusEvents = allEntries.filter((e) =>
-      e?.DetailType?.startsWith('app.status.'),
+      e?.DetailType?.startsWith("app.status."),
     );
     expect(statusEvents.length).toBe(0);
   });
 
-  test('calls publishAppStatusEvent for PENDING_APPROVAL→APPROVED transition (admin decision)', async () => {
-    seedApp('PENDING_APPROVAL', 1);
+  test("calls publishAppStatusEvent for PENDING_APPROVAL→APPROVED transition (admin decision)", async () => {
+    seedApp("PENDING_APPROVAL", 1);
 
     await invokeHandler(
-      makeAdminEvent('updateApp', {
-        input: { appId: 'app-1', status: 'APPROVED', version: 1 },
+      makeAdminEvent("updateApp", {
+        input: { appId: "app-1", status: "APPROVED", version: 1 },
       }),
     );
 
     expect(mockPublishAppStatusEvent).toHaveBeenCalledTimes(1);
     expect(mockPublishAppStatusEvent).toHaveBeenCalledWith(
       expect.objectContaining({
-        appId: 'app-1',
-        previousStatus: 'PENDING_APPROVAL',
-        newStatus: 'APPROVED',
+        appId: "app-1",
+        previousStatus: "PENDING_APPROVAL",
+        newStatus: "APPROVED",
         timestamp: expect.any(String),
       }),
     );
   });
 
-  test('does not call publishAppStatusEvent for non-status updates', async () => {
-    seedApp('DRAFT', 1);
+  test("does not call publishAppStatusEvent for non-status updates", async () => {
+    seedApp("DRAFT", 1);
 
     await invokeHandler(
-      makeEvent('updateApp', {
-        input: { appId: 'app-1', name: 'Updated Name', version: 1 },
+      makeEvent("updateApp", {
+        input: { appId: "app-1", name: "Updated Name", version: 1 },
       }),
     );
 
     expect(mockPublishAppStatusEvent).not.toHaveBeenCalled();
   });
 
-  test('does not fail updateApp if publishAppStatusEvent throws', async () => {
-    mockPublishAppStatusEvent.mockRejectedValueOnce(new Error('AppSync unreachable'));
+  test("does not fail updateApp if publishAppStatusEvent throws", async () => {
+    mockPublishAppStatusEvent.mockRejectedValueOnce(
+      new Error("AppSync unreachable"),
+    );
 
-    seedApp('REJECTED', 3);
+    seedApp("REJECTED", 3);
 
     const result = (await invokeHandler(
-      makeEvent('updateApp', {
-        input: { appId: 'app-1', status: 'DRAFT', version: 3 },
+      makeEvent("updateApp", {
+        input: { appId: "app-1", status: "DRAFT", version: 3 },
       }),
     )) as Record<string, unknown>;
 
     expect(result).toBeDefined();
-    expect(result.appId).toBe('app-1');
+    expect(result.appId).toBe("app-1");
   });
 
-  test('publishAppStatusEvent mutation emits app.status.published and echoes payload', async () => {
+  test("publishAppStatusEvent mutation emits app.status.published and echoes payload", async () => {
     const input = {
-      appId: 'app-xyz',
-      previousStatus: 'DRAFT',
-      newStatus: 'APPROVED',
-      timestamp: '2025-05-08T10:00:00.000Z',
+      appId: "app-xyz",
+      previousStatus: "DRAFT",
+      newStatus: "APPROVED",
+      timestamp: "2025-05-08T10:00:00.000Z",
     };
 
     const result = await invokeHandler(
-      makeEvent('publishAppStatusEvent', { input }),
+      makeEvent("publishAppStatusEvent", { input }),
     );
 
     expect(result).toEqual(input);
@@ -317,9 +337,9 @@ describe('registry-agent-record-resolver — status transition events', () => {
       .commandCalls(PutEventsCommand)
       .flatMap((c) => c.args[0].input.Entries || []);
     const published = entries.find(
-      (e) => e?.DetailType === 'app.status.published',
+      (e) => e?.DetailType === "app.status.published",
     );
     expect(published).toBeDefined();
-    expect(published!.Source).toBe('citadel.apps');
+    expect(published!.Source).toBe("citadel.apps");
   });
 });

--- a/backend/src/lambda/registry-agent-record-resolver.ts
+++ b/backend/src/lambda/registry-agent-record-resolver.ts
@@ -1055,7 +1055,7 @@ export const handler: AppSyncResolverHandler<
       case "updateApp":
         return await updateApp(args.input, userId, event);
       case "deleteApp":
-        return await deleteApp(args.appId, userId);
+        return await deleteApp(args.appId, userId, event);
       case "bindWorkflowToApp":
         return await bindWorkflowToApp(args.appId, args.workflowId, userId);
       case "unbindWorkflowFromApp":
@@ -1789,12 +1789,23 @@ async function updateApp(
   return projectAgentAppNormalized(finalRecord);
 }
 
-async function deleteApp(appId: string, userId: string): Promise<unknown> {
+async function deleteApp(
+  appId: string,
+  userId: string,
+  event: unknown,
+): Promise<unknown> {
   const existing = await getRegistryService().getResource("agent", appId);
   if (!existing) {
     throw new Error("App not found");
   }
   const projection = projectAgentApp(existing);
+
+  // Finding 6400b440: deleteApp is destructive and irreversible — gate it
+  // at 'owner' (matching grant/revoke's requirement, NOT the editor-level
+  // lifecycle mutations from 8f8fd119) BEFORE any side effect. Must run
+  // before revokeFabricatorAuthority and before deleteResource so a refused
+  // caller triggers zero calls to either.
+  await assertManifestOwnerAccess(appId, existing, event);
 
   // US-ARB-014: revoke the per-app fabricator authority unit BEFORE the
   // registry delete. If revoke throws an unrecoverable error we do NOT

--- a/backend/src/lambda/registry-agent-record-resolver.ts
+++ b/backend/src/lambda/registry-agent-record-resolver.ts
@@ -1061,15 +1061,16 @@ export const handler: AppSyncResolverHandler<
       case "unbindWorkflowFromApp":
         return await unbindWorkflowFromApp(args.appId, args.workflowId, userId);
       case "updateAgentBinding":
-        return await updateAgentBinding(args.input, userId);
+        return await updateAgentBinding(args.input, userId, event);
       case "addAppComponent":
-        return await addAppComponent(args.appId, args.component, userId);
+        return await addAppComponent(args.appId, args.component, userId, event);
       case "removeAppComponent":
         return await removeAppComponent(
           args.appId,
           args.componentType,
           args.componentId,
           userId,
+          event,
         );
       case "setAppConfigSchema":
         return await setAppConfigSchema(
@@ -1077,6 +1078,7 @@ export const handler: AppSyncResolverHandler<
           args.schema,
           args.version,
           userId,
+          event,
         );
       case "setAppConfigValues":
         return await setAppConfigValues(
@@ -1084,9 +1086,15 @@ export const handler: AppSyncResolverHandler<
           args.values,
           args.version,
           userId,
+          event,
         );
       case "setAppAuthConfig":
-        return await setAppAuthConfig(args.appId, args.authConfig, userId);
+        return await setAppAuthConfig(
+          args.appId,
+          args.authConfig,
+          userId,
+          event,
+        );
       case "grantAppAccess":
         return await grantAppAccess(
           args.appId,
@@ -1115,11 +1123,12 @@ export const handler: AppSyncResolverHandler<
           args.name,
           args.expiresIn,
           userId,
+          event,
         );
       case "revokeAppApiKey":
-        return await revokeAppApiKey(args.appId, args.keyId, userId);
+        return await revokeAppApiKey(args.appId, args.keyId, userId, event);
       case "rotateAppApiKey":
-        return await rotateAppApiKey(args.appId, args.keyId, userId);
+        return await rotateAppApiKey(args.appId, args.keyId, userId, event);
 
       default:
         throw new Error(`Unknown field: ${fieldName}`);
@@ -1543,7 +1552,33 @@ async function updateApp(
     throw new Error("App not found");
   }
 
+  // Editor-gate (finding 8f8fd119) — BEFORE any write. See
+  // assertManifestAccess for the store rationale (Registry manifest `access`
+  // map, not the ACCESS# DDB rows). Content edits, status transitions, and
+  // decisions below all flow through this single write path, so gating here
+  // covers the entire function.
+  await assertManifestAccess(input.appId, existing, event, "editor");
+
   const existingManifest = readManifest(existing);
+
+  // orgId reassignment is rejected outright, never authorized-and-applied.
+  // manifest.orgId is the tenant boundary assertManifestAccess itself reads
+  // (callerOrgId === manifest.orgId) and that getApp/listApps use to scope
+  // visibility — letting ANY caller (including a legitimate same-org
+  // editor) change it would let an app be walked out of its owning org's
+  // listApps and into another org's, i.e. a tenant-takeover primitive with
+  // no legitimate lifecycle use: no other gated mutation here needs to move
+  // an app between orgs, and the intended path for provisioning a NEW app
+  // in a different org is createApp, not an update of an existing one.
+  // Reject unconditionally (not just for non-owners) rather than silently
+  // ignoring the field, so a caller sees an explicit error instead of a
+  // confusing partial-apply.
+  if (input.orgId !== undefined && input.orgId !== existingManifest.orgId) {
+    throw new Error(
+      "ValidationError: orgId cannot be changed on an existing app",
+    );
+  }
+
   const existingVersion = existingManifest.version ?? 1;
   if (input.version !== undefined && input.version !== existingVersion) {
     throw new Error("Conflict: app was modified concurrently. Please retry.");
@@ -1844,6 +1879,19 @@ async function unbindWorkflowFromApp(
 // Exported for reuse by intake-orchestration-resolver (via
 // ensureAppAgentBindings) — the canonical READY-promotion core. Export-only
 // refactor: behaviour is identical for the AppSync mutation path.
+//
+// `event` is OPTIONAL and gates on 'editor' when present (finding 8f8fd119).
+// The AppSync dispatch call site always passes the real event. The ONLY
+// caller that omits it is ensureAppAgentBindings, invoked from
+// intake-orchestration-resolver as a server-internal step of the
+// fabrication/import conversational flow — it runs after the user has
+// already consented in-session to bind agents into an app THEY are actively
+// operating on, driven by userId derived the same way the AppSync path
+// derives it (getUserId from the SAME request's identity), not by an
+// external caller supplying an arbitrary appId. That trust boundary is
+// upstream of this function (the conversational flow itself), not a
+// justification to skip authorization for the AppSync mutation path — hence
+// gating whenever `event` IS supplied, unconditionally.
 export async function updateAgentBinding(
   input: {
     appId: string;
@@ -1854,10 +1902,14 @@ export async function updateAgentBinding(
     status?: string;
   },
   userId: string,
+  event?: unknown,
 ): Promise<unknown> {
   const record = await getRegistryService().getResource("agent", input.appId);
   if (!record) {
     throw new Error("App not found");
+  }
+  if (event !== undefined) {
+    await assertManifestAccess(input.appId, record, event, "editor");
   }
   const manifest = readManifest(record);
   const bindings = manifest.agentBindings || [];
@@ -1967,14 +2019,24 @@ export async function updateAgentBinding(
 // Exported for reuse by intake-orchestration-resolver (via
 // ensureAppAgentBindings) — the canonical agent-binding core. Export-only
 // refactor: behaviour is identical for the AppSync mutation path.
+//
+// `event` is OPTIONAL and gates on 'editor' when present (finding 8f8fd119)
+// — same rationale as updateAgentBinding above: gate unconditionally
+// whenever an event is supplied (the AppSync path always supplies one); the
+// ensureAppAgentBindings internal-reuse call site is the only omitter, and
+// that trust boundary lives upstream in the conversational fabrication flow.
 export async function addAppComponent(
   appId: string,
   component: { type: string; data: string },
   userId: string,
+  event?: unknown,
 ): Promise<unknown> {
   const record = await getRegistryService().getResource("agent", appId);
   if (!record) {
     throw new Error("App not found");
+  }
+  if (event !== undefined) {
+    await assertManifestAccess(appId, record, event, "editor");
   }
 
   const data =
@@ -2200,11 +2262,13 @@ async function removeAppComponent(
   componentType: string,
   componentId: string,
   userId: string,
+  event: unknown,
 ): Promise<unknown> {
   const record = await getRegistryService().getResource("agent", appId);
   if (!record) {
     throw new Error("App not found");
   }
+  await assertManifestAccess(appId, record, event, "editor");
 
   const mutatedContent = writeManifestMutation(record, (m) => {
     switch (componentType) {
@@ -2243,11 +2307,14 @@ async function setAppConfigSchema(
   schemaInput: string | object,
   version: number,
   userId: string,
+  event: unknown,
 ): Promise<unknown> {
   const record = await getRegistryService().getResource("agent", appId);
   if (!record) {
     throw new Error("App not found");
   }
+  await assertManifestAccess(appId, record, event, "editor");
+
   const manifest = readManifest(record);
   if ((manifest.version ?? 1) !== version) {
     throw new Error("Conflict: app was modified concurrently. Please retry.");
@@ -2291,11 +2358,14 @@ async function setAppConfigValues(
   valuesInput: string | object,
   version: number,
   userId: string,
+  event: unknown,
 ): Promise<unknown> {
   const record = await getRegistryService().getResource("agent", appId);
   if (!record) {
     throw new Error("App not found");
   }
+  await assertManifestAccess(appId, record, event, "editor");
+
   const manifest = readManifest(record);
   if ((manifest.version ?? 1) !== version) {
     throw new Error("Conflict: app was modified concurrently. Please retry.");
@@ -2344,11 +2414,13 @@ async function setAppAuthConfig(
   appId: string,
   authConfigInput: string | object,
   userId: string,
+  event: unknown,
 ): Promise<unknown> {
   const record = await getRegistryService().getResource("agent", appId);
   if (!record) {
     throw new Error("App not found");
   }
+  await assertManifestAccess(appId, record, event, "editor");
 
   const authConfig =
     typeof authConfigInput === "string"
@@ -2370,32 +2442,59 @@ async function setAppAuthConfig(
 }
 
 /**
- * Owner-gate for grantAppAccess/revokeAppAccess (finding 8b0e32a7, CRE item
- * 4). checkOperationAccess/checkAppAccess (app-access-control.ts) reserve
- * both operations at 'owner' but read a SEPARATE DynamoDB ACCESS# store
- * (appsTable GroupIndex) that this resolver's writes never update — that
- * store has ZERO production writers (autoAssignOwner/grantAppAccess/
- * revokeAppAccess in app-access-control.ts are exercised only by tests).
- * The canonical, write-consistent store is the Registry record MANIFEST's
- * `access` map: it is the ONLY store this resolver's grant/revoke actually
- * mutate (via writeManifestMutation), and it is read here the same way
- * getApp's own tenant gate reads the manifest's `orgId` — so a grant is
- * immediately visible to the next authorization check in-process (the
- * split-brain requirement).
+ * Role hierarchy for assertManifestAccess. Mirrors app-access-control.ts's
+ * ROLE_LEVEL exactly (owner > editor > viewer) — kept as a file-local copy
+ * rather than importing that module's map, because this gate authorizes
+ * against a DIFFERENT store (the Registry manifest's `access` map, not the
+ * ACCESS# DynamoDB rows app-access-control.ts reads) and must not create a
+ * coupling that makes it look like the two stores are kept in sync.
+ */
+const MANIFEST_ROLE_LEVEL: Record<string, number> = {
+  viewer: 1,
+  editor: 2,
+  owner: 3,
+};
+
+/**
+ * Shared manifest-access gate (finding 8b0e32a7 / CRE item 4, generalized
+ * for finding 8f8fd119). Originally `assertManifestOwnerAccess` — hardcoded
+ * to 'owner' for grantAppAccess/revokeAppAccess. Parameterised on
+ * `requiredRole` so the SAME gate, reading the SAME store, can reserve the
+ * editor-level lifecycle mutations (updateApp, addAppComponent,
+ * createAppApiKey, ...) at 'editor' while grant/revoke keep requiring
+ * 'owner' with byte-for-byte identical semantics (see the two thin
+ * `assertManifestOwnerAccess`-shaped call sites below, which still request
+ * 'owner').
+ *
+ * checkOperationAccess/checkAppAccess (app-access-control.ts) reserve these
+ * operations by role but read a SEPARATE DynamoDB ACCESS# store (appsTable
+ * GroupIndex) that this resolver's writes never update — that store has
+ * ZERO production writers (autoAssignOwner/grantAppAccess/revokeAppAccess in
+ * app-access-control.ts are exercised only by tests). The canonical,
+ * write-consistent store is the Registry record MANIFEST's `access` map: it
+ * is the ONLY store this resolver's mutations actually update (via
+ * writeManifestMutation), and it is read here the same way getApp's own
+ * tenant gate reads the manifest's `orgId` — so a grant is immediately
+ * visible to the next authorization check in-process (the split-brain
+ * requirement). This is also why assertRowOrg (eval-comparison-resolver.ts)
+ * is the wrong fit: it is an org-equality check on a plain DynamoDB row with
+ * no role hierarchy, and apps are stored in the Registry manifest.
  *
  * Fails closed: any missing identity, missing app, or Cognito lookup
  * failure (via extractOrgFromEvent) results in a thrown "Access denied"
  * BEFORE any manifest read is used to authorize a write. Admin group
  * bypasses, matching checkAppAccess's own convention. Same-org membership
- * alone is NOT sufficient — the caller must hold 'owner' in the manifest's
- * `access` map, or (for apps created before this fix, whose manifests never
- * had an owner entry populated) be the app's recorded `createdBy` — see the
- * fallback below.
+ * alone is NOT sufficient — the caller must hold `requiredRole` (or higher)
+ * in the manifest's `access` map, or (for apps created before the owner-gate
+ * fix, whose manifests never had an owner entry populated) be the app's
+ * recorded `createdBy` — see the fallback below, unchanged from the
+ * owner-only version.
  */
-async function assertManifestOwnerAccess(
+async function assertManifestAccess(
   appId: string,
   record: RegistryRecord,
   event: unknown,
+  requiredRole: "viewer" | "editor" | "owner",
 ): Promise<void> {
   if (isAdminFromEvent(event)) {
     return;
@@ -2405,29 +2504,39 @@ async function assertManifestOwnerAccess(
     (event as { identity?: Parameters<typeof getUserId>[0] })?.identity,
   );
   if (!callerId || callerId === "anonymous") {
-    throw new Error(`Access denied: requires owner role for app ${appId}`);
+    throw new Error(
+      `Access denied: requires ${requiredRole} role for app ${appId}`,
+    );
   }
 
   const callerOrgId = await extractOrgFromEvent(event);
   const manifest = readManifest(record);
   if (!callerOrgId || callerOrgId !== manifest.orgId) {
-    throw new Error(`Access denied: requires owner role for app ${appId}`);
+    throw new Error(
+      `Access denied: requires ${requiredRole} role for app ${appId}`,
+    );
   }
 
   const callerEntry = manifest.access?.[callerId];
-  const isExplicitOwner = callerEntry?.role === "owner";
+  const callerRole = callerEntry?.role;
+  const meetsExplicitRole =
+    !!callerRole &&
+    (MANIFEST_ROLE_LEVEL[callerRole] ?? 0) >=
+      (MANIFEST_ROLE_LEVEL[requiredRole] ?? 0);
 
-  // Backward-compat fallback: apps created BEFORE this fix have `access: {}`
-  // in their manifest (the field existed but nothing ever populated an
-  // owner entry into it) — with no fallback, existing app creators would be
-  // locked out of granting/revoking on their own apps. `createdBy` has
-  // always been stamped server-side at createApp time from the caller's
-  // verified identity, never client-suppliable, so treating the creator as
-  // an implicit owner when NO owner entry exists yet is safe and does not
-  // reopen the vulnerability: it only recognizes the one identity the
-  // system itself recorded as having created the app, and stops applying
-  // the instant a real owner entry exists (including the one seeded by
-  // createApp going forward).
+  // Backward-compat fallback: apps created BEFORE the owner-gate fix have
+  // `access: {}` in their manifest (the field existed but nothing ever
+  // populated an owner entry into it) — with no fallback, existing app
+  // creators would be locked out of managing their own apps. `createdBy`
+  // has always been stamped server-side at createApp time from the
+  // caller's verified identity, never client-suppliable, so treating the
+  // creator as an implicit OWNER when NO owner entry exists yet is safe
+  // and does not reopen the vulnerability: it only recognizes the one
+  // identity the system itself recorded as having created the app (the
+  // highest role), and stops applying the instant a real owner entry
+  // exists (including the one seeded by createApp going forward). An
+  // implicit creator-owner satisfies any requiredRole, since owner is the
+  // top of the hierarchy.
   const hasAnyOwnerEntry = Object.values(manifest.access ?? {}).some(
     (entry) => entry?.role === "owner",
   );
@@ -2436,9 +2545,25 @@ async function assertManifestOwnerAccess(
     !!manifest.createdBy &&
     manifest.createdBy === callerId;
 
-  if (!isExplicitOwner && !isImplicitCreatorOwner) {
-    throw new Error(`Access denied: requires owner role for app ${appId}`);
+  if (!meetsExplicitRole && !isImplicitCreatorOwner) {
+    throw new Error(
+      `Access denied: requires ${requiredRole} role for app ${appId}`,
+    );
   }
+}
+
+/**
+ * Thin owner-role wrapper preserving the exact call shape/behaviour of the
+ * pre-8f8fd119 `assertManifestOwnerAccess` for grantAppAccess/revokeAppAccess.
+ * Grant/revoke must continue to require 'owner' — this is not weakened by
+ * the generalization above.
+ */
+async function assertManifestOwnerAccess(
+  appId: string,
+  record: RegistryRecord,
+  event: unknown,
+): Promise<void> {
+  return assertManifestAccess(appId, record, event, "owner");
 }
 
 async function grantAppAccess(
@@ -2558,7 +2683,21 @@ async function createAppApiKey(
   name: string,
   expiresIn: number | undefined,
   userId: string,
+  event: unknown,
 ): Promise<unknown> {
+  // Editor-gate (finding 8f8fd119) — createAppApiKey/rotateAppApiKey are the
+  // highest-exposure ops in this finding: with no gate, ANY authenticated
+  // caller could mint a plaintext key for ANY app in ANY org, i.e. silent
+  // cross-tenant data-plane access. app-api-key-management.ts operates
+  // purely on AppsTable APIKEY# rows and never touches the Registry
+  // manifest, so the gate — and the record fetch it needs — lives here,
+  // strictly BEFORE createAppApiKeyImpl (key generation + DDB write).
+  const record = await getRegistryService().getResource("agent", appId);
+  if (!record) {
+    throw new Error("App not found");
+  }
+  await assertManifestAccess(appId, record, event, "editor");
+
   const result = await createAppApiKeyImpl(
     appId,
     name,
@@ -2584,7 +2723,16 @@ async function revokeAppApiKey(
   appId: string,
   keyId: string,
   userId: string,
+  event: unknown,
 ): Promise<unknown> {
+  // Editor-gate (finding 8f8fd119) — BEFORE any revoke write. See
+  // createAppApiKey above for why the record fetch lives in this wrapper.
+  const record = await getRegistryService().getResource("agent", appId);
+  if (!record) {
+    throw new Error("App not found");
+  }
+  await assertManifestAccess(appId, record, event, "editor");
+
   return revokeAppApiKeyImpl(appId, keyId, userId, getSharedDeps());
 }
 
@@ -2592,7 +2740,15 @@ async function rotateAppApiKey(
   appId: string,
   keyId: string,
   userId: string,
+  event: unknown,
 ): Promise<unknown> {
+  // Editor-gate (finding 8f8fd119) — BEFORE any key generation/revocation.
+  const record = await getRegistryService().getResource("agent", appId);
+  if (!record) {
+    throw new Error("App not found");
+  }
+  await assertManifestAccess(appId, record, event, "editor");
+
   const result = await rotateAppApiKeyImpl(
     appId,
     keyId,


### PR DESCRIPTION
## Summary

Following the external report's remediation, an audit of the same class found the app lifecycle mutations in the registry resolver had no authorization at all - no role check and no organization check - so any authenticated user organization. `checkOperationAccess` could act on any app in any existed but had no call sites.

Gated at **editor**, before any side effect:

- `createAppApiKey`, `rotateAppApiKey`, `revokeAppApiKey` - previously any user could mint a plaintext key for any app, giving silent cross-tenant data-plane access. This was the highest-exposure gap found
- `updateApp` - additionally rejects any `orgId` change outright, even for an owner: reassigning `manifest.orgId` is tenant takeover and no legitimate lifecycle path needs it
- `addAppComponent`, `removeAppComponent` - components become IAM permissions baked into the app's role at publish, so this was privilege escalation
- `updateAgentBinding`, `setAppConfigSchema`, `setAppConfigValues`, `setAppAuthConfig`

Gated at **owner** (destructive, matching grant/revoke) :

- `deleteApp` - had **no authorization whatsoever**, calling `revokeFabricatorAuthority` and `deleteResource` unguarded. Any authenticated user could irreversibly delete any organization's app

The owner gate from the previous PR is refactored into one role-parameterised `assertManifestAccess`, with `assertManifestOwnerAccess` retained as a thin wrapper. Grant and revoke still require owner, regression-tested.

## The enumeration hole is closed structurally

`deleteApp` was missed by a hand-maintained operation list. A new guard now parses the handler's **actual dispatch switch** and verifies each gated operation's body contains the gate call, so a future ungated mutation fails a test rather than depending on someone remembering. All 21 cases are accounted for: 13 gated, 8 exempt with explicit reasons. Bite-proven by adding a throwaway ungated case and confirming it fails.

## Testing

- Executed bite proofs, not inspected ones: with the gate removed, `deleteApp` resolves
`{success: true}` and `createAppApiKey` mints a key. Both restored byte-identically (sha256 verified)
- Per operation, cross-org and same-org non-editor callers refused with zero key generation, zero manifest writes, zero IAM changes and zero events
- `updateApp` cannot change `orgId` even as a legitimate editor
- Owner semantics unregressed: an editor cannot grant access; an owner can
- tsc, lint, `cdk synth` exit o; 315 targeted tests; full backend jest 7181

## Known remaining gap, disclosed not hidden

`bindWorkflowToApp` and `unbindWorkflowFromApp` are still ungated. Gating them breaks existing fixtures that seed no identity, so they need their own red-green cycle.