### PR TITLE
fix(security): require org and role auth for agent code access

### DIFF
--- a/backend/bin/app.ts
+++ b/backend/bin/app.ts
@@ -988,6 +988,14 @@ if (app.node.tryGetContext("nag") !== "false") {
     // only, scoped to the registry ARN + its records, to fetch the app's
     // manifest for the owner-role check before any provisioning/teardown.
     [gatewayStack, "AppPublishHandler/ServiceRole/DefaultPolicy/Resource"],
+    // Agent-code org/role gate (finding 1a9181a4): GetRegistryRecord
+    // only, scoped to the registry ARN + its records, to fetch the
+    // agent's Registry record for the org reconciliation check before any
+    // S3/DynamoDB access. Same shape as the publish handler's grant above.
+    [
+      registryStack,
+      "AgentCodeResolverFunction/ServiceRole/DefaultPolicy/Resource",
+    ],
   ];
   for (const [stack, path] of registryArnPaths) {
     NagSuppressions.addResourceSuppressionsByPath(

--- a/backend/lib/registry-stack.ts
+++ b/backend/lib/registry-stack.ts
@@ -623,6 +623,12 @@ export class RegistryStack extends cdk.Stack {
         environment: {
           AGENT_BUCKET_NAME: `citadel-code-${props.environment}-${this.account}-${this.region}`,
           AGENT_CONFIG_TABLE: props.agentConfigTable.tableName,
+          // Org/role gate (finding 1a9181a4): the resolver fetches the
+          // agent's Registry record via RegistryService before any S3 or
+          // DynamoDB access, reconciling its orgId against the caller via
+          // the shared assertRowOrg gate (auth-event.ts) — mirrors the
+          // publish handler's REGISTRY_ID wiring in gateway-stack.ts.
+          REGISTRY_ID: props.registryId,
         },
         timeout: cdk.Duration.seconds(30),
         logGroup: new logs.LogGroup(this, "AgentCodeResolverFunctionLogs", {
@@ -630,6 +636,18 @@ export class RegistryStack extends cdk.Stack {
           removalPolicy: cdk.RemovalPolicy.DESTROY,
         }),
       },
+    );
+
+    // Read-only Registry access for the org/role gate (finding 1a9181a4).
+    // GetRegistryRecord only — never Create/Update/Delete — scoped to this
+    // registry's ARN, exactly as gateway-stack.ts grants the publish
+    // handler's owner gate (finding 13a58234).
+    agentCodeResolverFunction.addToRolePolicy(
+      new iam.PolicyStatement({
+        effect: iam.Effect.ALLOW,
+        actions: ["bedrock-agentcore:GetRegistryRecord"],
+        resources: [props.registryArn, `${props.registryArn}/*`],
+      }),
     );
 
     // S3 permissions for agent code — baseline grants by explicit,

--- a/backend/scripts/split-gates/move-manifest.ts
+++ b/backend/scripts/split-gates/move-manifest.ts
@@ -1881,4 +1881,23 @@ export const ALLOWED_SATELLITE_ADDED_STATEMENTS: Record<
       conditionKeys: [],
     },
   ],
+  // Finding 1a9181a4: agent-code-resolver's org+role authz fix (a29f50b)
+  // wired a bedrock-agentcore:GetRegistryRecord-only grant on the Registry
+  // (02a95f3) to look up the agent's Registry record for the orgId
+  // reconciliation check. Read-only, scoped to the registry ARN — no
+  // Create/Update/Delete action is granted. The satellite's frozen
+  // baseline predates this branch's authz work, so it cannot cover the
+  // statement; allowlisted here per the PR 111 reconciliation pattern
+  // rather than regenerating the baseline (a separate governance act).
+  AgentCodeResolverFunction720FFFB6: [
+    {
+      effect: "Allow",
+      actions: ["bedrock-agentcore:GetRegistryRecord"],
+      resources: [
+        "GETATT:AgentCoreRegistry:RegistryArn",
+        "JOIN::GETATT:AgentCoreRegistry:RegistryArn/*",
+      ],
+      conditionKeys: [],
+    },
+  ],
 };

