### PR TITLE
fix(security): scope user-management reads to the caller's org

### DIFF
--- a/backend/src/lambda/__tests__/user-management-resolver-dispatch-gate-enumeration.test.ts
+++ b/backend/src/lambda/__tests__/user-management-resolver-dispatch-gate-enumeration.test.ts
@@ -1,0 +1,221 @@
+/**
+ * Enumeration-completeness guard for user-management-resolver.ts's dispatch
+ * switch (finding f21582e6 — the class-closing move mirroring
+ * registry-agent-record-resolver-dispatch-gate-enumeration.test.ts and
+ * app-publish-handler-dispatch-gate-enumeration.test.ts).
+ *
+ * Root cause of f21582e6 was that listUsers, getUser, listOrganizations and
+ * listAvailableRoles read NO identity at all — the bug class this guard
+ * closes is "a dispatch case whose handler never reads caller identity",
+ * not merely "no admin gate" (several ops in this module are deliberately
+ * non-admin-gated reads that still MUST read identity to fail closed).
+ *
+ * Unlike the two existing guards (which check for a single shared mutation
+ * gate function name, assertManifestAccess/assertManifestOwnerAccess), this
+ * module has no single shared gate call — each handler independently reads
+ * `event.identity?.username || event.identity?.claims?.username` (inline,
+ * for the pre-existing mutating ops) or calls the newer
+ * `requireCallerUsername(event)` helper (for the ops fixed by f21582e6).
+ * IDENTITY_READ_RE below matches either shape so pre-existing and
+ * newly-fixed handlers are both recognized.
+ *
+ * Every case must appear in exactly one of:
+ *   - GATED_OPS: handler function body reads caller identity (either shape)
+ *     before returning/mutating.
+ *   - EXEMPT_OPS: legitimately exempt, each with an explicit reason.
+ *
+ * If neither list accounts for a case, or a GATED op's handler function no
+ * longer reads identity, the test fails loudly.
+ */
+import * as fs from "fs";
+import * as path from "path";
+
+const RESOLVER_PATH = path.join(__dirname, "..", "user-management-resolver.ts");
+
+function extractDispatchCases(source: string): string[] {
+  const switchStart = source.indexOf("switch (fieldName)");
+  if (switchStart === -1) {
+    throw new Error(
+      "Could not locate `switch (fieldName)` in user-management-resolver.ts — " +
+        "dispatch structure changed; update this guard's parsing.",
+    );
+  }
+  const defaultIdx = source.indexOf("default:", switchStart);
+  if (defaultIdx === -1) {
+    throw new Error(
+      "Could not locate the dispatch switch's `default:` case — " +
+        "update this guard's parsing.",
+    );
+  }
+  const switchBody = source.slice(switchStart, defaultIdx);
+  const caseRe = /case\s+['"]([^'"]+)['"]\s*:/g;
+  const cases: string[] = [];
+  let m: RegExpExecArray | null;
+  while ((m = caseRe.exec(switchBody)) !== null) {
+    cases.push(m[1]);
+  }
+  return cases;
+}
+
+/**
+ * Extracts the handler function name a given case delegates to, e.g.
+ * `case 'listUsers': return await listUsers(event);` -> "listUsers".
+ */
+function extractHandlerCallSite(
+  switchBody: string,
+  fieldName: string,
+): string | null {
+  const caseRe = new RegExp(
+    `case\\s+['"]${fieldName}['"]\\s*:\\s*\\n?\\s*return\\s+await\\s+([A-Za-z0-9_]+)\\s*\\(`,
+  );
+  const m = caseRe.exec(switchBody);
+  return m ? m[1] : null;
+}
+
+/**
+ * Extracts a top-level `async function <name>(...) { ... }` body by
+ * brace-counting from the `function` keyword, matching the parameter
+ * list's closing paren first (parameter type annotations can contain
+ * object-literal-shaped braces).
+ */
+function extractFunctionBody(source: string, fnName: string): string {
+  const declRe = new RegExp(`async function ${fnName}\\s*\\(`);
+  const declMatch = declRe.exec(source);
+  if (!declMatch) {
+    throw new Error(
+      `Could not locate function declaration for '${fnName}' in user-management-resolver.ts`,
+    );
+  }
+  const paramsOpenIdx = source.indexOf("(", declMatch.index);
+  let parenDepth = 0;
+  let j = paramsOpenIdx;
+  for (; j < source.length; j++) {
+    if (source[j] === "(") parenDepth++;
+    else if (source[j] === ")") {
+      parenDepth--;
+      if (parenDepth === 0) break;
+    }
+  }
+  const bodyStart = source.indexOf("{", j);
+  let depth = 0;
+  let i = bodyStart;
+  for (; i < source.length; i++) {
+    if (source[i] === "{") depth++;
+    else if (source[i] === "}") {
+      depth--;
+      if (depth === 0) break;
+    }
+  }
+  return source.slice(bodyStart, i + 1);
+}
+
+/**
+ * Matches either identity-read shape present in this file:
+ *  - the pre-existing inline read: `event.identity?.username ||
+ *    event.identity?.claims?.username`
+ *  - the f21582e6 helper: `requireCallerUsername(event)`
+ */
+const IDENTITY_READ_RE =
+  /(event\.identity\?\.username\s*\|\|\s*event\.identity\?\.claims\?\.username)|(requireCallerUsername\s*\()/;
+
+/**
+ * Ops verified to read caller identity inside their handler function body.
+ * `reason` documents why (admin-gated mutation, org-scoped read, or
+ * self-scoped op) — enforcement is structural (IDENTITY_READ_RE against the
+ * real source), this is documentation for humans.
+ */
+const GATED_OPS: Record<string, { reason: string }> = {
+  listUsers: { reason: "org-scoped read; admin bypass (f21582e6 fix)" },
+  getUser: { reason: "org-scoped read; admin/self bypass (f21582e6 fix)" },
+  listAvailableRoles: {
+    reason:
+      "no tenant data, but must fail closed on unresolvable identity (f21582e6 fix)",
+  },
+  listOrganizations: { reason: "org-scoped read; admin bypass (f21582e6 fix)" },
+  adminCreateUser: { reason: "pre-existing admin-gated mutation" },
+  assignUserRole: {
+    reason:
+      "pre-existing admin-gated mutation; org-confinement gap accepted separately (finding 59e5a79c), NOT touched here",
+  },
+  removeUserRole: {
+    reason:
+      "pre-existing admin-gated mutation; org-confinement gap accepted separately (finding 59e5a79c), NOT touched here",
+  },
+  changePassword: {
+    reason: "pre-existing self-scoped mutation (own password only)",
+  },
+  adminResetUserPassword: { reason: "pre-existing admin-gated mutation" },
+  adminResendInvitation: { reason: "pre-existing admin-gated mutation" },
+};
+
+/**
+ * Ops that legitimately do not read identity directly in their OWN handler
+ * body, each with an explicit reason.
+ */
+const EXEMPT_OPS: Record<string, string> = {
+  getCurrentUserProfile:
+    "reads identity itself (inline shape) to resolve the caller's own username, " +
+    "then delegates the identity-gated work to getUser(username, event) — " +
+    "the delegate is separately covered by GATED_OPS.getUser",
+};
+
+describe("user-management-resolver — dispatch enumeration completeness", () => {
+  const source = fs.readFileSync(RESOLVER_PATH, "utf-8");
+  const cases = extractDispatchCases(source);
+
+  test("the dispatch switch actually has cases to check (sanity check on the parser itself)", () => {
+    expect(cases.length).toBeGreaterThanOrEqual(11);
+    expect(cases).toContain("listUsers");
+    expect(cases).toContain("getUser");
+    expect(cases).toContain("listOrganizations");
+    expect(cases).toContain("listAvailableRoles");
+  });
+
+  test("every dispatch case is accounted for in GATED_OPS or EXEMPT_OPS", () => {
+    const unaccounted = cases.filter(
+      (c) => !(c in GATED_OPS) && !(c in EXEMPT_OPS),
+    );
+    expect(unaccounted).toEqual([]);
+  });
+
+  test("GATED_OPS and EXEMPT_OPS do not both claim the same op", () => {
+    const overlap = Object.keys(GATED_OPS).filter((k) => k in EXEMPT_OPS);
+    expect(overlap).toEqual([]);
+  });
+
+  test("no GATED_OPS/EXEMPT_OPS entry references a case that no longer exists in the switch", () => {
+    const known = new Set(cases);
+    const staleGated = Object.keys(GATED_OPS).filter((k) => !known.has(k));
+    const staleExempt = Object.keys(EXEMPT_OPS).filter((k) => !known.has(k));
+    expect(staleGated).toEqual([]);
+    expect(staleExempt).toEqual([]);
+  });
+
+  test("getCurrentUserProfile (EXEMPT) still reads identity inline before delegating", () => {
+    const switchStart = source.indexOf("switch (fieldName)");
+    const defaultIdx = source.indexOf("default:", switchStart);
+    const switchBody = source.slice(switchStart, defaultIdx);
+    const handlerName = extractHandlerCallSite(
+      switchBody,
+      "getCurrentUserProfile",
+    );
+    expect(handlerName).not.toBeNull();
+    const body = extractFunctionBody(source, handlerName as string);
+    expect(IDENTITY_READ_RE.test(body)).toBe(true);
+  });
+
+  describe.each(Object.entries(GATED_OPS))(
+    "GATED_OPS['%s'] handler actually reads caller identity",
+    (fieldName, meta) => {
+      test(`${fieldName} (${meta.reason}) contains an identity-read (inline or requireCallerUsername)`, () => {
+        const switchStart = source.indexOf("switch (fieldName)");
+        const defaultIdx = source.indexOf("default:", switchStart);
+        const switchBody = source.slice(switchStart, defaultIdx);
+        const handlerName = extractHandlerCallSite(switchBody, fieldName);
+        expect(handlerName).not.toBeNull();
+        const body = extractFunctionBody(source, handlerName as string);
+        expect(IDENTITY_READ_RE.test(body)).toBe(true);
+      });
+    },
+  );
+});

--- a/backend/src/lambda/__tests__/user-management-resolver-fail-closed.test.ts
+++ b/backend/src/lambda/__tests__/user-management-resolver-fail-closed.test.ts
@@ -1,0 +1,309 @@
+/**
+ * Fail-closed regression tests for user-management-resolver.ts (bite proof
+ * gap, finding f21582e6 follow-up).
+ *
+ * A mutation-testing pass on `requireCallerOrg()` — changing `throw new
+ * Error(...)` to `return org || ""` — left ALL existing tests in
+ * user-management-resolver-org-scoping.test.ts green. The existing "fails
+ * closed" tests happen to exercise the case where `extractOrgFromEvent`
+ * itself resolves to `null` (no org claim, no Cognito attribute), which
+ * `requireCallerOrg` then rejects — but nothing asserted that
+ * `requireCallerOrg`'s OWN throw is what does the rejecting, and nothing
+ * asserted that removing it changes behavior. An empty-string org "resolved"
+ * by a mutated `requireCallerOrg` would satisfy `if (!org)` inside
+ * `extractOrgFromEvent`'s callers identically to `null`, so a pure
+ * `.rejects.toThrow()` on that path is not a proof the guard exists — it
+ * only proves `extractOrgFromEvent` returned a falsy value, which it does
+ * regardless of `requireCallerOrg`.
+ *
+ * This file closes that gap directly: every test here asserts a REFUSAL
+ * (thrown error), never an empty-list return, because an empty result is
+ * indistinguishable from a silent unfiltered-but-empty fallback. Two classes
+ * of caller are covered for every affected op (listUsers, getUser,
+ * listOrganizations, listAvailableRoles):
+ *   (a) identity entirely absent (event.identity is undefined/empty)
+ *   (b) identity present but the org claim is missing/empty (non-admin,
+ *       Cognito custom:organization attribute absent AND JWT claim absent)
+ *
+ * Also covers the latent risk the probe implied: if a caller's org ever
+ * resolved to "" instead of throwing, `organization !== callerOrg` would
+ * treat a user record with NO custom:organization attribute (i.e.
+ * `organization === undefined`) as same-org, because `undefined !== ""` is
+ * true... wait — actually `undefined !== ""` is TRUE, so on its own the
+ * loose comparison already excludes it. The real risk is a caller who is
+ * non-admin AND has no org (mutated to resolve to "") being compared against
+ * an org-less USER record whose `organization` attribute was also read as
+ * `undefined` — see the note in the "empty-org safety" section below for
+ * the precise mechanics verified against the current source.
+ */
+
+import {
+  ListUsersCommand,
+  AdminGetUserCommand,
+  AdminListGroupsForUserCommand,
+  ListGroupsCommand,
+} from "@aws-sdk/client-cognito-identity-provider";
+import { CognitoIdentityProviderClient } from "@aws-sdk/client-cognito-identity-provider";
+import { DynamoDBDocumentClient, ScanCommand } from "@aws-sdk/lib-dynamodb";
+import { mockClient } from "aws-sdk-client-mock";
+
+const cognitoMock = mockClient(CognitoIdentityProviderClient);
+const dynamoMock = mockClient(DynamoDBDocumentClient);
+
+process.env.USER_POOL_ID = "test-pool";
+process.env.ORGANISATION_TABLE = "test-orgs";
+
+import { handler } from "../user-management-resolver";
+
+type ResolverEvent = Parameters<typeof handler>[0];
+
+interface UserResult {
+  userId: string;
+  email: string;
+  organization?: string;
+}
+
+function buildEvent(
+  fieldName: string,
+  identity: ResolverEvent["identity"],
+  args: Partial<ResolverEvent["arguments"]> = {},
+): ResolverEvent {
+  return {
+    info: { fieldName },
+    identity,
+    arguments: args as ResolverEvent["arguments"],
+  };
+}
+
+function cognitoUser(
+  username: string,
+  org?: string,
+  statusEnabled = true,
+): {
+  Username: string;
+  Attributes: { Name: string; Value: string }[];
+  UserStatus: string;
+  Enabled: boolean;
+  UserCreateDate: Date;
+} {
+  const attrs = [
+    { Name: "email", Value: `${username}@example.com` },
+    { Name: "given_name", Value: "First" },
+    { Name: "family_name", Value: "Last" },
+  ];
+  if (org !== undefined) {
+    attrs.push({ Name: "custom:organization", Value: org });
+  }
+  return {
+    Username: username,
+    Attributes: attrs,
+    UserStatus: "CONFIRMED",
+    Enabled: statusEnabled,
+    UserCreateDate: new Date("2024-01-01T00:00:00Z"),
+  };
+}
+
+/** Stubs a non-admin caller with NO resolvable org: not an admin group
+ * member, no `custom:organization` JWT claim on the event, and the
+ * AdminGetUser fallback lookup returns no `custom:organization` attribute
+ * either. This is case (b) — identity present, org claim missing/empty. */
+function stubOrglessNonAdminCaller(username: string) {
+  cognitoMock
+    .on(AdminListGroupsForUserCommand, { Username: username })
+    .resolves({ Groups: [{ GroupName: "developer" }] });
+  cognitoMock.on(AdminGetUserCommand, { Username: username }).resolves({
+    Username: username,
+    UserAttributes: [],
+  });
+}
+
+beforeEach(() => {
+  cognitoMock.reset();
+  dynamoMock.reset();
+});
+
+// ---------------------------------------------------------------------------
+// (a) identity entirely absent — must REFUSE (throw), not return []
+// ---------------------------------------------------------------------------
+
+describe("fail-closed: identity entirely absent", () => {
+  test("listUsers throws when event.identity is undefined", async () => {
+    const event = buildEvent("listUsers", undefined);
+    await expect(handler(event)).rejects.toThrow(
+      /Unable to determine caller identity/,
+    );
+  });
+
+  test("listUsers throws when event.identity is an empty object", async () => {
+    const event = buildEvent("listUsers", {});
+    await expect(handler(event)).rejects.toThrow(
+      /Unable to determine caller identity/,
+    );
+  });
+
+  test("getUser throws when event.identity is undefined", async () => {
+    const event = buildEvent("getUser", undefined, { userId: "bob" });
+    await expect(handler(event)).rejects.toThrow(
+      /Unable to determine caller identity/,
+    );
+  });
+
+  test("listOrganizations throws when event.identity is undefined", async () => {
+    const event = buildEvent("listOrganizations", undefined);
+    await expect(handler(event)).rejects.toThrow(
+      /Unable to determine caller identity/,
+    );
+  });
+
+  test("listAvailableRoles throws when event.identity is undefined", async () => {
+    const event = buildEvent("listAvailableRoles", undefined);
+    await expect(handler(event)).rejects.toThrow(
+      /Unable to determine caller identity/,
+    );
+  });
+});
+
+// ---------------------------------------------------------------------------
+// (b) identity present but org claim missing/empty — must REFUSE, not
+// silently proceed with an empty-string org treated as a valid scope.
+// ---------------------------------------------------------------------------
+
+describe("fail-closed: identity present, caller org unresolvable", () => {
+  test("listUsers throws naming the org-resolution failure (not admin, no org anywhere)", async () => {
+    stubOrglessNonAdminCaller("orgless");
+    // If ListUsers were ever reached despite the org guard failing, this
+    // stub would make the test pass for the wrong reason (empty list from
+    // an unrelated cause) — assert the specific message so a silent
+    // fallback-to-[] cannot masquerade as a pass.
+    cognitoMock.on(ListUsersCommand).resolves({ Users: [] });
+
+    const event = buildEvent("listUsers", { username: "orgless" });
+    await expect(handler(event)).rejects.toThrow(
+      /Unable to determine caller's organization/,
+    );
+  });
+
+  test("getUser throws naming the org-resolution failure when target is not self", async () => {
+    stubOrglessNonAdminCaller("orgless");
+    cognitoMock.on(AdminGetUserCommand, { Username: "bob" }).resolves({
+      Username: "bob",
+      UserAttributes: [{ Name: "custom:organization", Value: "org-a" }],
+      UserStatus: "CONFIRMED",
+      Enabled: true,
+      UserCreateDate: new Date("2024-01-01T00:00:00Z"),
+    });
+    cognitoMock
+      .on(AdminListGroupsForUserCommand, { Username: "bob" })
+      .resolves({ Groups: [{ GroupName: "developer" }] });
+
+    const event = buildEvent(
+      "getUser",
+      { username: "orgless" },
+      { userId: "bob" },
+    );
+    await expect(handler(event)).rejects.toThrow(
+      /Unable to determine caller's organization/,
+    );
+  });
+
+  test("listOrganizations throws naming the org-resolution failure", async () => {
+    stubOrglessNonAdminCaller("orgless");
+    dynamoMock.on(ScanCommand).resolves({ Items: [] });
+
+    const event = buildEvent("listOrganizations", { username: "orgless" });
+    await expect(handler(event)).rejects.toThrow(
+      /Unable to determine caller's organization/,
+    );
+  });
+
+  test("listAvailableRoles does not require an org (only identity) — sanity boundary", async () => {
+    // listAvailableRoles returns no tenant data and deliberately does not
+    // call requireCallerOrg at all — only requireCallerUsername. Included
+    // here as a boundary check so a future change that adds an org
+    // requirement to this op is deliberate, not accidental.
+    cognitoMock.on(ListGroupsCommand).resolves({ Groups: [] });
+    const event = buildEvent("listAvailableRoles", { username: "orgless" });
+    await expect(handler(event)).resolves.toEqual([]);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Empty-org safety: a user record with NO custom:organization attribute
+// must never be treated as same-org as a caller, even if the caller's org
+// resolution were ever weakened to produce "" instead of throwing.
+// ---------------------------------------------------------------------------
+
+describe("empty-org safety: org-less user records never match on loose equality", () => {
+  test("listUsers never returns an org-less target user to a non-admin caller with a real org", async () => {
+    // Caller alice has a real org (org-a). Target user "ghost" has NO
+    // custom:organization attribute at all (organization === undefined in
+    // the mapped result) — e.g. created before the org attribute was
+    // populated, or via adminCreateUser (which never sets it — verified in
+    // adminCreateUser's UserAttributes list in user-management-resolver.ts,
+    // it only sets email/email_verified/given_name/family_name).
+    cognitoMock
+      .on(AdminListGroupsForUserCommand, { Username: "alice" })
+      .resolves({ Groups: [{ GroupName: "developer" }] });
+    cognitoMock.on(AdminGetUserCommand, { Username: "alice" }).resolves({
+      Username: "alice",
+      UserAttributes: [{ Name: "custom:organization", Value: "org-a" }],
+    });
+    cognitoMock.on(ListUsersCommand).resolves({
+      Users: [cognitoUser("alice", "org-a"), cognitoUser("ghost", undefined)],
+    });
+    cognitoMock
+      .on(AdminListGroupsForUserCommand, { Username: "ghost" })
+      .resolves({ Groups: [{ GroupName: "developer" }] });
+
+    const event = buildEvent("listUsers", { username: "alice" });
+    const result = (await handler(event)) as UserResult[];
+
+    expect(result.map((u) => u.userId)).toEqual(["alice"]);
+  });
+
+  test("getUser refuses an org-less target user for a non-admin caller with a real org", async () => {
+    cognitoMock
+      .on(AdminListGroupsForUserCommand, { Username: "alice" })
+      .resolves({ Groups: [{ GroupName: "developer" }] });
+    cognitoMock.on(AdminGetUserCommand, { Username: "alice" }).resolves({
+      Username: "alice",
+      UserAttributes: [{ Name: "custom:organization", Value: "org-a" }],
+    });
+    cognitoMock.on(AdminGetUserCommand, { Username: "ghost" }).resolves({
+      Username: "ghost",
+      UserAttributes: [],
+      UserStatus: "CONFIRMED",
+      Enabled: true,
+      UserCreateDate: new Date("2024-01-01T00:00:00Z"),
+    });
+    cognitoMock
+      .on(AdminListGroupsForUserCommand, { Username: "ghost" })
+      .resolves({ Groups: [{ GroupName: "developer" }] });
+
+    const event = buildEvent(
+      "getUser",
+      { username: "alice" },
+      { userId: "ghost" },
+    );
+
+    await expect(handler(event)).rejects.toThrow(/User not found/);
+  });
+
+  test("an org-less caller (non-admin, org resolves falsy) is refused before reaching any org-equality comparison", async () => {
+    // This is the actual latent-risk boundary: if the caller's own org is
+    // unresolvable, requireCallerOrg throws BEFORE any `organization !==
+    // callerOrg` comparison runs — so a mutated requireCallerOrg returning
+    // "" is the only way an org-less caller could ever reach the
+    // comparison at all. This test documents and pins that ordering: with
+    // the real (unmutated) guard, the throw happens first.
+    stubOrglessNonAdminCaller("orgless");
+    cognitoMock.on(ListUsersCommand).resolves({
+      Users: [cognitoUser("ghost", undefined)],
+    });
+
+    const event = buildEvent("listUsers", { username: "orgless" });
+    await expect(handler(event)).rejects.toThrow(
+      /Unable to determine caller's organization/,
+    );
+  });
+});

--- a/backend/src/lambda/__tests__/user-management-resolver-org-scoping.test.ts
+++ b/backend/src/lambda/__tests__/user-management-resolver-org-scoping.test.ts
@@ -1,0 +1,397 @@
+/**
+ * Org-scoping + credential-in-response tests for user-management-resolver.ts
+ * (finding f21582e6).
+ *
+ * Defect: listUsers, getUser, listOrganizations and listAvailableRoles read
+ * NO identity, apply NO admin gate, and apply NO org filter — any
+ * authenticated user of any tenant could enumerate every user (with role +
+ * custom:organization) and every organization. Separately,
+ * adminResetUserPassword / adminResendInvitation echoed the generated
+ * temporary password back in the response message.
+ *
+ * Fix under test:
+ *  - listUsers / getUser: non-admin callers see/only-access their own org;
+ *    the GLOBAL 'admin' Cognito group (checked via the module's existing
+ *    isUserAdmin()) retains cross-tenant visibility, preserved deliberately.
+ *  - listOrganizations: non-admin sees only the caller's own org; admin sees
+ *    all (same admin bypass).
+ *  - listAvailableRoles: no tenant data, stays global, but must read
+ *    identity (fails closed if caller identity is unresolvable).
+ *  - Fail closed when the caller's org cannot be resolved (non-admin).
+ *  - adminResetUserPassword / adminResendInvitation: temp password must
+ *    never appear in the response `message`.
+ *
+ * assignUserRole / removeUserRole / adminCreateUser are explicitly OUT OF
+ * SCOPE (finding 59e5a79c, separately accepted risk) — no test here asserts
+ * on their org-confinement behavior changing.
+ */
+
+import {
+  CognitoIdentityProviderClient,
+  ListUsersCommand,
+  AdminGetUserCommand,
+  AdminListGroupsForUserCommand,
+  ListGroupsCommand,
+  AdminSetUserPasswordCommand,
+} from "@aws-sdk/client-cognito-identity-provider";
+import { DynamoDBDocumentClient, ScanCommand } from "@aws-sdk/lib-dynamodb";
+import { mockClient } from "aws-sdk-client-mock";
+
+const cognitoMock = mockClient(CognitoIdentityProviderClient);
+const dynamoMock = mockClient(DynamoDBDocumentClient);
+
+process.env.USER_POOL_ID = "test-pool";
+process.env.ORGANISATION_TABLE = "test-orgs";
+
+import { handler } from "../user-management-resolver";
+
+// ---------------------------------------------------------------------------
+// Fixtures
+// ---------------------------------------------------------------------------
+
+function cognitoUser(username: string, org: string, statusEnabled = true) {
+  return {
+    Username: username,
+    Attributes: [
+      { Name: "email", Value: `${username}@example.com` },
+      { Name: "given_name", Value: "First" },
+      { Name: "family_name", Value: "Last" },
+      { Name: "custom:organization", Value: org },
+    ],
+    UserStatus: "CONFIRMED",
+    Enabled: statusEnabled,
+    UserCreateDate: new Date("2024-01-01T00:00:00Z"),
+  };
+}
+
+type ResolverEvent = Parameters<typeof handler>[0];
+
+interface UserResult {
+  userId: string;
+  email: string;
+  name: string;
+  role?: string;
+  organization?: string;
+}
+
+interface OrganizationResult {
+  orgId: string;
+  name: string;
+}
+
+interface UserManagementResponseResult {
+  success: boolean;
+  message?: string;
+}
+
+function buildEvent(
+  fieldName: string,
+  identity: ResolverEvent["identity"],
+  args: Partial<ResolverEvent["arguments"]> = {},
+): ResolverEvent {
+  return {
+    info: { fieldName },
+    identity,
+    arguments: args as ResolverEvent["arguments"],
+  };
+}
+
+beforeEach(() => {
+  cognitoMock.reset();
+  dynamoMock.reset();
+});
+
+// ---------------------------------------------------------------------------
+// listUsers — org scoping
+// ---------------------------------------------------------------------------
+
+describe("listUsers — org scoping", () => {
+  test("non-admin caller only sees users in their own org", async () => {
+    // caller "alice" is in org-a, not an admin
+    cognitoMock
+      .on(AdminListGroupsForUserCommand, { Username: "alice" })
+      .resolves({ Groups: [{ GroupName: "developer" }] });
+    cognitoMock.on(AdminGetUserCommand, { Username: "alice" }).resolves({
+      Username: "alice",
+      UserAttributes: [{ Name: "custom:organization", Value: "org-a" }],
+    });
+
+    cognitoMock.on(ListUsersCommand).resolves({
+      Users: [
+        cognitoUser("alice", "org-a"),
+        cognitoUser("bob", "org-a"),
+        cognitoUser("carol", "org-b"),
+      ],
+    });
+    // Per-user role lookups used inside listUsers' mapping loop.
+    cognitoMock
+      .on(AdminListGroupsForUserCommand, { Username: "bob" })
+      .resolves({ Groups: [{ GroupName: "developer" }] });
+    cognitoMock
+      .on(AdminListGroupsForUserCommand, { Username: "carol" })
+      .resolves({ Groups: [{ GroupName: "developer" }] });
+
+    const event = buildEvent("listUsers", { username: "alice" });
+    const result = (await handler(event)) as UserResult[];
+
+    const ids = result.map((u) => u.userId).sort();
+    expect(ids).toEqual(["alice", "bob"]);
+    expect(ids).not.toContain("carol");
+  });
+
+  test("GLOBAL admin caller sees users across all orgs (deliberately preserved)", async () => {
+    cognitoMock
+      .on(AdminListGroupsForUserCommand, { Username: "admin-user" })
+      .resolves({ Groups: [{ GroupName: "admin" }] });
+
+    cognitoMock.on(ListUsersCommand).resolves({
+      Users: [cognitoUser("alice", "org-a"), cognitoUser("carol", "org-b")],
+    });
+    cognitoMock
+      .on(AdminListGroupsForUserCommand, { Username: "alice" })
+      .resolves({ Groups: [{ GroupName: "developer" }] });
+    cognitoMock
+      .on(AdminListGroupsForUserCommand, { Username: "carol" })
+      .resolves({ Groups: [{ GroupName: "developer" }] });
+
+    const event = buildEvent("listUsers", { username: "admin-user" });
+    const result = (await handler(event)) as UserResult[];
+
+    const ids = result.map((u) => u.userId).sort();
+    expect(ids).toEqual(["alice", "carol"]);
+  });
+
+  test("fails closed when caller org cannot be resolved (non-admin, no org claim/attribute)", async () => {
+    cognitoMock
+      .on(AdminListGroupsForUserCommand, { Username: "orgless" })
+      .resolves({ Groups: [{ GroupName: "developer" }] });
+    cognitoMock.on(AdminGetUserCommand, { Username: "orgless" }).resolves({
+      Username: "orgless",
+      UserAttributes: [],
+    });
+
+    const event = buildEvent("listUsers", { username: "orgless" });
+
+    await expect(handler(event)).rejects.toThrow();
+  });
+
+  test("unresolvable caller identity is rejected, not silently allowed through", async () => {
+    const event = buildEvent("listUsers", {});
+    await expect(handler(event)).rejects.toThrow();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// getUser — org scoping
+// ---------------------------------------------------------------------------
+
+describe("getUser — org scoping", () => {
+  test("non-admin caller can fetch a same-org user", async () => {
+    cognitoMock
+      .on(AdminListGroupsForUserCommand, { Username: "alice" })
+      .resolves({ Groups: [{ GroupName: "developer" }] });
+    cognitoMock.on(AdminGetUserCommand, { Username: "alice" }).resolves({
+      Username: "alice",
+      UserAttributes: [{ Name: "custom:organization", Value: "org-a" }],
+    });
+    cognitoMock.on(AdminGetUserCommand, { Username: "bob" }).resolves({
+      Username: "bob",
+      UserAttributes: [{ Name: "custom:organization", Value: "org-a" }],
+      UserStatus: "CONFIRMED",
+      Enabled: true,
+      UserCreateDate: new Date("2024-01-01T00:00:00Z"),
+    });
+    cognitoMock
+      .on(AdminListGroupsForUserCommand, { Username: "bob" })
+      .resolves({ Groups: [{ GroupName: "developer" }] });
+
+    const event = buildEvent(
+      "getUser",
+      { username: "alice" },
+      { userId: "bob" },
+    );
+    const result = (await handler(event)) as UserResult;
+    expect(result.userId).toBe("bob");
+  });
+
+  test("non-admin caller is refused (or gets not-found) for a foreign-org userId", async () => {
+    cognitoMock
+      .on(AdminListGroupsForUserCommand, { Username: "alice" })
+      .resolves({ Groups: [{ GroupName: "developer" }] });
+    cognitoMock.on(AdminGetUserCommand, { Username: "alice" }).resolves({
+      Username: "alice",
+      UserAttributes: [{ Name: "custom:organization", Value: "org-a" }],
+    });
+    cognitoMock.on(AdminGetUserCommand, { Username: "carol" }).resolves({
+      Username: "carol",
+      UserAttributes: [{ Name: "custom:organization", Value: "org-b" }],
+      UserStatus: "CONFIRMED",
+      Enabled: true,
+      UserCreateDate: new Date("2024-01-01T00:00:00Z"),
+    });
+    // Fully stub the per-user groups lookup the CURRENT (unfixed) getUser
+    // also performs, so a pre-fix run fails for the org-check reason under
+    // test, not an unrelated missing-stub throw.
+    cognitoMock
+      .on(AdminListGroupsForUserCommand, { Username: "carol" })
+      .resolves({ Groups: [{ GroupName: "developer" }] });
+
+    const event = buildEvent(
+      "getUser",
+      { username: "alice" },
+      { userId: "carol" },
+    );
+
+    await expect(handler(event)).rejects.toThrow();
+  });
+
+  test("GLOBAL admin caller can fetch a cross-org user (deliberately preserved)", async () => {
+    cognitoMock
+      .on(AdminListGroupsForUserCommand, { Username: "admin-user" })
+      .resolves({ Groups: [{ GroupName: "admin" }] });
+    cognitoMock.on(AdminGetUserCommand, { Username: "carol" }).resolves({
+      Username: "carol",
+      UserAttributes: [{ Name: "custom:organization", Value: "org-b" }],
+      UserStatus: "CONFIRMED",
+      Enabled: true,
+      UserCreateDate: new Date("2024-01-01T00:00:00Z"),
+    });
+    cognitoMock
+      .on(AdminListGroupsForUserCommand, { Username: "carol" })
+      .resolves({ Groups: [{ GroupName: "developer" }] });
+
+    const event = buildEvent(
+      "getUser",
+      { username: "admin-user" },
+      { userId: "carol" },
+    );
+    const result = (await handler(event)) as UserResult;
+    expect(result.userId).toBe("carol");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// listOrganizations — org scoping
+// ---------------------------------------------------------------------------
+
+describe("listOrganizations — org scoping", () => {
+  const orgItems = [
+    { orgId: "org-a", name: "Org A", createdAt: "2024-01-01T00:00:00Z" },
+    { orgId: "org-b", name: "Org B", createdAt: "2024-01-01T00:00:00Z" },
+  ];
+
+  test("non-admin caller sees only their own org", async () => {
+    cognitoMock
+      .on(AdminListGroupsForUserCommand, { Username: "alice" })
+      .resolves({ Groups: [{ GroupName: "developer" }] });
+    cognitoMock.on(AdminGetUserCommand, { Username: "alice" }).resolves({
+      Username: "alice",
+      UserAttributes: [{ Name: "custom:organization", Value: "org-a" }],
+    });
+    dynamoMock.on(ScanCommand).resolves({ Items: orgItems });
+
+    const event = buildEvent("listOrganizations", { username: "alice" });
+    const result = (await handler(event)) as OrganizationResult[];
+
+    expect(result.map((o) => o.orgId)).toEqual(["org-a"]);
+  });
+
+  test("GLOBAL admin caller sees all organizations (deliberately preserved)", async () => {
+    cognitoMock
+      .on(AdminListGroupsForUserCommand, { Username: "admin-user" })
+      .resolves({ Groups: [{ GroupName: "admin" }] });
+    dynamoMock.on(ScanCommand).resolves({ Items: orgItems });
+
+    const event = buildEvent("listOrganizations", { username: "admin-user" });
+    const result = (await handler(event)) as OrganizationResult[];
+
+    expect(result.map((o) => o.orgId).sort()).toEqual(["org-a", "org-b"]);
+  });
+
+  test("fails closed when caller org cannot be resolved", async () => {
+    cognitoMock
+      .on(AdminListGroupsForUserCommand, { Username: "orgless" })
+      .resolves({ Groups: [{ GroupName: "developer" }] });
+    cognitoMock.on(AdminGetUserCommand, { Username: "orgless" }).resolves({
+      Username: "orgless",
+      UserAttributes: [],
+    });
+
+    const event = buildEvent("listOrganizations", { username: "orgless" });
+    await expect(handler(event)).rejects.toThrow();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// listAvailableRoles — must read identity but stays global
+// ---------------------------------------------------------------------------
+
+describe("listAvailableRoles — identity required, no tenant data", () => {
+  test("resolves for any caller with a resolvable identity (non-admin included)", async () => {
+    cognitoMock.on(ListGroupsCommand).resolves({
+      Groups: [{ GroupName: "admin" }, { GroupName: "developer" }],
+    });
+
+    const event = buildEvent("listAvailableRoles", { username: "alice" });
+    const result = await handler(event);
+
+    expect(result).toEqual(["admin", "developer"]);
+  });
+
+  test("fails closed when caller identity is unresolvable", async () => {
+    const event = buildEvent("listAvailableRoles", {});
+    await expect(handler(event)).rejects.toThrow();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Credential-in-response removal
+// ---------------------------------------------------------------------------
+
+describe("adminResetUserPassword / adminResendInvitation — no temp password in response", () => {
+  beforeEach(() => {
+    cognitoMock
+      .on(AdminListGroupsForUserCommand, { Username: "admin-user" })
+      .resolves({ Groups: [{ GroupName: "admin" }] });
+    cognitoMock.on(AdminSetUserPasswordCommand).resolves({});
+  });
+
+  test("adminResetUserPassword response never contains the temp password", async () => {
+    const event = buildEvent(
+      "adminResetUserPassword",
+      { username: "admin-user" },
+      { userId: "bob" },
+    );
+    const result = (await handler(event)) as UserManagementResponseResult;
+
+    expect(result.success).toBe(true);
+    // No 12+ char alnum/symbol blob resembling a generated password, and the
+    // literal label used previously must be gone.
+    expect(result.message).not.toMatch(/Temporary password:/i);
+  });
+
+  test("adminResendInvitation response never contains the temp password", async () => {
+    const event = buildEvent(
+      "adminResendInvitation",
+      { username: "admin-user" },
+      { userId: "bob" },
+    );
+    const result = (await handler(event)) as UserManagementResponseResult;
+
+    expect(result.success).toBe(true);
+    expect(result.message).not.toMatch(/Temporary password:/i);
+  });
+
+  test("adminResetUserPassword still requires admin (non-admin blocked)", async () => {
+    cognitoMock
+      .on(AdminListGroupsForUserCommand, { Username: "alice" })
+      .resolves({ Groups: [{ GroupName: "developer" }] });
+
+    const event = buildEvent(
+      "adminResetUserPassword",
+      { username: "alice" },
+      { userId: "bob" },
+    );
+    await expect(handler(event)).rejects.toThrow(/Only administrators/);
+  });
+});

--- a/backend/src/lambda/user-management-resolver.ts
+++ b/backend/src/lambda/user-management-resolver.ts
@@ -9,10 +9,11 @@ import {
   ListGroupsCommand,
   AdminSetUserPasswordCommand,
   AdminCreateUserCommand,
-} from '@aws-sdk/client-cognito-identity-provider';
-import { DynamoDBClient } from '@aws-sdk/client-dynamodb';
-import * as crypto from 'crypto';
-import { DynamoDBDocumentClient, ScanCommand } from '@aws-sdk/lib-dynamodb';
+} from "@aws-sdk/client-cognito-identity-provider";
+import { DynamoDBClient } from "@aws-sdk/client-dynamodb";
+import * as crypto from "crypto";
+import { DynamoDBDocumentClient, ScanCommand } from "@aws-sdk/lib-dynamodb";
+import { extractOrgFromEvent } from "../utils/auth-event";
 
 const cognitoClient = new CognitoIdentityProviderClient({});
 const dynamoClient = DynamoDBDocumentClient.from(new DynamoDBClient({}));
@@ -21,7 +22,7 @@ const ORGANISATION_TABLE = process.env.ORGANISATION_TABLE!;
 
 // Cache for user groups to reduce Cognito API calls
 // Cache persists across warm Lambda invocations
-const groupCache = new Map<string, { groups: string[], timestamp: number }>();
+const groupCache = new Map<string, { groups: string[]; timestamp: number }>();
 const CACHE_TTL = 5 * 60 * 1000; // 5 minutes
 
 interface AssignUserRoleInput {
@@ -61,7 +62,7 @@ async function isUserAdmin(username: string): Promise<boolean> {
   const cached = groupCache.get(username);
   if (cached && Date.now() - cached.timestamp < CACHE_TTL) {
     console.log(`Cache hit for user ${username}`);
-    return cached.groups.includes('admin');
+    return cached.groups.includes("admin");
   }
 
   // Cache miss - fetch from Cognito
@@ -70,15 +71,15 @@ async function isUserAdmin(username: string): Promise<boolean> {
     new AdminListGroupsForUserCommand({
       UserPoolId: USER_POOL_ID,
       Username: username,
-    })
+    }),
   );
 
-  const groups = groupsResponse.Groups?.map(g => g.GroupName!) || [];
-  
+  const groups = groupsResponse.Groups?.map((g) => g.GroupName!) || [];
+
   // Update cache
   groupCache.set(username, { groups, timestamp: Date.now() });
 
-  return groups.includes('admin');
+  return groups.includes("admin");
 }
 
 /** AppSync event slice this resolver reads: Cognito identity + arguments. */
@@ -92,122 +93,119 @@ interface UserManagementResolverEvent {
   };
 }
 
+/**
+ * Resolves the caller's username from the AppSync-injected Cognito
+ * identity. Throws when identity is unresolvable — every read op in this
+ * module must fail closed rather than proceed with an unknown caller
+ * (finding f21582e6).
+ */
+function requireCallerUsername(event: UserManagementResolverEvent): string {
+  const callerUsername =
+    event.identity?.username || event.identity?.claims?.username;
+  if (!callerUsername) {
+    throw new Error("Unable to determine caller identity");
+  }
+  return callerUsername;
+}
+
+/**
+ * Resolves the caller's org for a non-admin org-scoping decision. Reuses
+ * extractOrgFromEvent (JWT `custom:organization` claim, falling back to an
+ * AdminGetUser lookup) rather than inventing a second identity path.
+ * Throws when the org cannot be resolved — fail closed (finding f21582e6).
+ */
+async function requireCallerOrg(
+  event: UserManagementResolverEvent,
+): Promise<string> {
+  const org = await extractOrgFromEvent(event);
+  if (!org) {
+    throw new Error("Unable to determine caller's organization");
+  }
+  return org;
+}
+
 export const handler = async (event: UserManagementResolverEvent) => {
-  console.log('Event:', JSON.stringify(event, null, 2));
+  console.log("Event:", JSON.stringify(event, null, 2));
 
   const fieldName = event.info.fieldName;
 
   try {
     switch (fieldName) {
-      case 'listUsers':
-        return await listUsers();
-      case 'getUser':
-        return await getUser(event.arguments.userId);
-      case 'getCurrentUserProfile':
+      case "listUsers":
+        return await listUsers(event);
+      case "getUser":
+        return await getUser(event.arguments.userId, event);
+      case "getCurrentUserProfile":
         return await getCurrentUserProfile(event);
-      case 'listAvailableRoles':
-        return await listAvailableRoles();
-      case 'listOrganizations':
-        return await listOrganizations();
-      case 'adminCreateUser':
+      case "listAvailableRoles":
+        return await listAvailableRoles(event);
+      case "listOrganizations":
+        return await listOrganizations(event);
+      case "adminCreateUser":
         return await adminCreateUser(event, event.arguments.input);
-      case 'assignUserRole':
+      case "assignUserRole":
         return await assignUserRole(event.arguments.input, event);
-      case 'removeUserRole':
-        return await removeUserRole(event.arguments.userId, event.arguments.role, event);
-      case 'changePassword':
+      case "removeUserRole":
+        return await removeUserRole(
+          event.arguments.userId,
+          event.arguments.role,
+          event,
+        );
+      case "changePassword":
         return await changePassword(event, event.arguments.input);
-      case 'adminResetUserPassword':
+      case "adminResetUserPassword":
         return await adminResetUserPassword(event, event.arguments.userId);
-      case 'adminResendInvitation':
+      case "adminResendInvitation":
         return await adminResendInvitation(event, event.arguments.userId);
       default:
         throw new Error(`Unknown field: ${fieldName}`);
     }
   } catch (error) {
-    console.error('Error:', error);
+    console.error("Error:", error);
     throw error;
   }
 };
 
-async function listUsers(): Promise<User[]> {
+async function listUsers(event: UserManagementResolverEvent): Promise<User[]> {
+  const callerUsername = requireCallerUsername(event);
+  const callerIsAdmin = await isUserAdmin(callerUsername);
+  // Non-admin callers are confined to their own org; fail closed if it
+  // cannot be resolved (finding f21582e6). The GLOBAL 'admin' Cognito
+  // group retains cross-tenant visibility, preserved deliberately.
+  const callerOrg = callerIsAdmin ? null : await requireCallerOrg(event);
+
   const response = await cognitoClient.send(
     new ListUsersCommand({
       UserPoolId: USER_POOL_ID,
-    })
+    }),
   );
 
   const users: User[] = [];
 
   for (const user of response.Users || []) {
     const attributes = user.Attributes || [];
-    const email = attributes.find((attr) => attr.Name === 'email')?.Value || '';
-    const givenName = attributes.find((attr) => attr.Name === 'given_name')?.Value || '';
-    const familyName = attributes.find((attr) => attr.Name === 'family_name')?.Value || '';
-    const organization = attributes.find((attr) => attr.Name === 'custom:organization')?.Value;
+    const email = attributes.find((attr) => attr.Name === "email")?.Value || "";
+    const givenName =
+      attributes.find((attr) => attr.Name === "given_name")?.Value || "";
+    const familyName =
+      attributes.find((attr) => attr.Name === "family_name")?.Value || "";
+    const organization = attributes.find(
+      (attr) => attr.Name === "custom:organization",
+    )?.Value;
+
+    if (!callerIsAdmin && organization !== callerOrg) {
+      continue;
+    }
 
     // Get user's groups (roles)
     const groupsResponse = await cognitoClient.send(
       new AdminListGroupsForUserCommand({
         UserPoolId: USER_POOL_ID,
         Username: user.Username!,
-      })
+      }),
     );
 
     // Cognito does NOT guarantee the order in which Groups are returned for a
-      // multi-group user. Selecting `Groups[0]` was flaky — if an admin happened
-      // to also be in a non-admin group and Cognito returned that group first,
-      // the OrganizationContext on the frontend would fall through to the
-      // non-admin branch (and show "No Org" if the user had no
-      // custom:organization attribute set). Prefer 'admin' if present so the
-      // most-privileged role always wins; otherwise take the first returned
-      // group, matching the prior behaviour for single-group users.
-      const groupNames = (groupsResponse.Groups || [])
-        .map((g) => g.GroupName)
-        .filter((n): n is string => !!n);
-      const role =
-        groupNames.find((n) => n === 'admin') ?? groupNames[0];
-
-    users.push({
-      userId: user.Username!,
-      email,
-      name: `${givenName} ${familyName}`.trim(),
-      givenName,
-      familyName,
-      role,
-      organization,
-      status: user.UserStatus || 'UNKNOWN',
-      createdAt: user.UserCreateDate?.toISOString() || new Date().toISOString(),
-      enabled: user.Enabled || false,
-    });
-  }
-
-  return users;
-}
-
-async function getUser(userId: string): Promise<User> {
-  const response = await cognitoClient.send(
-    new AdminGetUserCommand({
-      UserPoolId: USER_POOL_ID,
-      Username: userId,
-    })
-  );
-
-  const attributes = response.UserAttributes || [];
-  const email = attributes.find((attr) => attr.Name === 'email')?.Value || '';
-  const givenName = attributes.find((attr) => attr.Name === 'given_name')?.Value || '';
-  const familyName = attributes.find((attr) => attr.Name === 'family_name')?.Value || '';
-  const organization = attributes.find((attr) => attr.Name === 'custom:organization')?.Value;
-
-  // Get user's groups (roles)
-  const groupsResponse = await cognitoClient.send(
-    new AdminListGroupsForUserCommand({
-      UserPoolId: USER_POOL_ID,
-      Username: userId,
-    })
-  );
-
-  // Cognito does NOT guarantee the order in which Groups are returned for a
     // multi-group user. Selecting `Groups[0]` was flaky — if an admin happened
     // to also be in a non-admin group and Cognito returned that group first,
     // the OrganizationContext on the frontend would fall through to the
@@ -218,8 +216,80 @@ async function getUser(userId: string): Promise<User> {
     const groupNames = (groupsResponse.Groups || [])
       .map((g) => g.GroupName)
       .filter((n): n is string => !!n);
-    const role =
-      groupNames.find((n) => n === 'admin') ?? groupNames[0];
+    const role = groupNames.find((n) => n === "admin") ?? groupNames[0];
+
+    users.push({
+      userId: user.Username!,
+      email,
+      name: `${givenName} ${familyName}`.trim(),
+      givenName,
+      familyName,
+      role,
+      organization,
+      status: user.UserStatus || "UNKNOWN",
+      createdAt: user.UserCreateDate?.toISOString() || new Date().toISOString(),
+      enabled: user.Enabled || false,
+    });
+  }
+
+  return users;
+}
+
+async function getUser(
+  userId: string,
+  event: UserManagementResolverEvent,
+): Promise<User> {
+  const callerUsername = requireCallerUsername(event);
+  const callerIsAdmin = await isUserAdmin(callerUsername);
+
+  const response = await cognitoClient.send(
+    new AdminGetUserCommand({
+      UserPoolId: USER_POOL_ID,
+      Username: userId,
+    }),
+  );
+
+  const attributes = response.UserAttributes || [];
+  const email = attributes.find((attr) => attr.Name === "email")?.Value || "";
+  const givenName =
+    attributes.find((attr) => attr.Name === "given_name")?.Value || "";
+  const familyName =
+    attributes.find((attr) => attr.Name === "family_name")?.Value || "";
+  const organization = attributes.find(
+    (attr) => attr.Name === "custom:organization",
+  )?.Value;
+
+  if (!callerIsAdmin && userId !== callerUsername) {
+    // Non-admin callers may always fetch their own profile (self-lookup,
+    // used by getCurrentUserProfile). For any other target, the caller's
+    // org must be resolvable and must match the target's org — fail
+    // closed otherwise (finding f21582e6).
+    const callerOrg = await requireCallerOrg(event);
+    if (organization !== callerOrg) {
+      throw new Error("User not found");
+    }
+  }
+
+  // Get user's groups (roles)
+  const groupsResponse = await cognitoClient.send(
+    new AdminListGroupsForUserCommand({
+      UserPoolId: USER_POOL_ID,
+      Username: userId,
+    }),
+  );
+
+  // Cognito does NOT guarantee the order in which Groups are returned for a
+  // multi-group user. Selecting `Groups[0]` was flaky — if an admin happened
+  // to also be in a non-admin group and Cognito returned that group first,
+  // the OrganizationContext on the frontend would fall through to the
+  // non-admin branch (and show "No Org" if the user had no
+  // custom:organization attribute set). Prefer 'admin' if present so the
+  // most-privileged role always wins; otherwise take the first returned
+  // group, matching the prior behaviour for single-group users.
+  const groupNames = (groupsResponse.Groups || [])
+    .map((g) => g.GroupName)
+    .filter((n): n is string => !!n);
+  const role = groupNames.find((n) => n === "admin") ?? groupNames[0];
 
   return {
     userId: response.Username!,
@@ -229,48 +299,57 @@ async function getUser(userId: string): Promise<User> {
     familyName,
     role,
     organization,
-    status: response.UserStatus || 'UNKNOWN',
-    createdAt: response.UserCreateDate?.toISOString() || new Date().toISOString(),
+    status: response.UserStatus || "UNKNOWN",
+    createdAt:
+      response.UserCreateDate?.toISOString() || new Date().toISOString(),
     enabled: response.Enabled || false,
   };
 }
 
-async function getCurrentUserProfile(event: UserManagementResolverEvent): Promise<User> {
+async function getCurrentUserProfile(
+  event: UserManagementResolverEvent,
+): Promise<User> {
   // Extract username from the Cognito identity
   const username = event.identity?.username || event.identity?.claims?.username;
-  
+
   if (!username) {
-    throw new Error('Unable to determine current user from request context');
+    throw new Error("Unable to determine current user from request context");
   }
 
-  return await getUser(username);
+  return await getUser(username, event);
 }
 
-async function assignUserRole(input: AssignUserRoleInput, event: UserManagementResolverEvent) {
+async function assignUserRole(
+  input: AssignUserRoleInput,
+  event: UserManagementResolverEvent,
+) {
   const { userId, role, organization } = input;
 
   // Verify the caller is an admin
-  const callerUsername = event.identity?.username || event.identity?.claims?.username;
-  
+  const callerUsername =
+    event.identity?.username || event.identity?.claims?.username;
+
   if (!callerUsername) {
-    throw new Error('Unable to determine caller identity');
+    throw new Error("Unable to determine caller identity");
   }
 
   // Check if caller is admin (with caching)
   const callerIsAdmin = await isUserAdmin(callerUsername);
-  
+
   if (!callerIsAdmin) {
-    throw new Error('Only administrators can assign user roles');
+    throw new Error("Only administrators can assign user roles");
   }
 
-  console.log(`Assigning role ${role} and organization ${organization} to user ${userId}`);
+  console.log(
+    `Assigning role ${role} and organization ${organization} to user ${userId}`,
+  );
 
   // Get current groups to remove user from old role
   const groupsResponse = await cognitoClient.send(
     new AdminListGroupsForUserCommand({
       UserPoolId: USER_POOL_ID,
       Username: userId,
-    })
+    }),
   );
 
   // Remove user from all existing groups
@@ -280,7 +359,7 @@ async function assignUserRole(input: AssignUserRoleInput, event: UserManagementR
         UserPoolId: USER_POOL_ID,
         Username: userId,
         GroupName: group.GroupName!,
-      })
+      }),
     );
   }
 
@@ -290,7 +369,7 @@ async function assignUserRole(input: AssignUserRoleInput, event: UserManagementR
       UserPoolId: USER_POOL_ID,
       Username: userId,
       GroupName: role,
-    })
+    }),
   );
 
   // Update organization custom attribute if provided
@@ -301,35 +380,42 @@ async function assignUserRole(input: AssignUserRoleInput, event: UserManagementR
         Username: userId,
         UserAttributes: [
           {
-            Name: 'custom:organization',
+            Name: "custom:organization",
             Value: organization,
           },
         ],
-      })
+      }),
     );
   }
 
-  console.log(`Successfully assigned role ${role} and organization ${organization} to user ${userId}`);
+  console.log(
+    `Successfully assigned role ${role} and organization ${organization} to user ${userId}`,
+  );
 
   return {
     success: true,
-    message: `User ${userId} assigned to role ${role}${organization ? ` and organization ${organization}` : ''}`,
+    message: `User ${userId} assigned to role ${role}${organization ? ` and organization ${organization}` : ""}`,
   };
 }
 
-async function removeUserRole(userId: string, role: string, event: UserManagementResolverEvent) {
+async function removeUserRole(
+  userId: string,
+  role: string,
+  event: UserManagementResolverEvent,
+) {
   // Verify the caller is an admin
-  const callerUsername = event.identity?.username || event.identity?.claims?.username;
-  
+  const callerUsername =
+    event.identity?.username || event.identity?.claims?.username;
+
   if (!callerUsername) {
-    throw new Error('Unable to determine caller identity');
+    throw new Error("Unable to determine caller identity");
   }
 
   // Check if caller is admin (with caching)
   const callerIsAdmin = await isUserAdmin(callerUsername);
-  
+
   if (!callerIsAdmin) {
-    throw new Error('Only administrators can remove user roles');
+    throw new Error("Only administrators can remove user roles");
   }
 
   await cognitoClient.send(
@@ -337,7 +423,7 @@ async function removeUserRole(userId: string, role: string, event: UserManagemen
       UserPoolId: USER_POOL_ID,
       Username: userId,
       GroupName: role,
-    })
+    }),
   );
 
   return {
@@ -346,69 +432,87 @@ async function removeUserRole(userId: string, role: string, event: UserManagemen
   };
 }
 
-async function listAvailableRoles(): Promise<string[]> {
+async function listAvailableRoles(
+  event: UserManagementResolverEvent,
+): Promise<string[]> {
+  // No tenant data is returned, so this stays global — but identity must
+  // still be read and resolvable, failing closed otherwise (finding
+  // f21582e6).
+  requireCallerUsername(event);
+
   const response = await cognitoClient.send(
     new ListGroupsCommand({
       UserPoolId: USER_POOL_ID,
-    })
+    }),
   );
 
   return (response.Groups || [])
-    .map(group => group.GroupName)
+    .map((group) => group.GroupName)
     .filter((name): name is string => !!name)
     .sort();
 }
 
