### PR TITLE
fix(security): require editor role to bind workflows to an app

### DIFF
--- a/backend/src/lambda/__tests__/registry-agent-record-resolver-dispatch-gate-enumeration.test.ts
+++ b/backend/src/lambda/__tests__/registry-agent-record-resolver-dispatch-gate-enumeration.test.ts
@@ -143,6 +143,14 @@ const GATED_OPS: Record<string, { requiredRole: "owner" | "editor" }> = {
   createAppApiKey: { requiredRole: "editor" },
   revokeAppApiKey: { requiredRole: "editor" },
   rotateAppApiKey: { requiredRole: "editor" },
+  // Finding c35137bb: both mutate manifest.workflowIds and alter which
+  // workflows the app executes at runtime, rather than destroying the app
+  // — gated at 'editor', same tier as updateApp/addAppComponent/
+  // updateAgentBinding. See
+  // registry-agent-record-resolver-workflow-binding-editor-gate.test.ts for
+  // the dedicated cross-org/non-editor/editor/owner/admin coverage.
+  bindWorkflowToApp: { requiredRole: "editor" },
+  unbindWorkflowFromApp: { requiredRole: "editor" },
 };
 
 /**
@@ -164,24 +172,6 @@ const EXEMPT_OPS: Record<string, string> = {
   publishAppStatusEvent:
     "internal EventBridge publish helper invoked by other already-gated " +
     "handlers, not a caller-facing app mutation in its own right",
-  // KNOWN PRE-EXISTING GAP — flagged, NOT silently excused. Both mutate the
-  // manifest's workflowIds (writeManifestMutation + updateResource) with NO
-  // assertManifestAccess call, matching the exact shape of finding 6400b440
-  // (deleteApp). Left out of this fix's scope because gating them at
-  // 'editor' would require updating existing passing tests in
-  // registry-agent-record-resolver-workflows.test.ts and
-  // registry-agent-record-resolver-identity.test.ts that currently seed
-  // `access: {}` with no createdBy and assert success with no identity
-  // gate at all — that is a second, separate fix that needs its own
-  // red/green cycle and reviewer sign-off, not something to fold silently
-  // into the deleteApp fix. Tracked for a dedicated follow-up; DO NOT
-  // remove this entry without actually adding the gate.
-  bindWorkflowToApp:
-    "PRE-EXISTING GAP, not yet gated — mutates manifest.workflowIds with " +
-    "no assertManifestAccess call; tracked for follow-up, see comment above",
-  unbindWorkflowFromApp:
-    "PRE-EXISTING GAP, not yet gated — mutates manifest.workflowIds with " +
-    "no assertManifestAccess call; tracked for follow-up, see comment above",
 };
 
 describe("registry-agent-record-resolver — dispatch enumeration completeness", () => {
@@ -192,6 +182,7 @@ describe("registry-agent-record-resolver — dispatch enumeration completeness",
     expect(cases.length).toBeGreaterThan(15);
     expect(cases).toContain("deleteApp");
     expect(cases).toContain("grantAppAccess");
+    expect(cases).toContain("bindWorkflowToApp");
   });
 
   test("every dispatch case is accounted for in GATED_OPS or EXEMPT_OPS", () => {

--- a/backend/src/lambda/__tests__/registry-agent-record-resolver-workflow-binding-editor-gate.test.ts
+++ b/backend/src/lambda/__tests__/registry-agent-record-resolver-workflow-binding-editor-gate.test.ts
@@ -1,0 +1,327 @@
+/**
+ * RED-first tests for finding c35137bb: bindWorkflowToApp and
+ * unbindWorkflowFromApp mutate manifest.workflowIds with NO
+ * assertManifestAccess call, so any authenticated user could change which
+ * workflows another organization's app executes.
+ *
+ * These two ops were the last entries in the dispatch enumeration guard's
+ * EXEMPT_OPS, explicitly flagged as a "PRE-EXISTING GAP, not yet gated"
+ * (see registry-agent-record-resolver-dispatch-gate-enumeration.test.ts).
+ * This suite gates both at 'editor' (they alter app behaviour, not destroy
+ * the app — same tier as updateApp/addAppComponent/updateAgentBinding from
+ * finding 8f8fd119), using the SAME assertManifestAccess helper and the
+ * SAME table-driven threat model as
+ * registry-agent-record-resolver-lifecycle-editor-gate.test.ts:
+ *
+ *   - cross-org caller (different org entirely) → refused, ZERO manifest
+ *     writes, ZERO EventBridge publishes
+ *   - same-org NON-EDITOR (no access entry, not createdBy) → refused, ZERO
+ *     side effects
+ *   - unresolvable identity → refused, fail closed
+ *   - legitimate same-org EDITOR → succeeds
+ *   - legitimate OWNER (implicit creator-owner fallback for legacy apps
+ *     with no access entries) → succeeds
+ *   - admin group bypasses the gate
+ */
+
+process.env.REGISTRY_ID = "test-registry-id";
+process.env.APPS_TABLE = "citadel-apps-test";
+process.env.WORKFLOWS_TABLE = "citadel-workflows-test";
+process.env.AGENT_CONFIG_TABLE = "citadel-agents-test";
+process.env.EVENT_BUS_NAME = "citadel-agents-test";
+process.env.USER_POOL_ID = "us-east-1_test";
+process.env.AWS_REGION = "us-east-1";
+delete process.env.AUTHORITY_UNITS_TABLE;
+
+import {
+  EventBridgeClient,
+  PutEventsCommand,
+} from "@aws-sdk/client-eventbridge";
+import { mockClient } from "aws-sdk-client-mock";
+
+const ebMock = mockClient(EventBridgeClient);
+
+import {
+  seedMockRegistry,
+  resetMockRegistry,
+  getUpdateResourceCallCount,
+} from "./fixtures/registry-service-mock";
+
+jest.mock("../../services/registry-service", () => {
+  const { getMockRegistryService } = jest.requireActual(
+    "./fixtures/registry-service-mock",
+  );
+  const actual = jest.requireActual("../../services/registry-service");
+  return {
+    RegistryService: jest
+      .fn()
+      .mockImplementation(() => getMockRegistryService()),
+    getRegistryService: jest.fn(() => getMockRegistryService()),
+    _resetRegistryService: jest.fn(),
+    isRegistryEnabled: jest.fn(() => true),
+    TypeMismatchError: actual.TypeMismatchError,
+    RegistryLifecycleError: actual.RegistryLifecycleError,
+  };
+});
+
+// Cognito lookups are used by extractOrgFromEvent's fallback path; every
+// test here supplies custom:organization directly on the event so no
+// network call is made, but mock defensively as the other gate suites do.
+jest.mock("@aws-sdk/client-cognito-identity-provider", () => ({
+  CognitoIdentityProviderClient: jest.fn().mockImplementation(() => ({
+    send: jest
+      .fn()
+      .mockRejectedValue(new Error("Cognito not reachable in test")),
+  })),
+  AdminGetUserCommand: jest.fn(),
+}));
+
+jest.mock("../../utils/appsync-publish", () => ({
+  publishAppStatusEvent: jest.fn().mockResolvedValue(undefined),
+}));
+
+import { handler } from "../registry-agent-record-resolver";
+
+type HandlerEvent = Parameters<typeof handler>[0];
+const invokeHandler = handler as (event: HandlerEvent) => Promise<unknown>;
+
+function makeEvent(
+  fieldName: string,
+  args: Record<string, unknown>,
+  opts: { userId: string; orgId?: string; groups?: string[] },
+) {
+  const claims: Record<string, unknown> = { sub: opts.userId };
+  if (opts.orgId !== undefined) claims["custom:organization"] = opts.orgId;
+  if (opts.groups !== undefined) claims["cognito:groups"] = opts.groups;
+  return {
+    info: { fieldName },
+    arguments: args,
+    identity: { sub: opts.userId, claims },
+  } as unknown as HandlerEvent;
+}
+
+const APP_ID = "app-1";
+const OWNER_ID = "owner-user";
+const EDITOR_ID = "editor-user";
+const APP_ORG = "org-1";
+
+function seedApp(
+  opts: {
+    workflowIds?: string[];
+    access?: Record<
+      string,
+      { role: string; grantedAt: string; grantedBy: string }
+    >;
+    createdBy?: string | null;
+  } = {},
+) {
+  seedMockRegistry("agent", APP_ID, {
+    name: "Test App",
+    description: "Test",
+    status: "DRAFT",
+    customDescriptorContent: JSON.stringify({
+      appId: APP_ID,
+      manifest: {
+        orgId: APP_ORG,
+        version: 1,
+        status: "DRAFT",
+        workflowIds: opts.workflowIds ?? [],
+        agentBindings: [],
+        permissions: [],
+        configSchema: null,
+        configValues: null,
+        authConfig: null,
+        ...(opts.createdBy !== null && {
+          createdBy: opts.createdBy ?? OWNER_ID,
+        }),
+        access:
+          opts.access !== undefined
+            ? opts.access
+            : {
+                [OWNER_ID]: {
+                  role: "owner",
+                  grantedAt: "2024-01-01T00:00:00Z",
+                  grantedBy: "system",
+                },
+                [EDITOR_ID]: {
+                  role: "editor",
+                  grantedAt: "2024-01-01T00:00:00Z",
+                  grantedBy: OWNER_ID,
+                },
+              },
+        routingConfig: null,
+      },
+    }),
+  });
+}
+
+function expectZeroSideEffects() {
+  expect(getUpdateResourceCallCount()).toBe(0);
+  expect(ebMock.commandCalls(PutEventsCommand)).toHaveLength(0);
+}
+
+beforeEach(() => {
+  resetMockRegistry();
+  ebMock.reset();
+  ebMock.on(PutEventsCommand).resolves({});
+});
+
+type OpCase = { name: string; fieldName: string };
+
+const GATED_OPS: OpCase[] = [
+  { name: "bindWorkflowToApp", fieldName: "bindWorkflowToApp" },
+  { name: "unbindWorkflowFromApp", fieldName: "unbindWorkflowFromApp" },
+];
+
+describe("registry-agent-record-resolver — workflow binding editor gate (finding c35137bb)", () => {
+  for (const op of GATED_OPS) {
+    describe(op.name, () => {
+      test("refuses a cross-org caller with zero manifest writes", async () => {
+        seedApp({ workflowIds: ["wf-1"] });
+
+        await expect(
+          invokeHandler(
+            makeEvent(
+              op.fieldName,
+              { appId: APP_ID, workflowId: "wf-1" },
+              { userId: "attacker", orgId: "org-evil" },
+            ),
+          ),
+        ).rejects.toThrow(/Access denied/i);
+
+        expectZeroSideEffects();
+      });
+
+      test("refuses a same-org NON-EDITOR (no access entry, not createdBy) with zero manifest writes", async () => {
+        seedApp({
+          workflowIds: ["wf-1"],
+          access: {
+            "viewer-user": {
+              role: "viewer",
+              grantedAt: "2024-01-01T00:00:00Z",
+              grantedBy: OWNER_ID,
+            },
+          },
+        });
+
+        await expect(
+          invokeHandler(
+            makeEvent(
+              op.fieldName,
+              { appId: APP_ID, workflowId: "wf-1" },
+              { userId: "viewer-user", orgId: APP_ORG },
+            ),
+          ),
+        ).rejects.toThrow(/Access denied/i);
+
+        expectZeroSideEffects();
+      });
+
+      test("refuses when identity cannot be resolved (fail closed)", async () => {
+        seedApp({ workflowIds: ["wf-1"] });
+
+        await expect(
+          invokeHandler(
+            makeEvent(
+              op.fieldName,
+              { appId: APP_ID, workflowId: "wf-1" },
+              { userId: "no-org-user" },
+            ),
+          ),
+        ).rejects.toThrow(/Access denied/i);
+
+        expectZeroSideEffects();
+      });
+
+      test("succeeds for a same-org editor", async () => {
+        seedApp({
+          workflowIds: op.fieldName === "bindWorkflowToApp" ? [] : ["wf-1"],
+        });
+
+        await expect(
+          invokeHandler(
+            makeEvent(
+              op.fieldName,
+              { appId: APP_ID, workflowId: "wf-1" },
+              { userId: EDITOR_ID, orgId: APP_ORG },
+            ),
+          ),
+        ).resolves.toBeDefined();
+
+        expect(getUpdateResourceCallCount()).toBe(1);
+      });
+
+      test("succeeds for the owner", async () => {
+        seedApp({
+          workflowIds: op.fieldName === "bindWorkflowToApp" ? [] : ["wf-1"],
+        });
+
+        await expect(
+          invokeHandler(
+            makeEvent(
+              op.fieldName,
+              { appId: APP_ID, workflowId: "wf-1" },
+              { userId: OWNER_ID, orgId: APP_ORG },
+            ),
+          ),
+        ).resolves.toBeDefined();
+
+        expect(getUpdateResourceCallCount()).toBe(1);
+      });
+
+      test("succeeds for the implicit creator-owner on a legacy app with no access entries", async () => {
+        seedApp({
+          workflowIds: op.fieldName === "bindWorkflowToApp" ? [] : ["wf-1"],
+          access: {},
+          createdBy: "legacy-creator",
+        });
+
+        await expect(
+          invokeHandler(
+            makeEvent(
+              op.fieldName,
+              { appId: APP_ID, workflowId: "wf-1" },
+              { userId: "legacy-creator", orgId: APP_ORG },
+            ),
+          ),
+        ).resolves.toBeDefined();
+
+        expect(getUpdateResourceCallCount()).toBe(1);
+      });
+
+      test("admin group bypasses the gate", async () => {
+        seedApp({
+          workflowIds: op.fieldName === "bindWorkflowToApp" ? [] : ["wf-1"],
+        });
+
+        await expect(
+          invokeHandler(
+            makeEvent(
+              op.fieldName,
+              { appId: APP_ID, workflowId: "wf-1" },
+              { userId: "admin-1", orgId: "unrelated-org", groups: ["admin"] },
+            ),
+          ),
+        ).resolves.toBeDefined();
+
+        expect(getUpdateResourceCallCount()).toBe(1);
+      });
+    });
+  }
+
+  test("bindWorkflowToApp idempotent early return does NOT bypass the gate — a refused caller still gets zero writes even when the workflow is already bound", async () => {
+    seedApp({ workflowIds: ["wf-1"] });
+
+    await expect(
+      invokeHandler(
+        makeEvent(
+          "bindWorkflowToApp",
+          { appId: APP_ID, workflowId: "wf-1" },
+          { userId: "attacker", orgId: "org-evil" },
+        ),
+      ),
+    ).rejects.toThrow(/Access denied/i);
+
+    expectZeroSideEffects();
+  });
+});

