### PR TITLE
fix(security): require app owner to publish or unpublish an app

### DIFF
--- a/backend/bin/app.ts
+++ b/backend/bin/app.ts
@@ -438,6 +438,12 @@ const gatewayStack = new GatewayStack(app, `citadel-gateway-${environment}`, {
   appsTable: backendStack.appsTable,
   eventBus: backendStack.agentEventBus,
   idempotencyTable: backendStack.idempotencyTable,
+  // Owner gate (finding 13a58234): publish/unpublish must read the app's
+  // Registry manifest before any provisioning/teardown. Same
+  // registryId/registryArn already threaded into ServicesStack/
+  // GovernanceStack/ArbiterStack below.
+  registryId: backendStack.registryId,
+  registryArn: backendStack.registryArn,
 });
 
 // Telemetry stack has already been instantiated above (before FrontendStack)
@@ -978,6 +984,10 @@ if (app.node.tryGetContext("nag") !== "false") {
     // only. Not a fresh per-function ServiceRole — the shared, hand-named
     // writer role — so its DefaultPolicy lives under backendStack.
     [backendStack, "AgentReleaseWriterRole/DefaultPolicy/Resource"],
+    // Publish handler owner gate (finding 13a58234): GetRegistryRecord
+    // only, scoped to the registry ARN + its records, to fetch the app's
+    // manifest for the owner-role check before any provisioning/teardown.
+    [gatewayStack, "AppPublishHandler/ServiceRole/DefaultPolicy/Resource"],
   ];
   for (const [stack, path] of registryArnPaths) {
     NagSuppressions.addResourceSuppressionsByPath(

--- a/backend/lib/gateway-stack.ts
+++ b/backend/lib/gateway-stack.ts
@@ -12,6 +12,15 @@ export interface GatewayStackProps extends cdk.StackProps {
   appsTable: dynamodb.ITable;
   eventBus: events.IEventBus;
   idempotencyTable: dynamodb.ITable;
+  /**
+   * AgentCore Registry id/ARN, threaded from BackendStack.registryId /
+   * BackendStack.registryArn (mirrors the arbiter-stack.ts registryId/
+   * registryArn props). Required for the publish handler's owner gate
+   * (finding 13a58234) — it reads (never writes) the app's Registry
+   * manifest via RegistryService before any provisioning/teardown.
+   */
+  registryId: string;
+  registryArn: string;
 }
 
 export class GatewayStack extends cdk.Stack {
@@ -81,6 +90,11 @@ export class GatewayStack extends cdk.Stack {
         AUTHORIZER_FUNCTION_ARN: this.authorizerFunction.functionArn,
         IDEMPOTENCY_TABLE: props.idempotencyTable.tableName,
         APIGW_EVENTBRIDGE_ROLE_ARN: apiGwEventBridgeRole.roleArn,
+        // Owner gate (finding 13a58234): the handler fetches the app's
+        // Registry manifest via RegistryService before any
+        // provisioning/teardown, gated at requiredRole='owner' via the
+        // shared assertManifestAccess (registry-agent-record-resolver.ts).
+        REGISTRY_ID: props.registryId,
       },
       timeout: cdk.Duration.seconds(120),
       logGroup: new logs.LogGroup(this, "AppPublishHandlerLogs", {
@@ -233,6 +247,21 @@ export class GatewayStack extends cdk.Stack {
         effect: iam.Effect.ALLOW,
         actions: ["lambda:AddPermission", "lambda:RemovePermission"],
         resources: [this.authorizerFunction.functionArn],
+      }),
+    );
+
+    // --- Publish Handler: Registry read grant (finding 13a58234) ---
+    // Least-privilege READ-ONLY: the owner gate calls
+    // RegistryService.getResource('agent', appId) to fetch the app's
+    // manifest before any provisioning/teardown. GetRegistryRecord only —
+    // no ListRegistryRecords/write actions, since this handler never lists
+    // or mutates Registry records. Mirrors the props.registryArn grant
+    // pattern in arbiter-stack.ts (supervisor/worker/fabricator Lambdas).
+    this.publishHandler.addToRolePolicy(
+      new iam.PolicyStatement({
+        effect: iam.Effect.ALLOW,
+        actions: ["bedrock-agentcore:GetRegistryRecord"],
+        resources: [props.registryArn, `${props.registryArn}/*`],
       }),
     );
 

--- a/backend/src/lambda/__tests__/app-publish-handler-dispatch-gate-enumeration.test.ts
+++ b/backend/src/lambda/__tests__/app-publish-handler-dispatch-gate-enumeration.test.ts
@@ -1,0 +1,206 @@
+/**
+ * Enumeration-completeness guard for app-publish-handler.ts's dispatch
+ * switch (finding 13a58234 follow-up — extends the class-closing move from
+ * registry-agent-record-resolver-dispatch-gate-enumeration.test.ts to this
+ * second dispatching handler).
+ *
+ * Same rationale as the sibling guard: derive the operation list directly
+ * from the handler's `switch (fieldName)` source rather than trusting a
+ * manually transcribed list, so a future case added to this switch without
+ * a corresponding gate call fails LOUDLY instead of silently shipping
+ * ungated.
+ *
+ * This handler currently has exactly two ops, publishApp and unpublishApp,
+ * both gated at requiredRole='owner' via the SAME assertManifestAccess
+ * helper the sibling resolver's guard checks for (finding 13a58234's fix
+ * reuses that gate rather than writing a second implementation). The
+ * EXEMPT_OPS list is intentionally empty — there is no legitimately
+ * ungated op on this dispatch surface.
+ */
+import * as fs from "fs";
+import * as path from "path";
+
+const HANDLER_PATH = path.join(__dirname, "..", "app-publish-handler.ts");
+
+function extractDispatchCases(source: string): string[] {
+  const switchStart = source.indexOf("switch (fieldName)");
+  if (switchStart === -1) {
+    throw new Error(
+      "Could not locate `switch (fieldName)` in app-publish-handler.ts — " +
+        "dispatch structure changed; update this guard's parsing.",
+    );
+  }
+  const defaultIdx = source.indexOf("default:", switchStart);
+  if (defaultIdx === -1) {
+    throw new Error(
+      "Could not locate the dispatch switch's `default:` case — " +
+        "update this guard's parsing.",
+    );
+  }
+  const switchBody = source.slice(switchStart, defaultIdx);
+  const caseRe = /case\s+"([^"]+)"\s*:/g;
+  const cases: string[] = [];
+  let m: RegExpExecArray | null;
+  while ((m = caseRe.exec(switchBody)) !== null) {
+    cases.push(m[1]);
+  }
+  return cases;
+}
+
+/**
+ * Extracts the handler function name a given case delegates to. Handles
+ * both call shapes present in this file's dispatch:
+ *   - `case "publishApp": return await publishApp(...)`
+ *   - `case "unpublishApp": { const x = await unpublishApp(...); ... }`
+ */
+function extractHandlerCallSite(
+  switchBody: string,
+  fieldName: string,
+): string | null {
+  const caseIdx = switchBody.indexOf(`case "${fieldName}"`);
+  if (caseIdx === -1) return null;
+  // Scan forward from the case label to the next `case ` or end of the
+  // switch body, then find the first `await SOMEFN(` in that slice —
+  // covers both the direct-return and block-with-local-const shapes.
+  const nextCaseIdx = switchBody.indexOf("case ", caseIdx + 1);
+  const slice = switchBody.slice(
+    caseIdx,
+    nextCaseIdx === -1 ? undefined : nextCaseIdx,
+  );
+  const callRe = /await\s+([A-Za-z0-9_]+)\s*\(/;
+  const m = callRe.exec(slice);
+  return m ? m[1] : null;
+}
+
+/**
+ * Extracts a top-level `export async function <name>(...) { ... }` or
+ * `async function <name>(...) { ... }` body by brace-counting from the
+ * `function` keyword, matching the parameter list's closing paren first
+ * (parameter type annotations can contain object-literal-shaped braces).
+ */
+function extractFunctionBody(source: string, fnName: string): string {
+  const declRe = new RegExp(`(?:export\\s+)?async function ${fnName}\\s*\\(`);
+  const declMatch = declRe.exec(source);
+  if (!declMatch) {
+    throw new Error(
+      `Could not locate function declaration for '${fnName}' in app-publish-handler.ts`,
+    );
+  }
+  const paramsOpenIdx = source.indexOf("(", declMatch.index);
+  let parenDepth = 0;
+  let j = paramsOpenIdx;
+  for (; j < source.length; j++) {
+    if (source[j] === "(") parenDepth++;
+    else if (source[j] === ")") {
+      parenDepth--;
+      if (parenDepth === 0) break;
+    }
+  }
+  const bodyStart = source.indexOf("{", j);
+  let depth = 0;
+  let i = bodyStart;
+  for (; i < source.length; i++) {
+    if (source[i] === "{") depth++;
+    else if (source[i] === "}") {
+      depth--;
+      if (depth === 0) break;
+    }
+  }
+  return source.slice(bodyStart, i + 1);
+}
+
+const GATE_CALL_RE = /assertManifest(Owner)?Access\s*\(/;
+
+/**
+ * Ops verified to call assertManifestAccess inside their handler function
+ * body before any mutating side effect (finding 13a58234). Both are
+ * owner-reserved: publish provisions billable external infrastructure and
+ * mints a plaintext API key; unpublish irreversibly tears the same down.
+ */
+const GATED_OPS: Record<string, { requiredRole: "owner" | "editor" }> = {
+  publishApp: { requiredRole: "owner" },
+  unpublishApp: { requiredRole: "owner" },
+};
+
+/**
+ * No legitimately ungated op exists on this dispatch surface — kept empty
+ * (rather than omitted) so the "every case accounted for" test below fails
+ * loudly, not silently, the moment a new case is added without updating
+ * this file.
+ */
+const EXEMPT_OPS: Record<string, string> = {};
+
+describe("app-publish-handler — dispatch enumeration completeness", () => {
+  const source = fs.readFileSync(HANDLER_PATH, "utf-8");
+  const cases = extractDispatchCases(source);
+
+  test("the dispatch switch actually has cases to check (sanity check on the parser itself)", () => {
+    expect(cases.length).toBe(2);
+    expect(cases).toContain("publishApp");
+    expect(cases).toContain("unpublishApp");
+  });
+
+  test("every dispatch case is accounted for in GATED_OPS or EXEMPT_OPS", () => {
+    const unaccounted = cases.filter(
+      (c) => !(c in GATED_OPS) && !(c in EXEMPT_OPS),
+    );
+    expect(unaccounted).toEqual([]);
+  });
+
+  test("GATED_OPS and EXEMPT_OPS do not both claim the same op", () => {
+    const overlap = Object.keys(GATED_OPS).filter((k) => k in EXEMPT_OPS);
+    expect(overlap).toEqual([]);
+  });
+
+  test("no GATED_OPS/EXEMPT_OPS entry references a case that no longer exists in the switch", () => {
+    const known = new Set(cases);
+    const staleGated = Object.keys(GATED_OPS).filter((k) => !known.has(k));
+    const staleExempt = Object.keys(EXEMPT_OPS).filter((k) => !known.has(k));
+    expect(staleGated).toEqual([]);
+    expect(staleExempt).toEqual([]);
+  });
+
+  describe.each(Object.entries(GATED_OPS))(
+    "GATED_OPS['%s'] handler actually calls a manifest-access gate",
+    (fieldName, meta) => {
+      test(`${fieldName} (requiredRole=${meta.requiredRole}) contains an assertManifestAccess/assertManifestOwnerAccess call`, () => {
+        const switchStart = source.indexOf("switch (fieldName)");
+        const defaultIdx = source.indexOf("default:", switchStart);
+        const switchBody = source.slice(switchStart, defaultIdx);
+        const handlerName = extractHandlerCallSite(switchBody, fieldName);
+        expect(handlerName).not.toBeNull();
+        const body = extractFunctionBody(source, handlerName as string);
+        expect(GATE_CALL_RE.test(body)).toBe(true);
+      });
+
+      test(`${fieldName}'s gate call is positioned BEFORE the first mutating side effect in its handler body`, () => {
+        const switchStart = source.indexOf("switch (fieldName)");
+        const defaultIdx = source.indexOf("default:", switchStart);
+        const switchBody = source.slice(switchStart, defaultIdx);
+        const handlerName = extractHandlerCallSite(switchBody, fieldName);
+        const body = extractFunctionBody(source, handlerName as string);
+        const gateIdx = body.search(GATE_CALL_RE);
+        expect(gateIdx).toBeGreaterThan(-1);
+
+        // Side-effecting call markers used by publishApp/unpublishApp:
+        // provisionApiGateway, generateApiKey, docClient.send with
+        // PutCommand/UpdateCommand, ensureRole/deleteRole, and
+        // eventBridgeClient.send. The gate must precede ALL of them.
+        const sideEffectMarkers = [
+          "provisionApiGateway(",
+          "generateApiKey(",
+          "ensureRole(",
+          "deleteRole(",
+          "new PutCommand(",
+          "new UpdateCommand(",
+          "eventBridgeClient.send(",
+        ];
+        for (const marker of sideEffectMarkers) {
+          const markerIdx = body.indexOf(marker);
+          if (markerIdx === -1) continue; // not every marker appears in every handler
+          expect(gateIdx).toBeLessThan(markerIdx);
+        }
+      });
+    },
+  );
+});

--- a/backend/src/lambda/__tests__/app-publish-handler-owner-gate.test.ts
+++ b/backend/src/lambda/__tests__/app-publish-handler-owner-gate.test.ts
@@ -1,0 +1,567 @@
+/**
+ * RED-first tests for finding 13a58234: publishApp/unpublishApp in
+ * app-publish-handler.ts had NO org or role check at all. Any
+ * authenticated caller could publish (mint+return a plaintext API key,
+ * provision a billable external API Gateway, create an IAM role) or
+ * unpublish (irreversibly delete the API Gateway/endpoint, revoke all
+ * keys, delete the IAM role) ANY org's app.
+ *
+ * Fix under test: both mutations now fetch the app's Registry record and
+ * gate via the SAME shared manifest-access gate landed in PR 134
+ * (assertManifestAccess from registry-agent-record-resolver.ts), pinned at
+ * requiredRole='owner', identical to grantAppAccess/revokeAppAccess and
+ * deleteApp. The handler previously could not read the Registry record at
+ * all; this suite exercises the new RegistryService wiring.
+ *
+ * Threat model asserted per operation (publishApp, unpublishApp):
+ *   - cross-org caller (different org entirely): refused, ZERO side effects
+ *   - same-org NON-OWNER (no access entry, no createdBy match): refused,
+ *     ZERO side effects
+ *   - missing identity / anonymous: refused, ZERO side effects
+ *   - unresolvable org (extractOrgFromEvent returns null): refused
+ *   - missing Registry record (app not found): refused
+ *   - record with no owner entry AND no createdBy: refused (no implicit
+ *     bypass possible)
+ *   - legitimate OWNER (explicit access entry): succeeds end to end
+ *   - legitimate implicit creator-owner (no access map yet, createdBy
+ *     matches caller): succeeds end to end
+ *   - admin bypass: succeeds even without an owner entry
+ *
+ * "Zero side effects" is asserted directly against the AWS SDK client
+ * mocks: zero ApiGatewayV2 Create/Delete calls, zero API key generation
+ * (no PutCommand with an APIKEY sortId), zero IAM role create/delete
+ * (PolicyManager.ensureRole/deleteRole spies), zero EventBridge
+ * PutEventsCommand calls, and zero app-metadata UpdateCommand status
+ * writes. Additionally, no plaintext apiKey is ever present on a refused
+ * publishApp response.
+ */
+
+process.env.REGISTRY_ID = "test-registry-id";
+process.env.APPS_TABLE = "citadel-apps-test";
+process.env.EVENT_BUS_NAME = "citadel-agents-test";
+process.env.ENVIRONMENT = "test";
+process.env.AUTHORIZER_FUNCTION_ARN =
+  "arn:aws:lambda:us-east-1:123456789012:function:test-authorizer";
+process.env.USER_POOL_ID = "us-east-1_test";
+process.env.AWS_REGION = "us-east-1";
+
+import {
+  ApiGatewayV2Client,
+  CreateApiCommand,
+  CreateStageCommand,
+  CreateIntegrationCommand,
+  CreateAuthorizerCommand,
+  CreateRouteCommand,
+  DeleteApiCommand,
+} from "@aws-sdk/client-apigatewayv2";
+import {
+  CloudWatchLogsClient,
+  CreateLogGroupCommand,
+  DescribeLogGroupsCommand,
+} from "@aws-sdk/client-cloudwatch-logs";
+import {
+  DynamoDBDocumentClient,
+  QueryCommand,
+  UpdateCommand,
+  PutCommand,
+} from "@aws-sdk/lib-dynamodb";
+import {
+  EventBridgeClient,
+  PutEventsCommand,
+} from "@aws-sdk/client-eventbridge";
+import { mockClient } from "aws-sdk-client-mock";
+
+import {
+  seedMockRegistry,
+  resetMockRegistry,
+} from "./fixtures/registry-service-mock";
+import * as apiKeyHash from "../../utils/api-key-hash";
+import { PolicyManager } from "../../utils/policy-manager";
+
+const apiGwMock = mockClient(ApiGatewayV2Client);
+const cwLogsMock = mockClient(CloudWatchLogsClient);
+const ddbMock = mockClient(DynamoDBDocumentClient);
+const ebMock = mockClient(EventBridgeClient);
+
+jest.mock("../../services/registry-service", () => {
+  const { getMockRegistryService } = jest.requireActual(
+    "./fixtures/registry-service-mock",
+  );
+  const actual = jest.requireActual("../../services/registry-service");
+  return {
+    RegistryService: jest
+      .fn()
+      .mockImplementation(() => getMockRegistryService()),
+    TypeMismatchError: actual.TypeMismatchError,
+    RegistryLifecycleError: actual.RegistryLifecycleError,
+  };
+});
+
+jest.mock("@aws-sdk/client-cognito-identity-provider", () => ({
+  CognitoIdentityProviderClient: jest.fn().mockImplementation(() => ({
+    send: jest
+      .fn()
+      .mockRejectedValue(new Error("Cognito not reachable in test")),
+  })),
+  AdminGetUserCommand: jest.fn(),
+}));
+
+import { handler } from "../app-publish-handler";
+
+const TEST_PEPPER = "e".repeat(64);
+
+const APP_ID = "app-1";
+const OWNER_ID = "owner-user";
+const ATTACKER_ID = "attacker-user";
+const APP_ORG = "org-1";
+const OTHER_ORG = "org-2";
+
+function seedApp(
+  opts: {
+    status?: string;
+    orgId?: string | null;
+    access?: Record<
+      string,
+      { role: string; grantedAt: string; grantedBy: string }
+    > | null;
+    createdBy?: string | null;
+  } = {},
+) {
+  const manifest: Record<string, unknown> = {
+    orgId: opts.orgId === undefined ? APP_ORG : opts.orgId,
+    version: 1,
+    status: opts.status ?? "ACTIVE",
+    workflowIds: ["wf-1"],
+    agentBindings: [],
+    permissions: [],
+    configSchema: null,
+    configValues: null,
+    authConfig: null,
+    routingConfig: null,
+  };
+  if (opts.createdBy !== null) {
+    manifest.createdBy = opts.createdBy ?? OWNER_ID;
+  }
+  manifest.access =
+    opts.access !== undefined
+      ? opts.access
+      : {
+          [OWNER_ID]: {
+            role: "owner",
+            grantedAt: "2024-01-01T00:00:00Z",
+            grantedBy: "system",
+          },
+        };
+
+  seedMockRegistry("agent", APP_ID, {
+    name: "Test App",
+    description: "Test",
+    status: opts.status ?? "ACTIVE",
+    customDescriptorContent: JSON.stringify({
+      appId: APP_ID,
+      manifest,
+    }),
+  });
+}
+
+function makeEvent(
+  fieldName: "publishApp" | "unpublishApp",
+  opts: { userId?: string; orgId?: string; groups?: string[] } = {},
+) {
+  const claims: Record<string, unknown> = {};
+  if (opts.userId !== undefined) claims.sub = opts.userId;
+  if (opts.orgId !== undefined) claims["custom:organization"] = opts.orgId;
+  if (opts.groups !== undefined) claims["cognito:groups"] = opts.groups;
+  return {
+    info: { fieldName },
+    arguments: { appId: APP_ID },
+    identity:
+      opts.userId !== undefined
+        ? { sub: opts.userId, claims }
+        : { claims: {} },
+  };
+}
+
+function setupDefaultAwsMocks() {
+  apiGwMock.reset();
+  cwLogsMock.reset();
+  ddbMock.reset();
+  ebMock.reset();
+
+  apiGwMock.on(CreateApiCommand).resolves({ ApiId: "api-123" });
+  apiGwMock.on(CreateStageCommand).resolves({});
+  apiGwMock.on(CreateIntegrationCommand).resolves({ IntegrationId: "int-1" });
+  apiGwMock.on(CreateAuthorizerCommand).resolves({ AuthorizerId: "auth-1" });
+  apiGwMock.on(CreateRouteCommand).resolves({});
+  apiGwMock.on(DeleteApiCommand).resolves({});
+
+  cwLogsMock.on(CreateLogGroupCommand).resolves({});
+  cwLogsMock.on(DescribeLogGroupsCommand).resolves({
+    logGroups: [
+      {
+        logGroupName: "/aws/apigateway/citadel-app-app-1-test",
+        arn: "arn:aws:logs:us-east-1:123456789012:log-group:test:*",
+      },
+    ],
+  });
+
+  ddbMock.on(QueryCommand).resolves({
+    Items: [
+      {
+        appId: APP_ID,
+        sortId: "METADATA",
+        groupId: `APP#${APP_ID}`,
+        name: "Test App",
+        status: "ACTIVE",
+        workflowIds: ["wf-1"],
+        orgId: APP_ORG,
+        version: 1,
+      },
+    ],
+  });
+  ddbMock.on(UpdateCommand).resolves({});
+  ddbMock.on(PutCommand).resolves({});
+
+  ebMock.on(PutEventsCommand).resolves({ Entries: [] });
+}
+
+function apiGwProvisioningCallCount(): number {
+  return apiGwMock.commandCalls(CreateApiCommand).length;
+}
+function apiGwDeleteCallCount(): number {
+  return apiGwMock.commandCalls(DeleteApiCommand).length;
+}
+function apiKeyPutCallCount(): number {
+  return ddbMock
+    .commandCalls(PutCommand)
+    .filter((c) =>
+      String(c.args[0].input.Item?.sortId ?? "").startsWith("APIKEY#"),
+    ).length;
+}
+function statusUpdateCallCount(): number {
+  return ddbMock.commandCalls(UpdateCommand).length;
+}
+function eventBridgePublishCount(): number {
+  return ebMock.commandCalls(PutEventsCommand).length;
+}
+
+let ensureRoleSpy: jest.SpyInstance;
+let deleteRoleSpy: jest.SpyInstance;
+
+function expectZeroSideEffects() {
+  expect(apiGwProvisioningCallCount()).toBe(0);
+  expect(apiGwDeleteCallCount()).toBe(0);
+  expect(apiKeyPutCallCount()).toBe(0);
+  expect(statusUpdateCallCount()).toBe(0);
+  expect(eventBridgePublishCount()).toBe(0);
+  expect(ensureRoleSpy).not.toHaveBeenCalled();
+  expect(deleteRoleSpy).not.toHaveBeenCalled();
+}
+
+describe("app-publish-handler — owner gate (finding 13a58234)", () => {
+  beforeEach(() => {
+    resetMockRegistry();
+    setupDefaultAwsMocks();
+    apiKeyHash.__resetApiKeyPepperCacheForTest();
+    jest.spyOn(apiKeyHash, "getApiKeyPepper").mockResolvedValue(TEST_PEPPER);
+    ensureRoleSpy = jest
+      .spyOn(PolicyManager.prototype, "ensureRole")
+      .mockResolvedValue(undefined as never);
+    deleteRoleSpy = jest
+      .spyOn(PolicyManager.prototype, "deleteRole")
+      .mockResolvedValue(undefined as never);
+    jest
+      .spyOn(PolicyManager.prototype, "getAccountContext")
+      .mockResolvedValue({ accountId: "123456789012" } as never);
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  describe("publishApp", () => {
+    test("cross-org caller is refused with ZERO provisioning/key/IAM/event/status side effects", async () => {
+      seedApp({ status: "ACTIVE" });
+      const event = makeEvent("publishApp", {
+        userId: ATTACKER_ID,
+        orgId: OTHER_ORG,
+      });
+
+      await expect(handler(event)).rejects.toThrow(
+        /Access denied/i,
+      );
+      expectZeroSideEffects();
+    });
+
+    test("same-org non-owner caller is refused with ZERO side effects", async () => {
+      seedApp({ status: "ACTIVE" });
+      const event = makeEvent("publishApp", {
+        userId: ATTACKER_ID,
+        orgId: APP_ORG,
+      });
+
+      await expect(handler(event)).rejects.toThrow(
+        /Access denied/i,
+      );
+      expectZeroSideEffects();
+    });
+
+    test("missing identity is refused with ZERO side effects", async () => {
+      seedApp({ status: "ACTIVE" });
+      const event = makeEvent("publishApp", {});
+
+      await expect(handler(event)).rejects.toThrow(
+        /Access denied/i,
+      );
+      expectZeroSideEffects();
+    });
+
+    test("unresolvable org (no custom:organization claim, Cognito lookup fails) is refused", async () => {
+      seedApp({ status: "ACTIVE" });
+      const event = makeEvent("publishApp", { userId: ATTACKER_ID });
+
+      await expect(handler(event)).rejects.toThrow(
+        /Access denied/i,
+      );
+      expectZeroSideEffects();
+    });
+
+    test("missing Registry record (app not found) is refused, not silently allowed", async () => {
+      // No seedApp call — record does not exist.
+      const event = makeEvent("publishApp", {
+        userId: OWNER_ID,
+        orgId: APP_ORG,
+      });
+
+      await expect(handler(event)).rejects.toThrow();
+      expectZeroSideEffects();
+    });
+
+    test("record with no owner entry and no createdBy is refused (no implicit bypass)", async () => {
+      seedApp({ status: "ACTIVE", access: {}, createdBy: null });
+      const event = makeEvent("publishApp", {
+        userId: ATTACKER_ID,
+        orgId: APP_ORG,
+      });
+
+      await expect(handler(event)).rejects.toThrow(
+        /Access denied/i,
+      );
+      expectZeroSideEffects();
+    });
+
+    test("refused publishApp NEVER returns a plaintext apiKey", async () => {
+      seedApp({ status: "ACTIVE" });
+      const event = makeEvent("publishApp", {
+        userId: ATTACKER_ID,
+        orgId: OTHER_ORG,
+      });
+
+      let caught: unknown;
+      try {
+        await handler(event);
+      } catch (err) {
+        caught = err;
+      }
+      expect(caught).toBeInstanceOf(Error);
+      // The rejection is an Error, not a PublishResult — no apiKey field
+      // could have leaked via a partial/successful-looking response.
+      expect((caught as { apiKey?: unknown }).apiKey).toBeUndefined();
+    });
+
+    test("legitimate explicit owner succeeds end to end", async () => {
+      seedApp({ status: "ACTIVE" });
+      const event = makeEvent("publishApp", {
+        userId: OWNER_ID,
+        orgId: APP_ORG,
+      });
+
+      const result = await handler(event);
+      expect(result.apiKey).toBeTruthy();
+      expect(apiGwProvisioningCallCount()).toBe(1);
+      expect(apiKeyPutCallCount()).toBe(1);
+      expect(statusUpdateCallCount()).toBeGreaterThanOrEqual(1);
+      expect(eventBridgePublishCount()).toBeGreaterThanOrEqual(1);
+    });
+
+    test("legitimate implicit creator-owner (no access map yet, createdBy matches) succeeds", async () => {
+      seedApp({ status: "ACTIVE", access: {}, createdBy: OWNER_ID });
+      const event = makeEvent("publishApp", {
+        userId: OWNER_ID,
+        orgId: APP_ORG,
+      });
+
+      const result = await handler(event);
+      expect(result.apiKey).toBeTruthy();
+    });
+
+    test("admin bypass succeeds even without an owner entry", async () => {
+      seedApp({ status: "ACTIVE", access: {}, createdBy: null });
+      const event = makeEvent("publishApp", {
+        userId: ATTACKER_ID,
+        orgId: OTHER_ORG,
+        groups: ["admin"],
+      });
+
+      const result = await handler(event);
+      expect(result.apiKey).toBeTruthy();
+    });
+  });
+
+  describe("unpublishApp", () => {
+    test("cross-org caller is refused with ZERO teardown side effects", async () => {
+      ddbMock.on(QueryCommand).resolves({
+        Items: [
+          {
+            appId: APP_ID,
+            sortId: "METADATA",
+            groupId: `APP#${APP_ID}`,
+            name: "Test App",
+            status: "PUBLISHED",
+            workflowIds: ["wf-1"],
+            orgId: APP_ORG,
+            apiId: "api-victim",
+            endpointUrl: "https://api-victim.execute-api.us-east-1.amazonaws.com",
+            version: 1,
+          },
+        ],
+      });
+      seedApp({ status: "PUBLISHED" });
+      const event = makeEvent("unpublishApp", {
+        userId: ATTACKER_ID,
+        orgId: OTHER_ORG,
+      });
+
+      await expect(handler(event)).rejects.toThrow(
+        /Access denied/i,
+      );
+      expect(apiGwDeleteCallCount()).toBe(0);
+      expect(statusUpdateCallCount()).toBe(0);
+      expect(eventBridgePublishCount()).toBe(0);
+      expect(deleteRoleSpy).not.toHaveBeenCalled();
+    });
+
+    test("same-org non-owner caller is refused with ZERO teardown side effects", async () => {
+      ddbMock.on(QueryCommand).resolves({
+        Items: [
+          {
+            appId: APP_ID,
+            sortId: "METADATA",
+            groupId: `APP#${APP_ID}`,
+            name: "Test App",
+            status: "PUBLISHED",
+            workflowIds: ["wf-1"],
+            orgId: APP_ORG,
+            apiId: "api-victim",
+            endpointUrl: "https://api-victim.execute-api.us-east-1.amazonaws.com",
+            version: 1,
+          },
+        ],
+      });
+      seedApp({ status: "PUBLISHED" });
+      const event = makeEvent("unpublishApp", {
+        userId: ATTACKER_ID,
+        orgId: APP_ORG,
+      });
+
+      await expect(handler(event)).rejects.toThrow(
+        /Access denied/i,
+      );
+      expect(apiGwDeleteCallCount()).toBe(0);
+      expect(statusUpdateCallCount()).toBe(0);
+      expect(eventBridgePublishCount()).toBe(0);
+      expect(deleteRoleSpy).not.toHaveBeenCalled();
+    });
+
+    test("missing identity is refused with ZERO teardown side effects", async () => {
+      seedApp({ status: "PUBLISHED" });
+      const event = makeEvent("unpublishApp", {});
+
+      await expect(handler(event)).rejects.toThrow(
+        /Access denied/i,
+      );
+      expect(apiGwDeleteCallCount()).toBe(0);
+      expect(deleteRoleSpy).not.toHaveBeenCalled();
+    });
+
+    test("missing Registry record is refused, not silently allowed", async () => {
+      const event = makeEvent("unpublishApp", {
+        userId: OWNER_ID,
+        orgId: APP_ORG,
+      });
+
+      await expect(handler(event)).rejects.toThrow();
+      expect(apiGwDeleteCallCount()).toBe(0);
+    });
+
+    test("record with no owner entry and no createdBy is refused", async () => {
+      seedApp({ status: "PUBLISHED", access: {}, createdBy: null });
+      const event = makeEvent("unpublishApp", {
+        userId: ATTACKER_ID,
+        orgId: APP_ORG,
+      });
+
+      await expect(handler(event)).rejects.toThrow(
+        /Access denied/i,
+      );
+      expect(apiGwDeleteCallCount()).toBe(0);
+      expect(deleteRoleSpy).not.toHaveBeenCalled();
+    });
+
+    test("legitimate explicit owner succeeds end to end", async () => {
+      ddbMock.on(QueryCommand).resolves({
+        Items: [
+          {
+            appId: APP_ID,
+            sortId: "METADATA",
+            groupId: `APP#${APP_ID}`,
+            name: "Test App",
+            status: "PUBLISHED",
+            workflowIds: ["wf-1"],
+            orgId: APP_ORG,
+            apiId: "api-1",
+            endpointUrl: "https://api-1.execute-api.us-east-1.amazonaws.com",
+            version: 1,
+          },
+        ],
+      });
+      seedApp({ status: "PUBLISHED" });
+      const event = makeEvent("unpublishApp", {
+        userId: OWNER_ID,
+        orgId: APP_ORG,
+      });
+
+      const result = await handler(event);
+      expect(result.status).toBe("DRAFT");
+      expect(apiGwDeleteCallCount()).toBe(1);
+    });
+
+    test("admin bypass succeeds even without an owner entry", async () => {
+      ddbMock.on(QueryCommand).resolves({
+        Items: [
+          {
+            appId: APP_ID,
+            sortId: "METADATA",
+            groupId: `APP#${APP_ID}`,
+            name: "Test App",
+            status: "PUBLISHED",
+            workflowIds: ["wf-1"],
+            orgId: APP_ORG,
+            apiId: "api-1",
+            endpointUrl: "https://api-1.execute-api.us-east-1.amazonaws.com",
+            version: 1,
+          },
+        ],
+      });
+      seedApp({ status: "PUBLISHED", access: {}, createdBy: null });
+      const event = makeEvent("unpublishApp", {
+        userId: ATTACKER_ID,
+        orgId: OTHER_ORG,
+        groups: ["admin"],
+      });
+
+      const result = await handler(event);
+      expect(result.status).toBe("DRAFT");
+    });
+  });
+});

--- a/backend/src/lambda/__tests__/app-publish-handler.test.ts
+++ b/backend/src/lambda/__tests__/app-publish-handler.test.ts
@@ -6,6 +6,8 @@
  *
  * Validates: Requirements 1.2, 1.3, 1.5, 1.7, 1.9, 1.10, 2.1, 2.2, 2.4, 2.8
  */
+process.env.REGISTRY_ID = "test-registry-id";
+
 import {
   ApiGatewayV2Client,
   CreateApiCommand,
@@ -39,6 +41,31 @@ import {
 import { mockClient } from "aws-sdk-client-mock";
 
 import {
+  seedMockRegistry,
+  resetMockRegistry,
+} from "./fixtures/registry-service-mock";
+
+// This file tests publishApp/unpublishApp directly (not through the
+// handler), so it must mock RegistryService itself for the owner gate
+// (finding 13a58234) — every call site below passes OWNER_EVENT, an
+// AppSync identity whose custom:organization/sub match the seeded app's
+// manifest owner, so the gate passes and existing behavior is exercised
+// unchanged.
+jest.mock("../../services/registry-service", () => {
+  const { getMockRegistryService } = jest.requireActual(
+    "./fixtures/registry-service-mock",
+  );
+  const actual = jest.requireActual("../../services/registry-service");
+  return {
+    RegistryService: jest
+      .fn()
+      .mockImplementation(() => getMockRegistryService()),
+    TypeMismatchError: actual.TypeMismatchError,
+    RegistryLifecycleError: actual.RegistryLifecycleError,
+  };
+});
+
+import {
   validatePublishPreconditions,
   provisionApiGateway,
   publishApp,
@@ -51,6 +78,41 @@ import { DynamoDBClient } from "@aws-sdk/client-dynamodb";
 import { PolicyManager } from "../../utils/policy-manager";
 import * as apiKeyHash from "../../utils/api-key-hash";
 import { hashApiKey, HASH_ALG } from "../../utils/api-key-hash";
+
+// ── Owner-gate fixture (finding 13a58234) ───────────────────
+
+const PUBLISH_OWNER_ID = "user-1";
+const PUBLISH_APP_ORG = "org-1";
+
+/** AppSync event authorized as the seeded app's owner — see seedOwnerApp. */
+const OWNER_EVENT = {
+  identity: {
+    sub: PUBLISH_OWNER_ID,
+    claims: { sub: PUBLISH_OWNER_ID, "custom:organization": PUBLISH_APP_ORG },
+  },
+};
+
+/**
+ * Seeds a mock Registry record for `appId` whose manifest.createdBy ==
+ * PUBLISH_OWNER_ID and manifest.orgId == PUBLISH_APP_ORG, so OWNER_EVENT
+ * satisfies assertManifestAccess's implicit-creator-owner fallback. Call
+ * once per appId used in a test (default "app-1", matching this file's
+ * existing fixtures).
+ */
+function seedOwnerApp(appId: string = "app-1") {
+  seedMockRegistry("agent", appId, {
+    name: "Test App",
+    status: "ACTIVE",
+    customDescriptorContent: JSON.stringify({
+      appId,
+      manifest: {
+        orgId: PUBLISH_APP_ORG,
+        createdBy: PUBLISH_OWNER_ID,
+        access: {},
+      },
+    }),
+  });
+}
 
 // ── Mocks ───────────────────────────────────────────────────
 
@@ -698,10 +760,12 @@ describe("publishApp", () => {
     deleteRole: jest.fn().mockResolvedValue(undefined),
   } as unknown as PolicyManager;
 
-  let defaultDeps: Parameters<typeof publishApp>[2];
+  let defaultDeps: Parameters<typeof publishApp>[3];
 
   beforeEach(() => {
     setupDefaultMocks();
+    resetMockRegistry();
+    seedOwnerApp();
     (mockPolicyManager.getAccountContext as jest.Mock).mockClear();
     (mockPolicyManager.ensureRole as jest.Mock).mockClear();
     defaultDeps = {
@@ -731,7 +795,7 @@ describe("publishApp", () => {
       ],
     });
 
-    const result = await publishApp("app-1", "user-1", defaultDeps);
+    const result = await publishApp("app-1", "user-1", OWNER_EVENT, defaultDeps);
 
     expect(result.app.status).toBe("PUBLISHED");
     expect(result.endpointUrl).toBe(
@@ -750,7 +814,7 @@ describe("publishApp", () => {
     ddbMock.on(QueryCommand).resolves({ Items: [] });
 
     await expect(
-      publishApp("nonexistent", "user-1", defaultDeps),
+      publishApp("nonexistent", "user-1", OWNER_EVENT, defaultDeps),
     ).rejects.toThrow("App not found");
   });
 
@@ -766,7 +830,7 @@ describe("publishApp", () => {
       ],
     });
 
-    await expect(publishApp("app-1", "user-1", defaultDeps)).rejects.toThrow(
+    await expect(publishApp("app-1", "user-1", OWNER_EVENT, defaultDeps)).rejects.toThrow(
       "Publish preconditions not met",
     );
   });
@@ -791,7 +855,7 @@ describe("publishApp", () => {
     ddbMock.on(PutCommand).resolves({});
     ddbMock.on(UpdateCommand).resolves({});
 
-    const result = await publishApp("app-1", "user-1", defaultDeps);
+    const result = await publishApp("app-1", "user-1", OWNER_EVENT, defaultDeps);
 
     // Verify result
     expect(result.app.status).toBe("PUBLISHED");
@@ -878,7 +942,7 @@ describe("publishApp", () => {
 
     apiGwMock.on(CreateStageCommand).rejects(new Error("Provisioning failed"));
 
-    await expect(publishApp("app-1", "user-1", defaultDeps)).rejects.toThrow(
+    await expect(publishApp("app-1", "user-1", OWNER_EVENT, defaultDeps)).rejects.toThrow(
       "Provisioning failed",
     );
 
@@ -905,7 +969,7 @@ describe("publishApp", () => {
     ddbMock.on(PutCommand).resolves({});
     ddbMock.on(UpdateCommand).resolves({});
 
-    await publishApp("app-1", "user-1", defaultDeps);
+    await publishApp("app-1", "user-1", OWNER_EVENT, defaultDeps);
 
     const createApiCall = apiGwMock.commandCalls(CreateApiCommand)[0];
     expect(createApiCall.args[0].input.Name).toBe("citadel-app-app-1-dev");
@@ -1035,10 +1099,12 @@ describe("publishApp intake progress-on-publish", () => {
     deleteRole: jest.fn().mockResolvedValue(undefined),
   } as unknown as PolicyManager;
 
-  let defaultDeps: Parameters<typeof publishApp>[2];
+  let defaultDeps: Parameters<typeof publishApp>[3];
 
   beforeEach(() => {
     setupDefaultMocks();
+    resetMockRegistry();
+    seedOwnerApp();
     defaultDeps = {
       docClient: DynamoDBDocumentClient.from(new DynamoDBClient({})),
       apiGwClient: new ApiGatewayV2Client({}),
@@ -1081,7 +1147,7 @@ describe("publishApp intake progress-on-publish", () => {
   test("emits implementation=100 intake progress event when the app carries a sourceProjectId", async () => {
     seedPublishableApp({ sourceProjectId: "proj-42" });
 
-    await publishApp("app-1", "user-1", defaultDeps);
+    await publishApp("app-1", "user-1", OWNER_EVENT, defaultDeps);
 
     const entries = findIntakeProgressEntries();
     expect(entries).toHaveLength(1);
@@ -1097,7 +1163,7 @@ describe("publishApp intake progress-on-publish", () => {
   test("emits NO intake progress event when the app has no sourceProjectId linkage (backward compatible)", async () => {
     seedPublishableApp();
 
-    await publishApp("app-1", "user-1", defaultDeps);
+    await publishApp("app-1", "user-1", OWNER_EVENT, defaultDeps);
 
     expect(findIntakeProgressEntries()).toHaveLength(0);
     // The status-transition event still goes out.
@@ -1119,7 +1185,7 @@ describe("publishApp intake progress-on-publish", () => {
         return Promise.resolve({});
       });
 
-    const result = await publishApp("app-1", "user-1", defaultDeps);
+    const result = await publishApp("app-1", "user-1", OWNER_EVENT, defaultDeps);
 
     expect(result.app.status).toBe("PUBLISHED");
     expect(result.endpointUrl).toBeTruthy();
@@ -1138,7 +1204,7 @@ describe("publishApp intake progress-on-publish", () => {
       ],
     });
 
-    await publishApp("app-1", "user-1", defaultDeps);
+    await publishApp("app-1", "user-1", OWNER_EVENT, defaultDeps);
 
     expect(findIntakeProgressEntries()).toHaveLength(0);
   });

--- a/backend/src/lambda/__tests__/app-unpublish-handler.test.ts
+++ b/backend/src/lambda/__tests__/app-unpublish-handler.test.ts
@@ -3,6 +3,8 @@
  *
  * Validates: Requirements 8.1, 8.2, 8.3, 8.4, 8.5, 8.6, 8.7, 8.8, 8.9
  */
+process.env.REGISTRY_ID = 'test-registry-id';
+
 import {
   ApiGatewayV2Client,
   DeleteApiCommand,
@@ -14,8 +16,70 @@ import { STSClient, GetCallerIdentityCommand } from '@aws-sdk/client-sts';
 import { IAMClient, DeleteRolePolicyCommand, DeleteRoleCommand } from '@aws-sdk/client-iam';
 import { mockClient } from 'aws-sdk-client-mock';
 
+import {
+  seedMockRegistry,
+  resetMockRegistry,
+} from './fixtures/registry-service-mock';
+
+// This file tests unpublishApp directly (not through the handler), so it
+// must mock RegistryService itself for the owner gate (finding 13a58234).
+// Every call site below passes OWNER_EVENT, an AppSync identity whose
+// custom:organization/sub match the seeded app's manifest owner, so the
+// gate passes and existing behavior is exercised unchanged.
+jest.mock('../../services/registry-service', () => {
+  const { getMockRegistryService } = jest.requireActual(
+    './fixtures/registry-service-mock',
+  );
+  const actual = jest.requireActual('../../services/registry-service');
+  return {
+    RegistryService: jest
+      .fn()
+      .mockImplementation(() => getMockRegistryService()),
+    TypeMismatchError: actual.TypeMismatchError,
+    RegistryLifecycleError: actual.RegistryLifecycleError,
+  };
+});
+
 import { unpublishApp, AppMetadata } from '../app-publish-handler';
 import { PolicyManager } from '../../utils/policy-manager';
+
+// ── Owner-gate fixture (finding 13a58234) ───────────────────
+
+const UNPUBLISH_OWNER_ID = 'user-1';
+const UNPUBLISH_APP_ORG = 'org-1';
+
+/** AppSync event authorized as the seeded app's owner — see seedOwnerApp. */
+const OWNER_EVENT = {
+  identity: {
+    sub: UNPUBLISH_OWNER_ID,
+    claims: {
+      sub: UNPUBLISH_OWNER_ID,
+      'custom:organization': UNPUBLISH_APP_ORG,
+    },
+  },
+};
+
+/**
+ * Seeds a mock Registry record for `appId` whose manifest.createdBy ==
+ * UNPUBLISH_OWNER_ID and manifest.orgId == UNPUBLISH_APP_ORG, so
+ * OWNER_EVENT satisfies assertManifestAccess's implicit-creator-owner
+ * fallback. Call once per appId used in a test (default 'app-1', matching
+ * this file's existing fixtures).
+ */
+function seedOwnerApp(appId: string = 'app-1') {
+  seedMockRegistry('agent', appId, {
+    name: 'Test App',
+    status: 'PUBLISHED',
+    customDescriptorContent: JSON.stringify({
+      appId,
+      manifest: {
+        orgId: UNPUBLISH_APP_ORG,
+        createdBy: UNPUBLISH_OWNER_ID,
+        access: {},
+      },
+    }),
+  });
+}
 
 // ── Mocks ───────────────────────────────────────────────────
 
@@ -85,6 +149,8 @@ beforeEach(() => {
   ebMock.reset();
   stsMock.reset();
   iamMock.reset();
+  resetMockRegistry();
+  seedOwnerApp();
 
   apiGwMock.on(DeleteApiCommand).resolves({});
   ddbMock.on(UpdateCommand).resolves({});
@@ -104,7 +170,7 @@ describe('unpublishApp — idempotency', () => {
     const draftApp = makePublishedApp({ status: 'DRAFT' });
     ddbMock.on(QueryCommand).resolves({ Items: [draftApp] });
 
-    const result = await unpublishApp('app-1', 'user-1', makeDefaultDeps());
+    const result = await unpublishApp('app-1', 'user-1', OWNER_EVENT, makeDefaultDeps());
 
     expect(result.app.status).toBe('DRAFT');
     expect(apiGwMock.commandCalls(DeleteApiCommand)).toHaveLength(0);
@@ -115,7 +181,7 @@ describe('unpublishApp — idempotency', () => {
     const activeApp = makePublishedApp({ status: 'ACTIVE' });
     ddbMock.on(QueryCommand).resolves({ Items: [activeApp] });
 
-    const result = await unpublishApp('app-1', 'user-1', makeDefaultDeps());
+    const result = await unpublishApp('app-1', 'user-1', OWNER_EVENT, makeDefaultDeps());
 
     expect(result.app.status).toBe('ACTIVE');
     expect(apiGwMock.commandCalls(DeleteApiCommand)).toHaveLength(0);
@@ -125,7 +191,7 @@ describe('unpublishApp — idempotency', () => {
     const archivedApp = makePublishedApp({ status: 'ARCHIVED' });
     ddbMock.on(QueryCommand).resolves({ Items: [archivedApp] });
 
-    const result = await unpublishApp('app-1', 'user-1', makeDefaultDeps());
+    const result = await unpublishApp('app-1', 'user-1', OWNER_EVENT, makeDefaultDeps());
 
     expect(result.app.status).toBe('ARCHIVED');
   });
@@ -145,7 +211,7 @@ describe('unpublishApp — full teardown', () => {
       ],
     });
 
-    const result = await unpublishApp('app-1', 'user-1', makeDefaultDeps());
+    const result = await unpublishApp('app-1', 'user-1', OWNER_EVENT, makeDefaultDeps());
 
     // Status should be DRAFT
     expect(result.app.status).toBe('DRAFT');
@@ -176,7 +242,7 @@ describe('unpublishApp — full teardown', () => {
       Items: [makePublishedApp()],
     });
 
-    await unpublishApp('app-1', 'user-1', makeDefaultDeps());
+    await unpublishApp('app-1', 'user-1', OWNER_EVENT, makeDefaultDeps());
 
     // Verify the metadata update removes endpointUrl and apiId
     const updateCalls = ddbMock.commandCalls(UpdateCommand);
@@ -193,7 +259,7 @@ describe('unpublishApp — full teardown', () => {
       Items: [makePublishedApp()],
     });
 
-    await unpublishApp('app-1', 'user-1', makeDefaultDeps());
+    await unpublishApp('app-1', 'user-1', OWNER_EVENT, makeDefaultDeps());
 
     const updateCalls = ddbMock.commandCalls(UpdateCommand);
     // Key is appId only — AppsTable has no sort key.
@@ -220,7 +286,7 @@ describe('unpublishApp — EventBridge event', () => {
       Items: [makePublishedApp()],
     });
 
-    await unpublishApp('app-1', 'user-1', makeDefaultDeps());
+    await unpublishApp('app-1', 'user-1', OWNER_EVENT, makeDefaultDeps());
 
     const ebCalls = ebMock.commandCalls(PutEventsCommand);
     expect(ebCalls).toHaveLength(1);
@@ -234,7 +300,7 @@ describe('unpublishApp — EventBridge event', () => {
       Items: [makePublishedApp({ orgId: 'org-test' })],
     });
 
-    await unpublishApp('app-1', 'user-1', makeDefaultDeps());
+    await unpublishApp('app-1', 'user-1', OWNER_EVENT, makeDefaultDeps());
 
     const ebCalls = ebMock.commandCalls(PutEventsCommand);
     const detail = JSON.parse(ebCalls[0].args[0].input.Entries![0].Detail!);
@@ -258,7 +324,7 @@ describe('unpublishApp — correlation ID', () => {
       Items: [makePublishedApp()],
     });
 
-    await unpublishApp('app-1', 'user-1', makeDefaultDeps());
+    await unpublishApp('app-1', 'user-1', OWNER_EVENT, makeDefaultDeps());
 
     const ebCalls = ebMock.commandCalls(PutEventsCommand);
     const detail = JSON.parse(ebCalls[0].args[0].input.Entries![0].Detail!);
@@ -277,7 +343,7 @@ describe('unpublishApp — best-effort teardown', () => {
     });
     apiGwMock.on(DeleteApiCommand).rejects(new Error('API GW delete failed'));
 
-    const result = await unpublishApp('app-1', 'user-1', makeDefaultDeps());
+    const result = await unpublishApp('app-1', 'user-1', OWNER_EVENT, makeDefaultDeps());
 
     // Should still set status to DRAFT
     expect(result.app.status).toBe('DRAFT');
@@ -318,7 +384,7 @@ describe('unpublishApp — best-effort teardown', () => {
       return {};
     });
 
-    const result = await unpublishApp('app-1', 'user-1', makeDefaultDeps());
+    const result = await unpublishApp('app-1', 'user-1', OWNER_EVENT, makeDefaultDeps());
 
     expect(result.app.status).toBe('DRAFT');
     expect(result.warnings).toBeDefined();
@@ -333,7 +399,7 @@ describe('unpublishApp — best-effort teardown', () => {
       new Error('IAM role delete failed'),
     );
 
-    const result = await unpublishApp('app-1', 'user-1', makeDefaultDeps());
+    const result = await unpublishApp('app-1', 'user-1', OWNER_EVENT, makeDefaultDeps());
 
     expect(result.app.status).toBe('DRAFT');
     expect(result.warnings).toBeDefined();
@@ -349,7 +415,7 @@ describe('unpublishApp — best-effort teardown', () => {
       new Error('IAM failed'),
     );
 
-    const result = await unpublishApp('app-1', 'user-1', makeDefaultDeps());
+    const result = await unpublishApp('app-1', 'user-1', OWNER_EVENT, makeDefaultDeps());
 
     expect(result.app.status).toBe('DRAFT');
     expect(result.warnings!.length).toBeGreaterThanOrEqual(2);
@@ -363,7 +429,7 @@ describe('unpublishApp — error handling', () => {
     ddbMock.on(QueryCommand).resolves({ Items: [] });
 
     await expect(
-      unpublishApp('nonexistent', 'user-1', makeDefaultDeps()),
+      unpublishApp('nonexistent', 'user-1', OWNER_EVENT, makeDefaultDeps()),
     ).rejects.toThrow('App not found');
   });
 });

--- a/backend/src/lambda/__tests__/test_publish_idempotency_properties.ts
+++ b/backend/src/lambda/__tests__/test_publish_idempotency_properties.ts
@@ -7,6 +7,8 @@
  * re-provisioning. For any non-published app, `unpublishApp` returns current
  * state without error.
  */
+process.env.REGISTRY_ID = 'test-registry-id';
+
 import * as fc from 'fast-check';
 import {
   ApiGatewayV2Client,
@@ -24,8 +26,72 @@ import { STSClient } from '@aws-sdk/client-sts';
 import { IAMClient } from '@aws-sdk/client-iam';
 import { mockClient } from 'aws-sdk-client-mock';
 
+import {
+  seedMockRegistry,
+  resetMockRegistry,
+} from './fixtures/registry-service-mock';
+
+// This file tests publishApp/unpublishApp directly (not through the
+// handler), so it must mock RegistryService itself for the owner gate
+// (finding 13a58234). Every call site below passes an OWNER_EVENT built
+// from the property-generated appId, and seedOwnerApp seeds a matching
+// Registry record per property run, so the gate passes and the pre-fix
+// idempotency behavior is exercised unchanged.
+jest.mock('../../services/registry-service', () => {
+  const { getMockRegistryService } = jest.requireActual(
+    './fixtures/registry-service-mock',
+  );
+  const actual = jest.requireActual('../../services/registry-service');
+  return {
+    RegistryService: jest
+      .fn()
+      .mockImplementation(() => getMockRegistryService()),
+    TypeMismatchError: actual.TypeMismatchError,
+    RegistryLifecycleError: actual.RegistryLifecycleError,
+  };
+});
+
 import { publishApp, unpublishApp, AppMetadata } from '../app-publish-handler';
 import { PolicyManager } from '../../utils/policy-manager';
+
+// ── Owner-gate fixture (finding 13a58234) ───────────────────
+
+const IDEMPOTENCY_OWNER_ID = 'user-1';
+const IDEMPOTENCY_APP_ORG = 'owner-org';
+
+/** AppSync event authorized as the seeded app's owner — see seedOwnerApp. */
+const OWNER_EVENT = {
+  identity: {
+    sub: IDEMPOTENCY_OWNER_ID,
+    claims: {
+      sub: IDEMPOTENCY_OWNER_ID,
+      'custom:organization': IDEMPOTENCY_APP_ORG,
+    },
+  },
+};
+
+/**
+ * Seeds a mock Registry record for `appId` whose manifest.createdBy ==
+ * IDEMPOTENCY_OWNER_ID and manifest.orgId == IDEMPOTENCY_APP_ORG, matching
+ * OWNER_EVENT's claims, so assertManifestAccess's org-equality check plus
+ * implicit-creator-owner fallback both pass regardless of the
+ * property-generated orgId used in the AppMetadata row itself (that value
+ * only flows into the EventBridge event detail, not the Registry gate).
+ */
+function seedOwnerApp(appId: string) {
+  seedMockRegistry('agent', appId, {
+    name: 'Test App',
+    status: 'ACTIVE',
+    customDescriptorContent: JSON.stringify({
+      appId,
+      manifest: {
+        orgId: IDEMPOTENCY_APP_ORG,
+        createdBy: IDEMPOTENCY_OWNER_ID,
+        access: {},
+      },
+    }),
+  });
+}
 
 // ── Mocks ───────────────────────────────────────────────────
 
@@ -96,6 +162,7 @@ describe('Property 4: Publish and unpublish idempotence', () => {
     ebMock.reset();
     stsMock.reset();
     iamMock.reset();
+    resetMockRegistry();
     (mockPolicyManager.getAccountContext as jest.Mock).mockClear();
     (mockPolicyManager.ensureRole as jest.Mock).mockClear();
     (mockPolicyManager.deleteRole as jest.Mock).mockClear();
@@ -120,6 +187,8 @@ describe('Property 4: Publish and unpublish idempotence', () => {
           apiGwMock.reset();
           ddbMock.reset();
           ebMock.reset();
+          resetMockRegistry();
+          seedOwnerApp(appId);
 
           const publishedApp: AppMetadata = {
             appId,
@@ -140,7 +209,7 @@ describe('Property 4: Publish and unpublish idempotence', () => {
             ],
           });
 
-          const result = await publishApp(appId, 'user-1', makeDeps());
+          const result = await publishApp(appId, 'user-1', OWNER_EVENT, makeDeps());
 
           // Returns current published state
           expect(result.app.status).toBe('PUBLISHED');
@@ -183,6 +252,8 @@ describe('Property 4: Publish and unpublish idempotence', () => {
           apiGwMock.reset();
           ddbMock.reset();
           ebMock.reset();
+          resetMockRegistry();
+          seedOwnerApp(appId);
           (mockPolicyManager.deleteRole as jest.Mock).mockClear();
 
           const app: AppMetadata = {
@@ -197,7 +268,7 @@ describe('Property 4: Publish and unpublish idempotence', () => {
 
           ddbMock.on(QueryCommand).resolves({ Items: [app] });
 
-          const result = await unpublishApp(appId, 'user-1', makeDeps());
+          const result = await unpublishApp(appId, 'user-1', OWNER_EVENT, makeDeps());
 
           // Returns current state unchanged
           expect(result.app.status).toBe(status);

--- a/backend/src/lambda/app-publish-handler.ts
+++ b/backend/src/lambda/app-publish-handler.ts
@@ -38,6 +38,8 @@ import {
 import { PolicyManager } from "../utils/policy-manager";
 import { updateAppMetaFields } from "../utils/apps-table-meta";
 import { hashApiKey, getApiKeyPepper, HASH_ALG } from "../utils/api-key-hash";
+import { RegistryService } from "../services/registry-service";
+import { assertManifestAccess } from "./registry-agent-record-resolver";
 
 // ── Types ───────────────────────────────────────────────────
 
@@ -241,6 +243,7 @@ let _apiGwClient: ApiGatewayV2Client | undefined;
 let _eventBridgeClient: EventBridgeClient | undefined;
 let _cwLogsClient: CloudWatchLogsClient | undefined;
 let _policyManager: PolicyManager | undefined;
+let _registryService: RegistryService | undefined;
 
 function getDocClient(): DynamoDBDocumentClient {
   if (!_docClient)
@@ -262,6 +265,28 @@ function getCwLogsClient(): CloudWatchLogsClient {
 function getPolicyManager(): PolicyManager {
   if (!_policyManager) _policyManager = new PolicyManager();
   return _policyManager;
+}
+
+/**
+ * Lazy RegistryService singleton, mirroring the same pattern used by
+ * registry-agent-record-resolver.ts. Read-only usage here: this handler
+ * ONLY calls getResource to fetch the manifest for the owner gate
+ * (finding 13a58234) — it must never write to the Registry.
+ */
+function getRegistryService(): RegistryService {
+  if (!_registryService) {
+    const registryId = process.env.REGISTRY_ID;
+    if (!registryId) {
+      throw new Error(
+        "REGISTRY_ID environment variable is required by app-publish-handler",
+      );
+    }
+    _registryService = new RegistryService({
+      registryId,
+      region: REGION,
+    });
+  }
+  return _registryService;
 }
 
 // ── Provision API Gateway ───────────────────────────────────
@@ -436,6 +461,7 @@ export async function provisionApiGateway(
 export async function publishApp(
   appId: string,
   userId: string,
+  resolverEvent: unknown,
   deps: {
     docClient: DynamoDBDocumentClient;
     apiGwClient: ApiGatewayV2Client;
@@ -459,6 +485,24 @@ export async function publishApp(
   },
 ): Promise<PublishResult> {
   const correlationId = uuidv4();
+
+  // 0. Owner gate (finding 13a58234) — BEFORE any provisioning, key
+  // generation, IAM change, EventBridge publish, or status write. Reuses
+  // the SAME shared manifest-access gate as grantAppAccess/revokeAppAccess
+  // and deleteApp (PR 134), pinned at requiredRole='owner': publish/
+  // unpublish provision or tear down billable, externally-reachable
+  // infrastructure and mint/revoke plaintext API keys, so they are
+  // owner-reserved, not editor-reserved. Fails closed on any missing
+  // identity, unresolvable org, missing record, or a record with no
+  // owner/createdBy (assertManifestAccess's own fail-closed contract).
+  const registryRecord = await getRegistryService().getResource(
+    "agent",
+    appId,
+  );
+  if (!registryRecord) {
+    throw new Error(`App not found: ${appId}`);
+  }
+  await assertManifestAccess(appId, registryRecord, resolverEvent, "owner");
 
   // 1. Fetch app metadata and components
   const componentsResult = await deps.docClient.send(
@@ -674,6 +718,7 @@ export interface UnpublishResult {
 export async function unpublishApp(
   appId: string,
   userId: string,
+  resolverEvent: unknown,
   deps: {
     docClient: DynamoDBDocumentClient;
     apiGwClient: ApiGatewayV2Client;
@@ -698,6 +743,18 @@ export async function unpublishApp(
 ): Promise<UnpublishResult> {
   const correlationId = uuidv4();
   const warnings: string[] = [];
+
+  // 0. Owner gate (finding 13a58234) — BEFORE any teardown (API Gateway
+  // delete, key revocation, IAM role delete, status write). Same shared
+  // gate as publishApp above; see that function's comment for rationale.
+  const registryRecord = await getRegistryService().getResource(
+    "agent",
+    appId,
+  );
+  if (!registryRecord) {
+    throw new Error(`App not found: ${appId}`);
+  }
+  await assertManifestAccess(appId, registryRecord, resolverEvent, "owner");
 
   // 1. Fetch app metadata and components
   const componentsResult = await deps.docClient.send(
@@ -833,7 +890,19 @@ export async function unpublishApp(
 interface AppPublishResolverEvent {
   info?: { fieldName?: string };
   arguments: { appId: string };
-  identity?: { sub?: string; claims?: { sub?: string } };
+  /**
+   * Broadened beyond {sub, claims.sub} to carry the full Cognito claims bag
+   * (custom:organization, custom:role, cognito:groups, or the nested
+   * claims.* equivalents) — assertManifestAccess's extractOrgFromEvent /
+   * isAdminFromEvent (auth-event.ts) read these directly off `identity`,
+   * mirroring every other AppSync resolver event shape in this codebase.
+   */
+  identity?: {
+    sub?: string;
+    username?: string;
+    claims?: Record<string, unknown>;
+    [key: string]: unknown;
+  };
 }
 
 export const handler = async (
@@ -843,13 +912,16 @@ export const handler = async (
 
   const { info, arguments: args, identity } = event;
   const fieldName = info?.fieldName;
-  const userId = identity?.sub || identity?.claims?.sub || "unknown";
+  const userId =
+    identity?.sub ||
+    (identity?.claims?.sub as string | undefined) ||
+    "unknown";
 
   switch (fieldName) {
     case "publishApp":
-      return await publishApp(args.appId, userId);
+      return await publishApp(args.appId, userId, event);
     case "unpublishApp": {
-      const unpublishResult = await unpublishApp(args.appId, userId);
+      const unpublishResult = await unpublishApp(args.appId, userId, event);
       return unpublishResult.app;
     }
     default:

--- a/backend/src/lambda/registry-agent-record-resolver.ts
+++ b/backend/src/lambda/registry-agent-record-resolver.ts
@@ -2501,7 +2501,7 @@ const MANIFEST_ROLE_LEVEL: Record<string, number> = {
  * recorded `createdBy` — see the fallback below, unchanged from the
  * owner-only version.
  */
-async function assertManifestAccess(
+export async function assertManifestAccess(
   appId: string,
   record: RegistryRecord,
   event: unknown,

--- a/backend/test/gateway-stack.test.ts
+++ b/backend/test/gateway-stack.test.ts
@@ -45,6 +45,9 @@ function createTestStack(): { stack: GatewayStack; template: Template } {
     appsTable,
     eventBus,
     idempotencyTable,
+    registryId: "test-registry-id",
+    registryArn:
+      "arn:aws:bedrock-agentcore:us-east-1:123456789012:registry/test-registry-id",
   });
 
   const template = Template.fromStack(stack);
@@ -97,6 +100,18 @@ describe("GatewayStack — Shared Lambda Functions (Task 1.1)", () => {
           ENVIRONMENT: "test",
           AUTHORIZER_FUNCTION_ARN: Match.anyValue(),
           IDEMPOTENCY_TABLE: Match.anyValue(),
+        }),
+      },
+    });
+  });
+
+  // --- Owner-gate registry wiring (finding 13a58234) ---
+  test("AppPublishHandler has REGISTRY_ID environment variable", () => {
+    template.hasResourceProperties("AWS::Lambda::Function", {
+      Handler: "app-publish-handler.handler",
+      Environment: {
+        Variables: Match.objectLike({
+          REGISTRY_ID: "test-registry-id",
         }),
       },
     });
@@ -304,6 +319,58 @@ describe("GatewayStack — IAM Permissions (Task 1.1)", () => {
         ]),
       },
     });
+  });
+
+  // --- Registry read grant (finding 13a58234) ---
+  // Regression guard: without this grant/env, the owner gate wiring
+  // silently fails closed in production (GetResource throws an access
+  // error) rather than merely being untested — asserting its presence
+  // here prevents that regression from shipping unnoticed.
+  test("publish handler has bedrock-agentcore:GetRegistryRecord scoped to the registry ARN (read-only, no list/write)", () => {
+    template.hasResourceProperties("AWS::IAM::Policy", {
+      PolicyDocument: {
+        Statement: Match.arrayWith([
+          Match.objectLike({
+            Effect: "Allow",
+            Action: "bedrock-agentcore:GetRegistryRecord",
+            Resource: Match.arrayWith([
+              "arn:aws:bedrock-agentcore:us-east-1:123456789012:registry/test-registry-id",
+              "arn:aws:bedrock-agentcore:us-east-1:123456789012:registry/test-registry-id/*",
+            ]),
+          }),
+        ]),
+      },
+    });
+  });
+
+  test("publish handler's registry grant does NOT include list or write actions", () => {
+    const policies = template.findResources("AWS::IAM::Policy");
+    const lambdas = template.findResources("AWS::Lambda::Function");
+    const handlerLogicalId = Object.keys(lambdas).find(
+      (k) => lambdas[k].Properties?.Handler === "app-publish-handler.handler",
+    );
+    const handlerRoleRef =
+      lambdas[handlerLogicalId!].Properties.Role?.["Fn::GetAtt"]?.[0];
+
+    const handlerPolicies = Object.values(policies).filter((p: any) =>
+      (p.Properties?.Roles ?? []).some((r: any) => r.Ref === handlerRoleRef),
+    );
+
+    const registryStatements = handlerPolicies.flatMap((policy: any) =>
+      (policy.Properties.PolicyDocument.Statement as any[]).filter((stmt) => {
+        const actions: string[] = Array.isArray(stmt.Action)
+          ? stmt.Action
+          : [stmt.Action];
+        return actions.some((a) => a.startsWith("bedrock-agentcore:"));
+      }),
+    );
+    expect(registryStatements.length).toBeGreaterThan(0);
+    for (const stmt of registryStatements) {
+      const actions: string[] = Array.isArray(stmt.Action)
+        ? stmt.Action
+        : [stmt.Action];
+      expect(actions).toEqual(["bedrock-agentcore:GetRegistryRecord"]);
+    }
   });
 });
 


### PR DESCRIPTION
## Summary
`publishApp` and `unpublishApp` are Cognito-authenticated AppSync mutations with no authorization - the handler read `identity.sub` only to stamp audit fields, never checking organization or role. Any authenticated user who knew an `appId` could act on any tenant's app.

- **Publish** provisions an IAM role and a billable, externally reachable API Gateway, mints a plaintext API key and **returns it to the caller** - and that key authorizes `POST /invoke` on the victim's app, so this was cross-tenant data-plane access, not just unwanted provisioning
- **Unpublish** deletes the endpoint, revokes all keys and deletes the IAM role - irreversible cross-tenant destruction

Both are now gated at **owner** using the shared `assertManifestAccess` (exported from the registry resolver - no second gate implementation), before any provisioning, key generation, IAM change, EventBridge publish or status write. Fails closed on missing identity, unresolvable organization, missing record, or a record with no owner/`createdBy`; the existing admin bypass is preserved.

## CDK wiring was required, not optional

The handler could not read the Registry record at all, so this adds `registryId` / `registryArn` through the gateway stack props, a `REGISTRY_ID` env var, and a least-privilege `bedrock-agentcore:GetRegistryRecord`-only grant scoped to the registry ARN - no list, no write. Template assertions cover both the env var and the exact action so the wiring cannot silently regress.

## Testing

Bite proofs were **executed**, not inspected:
- Gate removed from `publishApp` → the call succeeds and mints plus returns a live plaintext API key (captured in the evidence)
- Gate removed from `unpublishApp` → teardown executes and status drops to `DRAFT`
- Both files restored byte-identically (sha256 verified)

Adversarial checks: cross-org and same-org non-owner refused on both operations with
zero API Gateway provisioning or deletion, zero key generation, zero IAM role create/delete, zero EventBridge publishes and zero status writes - and no key value present on any refused path. Owner (explicit and implicit creator) plus admin succeed end to end.

tsc, lint, `cdk synth` exit 0; 17 targeted tests; full backend jest 7209.

## Class closed for this module

A dispatch-derived enumeration guard now covers this handler too: cases come from its own
`switch`, every case must be gated, and the exempt set is empty - so a future operation added here fails a test rather than shipping unguarded. Three pre-existing test files were migrated to mock the registry and pass an owner-authorized event, preserving prior behaviour.