-async function listOrganizations() {
+async function listOrganizations(event: UserManagementResolverEvent) {
+  const callerUsername = requireCallerUsername(event);
+  const callerIsAdmin = await isUserAdmin(callerUsername);
+  // Non-admin callers are confined to their own org; the GLOBAL 'admin'
+  // Cognito group retains cross-tenant visibility, preserved deliberately.
+  const callerOrg = callerIsAdmin ? null : await requireCallerOrg(event);
+
   const response = await dynamoClient.send(
     new ScanCommand({
       TableName: ORGANISATION_TABLE,
-    })
+    }),
   );
 
-  return (response.Items || []).map(item => {
-    console.log('Raw item from DynamoDB:', JSON.stringify(item));
-    
-    // Ensure createdAt is in proper ISO 8601 format for AppSync
-    let createdAt = item.createdAt;
-    console.log('Original createdAt:', createdAt, 'Type:', typeof createdAt);
-    
-    if (createdAt && typeof createdAt === 'string') {
-      // Remove microseconds if present
-      const parts = createdAt.split('.');
-      if (parts.length > 1) {
-        // Has microseconds, take only the date/time part
-        createdAt = parts[0];
-        console.log('After removing microseconds:', createdAt);
+  return (response.Items || [])
+    .filter((item) => callerIsAdmin || item.orgId === callerOrg)
+    .map((item) => {
+      console.log("Raw item from DynamoDB:", JSON.stringify(item));
+
+      // Ensure createdAt is in proper ISO 8601 format for AppSync
+      let createdAt = item.createdAt;
+      console.log("Original createdAt:", createdAt, "Type:", typeof createdAt);
+
+      if (createdAt && typeof createdAt === "string") {
+        // Remove microseconds if present
+        const parts = createdAt.split(".");
+        if (parts.length > 1) {
+          // Has microseconds, take only the date/time part
+          createdAt = parts[0];
+          console.log("After removing microseconds:", createdAt);
+        }
+        // Ensure it ends with 'Z' (but don't add if already present)
+        if (!createdAt.endsWith("Z")) {
+          createdAt = createdAt + "Z";
+          console.log("Added Z:", createdAt);
+        } else {
+          console.log("Already has Z, not adding");
+        }
       }
-      // Ensure it ends with 'Z' (but don't add if already present)
-      if (!createdAt.endsWith('Z')) {
-        createdAt = createdAt + 'Z';
-        console.log('Added Z:', createdAt);
-      } else {
-        console.log('Already has Z, not adding');
-      }
-    }
-    
-    console.log('Final createdAt:', createdAt);
-    
-    return {
-      orgId: item.orgId,
-      name: item.name || item.orgId,
-      description: item.description,
-      createdAt: createdAt,
-    };
-  });
+
+      console.log("Final createdAt:", createdAt);
+
+      return {
+        orgId: item.orgId,
+        name: item.name || item.orgId,
+        description: item.description,
+        createdAt: createdAt,
+      };
+    });
 }
 