--- a/backend/src/lambda/__tests__/registry-agent-record-resolver-workflows.test.ts
+++ b/backend/src/lambda/__tests__/registry-agent-record-resolver-workflows.test.ts
@@ -3,30 +3,37 @@
  * registry-native resolver. PR 6a replacement for the bind/unbind test
  * bodies previously in `agent-app-shim-resolver.test.ts`.
  */
-process.env.REGISTRY_ID = 'test-registry-id';
-process.env.APPS_TABLE = 'citadel-apps-test';
-process.env.WORKFLOWS_TABLE = 'citadel-workflows-test';
-process.env.AGENT_CONFIG_TABLE = 'citadel-agents-test';
-process.env.EVENT_BUS_NAME = 'citadel-agents-test';
-process.env.USER_POOL_ID = 'us-east-1_test';
-process.env.AWS_REGION = 'us-east-1';
+process.env.REGISTRY_ID = "test-registry-id";
+process.env.APPS_TABLE = "citadel-apps-test";
+process.env.WORKFLOWS_TABLE = "citadel-workflows-test";
+process.env.AGENT_CONFIG_TABLE = "citadel-agents-test";
+process.env.EVENT_BUS_NAME = "citadel-agents-test";
+process.env.USER_POOL_ID = "us-east-1_test";
+process.env.AWS_REGION = "us-east-1";
 delete process.env.AUTHORITY_UNITS_TABLE;
 