--- a/backend/src/lambda/__tests__/agent-code-resolver-authz.test.ts
+++ b/backend/src/lambda/__tests__/agent-code-resolver-authz.test.ts
@@ -1,0 +1,333 @@
+/**
+ * Authorization tests for agent-code-resolver.ts (finding 1a9181a4).
+ *
+ * BEFORE this fix: getAgentCode/updateAgentCode read/wrote S3+DynamoDB with
+ * NO identity read and NO org reconciliation — any authenticated caller of
+ * any org could read or OVERWRITE any tenant's agent Python source
+ * (RCE-adjacent, since the code executes with that agent's scoped creds).
+ *
+ * AFTER this fix: both ops load the agent's Registry record via
+ * RegistryService.getResource("agent", agentId) — the SAME lookup
+ * agent-config-resolver.ts uses for agent registry records (flat
+ * `orgId`, no per-record ACL map, unlike the AgentApp `manifest.access`
+ * shape guarded by assertManifestAccess in registry-agent-record-resolver.ts,
+ * which does not fit this resource type) — then reconcile the record's
+ * orgId against the SERVER-DERIVED caller org via the shared
+ * `assertRowOrg` gate (backend/src/utils/auth-event.ts), reused unchanged
+ * because RegistryService.mapToAgentConfig(record) already projects a
+ * `{orgId}`-shaped object. The write additionally requires the caller hold
+ * the `architect` platform role (or admin) — see the resolver file's
+ * top-of-write comment for the role justification.
+ *
+ * Acceptance (per task):
+ *  - cross-org caller refused on BOTH ops, with ZERO S3 get, ZERO S3 put,
+ *    ZERO DynamoDB access (mocks assert no calls at all)
+ *  - same-org caller lacking the architect/admin role refused on the WRITE
+ *    (read has no role requirement, mirroring getAgentConfigRegistry)
+ *  - legitimate (same-org, correctly-roled) caller succeeds on both ops
+ *  - fail closed on: absent identity, unresolvable org, missing registry
+ *    record
+ */
+import { DynamoDBDocumentClient, GetCommand } from "@aws-sdk/lib-dynamodb";
+import {
+  S3Client,
+  GetObjectCommand,
+  PutObjectCommand,
+} from "@aws-sdk/client-s3";
+import {
+  BedrockAgentCoreControlClient,
+  GetRegistryRecordCommand,
+} from "@aws-sdk/client-bedrock-agentcore-control";
+import { mockClient } from "aws-sdk-client-mock";
+
+const dynamoMock = mockClient(DynamoDBDocumentClient);
+const s3Mock = mockClient(S3Client);
+const registryMock = mockClient(BedrockAgentCoreControlClient);
+
+import { handler } from "../agent-code-resolver";
+
+type HandlerEvent = Parameters<typeof handler>[0];
+
+function makeEvent(
+  fieldName: string,
+  args: Record<string, unknown>,
+  identity?: Record<string, unknown>,
+): HandlerEvent {
+  return {
+    info: { fieldName },
+    arguments: args,
+    identity,
+  } as unknown as HandlerEvent;
+}
+
+/** Agent registry record custom metadata matching AgentCustomMetadata shape. */
+function agentDescriptor(orgId: string): string {
+  return JSON.stringify({
+    categories: [],
+    icon: "",
+    state: "active",
+    manifest: { note: "presence of `manifest` marks this record type=agent" },
+    orgId,
+  });
+}
+
+function mockRegistryRecord(recordId: string, orgId: string | null): void {
+  registryMock.on(GetRegistryRecordCommand).resolves({
+    recordId,
+    name: recordId,
+    status: "APPROVED",
+    descriptors:
+      orgId === null
+        ? undefined
+        : { custom: { inlineContent: agentDescriptor(orgId) } },
+  });
+}
+
+describe("agent-code-resolver — authorization (finding 1a9181a4)", () => {
+  beforeEach(() => {
+    dynamoMock.reset();
+    s3Mock.reset();
+    registryMock.reset();
+    process.env.AGENT_BUCKET_NAME = "test-bucket";
+    process.env.AGENT_CONFIG_TABLE = "test-agent-config";
+    process.env.REGISTRY_ID = "test-registry-id";
+  });
+
+  afterEach(() => {
+    delete process.env.AGENT_BUCKET_NAME;
+    delete process.env.AGENT_CONFIG_TABLE;
+    delete process.env.REGISTRY_ID;
+  });
+
+  const ORG_A = "org-a";
+  const ORG_B = "org-b";
+
+  const orgACaller = { sub: "user-a", "custom:organization": ORG_A };
+  const orgAArchitect = {
+    sub: "architect-a",
+    "custom:organization": ORG_A,
+    "custom:role": "architect",
+  };
+  const orgBCaller = { sub: "user-b", "custom:organization": ORG_B };
+  const adminCaller = {
+    sub: "admin-1",
+    "custom:organization": ORG_B,
+    "custom:role": "admin",
+  };
+
+  function expectZeroDataAccess() {
+    expect(s3Mock.commandCalls(GetObjectCommand)).toHaveLength(0);
+    expect(s3Mock.commandCalls(PutObjectCommand)).toHaveLength(0);
+    expect(dynamoMock.commandCalls(GetCommand)).toHaveLength(0);
+  }
+
+  describe("cross-org caller refused on both operations, zero data access", () => {
+    test("getAgentCode: org-B caller reading org-A's agent is refused before any S3/DynamoDB call", async () => {
+      mockRegistryRecord("agent-1", ORG_A);
+
+      await expect(
+        handler(makeEvent("getAgentCode", { agentId: "agent-1" }, orgBCaller)),
+      ).rejects.toThrow();
+
+      expectZeroDataAccess();
+    });
+
+    test("updateAgentCode: org-B caller overwriting org-A's agent is refused before any S3/DynamoDB call", async () => {
+      mockRegistryRecord("agent-1", ORG_A);
+
+      await expect(
+        handler(
+          makeEvent(
+            "updateAgentCode",
+            { input: { agentId: "agent-1", code: "os.system('rm -rf /')" } },
+            orgBCaller,
+          ),
+        ),
+      ).rejects.toThrow();
+
+      expectZeroDataAccess();
+    });
+  });
+
+  describe("same-org caller lacking the required role is refused on the write only", () => {
+    test("updateAgentCode: same-org caller with no architect/admin role is refused, zero data access", async () => {
+      mockRegistryRecord("agent-1", ORG_A);
+
+      await expect(
+        handler(
+          makeEvent(
+            "updateAgentCode",
+            { input: { agentId: "agent-1", code: "print(1)" } },
+            orgACaller,
+          ),
+        ),
+      ).rejects.toThrow();
+
+      expectZeroDataAccess();
+    });
+  });
+
+  describe("legitimate caller succeeds", () => {
+    test("getAgentCode: same-org caller (no role required for read) succeeds", async () => {
+      mockRegistryRecord("agent-1", ORG_A);
+      dynamoMock.on(GetCommand).resolves({
+        Item: { agentId: "agent-1", config: { filename: "agent-1.py" } },
+      });
+      s3Mock.on(GetObjectCommand).resolves({
+        Body: undefined,
+        VersionId: "v1",
+      });
+
+      const result = (await handler(
+        makeEvent("getAgentCode", { agentId: "agent-1" }, orgACaller),
+      )) as { agentId: string };
+
+      expect(result.agentId).toBe("agent-1");
+    });
+
+    test("updateAgentCode: same-org architect succeeds and writes to S3", async () => {
+      mockRegistryRecord("agent-1", ORG_A);
+      dynamoMock.on(GetCommand).resolves({
+        Item: { agentId: "agent-1", config: { filename: "agent-1.py" } },
+      });
+      s3Mock.on(PutObjectCommand).resolves({ VersionId: "v2" });
+
+      const result = (await handler(
+        makeEvent(
+          "updateAgentCode",
+          { input: { agentId: "agent-1", code: "print('ok')" } },
+          orgAArchitect,
+        ),
+      )) as { agentId: string; code: string };
+
+      expect(result.agentId).toBe("agent-1");
+      expect(result.code).toBe("print('ok')");
+      expect(s3Mock.commandCalls(PutObjectCommand)).toHaveLength(1);
+    });
+
+    test("updateAgentCode: admin succeeds regardless of org", async () => {
+      mockRegistryRecord("agent-1", ORG_A);
+      dynamoMock.on(GetCommand).resolves({
+        Item: { agentId: "agent-1", config: { filename: "agent-1.py" } },
+      });
+      s3Mock.on(PutObjectCommand).resolves({ VersionId: "v3" });
+
+      const result = (await handler(
+        makeEvent(
+          "updateAgentCode",
+          { input: { agentId: "agent-1", code: "print('admin')" } },
+          adminCaller,
+        ),
+      )) as { agentId: string };
+
+      expect(result.agentId).toBe("agent-1");
+      expect(s3Mock.commandCalls(PutObjectCommand)).toHaveLength(1);
+    });
+  });
+
+  describe("fail closed", () => {
+    test("getAgentCode: absent identity is refused, zero data access", async () => {
+      mockRegistryRecord("agent-1", ORG_A);
+
+      await expect(
+        handler(makeEvent("getAgentCode", { agentId: "agent-1" }, undefined)),
+      ).rejects.toThrow();
+
+      expectZeroDataAccess();
+    });
+
+    test("updateAgentCode: absent identity is refused, zero data access", async () => {
+      mockRegistryRecord("agent-1", ORG_A);
+
+      await expect(
+        handler(
+          makeEvent(
+            "updateAgentCode",
+            { input: { agentId: "agent-1", code: "x" } },
+            undefined,
+          ),
+        ),
+      ).rejects.toThrow();
+
+      expectZeroDataAccess();
+    });
+
+    test("getAgentCode: caller with unresolvable org (no custom:organization claim) is refused", async () => {
+      mockRegistryRecord("agent-1", ORG_A);
+
+      await expect(
+        handler(
+          makeEvent(
+            "getAgentCode",
+            { agentId: "agent-1" },
+            { sub: "no-org-user" },
+          ),
+        ),
+      ).rejects.toThrow();
+
+      expectZeroDataAccess();
+    });
+
+    test("updateAgentCode: caller with unresolvable org is refused", async () => {
+      mockRegistryRecord("agent-1", ORG_A);
+
+      await expect(
+        handler(
+          makeEvent(
+            "updateAgentCode",
+            { input: { agentId: "agent-1", code: "x" } },
+            { sub: "no-org-user" },
+          ),
+        ),
+      ).rejects.toThrow();
+
+      expectZeroDataAccess();
+    });
+
+    test("getAgentCode: missing registry record is refused (not silently treated as public)", async () => {
+      registryMock.on(GetRegistryRecordCommand).rejects(
+        Object.assign(new Error("not found"), {
+          name: "ResourceNotFoundException",
+        }),
+      );
+
+      await expect(
+        handler(
+          makeEvent("getAgentCode", { agentId: "ghost-agent" }, orgACaller),
+        ),
+      ).rejects.toThrow();
+
+      expectZeroDataAccess();
+    });
+
+    test("updateAgentCode: missing registry record is refused", async () => {
+      registryMock.on(GetRegistryRecordCommand).rejects(
+        Object.assign(new Error("not found"), {
+          name: "ResourceNotFoundException",
+        }),
+      );
+
+      await expect(
+        handler(
+          makeEvent(
+            "updateAgentCode",
+            { input: { agentId: "ghost-agent", code: "x" } },
+            orgAArchitect,
+          ),
+        ),
+      ).rejects.toThrow();
+
+      expectZeroDataAccess();
+    });
+
+    test("getAgentCode: registry record with no orgId (malformed/legacy) is refused for a non-admin caller", async () => {
+      mockRegistryRecord("agent-1", null);
+
+      await expect(
+        handler(makeEvent("getAgentCode", { agentId: "agent-1" }, orgACaller)),
+      ).rejects.toThrow();
+
+      expectZeroDataAccess();
+    });
+  });
+});