-async function changePassword(event: UserManagementResolverEvent, input: ChangePasswordInput) {
+async function changePassword(
+  event: UserManagementResolverEvent,
+  input: ChangePasswordInput,
+) {
   const { newPassword } = input;
-  
+
   // Get username from the Cognito identity
   const username = event.identity?.username || event.identity?.claims?.username;
-  
+
   if (!username) {
-    throw new Error('Unable to determine current user from request context');
+    throw new Error("Unable to determine current user from request context");
   }
 
   try {
@@ -420,76 +524,88 @@ async function changePassword(event: UserManagementResolverEvent, input: ChangeP
         Username: username,
         Password: newPassword,
         Permanent: true, // This is a permanent password, not temporary
-      })
+      }),
     );
 
     return {
       success: true,
-      message: 'Password changed successfully',
+      message: "Password changed successfully",
     };
   } catch (error: unknown) {
-    console.error('Error changing password:', error);
+    console.error("Error changing password:", error);
     return {
       success: false,
-      message: (error instanceof Error ? error.message : '') || 'Failed to change password',
+      message:
+        (error instanceof Error ? error.message : "") ||
+        "Failed to change password",
     };
   }
 }
 
-async function adminResetUserPassword(event: UserManagementResolverEvent, userId: string) {
+async function adminResetUserPassword(
+  event: UserManagementResolverEvent,
+  userId: string,
+) {
   // Verify the caller is an admin
-  const callerUsername = event.identity?.username || event.identity?.claims?.username;
-  
+  const callerUsername =
+    event.identity?.username || event.identity?.claims?.username;
+
   if (!callerUsername) {
-    throw new Error('Unable to determine caller identity');
+    throw new Error("Unable to determine caller identity");
   }
 
   // Check if caller is admin (with caching)
   const callerIsAdmin = await isUserAdmin(callerUsername);
-  
+
   if (!callerIsAdmin) {
-    throw new Error('Only administrators can reset user passwords');
+    throw new Error("Only administrators can reset user passwords");
   }
 
   try {
     // Generate a temporary password (user will be forced to change it on next login)
     const tempPassword = generateTemporaryPassword();
-    
+
     await cognitoClient.send(
       new AdminSetUserPasswordCommand({
         UserPoolId: USER_POOL_ID,
         Username: userId,
         Password: tempPassword,
         Permanent: false, // User must change password on next login
-      })
+      }),
     );
 
     return {
       success: true,
-      message: `Password reset successfully. Temporary password: ${tempPassword}`,
+      message: "Password reset successfully.",
     };
   } catch (error: unknown) {
-    console.error('Error resetting password:', error);
+    console.error("Error resetting password:", error);
     return {
       success: false,
-      message: (error instanceof Error ? error.message : '') || 'Failed to reset password',
+      message:
+        (error instanceof Error ? error.message : "") ||
+        "Failed to reset password",
     };
   }
 }
 