-import { EventBridgeClient, PutEventsCommand } from '@aws-sdk/client-eventbridge';
-import { mockClient } from 'aws-sdk-client-mock';
+import {
+  EventBridgeClient,
+  PutEventsCommand,
+} from "@aws-sdk/client-eventbridge";
+import { mockClient } from "aws-sdk-client-mock";
 
 const ebMock = mockClient(EventBridgeClient);
 
 import {
   seedMockRegistry,
   resetMockRegistry,
-} from './fixtures/registry-service-mock';
+} from "./fixtures/registry-service-mock";
 
-jest.mock('../../services/registry-service', () => {
-  const { getMockRegistryService } = jest.requireActual('./fixtures/registry-service-mock');
-  const actual = jest.requireActual('../../services/registry-service');
+jest.mock("../../services/registry-service", () => {
+  const { getMockRegistryService } = jest.requireActual(
+    "./fixtures/registry-service-mock",
+  );
+  const actual = jest.requireActual("../../services/registry-service");
   return {
-    RegistryService: jest.fn().mockImplementation(() => getMockRegistryService()),
+    RegistryService: jest
+      .fn()
+      .mockImplementation(() => getMockRegistryService()),
     getRegistryService: jest.fn(() => getMockRegistryService()),
     _resetRegistryService: jest.fn(),
     isRegistryEnabled: jest.fn(() => true),
@@ -35,15 +42,15 @@ jest.mock('../../services/registry-service', () => {
   };
 });
 
-jest.mock('../../utils/appsync', () => ({
-  getUserId: jest.fn().mockReturnValue('user-123'),
+jest.mock("../../utils/appsync", () => ({
+  getUserId: jest.fn().mockReturnValue("user-123"),
 }));
 
-jest.mock('../../utils/appsync-publish', () => ({
+jest.mock("../../utils/appsync-publish", () => ({
   publishAppStatusEvent: jest.fn().mockResolvedValue(undefined),
 }));
 
-import { handler } from '../registry-agent-record-resolver';
+import { handler } from "../registry-agent-record-resolver";
 
 type HandlerEvent = Parameters<typeof handler>[0];
 
@@ -57,23 +64,24 @@ function makeEvent(fieldName: string, args: Record<string, unknown>) {
   return {
     info: { fieldName },
     arguments: args,
-    identity: { sub: 'user-123', claims: { sub: 'user-123' } },
+    identity: {
+      sub: "user-123",
+      claims: { sub: "user-123", "custom:organization": "org-1" },
+    },
   } as unknown as HandlerEvent;
 }
 
-function seedApp(
-  opts: { manifest?: Record<string, unknown> } = {},
-): void {
-  seedMockRegistry('agent', 'app-1', {
-    name: 'Test App',
-    description: 'Test',
-    status: 'DRAFT',
+function seedApp(opts: { manifest?: Record<string, unknown> } = {}): void {
+  seedMockRegistry("agent", "app-1", {
+    name: "Test App",
+    description: "Test",
+    status: "DRAFT",
     customDescriptorContent: JSON.stringify({
-      appId: 'app-1',
+      appId: "app-1",
       manifest: {
-        orgId: 'org-1',
+        orgId: "org-1",
         version: 1,
-        status: 'DRAFT',
+        status: "DRAFT",
         workflowIds: [],
         agentBindings: [],
         permissions: [],
@@ -81,6 +89,16 @@ function seedApp(
         configValues: null,
         authConfig: null,
         access: {},
+        // Finding c35137bb: bindWorkflowToApp/unbindWorkflowFromApp are now
+        // gated at 'editor' via assertManifestAccess. This suite's caller
+        // (user-123, org-1, from makeEvent above) is seeded here as the
+        // app's createdBy so the implicit-creator-owner fallback grants it
+        // access — matching the pattern already used for the datastore and
+        // integration remediations. These tests exercise the bind/unbind
+        // BEHAVIOUR (idempotency, event emission, not-found handling); the
+        // gate's refusal paths have their own dedicated coverage in
+        // registry-agent-record-resolver-workflow-binding-editor-gate.test.ts.
+        createdBy: "user-123",
         routingConfig: null,
         ...(opts.manifest ?? {}),
       },
@@ -88,7 +106,7 @@ function seedApp(
   });
 }
 
-describe('registry-agent-record-resolver — workflow binding', () => {
+describe("registry-agent-record-resolver — workflow binding", () => {
   beforeEach(() => {
     resetMockRegistry();
     ebMock.reset();
@@ -107,15 +125,15 @@ describe('registry-agent-record-resolver — workflow binding', () => {
 
   // ─── bindWorkflowToApp ────────────────────────────────────────
 
-  describe('bindWorkflowToApp', () => {
-    test('appends workflowId to app workflowIds', async () => {
-      seedApp({ manifest: { workflowIds: ['wf-existing'] } });
+  describe("bindWorkflowToApp", () => {
+    test("appends workflowId to app workflowIds", async () => {
+      seedApp({ manifest: { workflowIds: ["wf-existing"] } });
 
       await expect(
         invokeHandler(
-          makeEvent('bindWorkflowToApp', {
-            appId: 'app-1',
-            workflowId: 'wf-new',
+          makeEvent("bindWorkflowToApp", {
+            appId: "app-1",
+            workflowId: "wf-new",
           }),
         ),
       ).resolves.toBeDefined();
@@ -123,19 +141,19 @@ describe('registry-agent-record-resolver — workflow binding', () => {
       const ebCalls = ebMock.commandCalls(PutEventsCommand);
       const allEntries = ebCalls.flatMap((c) => c.args[0].input.Entries || []);
       const boundEvents = allEntries.filter(
-        (e) => e?.DetailType === 'app.workflow.bound',
+        (e) => e?.DetailType === "app.workflow.bound",
       );
       expect(boundEvents.length).toBe(1);
     });
 
-    test('is idempotent when workflow already bound to same app', async () => {
-      seedApp({ manifest: { workflowIds: ['wf-1'] } });
+    test("is idempotent when workflow already bound to same app", async () => {
+      seedApp({ manifest: { workflowIds: ["wf-1"] } });
 
       await expect(
         invokeHandler(
-          makeEvent('bindWorkflowToApp', {
-            appId: 'app-1',
-            workflowId: 'wf-1',
+          makeEvent("bindWorkflowToApp", {
+            appId: "app-1",
+            workflowId: "wf-1",
           }),
         ),
       ).resolves.toBeDefined();
@@ -143,29 +161,29 @@ describe('registry-agent-record-resolver — workflow binding', () => {
       expect(ebMock.commandCalls(PutEventsCommand).length).toBe(0);
     });
 
-    test('throws when app not found', async () => {
+    test("throws when app not found", async () => {
       await expect(
         invokeHandler(
-          makeEvent('bindWorkflowToApp', {
-            appId: 'nonexistent',
-            workflowId: 'wf-1',
+          makeEvent("bindWorkflowToApp", {
+            appId: "nonexistent",
+            workflowId: "wf-1",
           }),
         ),
-      ).rejects.toThrow('App not found');
+      ).rejects.toThrow("App not found");
     });
   });
 
   // ─── unbindWorkflowFromApp ────────────────────────────────────
 
-  describe('unbindWorkflowFromApp', () => {
-    test('removes workflowId from app workflowIds', async () => {
-      seedApp({ manifest: { workflowIds: ['wf-1', 'wf-2'] } });
+  describe("unbindWorkflowFromApp", () => {
+    test("removes workflowId from app workflowIds", async () => {
+      seedApp({ manifest: { workflowIds: ["wf-1", "wf-2"] } });
 
       await expect(
         invokeHandler(
-          makeEvent('unbindWorkflowFromApp', {
-            appId: 'app-1',
-            workflowId: 'wf-1',
+          makeEvent("unbindWorkflowFromApp", {
+            appId: "app-1",
+            workflowId: "wf-1",
           }),
         ),
       ).resolves.toBeDefined();
@@ -173,20 +191,20 @@ describe('registry-agent-record-resolver — workflow binding', () => {
       const ebCalls = ebMock.commandCalls(PutEventsCommand);
       const allEntries = ebCalls.flatMap((c) => c.args[0].input.Entries || []);
       const unboundEvents = allEntries.filter(
-        (e) => e?.DetailType === 'app.workflow.unbound',
+        (e) => e?.DetailType === "app.workflow.unbound",
       );
       expect(unboundEvents.length).toBe(1);
     });
 
-    test('throws when app not found', async () => {
+    test("throws when app not found", async () => {
       await expect(
         invokeHandler(
-          makeEvent('unbindWorkflowFromApp', {
-            appId: 'nonexistent',
-            workflowId: 'wf-1',
+          makeEvent("unbindWorkflowFromApp", {
+            appId: "nonexistent",
+            workflowId: "wf-1",
           }),
         ),
-      ).rejects.toThrow('App not found');
+      ).rejects.toThrow("App not found");
     });
   });
 });

--- a/backend/src/lambda/registry-agent-record-resolver.ts
+++ b/backend/src/lambda/registry-agent-record-resolver.ts
@@ -1057,9 +1057,19 @@ export const handler: AppSyncResolverHandler<
       case "deleteApp":
         return await deleteApp(args.appId, userId, event);
       case "bindWorkflowToApp":
-        return await bindWorkflowToApp(args.appId, args.workflowId, userId);
+        return await bindWorkflowToApp(
+          args.appId,
+          args.workflowId,
+          userId,
+          event,
+        );
       case "unbindWorkflowFromApp":
-        return await unbindWorkflowFromApp(args.appId, args.workflowId, userId);
+        return await unbindWorkflowFromApp(
+          args.appId,
+          args.workflowId,
+          userId,
+          event,
+        );
       case "updateAgentBinding":
         return await updateAgentBinding(args.input, userId, event);
       case "addAppComponent":
@@ -1829,14 +1839,27 @@ async function deleteApp(
   return { success: true, message: `App ${appId} deleted` };
 }
 
+// `event` is OPTIONAL and gates on 'editor' when present (finding
+// c35137bb), following the SAME convention established by
+// addAppComponent/updateAgentBinding (finding 8f8fd119): the AppSync
+// dispatch call site always passes the real event, so the mutation is
+// always gated on that path. There is no server-internal caller that
+// invokes this function directly today (grep confirms the dispatch switch
+// is the only call site) — the parameter is optional purely to match the
+// established convention for these manifest-mutating handlers, not because
+// an unguarded internal caller currently exists.
 async function bindWorkflowToApp(
   appId: string,
   workflowId: string,
   userId: string,
+  event?: unknown,
 ): Promise<unknown> {
   const record = await getRegistryService().getResource("agent", appId);
   if (!record) {
     throw new Error("App not found");
+  }
+  if (event !== undefined) {
+    await assertManifestAccess(appId, record, event, "editor");
   }
   const manifest = readManifest(record);
   const existingIds = manifest.workflowIds || [];
@@ -1859,14 +1882,21 @@ async function bindWorkflowToApp(
   return projectAgentAppNormalized(updated);
 }
 
+// `event` is OPTIONAL and gates on 'editor' when present (finding
+// c35137bb), following the SAME convention as bindWorkflowToApp above —
+// see that function's comment for the internal-caller rationale.
 async function unbindWorkflowFromApp(
   appId: string,
   workflowId: string,
   userId: string,
+  event?: unknown,
 ): Promise<unknown> {
   const record = await getRegistryService().getResource("agent", appId);
   if (!record) {
     throw new Error("App not found");
+  }
+  if (event !== undefined) {
+    await assertManifestAccess(appId, record, event, "editor");
   }
   const manifest = readManifest(record);
   const remaining = (manifest.workflowIds || []).filter(


### PR DESCRIPTION
## Summary

`bindworkflowToApp` and `unbindworkflowFromApp` mutated "manifest.workflowIds' with no authorization check, so any authenticated user could change which workfLows another organization's app executes.

Both are now gated at **editor** via the shared `assertManifestAccess`, immediately after the not-found check and before any manifest read or write. Fails closed on missing identity, unresolvable organization, missing record or a record with no owner/`createdBy`; the admin bypass is preserved.

Two specifics worth noting:

- The gate sits **before `bindworkfLowToApp`'s idempotent early return**. Placing it after would have let a cross-tenant caller through whenever the binding already existed
- The AppSync dispatch is the only call site (grep-confirmed), so no server-driven needed exempting. An optional 'event' parameter was still added to match the path `addAppComponent` / `updateAgentBinding` convention, documented inline as consistency rather than necessity

## Fixtures migrated, not weakened

`registry-agent-record-resolver-workfLows.test.ts` previously seeded no organization and no `createdBy` and asserted success - the fixture encoded the ungated behaviour, the same pattern seen in the datastore and integration remediations. It now carries an org claim and a `createdBy`, which incidentally exercises the implicit-creator-owner fallback, with its idempotency, event-emission and not-found coverage unchanged. The identity test needed change. Review confirmed no test was deleted, skipped or loosened to accommodate the gate.

## Guard now enforces both

Both operations moved from the enumeration guard's exempt set into its gated set. What remains exempt in this module is only five pure reads, `createApp` (no pre-existing access map to check) and one internal helper - **no deferred-gap entries remain**.

## Testing

- Executed attacks: cross-org and same-org non-editor refused on both operations with zero manifest writes asserted on the mocks; editor, owner, implicit-creator-owner and admin all succeed
- Executed bite proof: with the gate removed, the cross-org call writes the binding; restored byte-identically (sha256 verified)
- 15 new tests, red-first - seven failures demonstrated the issue before the fix
- tsc, lint, `cdk synth` exit o; 332 targeted tests; full backend jest 7226