--- a/backend/src/lambda/__tests__/agent-code-resolver-dispatch-gate-enumeration.test.ts
+++ b/backend/src/lambda/__tests__/agent-code-resolver-dispatch-gate-enumeration.test.ts
@@ -1,0 +1,232 @@
+/**
+ * Enumeration-completeness guard for agent-code-resolver.ts's dispatch
+ * switch (finding 1a9181a4 — the fourth instance of the class-closing move
+ * started by registry-agent-record-resolver-dispatch-gate-enumeration.test.ts
+ * and continued by app-publish-handler-dispatch-gate-enumeration.test.ts /
+ * user-management-resolver-dispatch-gate-enumeration.test.ts).
+ *
+ * Root defect closed by finding 1a9181a4: getAgentCode and updateAgentCode
+ * made S3/DynamoDB calls with NO identity read and NO org reconciliation
+ * at all — any authenticated caller of any org could read or overwrite any
+ * tenant's agent Python source. The fix threads BOTH ops through a single
+ * shared gate, `assertAgentCodeAccess`, BEFORE any S3/DynamoDB call. This
+ * guard derives the operation list directly from the handler's
+ * `switch (fieldName)` source (not a manually transcribed list) so a future
+ * case added to this switch without a corresponding gate call fails
+ * LOUDLY instead of silently shipping ungated — same rationale as the three
+ * sibling guards.
+ *
+ * This handler has exactly two ops. Both call assertAgentCodeAccess; only
+ * updateAgentCode passes a `requiredWriteRole` argument (REQUIRED_WRITE_ROLE
+ * = 'architect') — reads require org membership only, mirroring
+ * getAgentConfigRegistry's read-side gate in agent-config-resolver.ts. The
+ * EXEMPT_OPS list is intentionally empty — there is no legitimately
+ * ungated op on this dispatch surface.
+ */
+import * as fs from "fs";
+import * as path from "path";
+
+const HANDLER_PATH = path.join(__dirname, "..", "agent-code-resolver.ts");
+
+function extractDispatchCases(source: string): string[] {
+  const switchStart = source.indexOf("switch (fieldName)");
+  if (switchStart === -1) {
+    throw new Error(
+      "Could not locate `switch (fieldName)` in agent-code-resolver.ts — " +
+        "dispatch structure changed; update this guard's parsing.",
+    );
+  }
+  const defaultIdx = source.indexOf("default:", switchStart);
+  if (defaultIdx === -1) {
+    throw new Error(
+      "Could not locate the dispatch switch's `default:` case — " +
+        "update this guard's parsing.",
+    );
+  }
+  const switchBody = source.slice(switchStart, defaultIdx);
+  const caseRe = /case\s+['"]([^'"]+)['"]\s*:/g;
+  const cases: string[] = [];
+  let m: RegExpExecArray | null;
+  while ((m = caseRe.exec(switchBody)) !== null) {
+    cases.push(m[1]);
+  }
+  return cases;
+}
+
+/**
+ * Extracts the handler function name a given case delegates to, e.g.
+ * `case 'getAgentCode': return await getAgentCode(...);` -> "getAgentCode".
+ */
+function extractHandlerCallSite(
+  switchBody: string,
+  fieldName: string,
+): string | null {
+  const caseIdx = switchBody.indexOf(`case '${fieldName}'`);
+  const idx =
+    caseIdx !== -1 ? caseIdx : switchBody.indexOf(`case "${fieldName}"`);
+  if (idx === -1) return null;
+  const nextCaseIdx = switchBody.indexOf("case ", idx + 1);
+  const slice = switchBody.slice(
+    idx,
+    nextCaseIdx === -1 ? undefined : nextCaseIdx,
+  );
+  const callRe = /await\s+([A-Za-z0-9_]+)\s*\(/;
+  const m = callRe.exec(slice);
+  return m ? m[1] : null;
+}
+
+/**
+ * Extracts a top-level `async function <name>(...) { ... }` body by
+ * brace-counting from the `function` keyword, matching the parameter
+ * list's closing paren first (parameter type annotations can contain
+ * object-literal-shaped braces).
+ */
+function extractFunctionBody(source: string, fnName: string): string {
+  const declRe = new RegExp(`(?:export\\s+)?async function ${fnName}\\s*\\(`);
+  const declMatch = declRe.exec(source);
+  if (!declMatch) {
+    throw new Error(
+      `Could not locate function declaration for '${fnName}' in agent-code-resolver.ts`,
+    );
+  }
+  const paramsOpenIdx = source.indexOf("(", declMatch.index);
+  let parenDepth = 0;
+  let j = paramsOpenIdx;
+  for (; j < source.length; j++) {
+    if (source[j] === "(") parenDepth++;
+    else if (source[j] === ")") {
+      parenDepth--;
+      if (parenDepth === 0) break;
+    }
+  }
+  const bodyStart = source.indexOf("{", j);
+  let depth = 0;
+  let i = bodyStart;
+  for (; i < source.length; i++) {
+    if (source[i] === "{") depth++;
+    else if (source[i] === "}") {
+      depth--;
+      if (depth === 0) break;
+    }
+  }
+  return source.slice(bodyStart, i + 1);
+}
+
+const GATE_CALL_RE = /assertAgentCodeAccess\s*\(/;
+
+/**
+ * Ops verified to call assertAgentCodeAccess inside their handler function
+ * body before any S3/DynamoDB side effect (finding 1a9181a4).
+ * updateAgentCode additionally requires REQUIRED_WRITE_ROLE ('architect');
+ * getAgentCode requires org membership only.
+ */
+const GATED_OPS: Record<string, { requiresWriteRole: boolean }> = {
+  getAgentCode: { requiresWriteRole: false },
+  updateAgentCode: { requiresWriteRole: true },
+};
+
+/**
+ * No legitimately ungated op exists on this dispatch surface — kept empty
+ * (rather than omitted) so the "every case accounted for" test below fails
+ * loudly, not silently, the moment a new case is added without updating
+ * this file.
+ */
+const EXEMPT_OPS: Record<string, string> = {};
+
+describe("agent-code-resolver — dispatch enumeration completeness", () => {
+  const source = fs.readFileSync(HANDLER_PATH, "utf-8");
+  const cases = extractDispatchCases(source);
+
+  test("the dispatch switch actually has cases to check (sanity check on the parser itself)", () => {
+    expect(cases.length).toBe(2);
+    expect(cases).toContain("getAgentCode");
+    expect(cases).toContain("updateAgentCode");
+  });
+
+  test("every dispatch case is accounted for in GATED_OPS or EXEMPT_OPS", () => {
+    const unaccounted = cases.filter(
+      (c) => !(c in GATED_OPS) && !(c in EXEMPT_OPS),
+    );
+    expect(unaccounted).toEqual([]);
+  });
+
+  test("GATED_OPS and EXEMPT_OPS do not both claim the same op", () => {
+    const overlap = Object.keys(GATED_OPS).filter((k) => k in EXEMPT_OPS);
+    expect(overlap).toEqual([]);
+  });
+
+  test("no GATED_OPS/EXEMPT_OPS entry references a case that no longer exists in the switch", () => {
+    const known = new Set(cases);
+    const staleGated = Object.keys(GATED_OPS).filter((k) => !known.has(k));
+    const staleExempt = Object.keys(EXEMPT_OPS).filter((k) => !known.has(k));
+    expect(staleGated).toEqual([]);
+    expect(staleExempt).toEqual([]);
+  });
+
+  describe.each(Object.entries(GATED_OPS))(
+    "GATED_OPS['%s'] handler actually calls the shared org/role gate",
+    (fieldName, meta) => {
+      test(`${fieldName} (requiresWriteRole=${meta.requiresWriteRole}) contains an assertAgentCodeAccess call`, () => {
+        const switchStart = source.indexOf("switch (fieldName)");
+        const defaultIdx = source.indexOf("default:", switchStart);
+        const switchBody = source.slice(switchStart, defaultIdx);
+        const handlerName = extractHandlerCallSite(switchBody, fieldName);
+        expect(handlerName).not.toBeNull();
+        const body = extractFunctionBody(source, handlerName as string);
+        expect(GATE_CALL_RE.test(body)).toBe(true);
+      });
+
+      test(`${fieldName}'s gate call is positioned BEFORE the first S3/DynamoDB side effect in its handler body`, () => {
+        const switchStart = source.indexOf("switch (fieldName)");
+        const defaultIdx = source.indexOf("default:", switchStart);
+        const switchBody = source.slice(switchStart, defaultIdx);
+        const handlerName = extractHandlerCallSite(switchBody, fieldName);
+        const body = extractFunctionBody(source, handlerName as string);
+        const gateIdx = body.search(GATE_CALL_RE);
+        expect(gateIdx).toBeGreaterThan(-1);
+
+        // Side-effecting call markers used by getAgentCode/updateAgentCode:
+        // the DynamoDB config GetCommand and the S3 Get/PutObjectCommand
+        // sends. The gate must precede ALL of them.
+        const sideEffectMarkers = [
+          "new GetCommand(",
+          "new GetObjectCommand(",
+          "new PutObjectCommand(",
+          "docClient.send(",
+          "s3Client.send(",
+        ];
+        for (const marker of sideEffectMarkers) {
+          const markerIdx = body.indexOf(marker);
+          if (markerIdx === -1) continue; // not every marker appears in every handler
+          expect(gateIdx).toBeLessThan(markerIdx);
+        }
+      });
+
+      if (fieldName === "updateAgentCode") {
+        test(`${fieldName} passes REQUIRED_WRITE_ROLE as the gate's requiredWriteRole argument`, () => {
+          const switchStart = source.indexOf("switch (fieldName)");
+          const defaultIdx = source.indexOf("default:", switchStart);
+          const switchBody = source.slice(switchStart, defaultIdx);
+          const handlerName = extractHandlerCallSite(switchBody, fieldName);
+          const body = extractFunctionBody(source, handlerName as string);
+          expect(
+            /assertAgentCodeAccess\s*\(\s*agentId\s*,\s*event\s*,\s*REQUIRED_WRITE_ROLE\s*\)/.test(
+              body,
+            ),
+          ).toBe(true);
+        });
+      } else {
+        test(`${fieldName} does NOT pass a requiredWriteRole argument (read-only, org membership suffices)`, () => {
+          const switchStart = source.indexOf("switch (fieldName)");
+          const defaultIdx = source.indexOf("default:", switchStart);
+          const switchBody = source.slice(switchStart, defaultIdx);
+          const handlerName = extractHandlerCallSite(switchBody, fieldName);
+          const body = extractFunctionBody(source, handlerName as string);
+          expect(
+            /assertAgentCodeAccess\s*\(\s*agentId\s*,\s*event\s*\)/.test(body),
+          ).toBe(true);
+        });
+      }
+    },
+  );
+});

--- a/backend/src/lambda/__tests__/agent-code-resolver.test.ts
+++ b/backend/src/lambda/__tests__/agent-code-resolver.test.ts
@@ -1,16 +1,32 @@
 /**
- * Tests for agent-code-resolver Lambda
+ * Tests for agent-code-resolver Lambda.
+ *
+ * Authorization is a SEPARATE concern covered exhaustively in
+ * agent-code-resolver-authz.test.ts (finding 1a9181a4). These tests focus
+ * on the S3/DynamoDB filename-resolution and code-body behavior, so every
+ * case here authorizes as a legitimate same-org caller (architect role for
+ * updateAgentCode's write) via a mocked Registry record, mirroring the
+ * "legitimate caller succeeds" cases in the authz suite.
  */
-import { DynamoDBDocumentClient, GetCommand } from '@aws-sdk/lib-dynamodb';
-import { S3Client, GetObjectCommand, PutObjectCommand } from '@aws-sdk/client-s3';
-import { mockClient } from 'aws-sdk-client-mock';
-import { Readable } from 'stream';
-import { sdkStreamMixin } from '@smithy/util-stream';
+import { DynamoDBDocumentClient, GetCommand } from "@aws-sdk/lib-dynamodb";
+import {
+  S3Client,
+  GetObjectCommand,
+  PutObjectCommand,
+} from "@aws-sdk/client-s3";
+import {
+  BedrockAgentCoreControlClient,
+  GetRegistryRecordCommand,
+} from "@aws-sdk/client-bedrock-agentcore-control";
+import { mockClient } from "aws-sdk-client-mock";
+import { Readable } from "stream";
+import { sdkStreamMixin } from "@smithy/util-stream";
 
 const dynamoMock = mockClient(DynamoDBDocumentClient);
 const s3Mock = mockClient(S3Client);
+const registryMock = mockClient(BedrockAgentCoreControlClient);
 
-import { handler } from '../agent-code-resolver';
+import { handler } from "../agent-code-resolver";
 
 type HandlerEvent = Parameters<typeof handler>[0];
 
@@ -26,119 +42,176 @@ async function invoke<T = AgentCodeResult>(event: HandlerEvent): Promise<T> {
   return (await handler(event)) as T;
 }
 
-describe('agent-code-resolver', () => {
+const ORG_ID = "org-a";
+const READER_IDENTITY = { sub: "reader-1", "custom:organization": ORG_ID };
+const WRITER_IDENTITY = {
+  sub: "writer-1",
+  "custom:organization": ORG_ID,
+  "custom:role": "architect",
+};
+
+/** Mocks a same-org Registry record for the given agentId so the org/role gate passes. */
+function mockAuthorizedAgent(agentId: string): void {
+  registryMock.on(GetRegistryRecordCommand).resolves({
+    recordId: agentId,
+    name: agentId,
+    status: "APPROVED",
+    descriptors: {
+      custom: {
+        inlineContent: JSON.stringify({
+          categories: [],
+          icon: "",
+          state: "active",
+          manifest: { note: "marks record type=agent" },
+          orgId: ORG_ID,
+        }),
+      },
+    },
+  });
+}
+
+describe("agent-code-resolver", () => {
   beforeEach(() => {
     dynamoMock.reset();
     s3Mock.reset();
-    process.env.AGENT_BUCKET_NAME = 'test-bucket';
-    process.env.AGENT_CONFIG_TABLE = 'test-agent-config';
+    registryMock.reset();
+    process.env.AGENT_BUCKET_NAME = "test-bucket";
+    process.env.AGENT_CONFIG_TABLE = "test-agent-config";
+    process.env.REGISTRY_ID = "test-registry-id";
   });
 
   afterEach(() => {
     delete process.env.AGENT_BUCKET_NAME;
     delete process.env.AGENT_CONFIG_TABLE;
+    delete process.env.REGISTRY_ID;
   });
 
-  const makeEvent = (fieldName: string, args: Record<string, unknown>): HandlerEvent =>
+  const makeEvent = (
+    fieldName: string,
+    args: Record<string, unknown>,
+    identity: Record<string, unknown>,
+  ): HandlerEvent =>
     ({
       info: { fieldName },
       arguments: args,
+      identity,
     }) as unknown as HandlerEvent;
 
-  describe('getAgentCode', () => {
-    test('returns code from S3 using filename from config', async () => {
+  describe("getAgentCode", () => {
+    test("returns code from S3 using filename from config", async () => {
+      mockAuthorizedAgent("a1");
       dynamoMock.on(GetCommand).resolves({
-        Item: { agentId: 'a1', config: { filename: 'my_agent.py' } },
+        Item: { agentId: "a1", config: { filename: "my_agent.py" } },
       });
 
       const stream = new Readable();
-      stream.push('def handler(): pass');
+      stream.push("def handler(): pass");
       stream.push(null);
       const sdkStream = sdkStreamMixin(stream);
 
       s3Mock.on(GetObjectCommand).resolves({
         Body: sdkStream,
-        VersionId: 'v1',
-        LastModified: new Date('2025-01-01'),
+        VersionId: "v1",
+        LastModified: new Date("2025-01-01"),
       });
 
-      const result = await invoke(makeEvent('getAgentCode', { agentId: 'a1' }));
+      const result = await invoke(
+        makeEvent("getAgentCode", { agentId: "a1" }, READER_IDENTITY),
+      );
 
-      expect(result.agentId).toBe('a1');
-      expect(result.code).toBe('def handler(): pass');
-      expect(result.version).toBe('v1');
+      expect(result.agentId).toBe("a1");
+      expect(result.code).toBe("def handler(): pass");
+      expect(result.version).toBe("v1");
     });
 
-    test('returns default code when S3 key not found', async () => {
+    test("returns default code when S3 key not found", async () => {
+      mockAuthorizedAgent("a1");
       dynamoMock.on(GetCommand).resolves({
-        Item: { agentId: 'a1', config: { filename: 'missing.py' } },
+        Item: { agentId: "a1", config: { filename: "missing.py" } },
       });
 
-      const noSuchKeyError = new Error('NoSuchKey');
-      noSuchKeyError.name = 'NoSuchKey';
+      const noSuchKeyError = new Error("NoSuchKey");
+      noSuchKeyError.name = "NoSuchKey";
       s3Mock.on(GetObjectCommand).rejects(noSuchKeyError);
 
-      const result = await invoke(makeEvent('getAgentCode', { agentId: 'a1' }));
+      const result = await invoke(
+        makeEvent("getAgentCode", { agentId: "a1" }, READER_IDENTITY),
+      );
 
-      expect(result.agentId).toBe('a1');
-      expect(result.code).toContain('def handler');
+      expect(result.agentId).toBe("a1");
+      expect(result.code).toContain("def handler");
       expect(result.version).toBeNull();
     });
 
-    test('falls back to agentId.py in S3 when no DynamoDB config exists (registry-based agent)', async () => {
+    test("falls back to agentId.py in S3 when no DynamoDB config exists (registry-based agent)", async () => {
+      mockAuthorizedAgent("missing");
       dynamoMock.on(GetCommand).resolves({});
 
-      const noSuchKeyError = new Error('NoSuchKey');
-      noSuchKeyError.name = 'NoSuchKey';
+      const noSuchKeyError = new Error("NoSuchKey");
+      noSuchKeyError.name = "NoSuchKey";
       s3Mock.on(GetObjectCommand).rejects(noSuchKeyError);
 
-      const result = await invoke(makeEvent('getAgentCode', { agentId: 'missing' }));
+      const result = await invoke(
+        makeEvent("getAgentCode", { agentId: "missing" }, READER_IDENTITY),
+      );
 
-      expect(result.agentId).toBe('missing');
-      expect(result.code).toContain('def handler');
+      expect(result.agentId).toBe("missing");
+      expect(result.code).toContain("def handler");
       expect(result.version).toBeNull();
 
       const getCalls = s3Mock.commandCalls(GetObjectCommand);
-      expect(getCalls[0].args[0].input.Key).toBe('agents/missing.py');
+      expect(getCalls[0].args[0].input.Key).toBe("agents/missing.py");
     });
   });
 
-  describe('updateAgentCode', () => {
-    test('writes code to S3', async () => {
+  describe("updateAgentCode", () => {
+    test("writes code to S3", async () => {
+      mockAuthorizedAgent("a1");
       dynamoMock.on(GetCommand).resolves({
-        Item: { agentId: 'a1', config: { filename: 'my_agent.py' } },
+        Item: { agentId: "a1", config: { filename: "my_agent.py" } },
       });
-      s3Mock.on(PutObjectCommand).resolves({ VersionId: 'v2' });
+      s3Mock.on(PutObjectCommand).resolves({ VersionId: "v2" });
 
-      const result = await invoke(makeEvent('updateAgentCode', {
-        input: { agentId: 'a1', code: 'print("hello")' },
-      }));
+      const result = await invoke(
+        makeEvent(
+          "updateAgentCode",
+          { input: { agentId: "a1", code: 'print("hello")' } },
+          WRITER_IDENTITY,
+        ),
+      );
 
-      expect(result.agentId).toBe('a1');
+      expect(result.agentId).toBe("a1");
       expect(result.code).toBe('print("hello")');
 
       const putCalls = s3Mock.commandCalls(PutObjectCommand);
       expect(putCalls).toHaveLength(1);
-      expect(putCalls[0].args[0].input.Key).toBe('agents/my_agent.py');
+      expect(putCalls[0].args[0].input.Key).toBe("agents/my_agent.py");
     });
 
-    test('falls back to agentId.py in S3 when no DynamoDB config exists (registry-based agent)', async () => {
+    test("falls back to agentId.py in S3 when no DynamoDB config exists (registry-based agent)", async () => {
+      mockAuthorizedAgent("missing");
       dynamoMock.on(GetCommand).resolves({});
-      s3Mock.on(PutObjectCommand).resolves({ VersionId: 'v3' });
+      s3Mock.on(PutObjectCommand).resolves({ VersionId: "v3" });
 
-      const result = await invoke(makeEvent('updateAgentCode', {
-        input: { agentId: 'missing', code: 'x' },
-      }));
+      const result = await invoke(
+        makeEvent(
+          "updateAgentCode",
+          { input: { agentId: "missing", code: "x" } },
+          WRITER_IDENTITY,
+        ),
+      );
 
-      expect(result.agentId).toBe('missing');
-      expect(result.code).toBe('x');
+      expect(result.agentId).toBe("missing");
+      expect(result.code).toBe("x");
 
       const putCalls = s3Mock.commandCalls(PutObjectCommand);
-      expect(putCalls[0].args[0].input.Key).toBe('agents/missing.py');
+      expect(putCalls[0].args[0].input.Key).toBe("agents/missing.py");
     });
   });
 
-  test('throws on unknown field', async () => {
-    await expect(handler(makeEvent('unknownField', {}))).rejects.toThrow('Unknown field');
+  test("throws on unknown field", async () => {
+    await expect(
+      handler(makeEvent("unknownField", {}, READER_IDENTITY)),
+    ).rejects.toThrow("Unknown field");
   });
 });

--- a/backend/src/lambda/agent-code-resolver.ts
+++ b/backend/src/lambda/agent-code-resolver.ts
@@ -1,7 +1,17 @@
-import { S3Client, GetObjectCommand, PutObjectCommand } from '@aws-sdk/client-s3';
-import { DynamoDBClient } from '@aws-sdk/client-dynamodb';
-import { DynamoDBDocumentClient, GetCommand } from '@aws-sdk/lib-dynamodb';
-import { AppSyncResolverEvent } from 'aws-lambda';
+import {
+  S3Client,
+  GetObjectCommand,
+  PutObjectCommand,
+} from "@aws-sdk/client-s3";
+import { DynamoDBClient } from "@aws-sdk/client-dynamodb";
+import { DynamoDBDocumentClient, GetCommand } from "@aws-sdk/lib-dynamodb";
+import { AppSyncResolverEvent } from "aws-lambda";
+import {
+  assertRowOrg,
+  isAdminFromEvent,
+  hasRoleFromEvent,
+} from "../utils/auth-event";
+import { RegistryService } from "../services/registry-service";
 
 const s3Client = new S3Client({});
 const dynamoClient = new DynamoDBClient({});
@@ -9,6 +19,29 @@ const docClient = DynamoDBDocumentClient.from(dynamoClient);
 
 const AGENT_BUCKET_NAME = process.env.AGENT_BUCKET_NAME!;
 const AGENT_CONFIG_TABLE = process.env.AGENT_CONFIG_TABLE!;
+const REGION = process.env.AWS_REGION || "us-east-1";
+
+let _registryService: RegistryService | undefined;
+
+/**
+ * Lazy RegistryService singleton, mirroring the pattern in
+ * app-publish-handler.ts / registry-agent-record-resolver.ts. Read-only
+ * usage here: this resolver only calls getResource to fetch the agent's
+ * manifest for the org/role gate (finding 1a9181a4) — it never writes to
+ * the Registry.
+ */
+function getRegistryService(): RegistryService {
+  if (!_registryService) {
+    const registryId = process.env.REGISTRY_ID;
+    if (!registryId) {
+      throw new Error(
+        "REGISTRY_ID environment variable is required by agent-code-resolver",
+      );
+    }
+    _registryService = new RegistryService({ registryId, region: REGION });
+  }
+  return _registryService;
+}
 
 interface GetAgentCodeArgs {
   agentId: string;
@@ -21,19 +54,92 @@ interface UpdateAgentCodeArgs {
   };
 }
 
+/**
+ * Role required to overwrite an agent's executable source. Reusable
+ * platform-role check (backend/src/utils/auth-event.ts hasRoleFromEvent) —
+ * NOT the app-manifest `access` role map (viewer/editor/owner) used by
+ * assertManifestAccess in registry-agent-record-resolver.ts, which does not
+ * apply here: agent Registry records (RegistryService.getResource("agent",
+ * id) as used by agent-config-resolver.ts) carry a flat `orgId` in their
+ * customDescriptorContent, with NO per-record access/ACL map to check a
+ * manifest role against. The available role signal is the caller's own
+ * platform role claim (custom:role / cognito:groups), whose vocabulary is
+ * admin / project manager / architect / developer (README.md "Access
+ * Control"). 'architect' is chosen — not 'developer' — because overwriting
+ * an agent's Python source is equivalent to deploying code that will run
+ * with that agent's scoped credentials and tool bindings (per the finding),
+ * the same trust tier already required for comparable agent-lifecycle
+ * mutations in this codebase (agent-import-resolver.ts gates import/attest/
+ * activate/gateway-publish operations on isAdminFromEvent(event) ||
+ * hasRoleFromEvent(event, "architect")). This mirrors the task's owner/
+ * editor framing one level down: publish (app-level, provisions billable
+ * infra + mints a plaintext key) is owner-reserved; overwriting agent code
+ * (agent-level, no infra provisioning) is architect-reserved, the next tier
+ * down used elsewhere in this codebase for agent-lifecycle authority.
+ */
+const REQUIRED_WRITE_ROLE = "architect";
+
+/**
+ * Org (and, for the write, role) reconciliation gate shared by both
+ * operations below. Loads the agent's Registry record via
+ * RegistryService.getResource("agent", agentId) — the SAME lookup
+ * agent-config-resolver.ts's getAgentConfigRegistry uses for this resource
+ * type — then reuses the shared `assertRowOrg` gate (auth-event.ts) for org
+ * reconciliation, since RegistryService.mapToAgentConfig(record) already
+ * projects the record into a `{orgId}`-shaped object assertRowOrg expects.
+ * This is NOT the registry-agent-record-resolver.ts assertManifestAccess
+ * gate: that helper reads `manifest.access` (a per-app role map) which
+ * agent Registry records never populate — using it here would silently
+ * treat every non-admin caller as unauthorized (or, if orgId were merged in
+ * unsafely, risk misreading the wrong manifest shape). Fails closed on any
+ * missing identity, unresolvable caller org, missing/mismatched record,
+ * or record with no orgId (assertRowOrg's own fail-closed contract) BEFORE
+ * any S3 or DynamoDB call is made. `requiredWriteRole`, when supplied,
+ * additionally requires the caller be admin or hold that platform role —
+ * checked only after the org gate passes, so a cross-org caller never
+ * learns whether they merely lack the right role.
+ */
+async function assertAgentCodeAccess(
+  agentId: string,
+  event: unknown,
+  requiredWriteRole?: string,
+): Promise<void> {
+  const record = await getRegistryService().getResource("agent", agentId);
+  if (!record) {
+    throw new Error(`Access denied: agent ${agentId} not found`);
+  }
+
+  const mapped = getRegistryService().mapToAgentConfig(record);
+  await assertRowOrg(mapped, event);
+
+  if (requiredWriteRole) {
+    if (
+      !isAdminFromEvent(event) &&
+      !hasRoleFromEvent(event, requiredWriteRole)
+    ) {
+      throw new Error(
+        `Access denied: requires ${requiredWriteRole} role to update agent ${agentId}`,
+      );
+    }
+  }
+}
+
 export const handler = async (
   event: AppSyncResolverEvent<Partial<GetAgentCodeArgs & UpdateAgentCodeArgs>>,
 ) => {
-  console.log('Agent Code Resolver Event:', JSON.stringify(event, null, 2));
+  console.log("Agent Code Resolver Event:", JSON.stringify(event, null, 2));
 
   const fieldName = event.info.fieldName;
 
   try {
     switch (fieldName) {
-      case 'getAgentCode':
-        return await getAgentCode(event.arguments as GetAgentCodeArgs);
-      case 'updateAgentCode':
-        return await updateAgentCode(event.arguments as UpdateAgentCodeArgs);
+      case "getAgentCode":
+        return await getAgentCode(event.arguments as GetAgentCodeArgs, event);
+      case "updateAgentCode":
+        return await updateAgentCode(
+          event.arguments as UpdateAgentCodeArgs,
+          event,
+        );
       default:
         throw new Error(`Unknown field: ${fieldName}`);
     }
@@ -43,8 +149,13 @@ export const handler = async (
   }
 };
 
-async function getAgentCode(args: GetAgentCodeArgs) {
+async function getAgentCode(args: GetAgentCodeArgs, event: unknown) {
   const { agentId } = args;
+
+  // Org gate (finding 1a9181a4) — BEFORE any S3 or DynamoDB access. Reads
+  // require org membership only, no additional role (mirrors
+  // getAgentConfigRegistry's read-side gate in agent-config-resolver.ts).
+  await assertAgentCodeAccess(agentId, event);
 
   try {
     // Get agent config from DynamoDB to retrieve filename
@@ -54,12 +165,12 @@ async function getAgentCode(args: GetAgentCodeArgs) {
     });
 
     const configResponse = await docClient.send(getConfigCommand);
-    
+
     let filename: string;
     if (configResponse.Item) {
       // Parse config to get filename
       let config = configResponse.Item.config;
-      if (typeof config === 'string') {
+      if (typeof config === "string") {
         try {
           config = JSON.parse(config);
         } catch {
@@ -86,12 +197,12 @@ async function getAgentCode(args: GetAgentCodeArgs) {
 
     return {
       agentId,
-      code: code || '# Agent code not found\n',
+      code: code || "# Agent code not found\n",
       version: s3Response.VersionId,
       lastModified: s3Response.LastModified?.toISOString(),
     };
   } catch (error: unknown) {
-    if (error instanceof Error && error.name === 'NoSuchKey') {
+    if (error instanceof Error && error.name === "NoSuchKey") {
       // Return default code if file doesn't exist
       return {
         agentId,
@@ -115,13 +226,19 @@ def handler(event, context):
         lastModified: null,
       };
     }
-    console.error('Error getting agent code:', error);
+    console.error("Error getting agent code:", error);
     throw error;
   }
 }
 
-async function updateAgentCode(args: UpdateAgentCodeArgs) {
+async function updateAgentCode(args: UpdateAgentCodeArgs, event: unknown) {
   const { agentId, code } = args.input;
+
+  // Org + role gate (finding 1a9181a4) — BEFORE any S3 or DynamoDB access.
+  // The write additionally requires REQUIRED_WRITE_ROLE (or admin): see
+  // that constant's comment for why 'architect' was chosen over mere org
+  // membership.
+  await assertAgentCodeAccess(agentId, event, REQUIRED_WRITE_ROLE);
 
   try {
     // Get agent config from DynamoDB to retrieve filename
@@ -131,12 +248,12 @@ async function updateAgentCode(args: UpdateAgentCodeArgs) {
     });
 
     const configResponse = await docClient.send(getConfigCommand);
-    
+
     let filename: string;
     if (configResponse.Item) {
       // Parse config to get filename
       let config = configResponse.Item.config;
-      if (typeof config === 'string') {
+      if (typeof config === "string") {
         try {
           config = JSON.parse(config);
         } catch {
@@ -156,7 +273,7 @@ async function updateAgentCode(args: UpdateAgentCodeArgs) {
       Bucket: AGENT_BUCKET_NAME,
       Key: key,
       Body: code,
-      ContentType: 'text/x-python',
+      ContentType: "text/x-python",
     });
 
     const s3Response = await s3Client.send(s3Command);
@@ -168,7 +285,9 @@ async function updateAgentCode(args: UpdateAgentCodeArgs) {
       lastModified: new Date().toISOString(),
     };
   } catch (error: unknown) {
-    console.error('Error updating agent code:', error);
-    throw new Error(`Failed to update agent code: ${error instanceof Error ? error.message : String(error)}`);
+    console.error("Error updating agent code:", error);
+    throw new Error(
+      `Failed to update agent code: ${error instanceof Error ? error.message : String(error)}`,
+    );
   }
 }

--- a/backend/test/registry-stack.test.ts
+++ b/backend/test/registry-stack.test.ts
@@ -434,6 +434,62 @@ describe("RegistryStack — backend-stack-split phase 2", () => {
     // 6 data sources => 6 appsync-assumable roles.
     expect(Object.keys(roles)).toHaveLength(6);
   });
+
+  describe("agent-code-resolver org/role gate wiring (finding 1a9181a4)", () => {
+    function agentCodeResolverFn(): Record<string, any> {
+      const fns = template.findResources("AWS::Lambda::Function", {
+        Properties: { Handler: "agent-code-resolver.handler" },
+      });
+      const fnLogicalId = Object.keys(fns)[0];
+      expect(fnLogicalId).toBeDefined();
+      return fns[fnLogicalId];
+    }
+
+    test("is wired with REGISTRY_ID, mirroring the publish handler's owner-gate wiring", () => {
+      const fn = agentCodeResolverFn();
+      const envVars = fn.Properties.Environment?.Variables ?? {};
+      expect(envVars.REGISTRY_ID).toBeDefined();
+    });
+
+    test("has a READ-ONLY bedrock-agentcore:GetRegistryRecord statement scoped to the registry ARN — no Create/Update/Delete", () => {
+      const fn = agentCodeResolverFn();
+      const roleRef = fn.Properties.Role?.["Fn::GetAtt"]?.[0];
+      expect(roleRef).toBeDefined();
+
+      const policies = template.findResources("AWS::IAM::Policy");
+      const attached = Object.values(policies).filter(
+        (p: Record<string, any>) =>
+          (p.Properties?.Roles ?? []).some(
+            (r: Record<string, any>) => r?.Ref === roleRef,
+          ),
+      );
+      const statements = attached.flatMap(
+        (p: Record<string, any>) => p.Properties.PolicyDocument.Statement,
+      );
+
+      const registryStatements = statements.filter((s: Record<string, any>) => {
+        const actions = Array.isArray(s.Action) ? s.Action : [s.Action];
+        return actions.some(
+          (a: string) => typeof a === "string" && a.startsWith("bedrock-agentcore:"),
+        );
+      });
+      expect(registryStatements.length).toBeGreaterThan(0);
+
+      for (const stmt of registryStatements) {
+        const actions = Array.isArray(stmt.Action) ? stmt.Action : [stmt.Action];
+        expect(new Set(actions)).toEqual(
+          new Set(["bedrock-agentcore:GetRegistryRecord"]),
+        );
+        // No write-capable registry action anywhere on this role.
+        expect(actions).not.toContain("bedrock-agentcore:CreateRegistryRecord");
+        expect(actions).not.toContain("bedrock-agentcore:UpdateRegistryRecord");
+        expect(actions).not.toContain(
+          "bedrock-agentcore:UpdateRegistryRecordStatus",
+        );
+        expect(actions).not.toContain("bedrock-agentcore:DeleteRegistryRecord");
+      }
+    });
+  });
 });
 
 // CIT-125 slice A follow-up (design A.6 #6, deferred from the feature PR


### PR DESCRIPTION
## Summary

`agent-code-resolver` had **no authorization of any kind**. `updateAgentCode` took a client-supplied `agentId` and overwrote that agent's Python source, so any authenticated user of any organization could inject code into any tenant's agent - code that then executes with that agent's scoped credentials and tool bindings. `getAgentCode` returned any agent's source to any caller. No identity read, no organization check, no role check.

This is more severe than the externally reported items that prompted this work: reachable by a non-admin, a write, and its effect is code execution rather than data disclosure.

- Both operations now call a gate before **any** S3 or DynamoDB access: the agent's registry record is loaded via `RegistryService.getResource`, projected through `mapToAgentConfig` (the same lookup `agent-config-resolver` uses for this record type), and reconciled against the server-derived caller organization using the existing `assertRowOrg` 
- The write additionally requires the **architect** role (or admin). Overwriting agent code is equivalent to deploying code, so organization membership alone is insufficient. That tier  matches what `agent-import-resolver` already requires for comparable agent-lifecycle mutations, one below the owner requirement on app publishing. Reads require organization membership only
- Fails closed on cross-org caller, absent identity, unresolvable organization, and a missing or organization-less registry record

## Helper choice worth noting

`assertManifestAccess` was considered and **rejected**: it reads a per-app `manifest.access` role map that agent registry records never populate, so using it would have produced a gate authorising against absent data - the same trap that made the app-access store defect worse than it appeared. The record shape was read rather than assuming the familiar helper fit.

## CDK

The resolver had no registry read access, so `REGISTRY_ID` plus a `bedrock-agentcore:GetRegistryRecord`-only grant scoped to the registry was added - no create, update or delete - mirroring the publish-handler wiring, with two template assertions so it cannot silently regress.

## Testing

- Executed bite proofs, both operations: with the gate removed, the cross-org `PutObject` and
`GetObject` both succeed. Restored byte-identically (sha256 verified)
- Cross-org callers refused with zero S3 reads, zero S3 writes and zero DynamoDB access; a same-org caller lacking the architect role refused on the write; legitimate caller succeeds
- Fail-closed cases each probed individually
- A fourth dispatch-derived gate-enumeration guard covers this module and was itself proven load-bearing by stripping a gate
- tsc, lint, `cdk synth`, exit 0; 506 targeted tests across the resolver, registry stack, all four enumeration guards and the parity guards; full backend jest 7280; `split:gates` all rails pass with no new allowlist entry required

## Notes

- Found by a triage sweep that ranked previously unexamined resolver modules by impact
- `tool-config-resolver` is the remaining critical from that sweep: `updateToolConfig` and
`deleteToolConfig` allow cross-tenant destruction including credential bindings