-async function adminCreateUser(event: UserManagementResolverEvent, input: AdminCreateUserInput) {
+async function adminCreateUser(
+  event: UserManagementResolverEvent,
+  input: AdminCreateUserInput,
+) {
   // Verify the caller is an admin
-  const callerUsername = event.identity?.username || event.identity?.claims?.username;
-  
+  const callerUsername =
+    event.identity?.username || event.identity?.claims?.username;
+
   if (!callerUsername) {
-    throw new Error('Unable to determine caller identity');
+    throw new Error("Unable to determine caller identity");
   }
 
   // Check if caller is admin (with caching)
   const callerIsAdmin = await isUserAdmin(callerUsername);
-  
+
   if (!callerIsAdmin) {
-    throw new Error('Only administrators can create users');
+    throw new Error("Only administrators can create users");
   }
 
   const { email, givenName, familyName } = input;
@@ -502,14 +618,14 @@ async function adminCreateUser(event: UserManagementResolverEvent, input: AdminC
         UserPoolId: USER_POOL_ID,
         Username: email,
         UserAttributes: [
-          { Name: 'email', Value: email },
-          { Name: 'email_verified', Value: 'true' }, // Set to true so email is verified
-          { Name: 'given_name', Value: givenName },
-          { Name: 'family_name', Value: familyName },
+          { Name: "email", Value: email },
+          { Name: "email_verified", Value: "true" }, // Set to true so email is verified
+          { Name: "given_name", Value: givenName },
+          { Name: "family_name", Value: familyName },
         ],
         // Remove MessageAction to allow Cognito to send the welcome email
-        DesiredDeliveryMediums: ['EMAIL'],
-      })
+        DesiredDeliveryMediums: ["EMAIL"],
+      }),
     );
 
     console.log(`Successfully created user ${email}`);
@@ -519,83 +635,92 @@ async function adminCreateUser(event: UserManagementResolverEvent, input: AdminC
       message: `User ${email} created successfully. An invitation email with temporary password has been sent to their email address.`,
     };
   } catch (error: unknown) {
-    console.error('Error creating user:', error);
-    
-    if (error instanceof Error && error.name === 'UsernameExistsException') {
+    console.error("Error creating user:", error);
+
+    if (error instanceof Error && error.name === "UsernameExistsException") {
       return {
         success: false,
-        message: 'A user with this email already exists',
+        message: "A user with this email already exists",
       };
     }
-    
+
     return {
       success: false,
-      message: (error instanceof Error ? error.message : '') || 'Failed to create user',
+      message:
+        (error instanceof Error ? error.message : "") ||
+        "Failed to create user",
     };
   }
 }
 
-async function adminResendInvitation(event: UserManagementResolverEvent, userId: string) {
+async function adminResendInvitation(
+  event: UserManagementResolverEvent,
+  userId: string,
+) {
   // Verify the caller is an admin
-  const callerUsername = event.identity?.username || event.identity?.claims?.username;
-  
+  const callerUsername =
+    event.identity?.username || event.identity?.claims?.username;
+
   if (!callerUsername) {
-    throw new Error('Unable to determine caller identity');
+    throw new Error("Unable to determine caller identity");
   }
 
   // Check if caller is admin (with caching)
   const callerIsAdmin = await isUserAdmin(callerUsername);
-  
+
   if (!callerIsAdmin) {
-    throw new Error('Only administrators can resend invitations');
+    throw new Error("Only administrators can resend invitations");
   }
 
   try {
     // Generate a temporary password and set it
     const tempPassword = generateTemporaryPassword();
-    
+
     await cognitoClient.send(
       new AdminSetUserPasswordCommand({
         UserPoolId: USER_POOL_ID,
         Username: userId,
         Password: tempPassword,
         Permanent: false, // User must change password on first login
-      })
+      }),
     );
 
     return {
       success: true,
-      message: `Invitation resent. Temporary password: ${tempPassword}`,
+      message: "Invitation resent.",
     };
   } catch (error: unknown) {
-    console.error('Error resending invitation:', error);
+    console.error("Error resending invitation:", error);
     return {
       success: false,
-      message: (error instanceof Error ? error.message : '') || 'Failed to resend invitation',
+      message:
+        (error instanceof Error ? error.message : "") ||
+        "Failed to resend invitation",
     };
   }
 }
 
 function generateTemporaryPassword(): string {
   const length = 12;
-  const charset = 'abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789!@#$%^&*';
-  let password = '';
-  
+  const charset =
+    "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789!@#$%^&*";
+  let password = "";
+
   // Ensure password meets Cognito requirements
-  password += 'A'; // uppercase
-  password += 'a'; // lowercase
-  password += '1'; // digit
-  password += '!'; // symbol
-  
+  password += "A"; // uppercase
+  password += "a"; // lowercase
+  password += "1"; // digit
+  password += "!"; // symbol
+
   for (let i = password.length; i < length; i++) {
     password += charset.charAt(crypto.randomInt(charset.length));
   }
-  
+
   // Shuffle the password using crypto-secure randomness
-  const arr = password.split('');
+  const arr = password.split("");
   for (let i = arr.length - 1; i > 0; i--) {
     const j = crypto.randomInt(i + 1);
     [arr[i], arr[j]] = [arr[j], arr[i]];
   }
-  return arr.join('');
+  return arr.join("");
 }


### PR DESCRIPTION
## Summary

`listUsers`, `getUser`, `Listorganizations` and `ListAvailableRoles` read no identity, applied no admin gate and applied no organization filter, and are wired with default Cognito auth (no group directive in the schema). Any authenticated user of any tenant could therefore enumerate every user across all organizations - including their role and `custom:organization` - and list every organization. That is cross-tenant disclosure and reconnaissance primitive for the admin-only mutations in the same module.

- Non-admins are now confined to their own organization for `listUsers`, `getUser` and `ListOrganizations`, using the existing `extractOrgFromEvent` helper rather than a second identity path
- `ListAvailableRoles` returns no tenant data so it stays global, but now reads identity
- All four fail closed when identity or organization cannot be resolved
- The **global** Cognito admin group keeps cross-tenant visibility - preserved deliberately as existing intent, reachable only via the server-side group check, never a client argument
- `getUser` retains a self-lookup bypass so the current-user profile path is unchanged
- Temporary passwords no longer appear in `adminResetUserPassword` / `adminResendInvitation` responses. The message text was corrected rather than claiming email delivery, because neither operation actually triggers a Cognito email
- New dispatch-derived gate-enumeration guard for this module, mirroring the two that exist

## The fail-closed behaviour was claimed before it was tested

The first pass asserted fail-closed handling. A mutation - `requireCallerOrg` returning `org || ""` instead of throwing - left **all fifteen tests passing**. The behaviour was correct but unasserted, so nothing would have caught a regression.

A second commit adds twelve refusal tests: absent identity and unresolvable organization, per operation, each asserting a **throw** rather than an empty result. An empty list cannot distinguish fail-closed from a silent unfiltered fallback that happens to return nothing.

That work also confirmed a real hazard behind the mutation: `custom:organization` is an optional attribute that `adminCreateUser` never sets, so users with no organization genuinely exist. Had the empty-string fallback shipped, those records would have matched any caller. Three tests now pin that they cannot.

## Testing

- Executed bite proofs with byte-identical restores: removing the `listUsers` filter returns a foreign-org user; removing the `getUser` refusal returns a foreign record; both mutations above now fail the new tests; stripping an identity read fails the new dispatch guard
- Cross-org absence proven against seeded data in both organizations, so it is not vacuous
- No UI breakage: the team screen and organization context callers still work for both a same-org user and an admin
- tsc, lint exit 0; 42 targeted tests; full backend jest 7255