### PR TITLE
fix(security): org-reconcile tool config updates and deletions

### DIFF
--- a/backend/src/lambda/__tests__/tool-config-resolver-dispatch-gate-enumeration.test.ts
+++ b/backend/src/lambda/__tests__/tool-config-resolver-dispatch-gate-enumeration.test.ts
@@ -1,0 +1,302 @@
+/**
+ * Enumeration-completeness guard for tool-config-resolver.ts's dispatch
+ * switch (finding 13065e38 — the fifth instance of the class-closing move
+ * started by registry-agent-record-resolver-dispatch-gate-enumeration.test.ts
+ * and continued by app-publish-handler-dispatch-gate-enumeration.test.ts /
+ * user-management-resolver-dispatch-gate-enumeration.test.ts /
+ * agent-code-resolver-dispatch-gate-enumeration.test.ts).
+ *
+ * Root defect closed by finding 13065e38: updateToolConfig and
+ * deleteToolConfig (both the legacy DynamoDB path and the Registry path)
+ * performed NO org reconciliation before their write/delete — any
+ * authenticated caller of any org could rewrite or destroy another
+ * tenant's tool config, including its integrationBindings/dataStoreBindings
+ * which scope datastore/integration credentials. The fix threads `event`
+ * into every mutation-shaped case and each callee function fetches the
+ * existing row/record THEN calls the shared `assertRowOrg` gate BEFORE any
+ * DynamoDB PutCommand/DeleteCommand or Registry updateResource/
+ * deleteResource call.
+ *
+ * Unlike the four sibling guards, this dispatch switch has a DUAL-PATH
+ * shape per case: `registryEnabled ? await xRegistry(...) : await x(...)`.
+ * This guard's parser extracts BOTH call sites per case (not one) and
+ * verifies the case threads `event` as an argument to whichever callee(s)
+ * are expected to receive it, then verifies that callee's own function
+ * body actually contains an `assertRowOrg(` call before its first
+ * DynamoDB/Registry side effect.
+ */
+import * as fs from "fs";
+import * as path from "path";
+
+const HANDLER_PATH = path.join(__dirname, "..", "tool-config-resolver.ts");
+
+function extractDispatchCases(source: string): string[] {
+  const switchStart = source.indexOf("switch (fieldName)");
+  if (switchStart === -1) {
+    throw new Error(
+      "Could not locate `switch (fieldName)` in tool-config-resolver.ts — " +
+        "dispatch structure changed; update this guard's parsing.",
+    );
+  }
+  const defaultIdx = source.indexOf("default:", switchStart);
+  if (defaultIdx === -1) {
+    throw new Error(
+      "Could not locate the dispatch switch's `default:` case — " +
+        "update this guard's parsing.",
+    );
+  }
+  const switchBody = source.slice(switchStart, defaultIdx);
+  const caseRe = /case\s+['"]([^'"]+)['"]\s*:/g;
+  const cases: string[] = [];
+  let m: RegExpExecArray | null;
+  while ((m = caseRe.exec(switchBody)) !== null) {
+    cases.push(m[1]);
+  }
+  return cases;
+}
+
+/** Slices out a single `case '<fieldName>': ... case` (or default) block. */
+function extractCaseBody(source: string, fieldName: string): string {
+  const switchStart = source.indexOf("switch (fieldName)");
+  const defaultIdx = source.indexOf("default:", switchStart);
+  const switchBody = source.slice(switchStart, defaultIdx);
+
+  const caseIdx =
+    switchBody.indexOf(`case "${fieldName}"`) !== -1
+      ? switchBody.indexOf(`case "${fieldName}"`)
+      : switchBody.indexOf(`case '${fieldName}'`);
+  if (caseIdx === -1) {
+    throw new Error(`Could not locate case '${fieldName}' in dispatch switch`);
+  }
+  const nextCaseIdx = switchBody.indexOf("case ", caseIdx + 1);
+  return switchBody.slice(
+    caseIdx,
+    nextCaseIdx === -1 ? undefined : nextCaseIdx,
+  );
+}
+
+/** Extracts every `await <fnName>(` call site name inside a case body. */
+function extractCallSiteNames(caseBody: string): string[] {
+  const callRe = /await\s+([A-Za-z0-9_]+)\s*\(/g;
+  const names: string[] = [];
+  let m: RegExpExecArray | null;
+  while ((m = callRe.exec(caseBody)) !== null) {
+    names.push(m[1]);
+  }
+  return names;
+}
+
+/**
+ * Extracts a top-level `(async )?function <name>(...) { ... }` body (also
+ * matches `export async function`) by brace-counting from the function
+ * keyword, matching the parameter list's closing paren first.
+ */
+function extractFunctionBody(source: string, fnName: string): string {
+  // Word-bounded to the exact function name so `deleteToolConfig` does not
+  // match inside `deleteToolConfigRegistry`'s declaration (the `\s*\(`
+  // requires the name be followed directly by whitespace/paren, and the
+  // interpolated regex source has no trailing wildcard, so this is already
+  // exact — but the `\b` makes the intent explicit and future-proof if the
+  // pattern is ever loosened).
+  const declRe = new RegExp(
+    `(?:export\\s+)?async function ${fnName}\\b\\s*\\(`,
+  );
+  const declMatch = declRe.exec(source);
+  if (!declMatch) {
+    throw new Error(
+      `Could not locate function declaration for '${fnName}' in tool-config-resolver.ts`,
+    );
+  }
+  const paramsOpenIdx = source.indexOf("(", declMatch.index);
+  let parenDepth = 0;
+  let j = paramsOpenIdx;
+  for (; j < source.length; j++) {
+    if (source[j] === "(") parenDepth++;
+    else if (source[j] === ")") {
+      parenDepth--;
+      if (parenDepth === 0) break;
+    }
+  }
+  // After the parameter list's closing paren, an optional return-type
+  // annotation (`: Promise<{ success: boolean; message?: string }>`) may
+  // itself contain object-literal-shaped braces. Skip past it by finding
+  // the FIRST `{` that is followed (after whitespace) by something other
+  // than what a return-type object literal would produce — simplest robust
+  // rule: walk forward counting `<`/`>` depth for generic brackets and
+  // treat the body's opening brace as the first `{` encountered ONLY once
+  // angle-bracket depth is back to zero (return types here are always
+  // `Promise<...>`; the body brace follows the closing `>`).
+  let angleDepth = 0;
+  let k = j + 1;
+  for (; k < source.length; k++) {
+    if (source[k] === "<") angleDepth++;
+    else if (source[k] === ">") {
+      if (angleDepth > 0) angleDepth--;
+    } else if (source[k] === "{" && angleDepth === 0) {
+      break;
+    }
+  }
+  const bodyStart = k;
+  let depth = 0;
+  let i = bodyStart;
+  for (; i < source.length; i++) {
+    if (source[i] === "{") depth++;
+    else if (source[i] === "}") {
+      depth--;
+      if (depth === 0) break;
+    }
+  }
+  return source.slice(bodyStart, i + 1);
+}
+
+const GATE_CALL_RE = /assertRowOrg\s*\(/;
+
+/**
+ * Ops verified to thread `event` into BOTH their registry and legacy
+ * callees, each of which calls the shared `assertRowOrg` gate (fetch existing
+ * row/record, then verify) before any write/delete side effect. Read ops
+ * (getToolConfig*, listToolConfigs*) are handled by the pre-existing
+ * org-filter/404-shape and are NOT re-verified by this guard — it exists
+ * specifically to close the update/delete write-path gap.
+ */
+const GATED_OPS: Record<string, { registryFn: string; legacyFn: string }> = {
+  updateToolConfig: {
+    registryFn: "updateToolConfigRegistry",
+    legacyFn: "updateToolConfig",
+  },
+  deleteToolConfig: {
+    registryFn: "deleteToolConfigRegistry",
+    legacyFn: "deleteToolConfig",
+  },
+};
+
+/**
+ * Ops on this dispatch surface that are legitimately NOT org-write-gated:
+ *  - listToolConfigs / getToolConfig: reads, already org-filtered/404-shaped
+ *    at the collection/record level (not a write, no assertRowOrg needed).
+ *  - createToolConfig: no client-supplied orgId to reconcile (Registry path
+ *    derives orgId from the caller via extractOrgFromEvent; the legacy path
+ *    was fixed in the same change to do the same rather than leaving orgId
+ *    blank — see createToolConfig's server-derived-orgId comment). There is
+ *    no existing row to fetch-then-verify against on a create.
+ *  - listIntegrationOperations: static lookup table, not tenant data.
+ *  - searchToolConfigs: Registry semantic search, pre-existing scope (not
+ *    part of this finding; tracked separately if it needs org filtering).
+ */
+const EXEMPT_OPS: Record<string, string> = {
+  listToolConfigs: "read, already org-filtered (listToolConfigsRegistry)",
+  getToolConfig:
+    "read, already org-filtered/404-shaped (getToolConfigRegistry)",
+  createToolConfig:
+    "no client orgId to reconcile; orgId is server-derived on both paths",
+  listIntegrationOperations: "static lookup table, not tenant data",
+  searchToolConfigs: "Registry semantic search, out of scope for this finding",
+};
+
+describe("tool-config-resolver — dispatch enumeration completeness", () => {
+  const source = fs.readFileSync(HANDLER_PATH, "utf-8");
+  const cases = extractDispatchCases(source);
+
+  test("the dispatch switch actually has cases to check (sanity check on the parser itself)", () => {
+    expect(cases.length).toBeGreaterThanOrEqual(7);
+    expect(cases).toEqual(
+      expect.arrayContaining([
+        "listToolConfigs",
+        "getToolConfig",
+        "createToolConfig",
+        "updateToolConfig",
+        "deleteToolConfig",
+        "listIntegrationOperations",
+        "searchToolConfigs",
+      ]),
+    );
+  });
+
+  test("every dispatch case is accounted for in GATED_OPS or EXEMPT_OPS", () => {
+    const unaccounted = cases.filter(
+      (c) => !(c in GATED_OPS) && !(c in EXEMPT_OPS),
+    );
+    expect(unaccounted).toEqual([]);
+  });
+
+  test("GATED_OPS and EXEMPT_OPS do not both claim the same op", () => {
+    const overlap = Object.keys(GATED_OPS).filter((k) => k in EXEMPT_OPS);
+    expect(overlap).toEqual([]);
+  });
+
+  test("no GATED_OPS/EXEMPT_OPS entry references a case that no longer exists in the switch", () => {
+    const known = new Set(cases);
+    const staleGated = Object.keys(GATED_OPS).filter((k) => !known.has(k));
+    const staleExempt = Object.keys(EXEMPT_OPS).filter((k) => !known.has(k));
+    expect(staleGated).toEqual([]);
+    expect(staleExempt).toEqual([]);
+  });
+
+  describe.each(Object.entries(GATED_OPS))(
+    "GATED_OPS['%s'] threads `event` to both callees, each gated by assertRowOrg",
+    (fieldName, meta) => {
+      test(`${fieldName}'s case dispatches to both ${meta.registryFn} and ${meta.legacyFn}`, () => {
+        const caseBody = extractCaseBody(source, fieldName);
+        const callSites = extractCallSiteNames(caseBody);
+        expect(callSites).toContain(meta.registryFn);
+        expect(callSites).toContain(meta.legacyFn);
+      });
+
+      test(`${fieldName}'s case passes \`event\` as an argument to ${meta.registryFn}`, () => {
+        const caseBody = extractCaseBody(source, fieldName);
+        const registryCallRe = new RegExp(
+          `${meta.registryFn}\\s*\\([^)]*\\bevent\\b`,
+        );
+        expect(registryCallRe.test(caseBody)).toBe(true);
+      });
+
+      test(`${fieldName}'s case passes \`event\` as an argument to ${meta.legacyFn}`, () => {
+        const caseBody = extractCaseBody(source, fieldName);
+        const legacyCallRe = new RegExp(
+          `${meta.legacyFn}\\s*\\([^)]*\\bevent\\b`,
+        );
+        expect(legacyCallRe.test(caseBody)).toBe(true);
+      });
+
+      test(`${meta.registryFn}'s function body contains an assertRowOrg call`, () => {
+        const body = extractFunctionBody(source, meta.registryFn);
+        expect(GATE_CALL_RE.test(body)).toBe(true);
+      });
+
+      test(`${meta.legacyFn}'s function body contains an assertRowOrg call`, () => {
+        const body = extractFunctionBody(source, meta.legacyFn);
+        expect(GATE_CALL_RE.test(body)).toBe(true);
+      });
+
+      test(`${meta.registryFn}'s gate call precedes its first Registry side effect`, () => {
+        const body = extractFunctionBody(source, meta.registryFn);
+        const gateIdx = body.search(GATE_CALL_RE);
+        expect(gateIdx).toBeGreaterThan(-1);
+
+        const sideEffectMarkers = [
+          "updateResource(",
+          "deleteResource(",
+          "updateResourceStatus(",
+        ];
+        for (const marker of sideEffectMarkers) {
+          const markerIdx = body.indexOf(marker);
+          if (markerIdx === -1) continue; // not every marker appears in every fn
+          expect(gateIdx).toBeLessThan(markerIdx);
+        }
+      });
+
+      test(`${meta.legacyFn}'s gate call precedes its first DynamoDB write side effect`, () => {
+        const body = extractFunctionBody(source, meta.legacyFn);
+        const gateIdx = body.search(GATE_CALL_RE);
+        expect(gateIdx).toBeGreaterThan(-1);
+
+        const sideEffectMarkers = ["new PutCommand(", "new DeleteCommand("];
+        for (const marker of sideEffectMarkers) {
+          const markerIdx = body.indexOf(marker);
+          if (markerIdx === -1) continue;
+          expect(gateIdx).toBeLessThan(markerIdx);
+        }
+      });
+    },
+  );
+});

--- a/backend/src/lambda/__tests__/tool-config-resolver-handler-dispatch.test.ts
+++ b/backend/src/lambda/__tests__/tool-config-resolver-handler-dispatch.test.ts
@@ -9,8 +9,14 @@
  *
  * Validates: Requirements 4.6, 11.2, 11.3
  */
-import { DynamoDBDocumentClient, GetCommand, PutCommand, ScanCommand, DeleteCommand } from '@aws-sdk/lib-dynamodb';
-import { mockClient } from 'aws-sdk-client-mock';
+import {
+  DynamoDBDocumentClient,
+  GetCommand,
+  PutCommand,
+  ScanCommand,
+  DeleteCommand,
+} from "@aws-sdk/lib-dynamodb";
+import { mockClient } from "aws-sdk-client-mock";
 
 const dynamoMock = mockClient(DynamoDBDocumentClient);
 
@@ -25,7 +31,9 @@ const mockUpdateResource = jest.fn();
 const mockDeleteResource = jest.fn();
 const mockUpdateResourceStatus = jest.fn();
 const mockSearchResources = jest.fn();
-const mockSerializeCustomMetadata = jest.fn((meta: unknown) => JSON.stringify(meta));
+const mockSerializeCustomMetadata = jest.fn((meta: unknown) =>
+  JSON.stringify(meta),
+);
 const mockDeserializeCustomMetadata = jest.fn(
   (json: string | null, defaults: Record<string, unknown>) => {
     if (!json) return defaults;
@@ -37,12 +45,20 @@ const mockDeserializeCustomMetadata = jest.fn(
   },
 );
 const mockToRegistryStatus = jest.fn((state: string) => {
-  const map: Record<string, string> = { active: 'APPROVED', inactive: 'DEPRECATED', maintenance: 'DRAFT' };
-  return map[state] || 'DEPRECATED';
+  const map: Record<string, string> = {
+    active: "APPROVED",
+    inactive: "DEPRECATED",
+    maintenance: "DRAFT",
+  };
+  return map[state] || "DEPRECATED";
 });
 const mockToInternalState = jest.fn((status: string) => {
-  const map: Record<string, string> = { APPROVED: 'active', DEPRECATED: 'inactive', DRAFT: 'maintenance' };
-  return map[status] || 'inactive';
+  const map: Record<string, string> = {
+    APPROVED: "active",
+    DEPRECATED: "inactive",
+    DRAFT: "maintenance",
+  };
+  return map[status] || "inactive";
 });
 
 /** Registry record fixture shape consumed by the mock mapper. */
@@ -58,12 +74,18 @@ interface RegistryRecordFixture {
 
 const mockMapToToolConfig = jest.fn((record: RegistryRecordFixture) => {
   const meta = record.customDescriptorContent
-    ? (() => { try { return JSON.parse(record.customDescriptorContent); } catch { return {}; } })()
+    ? (() => {
+        try {
+          return JSON.parse(record.customDescriptorContent);
+        } catch {
+          return {};
+        }
+      })()
     : {};
   return {
     toolId: record.recordId,
-    orgId: meta.orgId ?? '',
-    config: record.description || '',
+    orgId: meta.orgId ?? "",
+    config: record.description || "",
     state: mockToInternalState(record.status),
     categories: meta.categories || [],
     integrationBindings: meta.integrationBindings || null,
@@ -73,9 +95,9 @@ const mockMapToToolConfig = jest.fn((record: RegistryRecordFixture) => {
   };
 });
 
-jest.mock('../../services/registry-service', () => ({
+jest.mock("../../services/registry-service", () => ({
   RegistryService: jest.fn().mockImplementation(() => ({
-    getRegistryId: () => 'test-registry',
+    getRegistryId: () => "test-registry",
     listResources: mockListResources,
     getResource: mockGetResource,
     createResource: mockCreateResource,
@@ -91,13 +113,13 @@ jest.mock('../../services/registry-service', () => ({
   })),
 }));
 
-import { handler, _resetRegistryService } from '../tool-config-resolver';
+import { handler, _resetRegistryService } from "../tool-config-resolver";
 
 // ---------------------------------------------------------------------------
 
 const defaultIdentity = {
-  sub: 'test-user',
-  claims: { 'custom:organization': 'test-org-a' },
+  sub: "test-user",
+  claims: { "custom:organization": "test-org-a" },
 };
 
 const makeEvent = (
@@ -111,27 +133,27 @@ const makeEvent = (
 });
 
 const sampleRegistryRecord = {
-  recordId: 'tool-r1',
-  name: 'RegistryTool',
+  recordId: "tool-r1",
+  name: "RegistryTool",
   description: '{"name":"RegistryTool"}',
-  status: 'APPROVED',
+  status: "APPROVED",
   customDescriptorContent: JSON.stringify({
-    categories: ['cat1'],
-    icon: 'icon.png',
-    state: 'active',
-    orgId: 'test-org-a',
+    categories: ["cat1"],
+    icon: "icon.png",
+    state: "active",
+    orgId: "test-org-a",
     integrationBindings: [
-      { integrationId: 'int1', integrationType: 'SLACK', direction: 'OUTPUT' },
+      { integrationId: "int1", integrationType: "SLACK", direction: "OUTPUT" },
     ],
     dataStoreBindings: [
-      { dataStoreId: 'ds1', dataStoreType: 'S3', direction: 'BIDIRECTIONAL' },
+      { dataStoreId: "ds1", dataStoreType: "S3", direction: "BIDIRECTIONAL" },
     ],
   }),
-  createdAt: new Date('2025-01-01T00:00:00Z'),
-  updatedAt: new Date('2025-01-01T00:00:00Z'),
+  createdAt: new Date("2025-01-01T00:00:00Z"),
+  updatedAt: new Date("2025-01-01T00:00:00Z"),
 };
 
-describe('tool-config-resolver handler switch dispatch (task 7.5)', () => {
+describe("tool-config-resolver handler switch dispatch (task 7.5)", () => {
   const originalEnv = process.env;
 
   beforeEach(() => {
@@ -140,8 +162,8 @@ describe('tool-config-resolver handler switch dispatch (task 7.5)', () => {
     _resetRegistryService();
     process.env = {
       ...originalEnv,
-      TOOLS_CONFIG_TABLE: 'test-tools-config',
-      REGISTRY_ID: 'test-registry',
+      TOOLS_CONFIG_TABLE: "test-tools-config",
+      REGISTRY_ID: "test-registry",
     };
   });
 
@@ -151,185 +173,232 @@ describe('tool-config-resolver handler switch dispatch (task 7.5)', () => {
 
   // ─── REGISTRY_ENABLED=false: routes to DynamoDB ──────────────
 
-  describe('when REGISTRY_ENABLED is false', () => {
+  describe("when REGISTRY_ENABLED is false", () => {
     beforeEach(() => {
-      process.env.REGISTRY_ENABLED = 'false';
+      process.env.REGISTRY_ENABLED = "false";
     });
 
-    test('listToolConfigs uses DynamoDB scan', async () => {
+    test("listToolConfigs uses DynamoDB scan", async () => {
       dynamoMock.on(ScanCommand).resolves({
         Items: [
           {
-            toolId: 't1',
-            config: { name: 'T1' },
-            state: 'active',
-            integrationBindings: [{ integrationId: 'int1', integrationType: 'SLACK', direction: 'output' }],
-            dataStoreBindings: [{ dataStoreId: 'ds1', dataStoreType: 'S3', direction: 'bidirectional' }],
+            toolId: "t1",
+            config: { name: "T1" },
+            state: "active",
+            integrationBindings: [
+              {
+                integrationId: "int1",
+                integrationType: "SLACK",
+                direction: "output",
+              },
+            ],
+            dataStoreBindings: [
+              {
+                dataStoreId: "ds1",
+                dataStoreType: "S3",
+                direction: "bidirectional",
+              },
+            ],
           },
         ],
       });
 
-      const result = await handler(makeEvent('listToolConfigs'));
+      const result = await handler(makeEvent("listToolConfigs"));
 
       expect(mockListResources).not.toHaveBeenCalled();
       expect(result).toHaveLength(1);
-      expect(result[0].toolId).toBe('t1');
+      expect(result[0].toolId).toBe("t1");
       // GraphQL response shape: config is a JSON string
-      expect(typeof result[0].config).toBe('string');
+      expect(typeof result[0].config).toBe("string");
       // Bindings preserved (direction normalised to upper case by the resolver)
       expect(result[0].integrationBindings).toHaveLength(1);
-      expect(result[0].integrationBindings[0].direction).toBe('OUTPUT');
+      expect(result[0].integrationBindings[0].direction).toBe("OUTPUT");
       expect(result[0].dataStoreBindings).toHaveLength(1);
-      expect(result[0].dataStoreBindings[0].direction).toBe('BIDIRECTIONAL');
+      expect(result[0].dataStoreBindings[0].direction).toBe("BIDIRECTIONAL");
     });
 
-    test('getToolConfig uses DynamoDB GetItem', async () => {
+    test("getToolConfig uses DynamoDB GetItem", async () => {
       dynamoMock.on(GetCommand).resolves({
         Item: {
-          toolId: 't1',
-          config: { name: 'T1' },
-          state: 'active',
-          integrationBindings: [{ integrationId: 'int1', integrationType: 'SLACK' }],
+          toolId: "t1",
+          config: { name: "T1" },
+          state: "active",
+          integrationBindings: [
+            { integrationId: "int1", integrationType: "SLACK" },
+          ],
         },
       });
 
-      const result = await handler(makeEvent('getToolConfig', { toolId: 't1' }));
+      const result = await handler(
+        makeEvent("getToolConfig", { toolId: "t1" }),
+      );
 
       expect(mockGetResource).not.toHaveBeenCalled();
-      expect(result?.toolId).toBe('t1');
-      expect(typeof result?.config).toBe('string');
+      expect(result?.toolId).toBe("t1");
+      expect(typeof result?.config).toBe("string");
       // Bindings preserved in the response shape
       expect(result?.integrationBindings).toHaveLength(1);
     });
 
-    test('createToolConfig uses DynamoDB Put', async () => {
+    test("createToolConfig uses DynamoDB Put", async () => {
       dynamoMock.on(PutCommand).resolves({});
 
-      const result = await handler(makeEvent('createToolConfig', {
-        input: {
-          toolId: 'new',
-          config: '{"name":"N"}',
-          state: 'active',
-          integrationBindings: [{ integrationId: 'int1', integrationType: 'SLACK' }],
-        },
-      }));
+      const result = await handler(
+        makeEvent("createToolConfig", {
+          input: {
+            toolId: "new",
+            config: '{"name":"N"}',
+            state: "active",
+            integrationBindings: [
+              { integrationId: "int1", integrationType: "SLACK" },
+            ],
+          },
+        }),
+      );
 
       expect(mockCreateResource).not.toHaveBeenCalled();
-      expect(result.toolId).toBe('new');
-      expect(typeof result.config).toBe('string');
+      expect(result.toolId).toBe("new");
+      expect(typeof result.config).toBe("string");
       expect(result.integrationBindings).toHaveLength(1);
       expect(result.createdAt).toBeDefined();
       expect(result.updatedAt).toBeDefined();
     });
 
-    test('updateToolConfig uses DynamoDB Put', async () => {
+    test("updateToolConfig uses DynamoDB Put", async () => {
       dynamoMock.on(GetCommand).resolves({
         Item: {
-          toolId: 't1',
+          toolId: "t1",
+          orgId: "test-org-a",
           config: '{"old":true}',
-          state: 'active',
-          createdAt: '2025-01-01',
+          state: "active",
+          createdAt: "2025-01-01",
         },
       });
       dynamoMock.on(PutCommand).resolves({});
 
-      const result = await handler(makeEvent('updateToolConfig', {
-        input: { toolId: 't1', config: '{"new":true}' },
-      }));
+      const result = await handler(
+        makeEvent("updateToolConfig", {
+          input: { toolId: "t1", config: '{"new":true}' },
+        }),
+      );
 
       expect(mockUpdateResource).not.toHaveBeenCalled();
-      expect(result.toolId).toBe('t1');
-      expect(typeof result.config).toBe('string');
+      expect(result.toolId).toBe("t1");
+      expect(typeof result.config).toBe("string");
     });
 
-    test('deleteToolConfig uses DynamoDB Delete', async () => {
+    test("deleteToolConfig uses DynamoDB Delete", async () => {
+      dynamoMock.on(GetCommand).resolves({
+        Item: {
+          toolId: "t1",
+          orgId: "test-org-a",
+          config: "{}",
+          state: "active",
+        },
+      });
       dynamoMock.on(DeleteCommand).resolves({});
 
-      const result = await handler(makeEvent('deleteToolConfig', { toolId: 't1' }));
+      const result = await handler(
+        makeEvent("deleteToolConfig", { toolId: "t1" }),
+      );
 
       expect(mockDeleteResource).not.toHaveBeenCalled();
       expect(result.success).toBe(true);
     });
 
-    test('listIntegrationOperations is flag-independent', async () => {
-      const result = await handler(makeEvent('listIntegrationOperations', { integrationType: 'SLACK' }));
+    test("listIntegrationOperations is flag-independent", async () => {
+      const result = await handler(
+        makeEvent("listIntegrationOperations", { integrationType: "SLACK" }),
+      );
       expect(Array.isArray(result)).toBe(true);
     });
   });
 
   // ─── REGISTRY_ENABLED=true: routes to Registry ──────────────
 
-  describe('when REGISTRY_ENABLED is true', () => {
+  describe("when REGISTRY_ENABLED is true", () => {
     beforeEach(() => {
-      process.env.REGISTRY_ENABLED = 'true';
+      process.env.REGISTRY_ENABLED = "true";
     });
 
-    test('listToolConfigs uses RegistryService.listResources (merged with DDB)', async () => {
+    test("listToolConfigs uses RegistryService.listResources (merged with DDB)", async () => {
       mockListResources.mockResolvedValue([sampleRegistryRecord]);
       dynamoMock.on(ScanCommand).resolves({ Items: [] });
 
-      const result = await handler(makeEvent('listToolConfigs'));
+      const result = await handler(makeEvent("listToolConfigs"));
 
-      expect(mockListResources).toHaveBeenCalledWith('tool');
+      expect(mockListResources).toHaveBeenCalledWith("tool");
       expect(result).toHaveLength(1);
-      expect(result[0].toolId).toBe('tool-r1');
+      expect(result[0].toolId).toBe("tool-r1");
       // Bindings preserved in the GraphQL response shape from Registry mapping
       expect(result[0].integrationBindings).toHaveLength(1);
       expect(result[0].dataStoreBindings).toHaveLength(1);
     });
 
-    test('getToolConfig uses RegistryService.getResource', async () => {
+    test("getToolConfig uses RegistryService.getResource", async () => {
       mockGetResource.mockResolvedValue(sampleRegistryRecord);
 
-      const result = await handler(makeEvent('getToolConfig', { toolId: 'tool-r1' }));
+      const result = await handler(
+        makeEvent("getToolConfig", { toolId: "tool-r1" }),
+      );
 
-      expect(mockGetResource).toHaveBeenCalledWith('tool', 'tool-r1');
-      expect(result?.toolId).toBe('tool-r1');
+      expect(mockGetResource).toHaveBeenCalledWith("tool", "tool-r1");
+      expect(result?.toolId).toBe("tool-r1");
       expect(result?.integrationBindings).toHaveLength(1);
     });
 
-    test('createToolConfig uses RegistryService.createResource', async () => {
+    test("createToolConfig uses RegistryService.createResource", async () => {
       mockCreateResource.mockResolvedValue(sampleRegistryRecord);
 
-      const result = await handler(makeEvent('createToolConfig', {
-        input: {
-          toolId: 'tool-r1',
-          config: '{"name":"RegistryTool"}',
-          integrationBindings: [{ integrationId: 'int1', integrationType: 'SLACK' }],
-          dataStoreBindings: [{ dataStoreId: 'ds1', dataStoreType: 'S3' }],
-        },
-      }));
+      const result = await handler(
+        makeEvent("createToolConfig", {
+          input: {
+            toolId: "tool-r1",
+            config: '{"name":"RegistryTool"}',
+            integrationBindings: [
+              { integrationId: "int1", integrationType: "SLACK" },
+            ],
+            dataStoreBindings: [{ dataStoreId: "ds1", dataStoreType: "S3" }],
+          },
+        }),
+      );
 
       expect(mockCreateResource).toHaveBeenCalled();
-      expect(result.toolId).toBe('tool-r1');
+      expect(result.toolId).toBe("tool-r1");
       // GraphQL response preserves bindings
       expect(result.integrationBindings).toHaveLength(1);
       expect(result.dataStoreBindings).toHaveLength(1);
     });
 
-    test('updateToolConfig uses RegistryService.updateResource', async () => {
+    test("updateToolConfig uses RegistryService.updateResource", async () => {
       mockGetResource.mockResolvedValue(sampleRegistryRecord);
       mockUpdateResource.mockResolvedValue(sampleRegistryRecord);
 
-      const result = await handler(makeEvent('updateToolConfig', {
-        input: { toolId: 'tool-r1', categories: ['new-cat'] },
-      }));
+      const result = await handler(
+        makeEvent("updateToolConfig", {
+          input: { toolId: "tool-r1", categories: ["new-cat"] },
+        }),
+      );
 
       expect(mockUpdateResource).toHaveBeenCalled();
-      expect(result.toolId).toBe('tool-r1');
+      expect(result.toolId).toBe("tool-r1");
     });
 
-    test('deleteToolConfig uses RegistryService.deleteResource', async () => {
+    test("deleteToolConfig uses RegistryService.deleteResource", async () => {
       mockDeleteResource.mockResolvedValue(undefined);
 
-      const result = await handler(makeEvent('deleteToolConfig', { toolId: 'tool-r1' }));
+      const result = await handler(
+        makeEvent("deleteToolConfig", { toolId: "tool-r1" }),
+      );
 
-      expect(mockDeleteResource).toHaveBeenCalledWith('tool', 'tool-r1');
+      expect(mockDeleteResource).toHaveBeenCalledWith("tool", "tool-r1");
       expect(result.success).toBe(true);
     });
 
-    test('listIntegrationOperations is flag-independent', async () => {
-      const result = await handler(makeEvent('listIntegrationOperations', { integrationType: 'SLACK' }));
+    test("listIntegrationOperations is flag-independent", async () => {
+      const result = await handler(
+        makeEvent("listIntegrationOperations", { integrationType: "SLACK" }),
+      );
       expect(Array.isArray(result)).toBe(true);
       // Registry APIs should not have been called for this field
       expect(mockListResources).not.toHaveBeenCalled();
@@ -339,106 +408,143 @@ describe('tool-config-resolver handler switch dispatch (task 7.5)', () => {
 
   // ─── searchToolConfigs: Registry-only (per requirement 9.3) ─────
 
-  describe('searchToolConfigs is always wired to Registry', () => {
-    test('routes to RegistryService.searchResources regardless of flag', async () => {
-      process.env.REGISTRY_ENABLED = 'true';
+  describe("searchToolConfigs is always wired to Registry", () => {
+    test("routes to RegistryService.searchResources regardless of flag", async () => {
+      process.env.REGISTRY_ENABLED = "true";
       mockSearchResources.mockResolvedValue([sampleRegistryRecord]);
 
-      const result = await handler(makeEvent('searchToolConfigs', { query: 'test' }));
+      const result = await handler(
+        makeEvent("searchToolConfigs", { query: "test" }),
+      );
 
-      expect(mockSearchResources).toHaveBeenCalledWith('tool', 'test');
+      expect(mockSearchResources).toHaveBeenCalledWith("tool", "test");
       expect(result).toHaveLength(1);
-      expect(result[0].toolId).toBe('tool-r1');
+      expect(result[0].toolId).toBe("tool-r1");
     });
   });
 
   // ─── Phase-2a org scoping ───────────────────────────────────
-  describe('Phase-2a org scoping (handler)', () => {
+  describe("Phase-2a org scoping (handler)", () => {
     beforeEach(() => {
-      process.env.REGISTRY_ENABLED = 'true';
+      process.env.REGISTRY_ENABLED = "true";
     });
 
-    test('(a) create: orgId captured from JWT claim and serialized into customMetadata', async () => {
+    test("(a) create: orgId captured from JWT claim and serialized into customMetadata", async () => {
       mockCreateResource.mockResolvedValue(sampleRegistryRecord);
 
-      await handler(makeEvent(
-        'createToolConfig',
-        { input: { toolId: 'tool-r1', config: '{"name":"RegistryTool"}' } },
-      ));
+      await handler(
+        makeEvent("createToolConfig", {
+          input: { toolId: "tool-r1", config: '{"name":"RegistryTool"}' },
+        }),
+      );
 
       expect(mockSerializeCustomMetadata).toHaveBeenCalledWith(
-        expect.objectContaining({ orgId: 'test-org-a' }),
+        expect.objectContaining({ orgId: "test-org-a" }),
       );
     });
 
-    test('(b) update: existing orgId is preserved', async () => {
+    test("(b) update: existing orgId is preserved for a same-org caller", async () => {
       const owned = {
         ...sampleRegistryRecord,
-        customDescriptorContent: JSON.stringify({ orgId: 'original-owner-org' }),
+        customDescriptorContent: JSON.stringify({
+          orgId: "original-owner-org",
+        }),
       };
       mockGetResource.mockResolvedValue(owned);
       mockUpdateResource.mockResolvedValue(owned);
 
-      await handler(makeEvent(
-        'updateToolConfig',
-        { input: { toolId: 'tool-r1', categories: ['x'] } },
-        { sub: 'u', claims: { 'custom:organization': 'different-caller-org' } },
-      ));
+      await handler(
+        makeEvent(
+          "updateToolConfig",
+          { input: { toolId: "tool-r1", categories: ["x"] } },
+          { sub: "u", claims: { "custom:organization": "original-owner-org" } },
+        ),
+      );
 
       expect(mockSerializeCustomMetadata).toHaveBeenCalledWith(
-        expect.objectContaining({ orgId: 'original-owner-org' }),
+        expect.objectContaining({ orgId: "original-owner-org" }),
       );
     });
 
-    test('(c) list filters to caller org', async () => {
+    test("(b2) update: cross-org caller is refused BEFORE any Registry write (finding 13065e38)", async () => {
+      const owned = {
+        ...sampleRegistryRecord,
+        customDescriptorContent: JSON.stringify({
+          orgId: "original-owner-org",
+        }),
+      };
+      mockGetResource.mockResolvedValue(owned);
+
+      await expect(
+        handler(
+          makeEvent(
+            "updateToolConfig",
+            { input: { toolId: "tool-r1", categories: ["x"] } },
+            {
+              sub: "u",
+              claims: { "custom:organization": "different-caller-org" },
+            },
+          ),
+        ),
+      ).rejects.toThrow("Access denied");
+
+      expect(mockUpdateResource).not.toHaveBeenCalled();
+      expect(mockSerializeCustomMetadata).not.toHaveBeenCalled();
+    });
+
+    test("(c) list filters to caller org", async () => {
       const ours = {
         ...sampleRegistryRecord,
-        recordId: 'tool-a',
-        customDescriptorContent: JSON.stringify({ orgId: 'test-org-a' }),
+        recordId: "tool-a",
+        customDescriptorContent: JSON.stringify({ orgId: "test-org-a" }),
       };
       const theirs = {
         ...sampleRegistryRecord,
-        recordId: 'tool-b',
-        customDescriptorContent: JSON.stringify({ orgId: 'other-org' }),
+        recordId: "tool-b",
+        customDescriptorContent: JSON.stringify({ orgId: "other-org" }),
       };
       mockListResources.mockResolvedValue([ours, theirs]);
       dynamoMock.on(ScanCommand).resolves({ Items: [] });
 
-      const result = await handler(makeEvent('listToolConfigs'));
+      const result = await handler(makeEvent("listToolConfigs"));
       expect(result).toHaveLength(1);
-      expect(result[0].toolId).toBe('tool-a');
+      expect(result[0].toolId).toBe("tool-a");
     });
 
-    test('(d) admin list returns all orgs', async () => {
+    test("(d) admin list returns all orgs", async () => {
       const ours = {
         ...sampleRegistryRecord,
-        recordId: 'tool-a',
-        customDescriptorContent: JSON.stringify({ orgId: 'test-org-a' }),
+        recordId: "tool-a",
+        customDescriptorContent: JSON.stringify({ orgId: "test-org-a" }),
       };
       const theirs = {
         ...sampleRegistryRecord,
-        recordId: 'tool-b',
-        customDescriptorContent: JSON.stringify({ orgId: 'other-org' }),
+        recordId: "tool-b",
+        customDescriptorContent: JSON.stringify({ orgId: "other-org" }),
       };
       mockListResources.mockResolvedValue([ours, theirs]);
       dynamoMock.on(ScanCommand).resolves({ Items: [] });
 
       const adminIdentity = {
-        sub: 'admin',
-        claims: { 'custom:organization': 'admin-home', 'custom:role': 'admin' },
+        sub: "admin",
+        claims: { "custom:organization": "admin-home", "custom:role": "admin" },
       };
-      const result = await handler(makeEvent('listToolConfigs', {}, adminIdentity));
+      const result = await handler(
+        makeEvent("listToolConfigs", {}, adminIdentity),
+      );
       expect(result).toHaveLength(2);
     });
 
-    test('(e) get cross-org returns Not found (null)', async () => {
+    test("(e) get cross-org returns Not found (null)", async () => {
       mockGetResource.mockResolvedValue({
         ...sampleRegistryRecord,
-        customDescriptorContent: JSON.stringify({ orgId: 'other-org' }),
+        customDescriptorContent: JSON.stringify({ orgId: "other-org" }),
       });
       dynamoMock.on(GetCommand).resolves({});
 
-      const result = await handler(makeEvent('getToolConfig', { toolId: 'tool-r1' }));
+      const result = await handler(
+        makeEvent("getToolConfig", { toolId: "tool-r1" }),
+      );
       expect(result).toBeNull();
     });
   });
@@ -453,42 +559,42 @@ describe('tool-config-resolver handler switch dispatch (task 7.5)', () => {
   // serializeCustomMetadata, which is where the resolver stores it as
   // `createdBy`.
 
-  describe('caller identity is threaded into createToolConfigRegistry', () => {
+  describe("caller identity is threaded into createToolConfigRegistry", () => {
     beforeEach(() => {
-      process.env.REGISTRY_ENABLED = 'true';
+      process.env.REGISTRY_ENABLED = "true";
       mockCreateResource.mockResolvedValue(sampleRegistryRecord);
     });
 
-    test('uses identity.sub when provided (Cognito auth mode)', async () => {
+    test("uses identity.sub when provided (Cognito auth mode)", async () => {
       await handler(
         makeEvent(
-          'createToolConfig',
-          { input: { toolId: 'tool-r1', config: '{"name":"X"}' } },
+          "createToolConfig",
+          { input: { toolId: "tool-r1", config: '{"name":"X"}' } },
           {
-            sub: 'test-user-abc',
-            username: 'ignored-when-sub-present',
-            claims: { 'custom:organization': 'test-org-a' },
+            sub: "test-user-abc",
+            username: "ignored-when-sub-present",
+            claims: { "custom:organization": "test-org-a" },
           },
         ),
       );
       expect(mockSerializeCustomMetadata).toHaveBeenCalledWith(
-        expect.objectContaining({ createdBy: 'test-user-abc' }),
+        expect.objectContaining({ createdBy: "test-user-abc" }),
       );
     });
 
-    test('falls back to identity.username when no sub is present (IAM auth mode)', async () => {
+    test("falls back to identity.username when no sub is present (IAM auth mode)", async () => {
       await handler(
         makeEvent(
-          'createToolConfig',
-          { input: { toolId: 'tool-r1', config: '{"name":"X"}' } },
+          "createToolConfig",
+          { input: { toolId: "tool-r1", config: '{"name":"X"}' } },
           {
-            username: 'iam-caller',
-            claims: { 'custom:organization': 'test-org-a' },
+            username: "iam-caller",
+            claims: { "custom:organization": "test-org-a" },
           },
         ),
       );
       expect(mockSerializeCustomMetadata).toHaveBeenCalledWith(
-        expect.objectContaining({ createdBy: 'iam-caller' }),
+        expect.objectContaining({ createdBy: "iam-caller" }),
       );
     });
 
@@ -500,49 +606,56 @@ describe('tool-config-resolver handler switch dispatch (task 7.5)', () => {
       // observable) and leaving sub/username unset.
       await handler(
         makeEvent(
-          'createToolConfig',
-          { input: { toolId: 'tool-r1', config: '{"name":"X"}' } },
-          { claims: { 'custom:organization': 'test-org-a' } },
+          "createToolConfig",
+          { input: { toolId: "tool-r1", config: '{"name":"X"}' } },
+          { claims: { "custom:organization": "test-org-a" } },
         ),
       );
       expect(mockSerializeCustomMetadata).toHaveBeenCalledWith(
-        expect.objectContaining({ createdBy: 'unknown' }),
+        expect.objectContaining({ createdBy: "unknown" }),
       );
     });
   });
 
-  describe('caller identity is threaded into updateToolConfigRegistry', () => {
+  describe("caller identity is threaded into updateToolConfigRegistry", () => {
     beforeEach(() => {
-      process.env.REGISTRY_ENABLED = 'true';
+      process.env.REGISTRY_ENABLED = "true";
       mockGetResource.mockResolvedValue(sampleRegistryRecord);
       mockUpdateResource.mockResolvedValue(sampleRegistryRecord);
     });
 
-    test('uses identity.sub when provided', async () => {
+    test("uses identity.sub when provided", async () => {
       await handler(
         makeEvent(
-          'updateToolConfig',
-          { input: { toolId: 'tool-r1', categories: ['x'] } },
-          { sub: 'editor-sub-id', claims: { 'custom:organization': 'test-org-a' } },
+          "updateToolConfig",
+          { input: { toolId: "tool-r1", categories: ["x"] } },
+          {
+            sub: "editor-sub-id",
+            claims: { "custom:organization": "test-org-a" },
+          },
         ),
       );
       // sampleRegistryRecord has no createdBy in customDescriptorContent, so
       // the caller's sub becomes the record's createdBy on first edit.
       expect(mockSerializeCustomMetadata).toHaveBeenCalledWith(
-        expect.objectContaining({ createdBy: 'editor-sub-id' }),
+        expect.objectContaining({ createdBy: "editor-sub-id" }),
       );
     });
   });
 
   // ─── Unknown field ──────────────────────────────────────────
 
-  test('throws on unknown GraphQL field (flag off)', async () => {
-    process.env.REGISTRY_ENABLED = 'false';
-    await expect(handler(makeEvent('unknownField'))).rejects.toThrow('Unknown field');
+  test("throws on unknown GraphQL field (flag off)", async () => {
+    process.env.REGISTRY_ENABLED = "false";
+    await expect(handler(makeEvent("unknownField"))).rejects.toThrow(
+      "Unknown field",
+    );
   });
 
-  test('throws on unknown GraphQL field (flag on)', async () => {
-    process.env.REGISTRY_ENABLED = 'true';
-    await expect(handler(makeEvent('unknownField'))).rejects.toThrow('Unknown field');
+  test("throws on unknown GraphQL field (flag on)", async () => {
+    process.env.REGISTRY_ENABLED = "true";
+    await expect(handler(makeEvent("unknownField"))).rejects.toThrow(
+      "Unknown field",
+    );
   });
 });

--- a/backend/src/lambda/__tests__/tool-config-resolver-org-scoping.test.ts
+++ b/backend/src/lambda/__tests__/tool-config-resolver-org-scoping.test.ts
@@ -1,0 +1,642 @@
+/**
+ * Org-scoping regression tests for tool-config-resolver.ts (finding
+ * 13065e38). Reads (getToolConfig/getToolConfigRegistry/list*) were already
+ * org-filtered. updateToolConfig/deleteToolConfig (legacy DynamoDB path) and
+ * updateToolConfigRegistry/deleteToolConfigRegistry (Registry path) took NO
+ * event/identity at all and performed no org reconciliation whatsoever — any
+ * authenticated caller of any org could rewrite or destroy another tenant's
+ * tool config, including its integrationBindings/dataStoreBindings which
+ * scope datastore/integration credentials.
+ *
+ * Fix: both paths now fetch-then-verify via the shared `assertRowOrg` gate
+ * (backend/src/utils/auth-event.ts) BEFORE any DynamoDB PutCommand/
+ * DeleteCommand or Registry updateResource/deleteResource call — mirroring
+ * datastore-resolver.ts's updateDataStore/deleteDataStore remediation
+ * (finding ca76d041).
+ *
+ * Acceptance (from the task): cross-org caller refused on update and delete
+ * with ZERO DynamoDB writes/deletes recorded; same-org succeeds; fail closed
+ * on absent identity, unresolvable org, missing row, row without orgId.
+ */
+import {
+  DynamoDBDocumentClient,
+  GetCommand,
+  PutCommand,
+  DeleteCommand,
+} from "@aws-sdk/lib-dynamodb";
+import { mockClient } from "aws-sdk-client-mock";
+
+const dynamoMock = mockClient(DynamoDBDocumentClient);
+
+import { handler, _resetRegistryService } from "../tool-config-resolver";
+import { CrossOrgAccessError } from "../../utils/auth-event";
+
+const mockCreateResource = jest.fn();
+const mockGetResource = jest.fn();
+const mockUpdateResource = jest.fn();
+const mockDeleteResource = jest.fn();
+const mockListResources = jest.fn();
+const mockUpdateResourceStatus = jest.fn();
+const mockSearchResources = jest.fn();
+const mockSerializeCustomMetadata = jest.fn((meta: unknown) =>
+  JSON.stringify(meta),
+);
+const mockDeserializeCustomMetadata = jest.fn(
+  (json: string | null, defaults: Record<string, unknown>) => {
+    if (!json) return defaults;
+    try {
+      return { ...defaults, ...JSON.parse(json) };
+    } catch {
+      return defaults;
+    }
+  },
+);
+const mockToRegistryStatus = jest.fn(() => "APPROVED");
+const mockToInternalState = jest.fn(() => "active");
+const mockMapToToolConfig = jest.fn((record: Record<string, unknown>) => {
+  const meta = record.customDescriptorContent
+    ? (() => {
+        try {
+          return JSON.parse(record.customDescriptorContent as string);
+        } catch {
+          return {};
+        }
+      })()
+    : ({} as Record<string, unknown>);
+  return {
+    toolId: record.recordId,
+    orgId: meta.orgId ?? "",
+    config: record.description || "",
+    state: "active",
+    categories: [],
+    createdAt: record.createdAt,
+    updatedAt: record.updatedAt,
+  };
+});
+
+jest.mock("../../services/registry-service", () => ({
+  RegistryService: jest.fn().mockImplementation(() => ({
+    getRegistryId: () => "test-registry",
+    createResource: mockCreateResource,
+    getResource: mockGetResource,
+    updateResource: mockUpdateResource,
+    deleteResource: mockDeleteResource,
+    listResources: mockListResources,
+    updateResourceStatus: mockUpdateResourceStatus,
+    searchResources: mockSearchResources,
+    serializeCustomMetadata: mockSerializeCustomMetadata,
+    deserializeCustomMetadata: mockDeserializeCustomMetadata,
+    toRegistryStatus: mockToRegistryStatus,
+    toInternalState: mockToInternalState,
+    mapToToolConfig: mockMapToToolConfig,
+  })),
+}));
+
+const ORG_A = "org-a";
+const ORG_B = "org-b";
+
+const eventForOrg = (orgId: string | undefined, admin = false) => ({
+  identity: {
+    sub: "test-user",
+    claims: {
+      ...(orgId ? { "custom:organization": orgId } : {}),
+      ...(admin ? { "custom:role": "admin" } : {}),
+    },
+  },
+});
+
+const makeEvent = (
+  fieldName: string,
+  args: Record<string, unknown>,
+  identity?: Record<string, unknown>,
+) => ({
+  info: { fieldName },
+  arguments: args,
+  identity: identity ?? eventForOrg(ORG_A).identity,
+});
+
+describe("tool-config-resolver — org scoping (finding 13065e38)", () => {
+  const originalEnv = process.env;
+
+  beforeEach(() => {
+    process.env = { ...originalEnv, TOOLS_CONFIG_TABLE: "test-tools-config" };
+    dynamoMock.reset();
+    jest.clearAllMocks();
+    _resetRegistryService();
+  });
+
+  afterAll(() => {
+    process.env = originalEnv;
+  });
+
+  // ─── Legacy DynamoDB path: updateToolConfig ──────────────────────────
+
+  describe("updateToolConfig (legacy DynamoDB path)", () => {
+    test("refuses a cross-org caller and performs ZERO DynamoDB writes", async () => {
+      dynamoMock.on(GetCommand).resolves({
+        Item: {
+          toolId: "t1",
+          orgId: ORG_A,
+          config: "{}",
+          state: "active",
+          createdAt: "2025-01-01",
+        },
+      });
+
+      await expect(
+        handler(
+          makeEvent(
+            "updateToolConfig",
+            { input: { toolId: "t1", config: '{"evil":true}' } },
+            eventForOrg(ORG_B).identity,
+          ),
+        ),
+      ).rejects.toThrow(CrossOrgAccessError);
+
+      expect(dynamoMock.commandCalls(PutCommand)).toHaveLength(0);
+    });
+
+    test("same-org caller succeeds", async () => {
+      dynamoMock.on(GetCommand).resolves({
+        Item: {
+          toolId: "t1",
+          orgId: ORG_A,
+          config: "{}",
+          state: "active",
+          createdAt: "2025-01-01",
+        },
+      });
+      dynamoMock.on(PutCommand).resolves({});
+
+      const result = await handler(
+        makeEvent(
+          "updateToolConfig",
+          { input: { toolId: "t1", config: '{"ok":true}' } },
+          eventForOrg(ORG_A).identity,
+        ),
+      );
+
+      expect(JSON.parse(result.config)).toEqual({ ok: true });
+      expect(dynamoMock.commandCalls(PutCommand)).toHaveLength(1);
+    });
+
+    test("admin bypasses the org check", async () => {
+      dynamoMock.on(GetCommand).resolves({
+        Item: {
+          toolId: "t1",
+          orgId: ORG_A,
+          config: "{}",
+          state: "active",
+          createdAt: "2025-01-01",
+        },
+      });
+      dynamoMock.on(PutCommand).resolves({});
+
+      const result = await handler(
+        makeEvent(
+          "updateToolConfig",
+          { input: { toolId: "t1", config: '{"ok":true}' } },
+          eventForOrg(ORG_B, true).identity,
+        ),
+      );
+
+      expect(dynamoMock.commandCalls(PutCommand)).toHaveLength(1);
+      expect(result.toolId).toBe("t1");
+    });
+
+    test("fails closed when caller has no resolvable org", async () => {
+      dynamoMock.on(GetCommand).resolves({
+        Item: {
+          toolId: "t1",
+          orgId: ORG_A,
+          config: "{}",
+          state: "active",
+          createdAt: "2025-01-01",
+        },
+      });
+
+      await expect(
+        handler(
+          makeEvent(
+            "updateToolConfig",
+            { input: { toolId: "t1", config: "{}" } },
+            { sub: "no-org-user" },
+          ),
+        ),
+      ).rejects.toThrow(CrossOrgAccessError);
+      expect(dynamoMock.commandCalls(PutCommand)).toHaveLength(0);
+    });
+
+    test("fails closed when the row has no orgId (legacy row)", async () => {
+      dynamoMock.on(GetCommand).resolves({
+        Item: {
+          toolId: "t1",
+          config: "{}",
+          state: "active",
+          createdAt: "2025-01-01",
+        },
+      });
+
+      await expect(
+        handler(
+          makeEvent(
+            "updateToolConfig",
+            { input: { toolId: "t1", config: "{}" } },
+            eventForOrg(ORG_A).identity,
+          ),
+        ),
+      ).rejects.toThrow(CrossOrgAccessError);
+      expect(dynamoMock.commandCalls(PutCommand)).toHaveLength(0);
+    });
+
+    test("still throws not-found for a missing row (org gate never reached)", async () => {
+      dynamoMock.on(GetCommand).resolves({});
+
+      await expect(
+        handler(
+          makeEvent(
+            "updateToolConfig",
+            { input: { toolId: "missing" } },
+            eventForOrg(ORG_A).identity,
+          ),
+        ),
+      ).rejects.toThrow("Tool config not found");
+      expect(dynamoMock.commandCalls(PutCommand)).toHaveLength(0);
+    });
+  });
+
+  // ─── Legacy DynamoDB path: deleteToolConfig ──────────────────────────
+
+  describe("deleteToolConfig (legacy DynamoDB path)", () => {
+    test("refuses a cross-org caller and performs ZERO DynamoDB deletes", async () => {
+      dynamoMock.on(GetCommand).resolves({
+        Item: { toolId: "t1", orgId: ORG_A, config: "{}", state: "active" },
+      });
+
+      await expect(
+        handler(
+          makeEvent(
+            "deleteToolConfig",
+            { toolId: "t1" },
+            eventForOrg(ORG_B).identity,
+          ),
+        ),
+      ).rejects.toThrow(CrossOrgAccessError);
+      expect(dynamoMock.commandCalls(DeleteCommand)).toHaveLength(0);
+    });
+
+    test("same-org caller succeeds", async () => {
+      dynamoMock.on(GetCommand).resolves({
+        Item: { toolId: "t1", orgId: ORG_A, config: "{}", state: "active" },
+      });
+      dynamoMock.on(DeleteCommand).resolves({});
+
+      const result = await handler(
+        makeEvent(
+          "deleteToolConfig",
+          { toolId: "t1" },
+          eventForOrg(ORG_A).identity,
+        ),
+      );
+
+      expect(result.success).toBe(true);
+      expect(dynamoMock.commandCalls(DeleteCommand)).toHaveLength(1);
+    });
+
+    test("admin bypasses the org check", async () => {
+      dynamoMock.on(GetCommand).resolves({
+        Item: { toolId: "t1", orgId: ORG_A, config: "{}", state: "active" },
+      });
+      dynamoMock.on(DeleteCommand).resolves({});
+
+      const result = await handler(
+        makeEvent(
+          "deleteToolConfig",
+          { toolId: "t1" },
+          eventForOrg(ORG_B, true).identity,
+        ),
+      );
+
+      expect(result.success).toBe(true);
+      expect(dynamoMock.commandCalls(DeleteCommand)).toHaveLength(1);
+    });
+
+    test("fails closed when caller has no resolvable org", async () => {
+      dynamoMock.on(GetCommand).resolves({
+        Item: { toolId: "t1", orgId: ORG_A, config: "{}", state: "active" },
+      });
+
+      await expect(
+        handler(
+          makeEvent("deleteToolConfig", { toolId: "t1" }, { sub: "no-org" }),
+        ),
+      ).rejects.toThrow(CrossOrgAccessError);
+      expect(dynamoMock.commandCalls(DeleteCommand)).toHaveLength(0);
+    });
+
+    test("fails closed when the row has no orgId", async () => {
+      dynamoMock.on(GetCommand).resolves({
+        Item: { toolId: "t1", config: "{}", state: "active" },
+      });
+
+      await expect(
+        handler(
+          makeEvent(
+            "deleteToolConfig",
+            { toolId: "t1" },
+            eventForOrg(ORG_A).identity,
+          ),
+        ),
+      ).rejects.toThrow(CrossOrgAccessError);
+      expect(dynamoMock.commandCalls(DeleteCommand)).toHaveLength(0);
+    });
+
+    test("fails closed when the row is missing", async () => {
+      dynamoMock.on(GetCommand).resolves({});
+
+      await expect(
+        handler(
+          makeEvent(
+            "deleteToolConfig",
+            { toolId: "missing" },
+            eventForOrg(ORG_A).identity,
+          ),
+        ),
+      ).rejects.toThrow(CrossOrgAccessError);
+      expect(dynamoMock.commandCalls(DeleteCommand)).toHaveLength(0);
+    });
+  });
+
+  // ─── Registry path: updateToolConfigRegistry ─────────────────────────
+
+  describe("updateToolConfigRegistry (Registry path)", () => {
+    beforeEach(() => {
+      process.env.REGISTRY_ENABLED = "true";
+      process.env.REGISTRY_ID = "test-registry";
+    });
+
+    test("refuses a cross-org caller and performs ZERO Registry/DynamoDB writes", async () => {
+      mockGetResource.mockResolvedValue({
+        recordId: "t1",
+        name: "Tool1",
+        description: "{}",
+        status: "APPROVED",
+        customDescriptorContent: JSON.stringify({ orgId: ORG_A }),
+      });
+
+      await expect(
+        handler(
+          makeEvent(
+            "updateToolConfig",
+            { input: { toolId: "t1", config: '{"evil":true}' } },
+            eventForOrg(ORG_B).identity,
+          ),
+        ),
+      ).rejects.toThrow(CrossOrgAccessError);
+
+      expect(mockUpdateResource).not.toHaveBeenCalled();
+      expect(mockUpdateResourceStatus).not.toHaveBeenCalled();
+      expect(dynamoMock.commandCalls(PutCommand)).toHaveLength(0);
+    });
+
+    test("same-org caller succeeds", async () => {
+      mockGetResource.mockResolvedValue({
+        recordId: "t1",
+        name: "Tool1",
+        description: "{}",
+        status: "APPROVED",
+        customDescriptorContent: JSON.stringify({ orgId: ORG_A }),
+      });
+      mockUpdateResource.mockResolvedValue({
+        recordId: "t1",
+        name: "Tool1",
+        description: "{}",
+        status: "APPROVED",
+      });
+
+      const result = await handler(
+        makeEvent(
+          "updateToolConfig",
+          { input: { toolId: "t1", config: '{"ok":true}' } },
+          eventForOrg(ORG_A).identity,
+        ),
+      );
+
+      expect(mockUpdateResource).toHaveBeenCalled();
+      expect(result.toolId).toBe("t1");
+    });
+
+    test("admin bypasses the org check", async () => {
+      mockGetResource.mockResolvedValue({
+        recordId: "t1",
+        name: "Tool1",
+        description: "{}",
+        status: "APPROVED",
+        customDescriptorContent: JSON.stringify({ orgId: ORG_A }),
+      });
+      mockUpdateResource.mockResolvedValue({
+        recordId: "t1",
+        name: "Tool1",
+        description: "{}",
+        status: "APPROVED",
+      });
+
+      const result = await handler(
+        makeEvent(
+          "updateToolConfig",
+          { input: { toolId: "t1", config: "{}" } },
+          eventForOrg(ORG_B, true).identity,
+        ),
+      );
+
+      expect(mockUpdateResource).toHaveBeenCalled();
+      expect(result.toolId).toBe("t1");
+    });
+
+    test("fails closed when caller has no resolvable org", async () => {
+      mockGetResource.mockResolvedValue({
+        recordId: "t1",
+        name: "Tool1",
+        description: "{}",
+        status: "APPROVED",
+        customDescriptorContent: JSON.stringify({ orgId: ORG_A }),
+      });
+
+      await expect(
+        handler(
+          makeEvent(
+            "updateToolConfig",
+            { input: { toolId: "t1", config: "{}" } },
+            { sub: "no-org" },
+          ),
+        ),
+      ).rejects.toThrow(CrossOrgAccessError);
+      expect(mockUpdateResource).not.toHaveBeenCalled();
+    });
+
+    test("fails closed when the Registry record has no orgId in metadata", async () => {
+      mockGetResource.mockResolvedValue({
+        recordId: "t1",
+        name: "Tool1",
+        description: "{}",
+        status: "APPROVED",
+        customDescriptorContent: JSON.stringify({}),
+      });
+
+      await expect(
+        handler(
+          makeEvent(
+            "updateToolConfig",
+            { input: { toolId: "t1", config: "{}" } },
+            eventForOrg(ORG_A).identity,
+          ),
+        ),
+      ).rejects.toThrow(CrossOrgAccessError);
+      expect(mockUpdateResource).not.toHaveBeenCalled();
+    });
+
+    test("still throws not-found for a missing record (org gate never reached)", async () => {
+      mockGetResource.mockResolvedValue(null);
+      dynamoMock.on(GetCommand).resolves({});
+
+      await expect(
+        handler(
+          makeEvent(
+            "updateToolConfig",
+            { input: { toolId: "missing" } },
+            eventForOrg(ORG_A).identity,
+          ),
+        ),
+      ).rejects.toThrow("Tool config not found");
+      expect(mockUpdateResource).not.toHaveBeenCalled();
+    });
+  });
+
+  // ─── Registry path: deleteToolConfigRegistry ─────────────────────────
+
+  describe("deleteToolConfigRegistry (Registry path)", () => {
+    beforeEach(() => {
+      process.env.REGISTRY_ENABLED = "true";
+      process.env.REGISTRY_ID = "test-registry";
+    });
+
+    test("refuses a cross-org caller and performs ZERO Registry deletes", async () => {
+      mockGetResource.mockResolvedValue({
+        recordId: "t1",
+        name: "Tool1",
+        description: "{}",
+        status: "APPROVED",
+        customDescriptorContent: JSON.stringify({ orgId: ORG_A }),
+      });
+
+      await expect(
+        handler(
+          makeEvent(
+            "deleteToolConfig",
+            { toolId: "t1" },
+            eventForOrg(ORG_B).identity,
+          ),
+        ),
+      ).rejects.toThrow(CrossOrgAccessError);
+      expect(mockDeleteResource).not.toHaveBeenCalled();
+    });
+
+    test("same-org caller succeeds", async () => {
+      mockGetResource.mockResolvedValue({
+        recordId: "t1",
+        name: "Tool1",
+        description: "{}",
+        status: "APPROVED",
+        customDescriptorContent: JSON.stringify({ orgId: ORG_A }),
+      });
+      mockDeleteResource.mockResolvedValue(undefined);
+
+      const result = await handler(
+        makeEvent(
+          "deleteToolConfig",
+          { toolId: "t1" },
+          eventForOrg(ORG_A).identity,
+        ),
+      );
+
+      expect(result.success).toBe(true);
+      expect(mockDeleteResource).toHaveBeenCalledWith("tool", "t1");
+    });
+
+    test("admin bypasses the org check", async () => {
+      mockGetResource.mockResolvedValue({
+        recordId: "t1",
+        name: "Tool1",
+        description: "{}",
+        status: "APPROVED",
+        customDescriptorContent: JSON.stringify({ orgId: ORG_A }),
+      });
+      mockDeleteResource.mockResolvedValue(undefined);
+
+      const result = await handler(
+        makeEvent(
+          "deleteToolConfig",
+          { toolId: "t1" },
+          eventForOrg(ORG_B, true).identity,
+        ),
+      );
+
+      expect(result.success).toBe(true);
+      expect(mockDeleteResource).toHaveBeenCalledWith("tool", "t1");
+    });
+
+    test("fails closed when caller has no resolvable org", async () => {
+      mockGetResource.mockResolvedValue({
+        recordId: "t1",
+        name: "Tool1",
+        description: "{}",
+        status: "APPROVED",
+        customDescriptorContent: JSON.stringify({ orgId: ORG_A }),
+      });
+
+      await expect(
+        handler(
+          makeEvent("deleteToolConfig", { toolId: "t1" }, { sub: "no-org" }),
+        ),
+      ).rejects.toThrow(CrossOrgAccessError);
+      expect(mockDeleteResource).not.toHaveBeenCalled();
+    });
+
+    test("fails closed when the Registry record has no orgId in metadata", async () => {
+      mockGetResource.mockResolvedValue({
+        recordId: "t1",
+        name: "Tool1",
+        description: "{}",
+        status: "APPROVED",
+        customDescriptorContent: JSON.stringify({}),
+      });
+
+      await expect(
+        handler(
+          makeEvent(
+            "deleteToolConfig",
+            { toolId: "t1" },
+            eventForOrg(ORG_A).identity,
+          ),
+        ),
+      ).rejects.toThrow(CrossOrgAccessError);
+      expect(mockDeleteResource).not.toHaveBeenCalled();
+    });
+
+    test("fails closed when the record is missing entirely (both Registry and legacy)", async () => {
+      mockGetResource.mockResolvedValue(null);
+      dynamoMock.on(GetCommand).resolves({});
+
+      await expect(
+        handler(
+          makeEvent(
+            "deleteToolConfig",
+            { toolId: "missing" },
+            eventForOrg(ORG_A).identity,
+          ),
+        ),
+      ).rejects.toThrow(CrossOrgAccessError);
+      expect(mockDeleteResource).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/backend/src/lambda/__tests__/tool-config-resolver-registry-crud.test.ts
+++ b/backend/src/lambda/__tests__/tool-config-resolver-registry-crud.test.ts
@@ -11,7 +11,7 @@ import {
   deleteToolConfigRegistry,
   _resetRegistryService,
   handler,
-} from '../tool-config-resolver';
+} from "../tool-config-resolver";
 
 // ---------------------------------------------------------------------------
 // Mock RegistryService
@@ -24,7 +24,9 @@ const mockDeleteResource = jest.fn();
 const mockListResources = jest.fn();
 const mockUpdateResourceStatus = jest.fn();
 const mockSearchResources = jest.fn();
-const mockSerializeCustomMetadata = jest.fn((meta: unknown) => JSON.stringify(meta));
+const mockSerializeCustomMetadata = jest.fn((meta: unknown) =>
+  JSON.stringify(meta),
+);
 const mockDeserializeCustomMetadata = jest.fn(
   (json: string | null, defaults: Record<string, unknown>) => {
     if (!json) return defaults;
@@ -36,12 +38,20 @@ const mockDeserializeCustomMetadata = jest.fn(
   },
 );
 const mockToRegistryStatus = jest.fn((state: string) => {
-  const map: Record<string, string> = { active: 'APPROVED', inactive: 'DEPRECATED', maintenance: 'DRAFT' };
-  return map[state] || 'DEPRECATED';
+  const map: Record<string, string> = {
+    active: "APPROVED",
+    inactive: "DEPRECATED",
+    maintenance: "DRAFT",
+  };
+  return map[state] || "DEPRECATED";
 });
 const mockToInternalState = jest.fn((status: string) => {
-  const map: Record<string, string> = { APPROVED: 'active', DEPRECATED: 'inactive', DRAFT: 'maintenance' };
-  return map[status] || 'inactive';
+  const map: Record<string, string> = {
+    APPROVED: "active",
+    DEPRECATED: "inactive",
+    DRAFT: "maintenance",
+  };
+  return map[status] || "inactive";
 });
 
 /** Registry record fixture shape consumed by the mock mappers. */
@@ -57,12 +67,18 @@ interface RegistryRecordFixture {
 
 const mockMapToToolConfig = jest.fn((record: RegistryRecordFixture) => {
   const meta = record.customDescriptorContent
-    ? (() => { try { return JSON.parse(record.customDescriptorContent); } catch { return {}; } })()
+    ? (() => {
+        try {
+          return JSON.parse(record.customDescriptorContent);
+        } catch {
+          return {};
+        }
+      })()
     : {};
   return {
     toolId: record.recordId,
-    orgId: meta.orgId ?? '',
-    config: record.description || '',
+    orgId: meta.orgId ?? "",
+    config: record.description || "",
     state: mockToInternalState(record.status),
     categories: meta.categories || [],
     integrationBindings: meta.integrationBindings || null,
@@ -73,16 +89,16 @@ const mockMapToToolConfig = jest.fn((record: RegistryRecordFixture) => {
 });
 const mockMapToAgentConfig = jest.fn((record: RegistryRecordFixture) => ({
   agentId: record.recordId,
-  config: record.description || '',
-  state: 'active',
+  config: record.description || "",
+  state: "active",
   categories: [],
   createdAt: record.createdAt?.toISOString?.() ?? record.createdAt,
   updatedAt: record.updatedAt?.toISOString?.() ?? record.updatedAt,
 }));
 
-jest.mock('../../services/registry-service', () => ({
+jest.mock("../../services/registry-service", () => ({
   RegistryService: jest.fn().mockImplementation(() => ({
-    getRegistryId: () => 'test-registry',
+    getRegistryId: () => "test-registry",
     createResource: mockCreateResource,
     getResource: mockGetResource,
     updateResource: mockUpdateResource,
@@ -100,26 +116,30 @@ jest.mock('../../services/registry-service', () => ({
 }));
 
 // Mock DynamoDB for fallback paths
-import { DynamoDBDocumentClient, ScanCommand, GetCommand } from '@aws-sdk/lib-dynamodb';
-import { mockClient } from 'aws-sdk-client-mock';
+import {
+  DynamoDBDocumentClient,
+  ScanCommand,
+  GetCommand,
+} from "@aws-sdk/lib-dynamodb";
+import { mockClient } from "aws-sdk-client-mock";
 const dynamoMock = mockClient(DynamoDBDocumentClient);
 
-describe('Registry-backed CRUD functions (tasks 7.2–7.6)', () => {
+describe("Registry-backed CRUD functions (tasks 7.2–7.6)", () => {
   const originalEnv = process.env;
   // Fixture identity that carries a tenant claim the same way AppSync
   // delivers it in production. Tests pass this to the registry-path
   // functions as the third arg so extractOrgFromEvent resolves without
   // falling back to Cognito.
   const eventWithOrg = {
-    identity: { claims: { 'custom:organization': 'test-org-a' } },
+    identity: { claims: { "custom:organization": "test-org-a" } },
   };
 
   beforeEach(() => {
     process.env = {
       ...originalEnv,
-      REGISTRY_ENABLED: 'true',
-      REGISTRY_ID: 'test-registry',
-      TOOLS_CONFIG_TABLE: 'test-tools',
+      REGISTRY_ENABLED: "true",
+      REGISTRY_ID: "test-registry",
+      TOOLS_CONFIG_TABLE: "test-tools",
     };
     _resetRegistryService();
     jest.clearAllMocks();
@@ -138,66 +158,99 @@ describe('Registry-backed CRUD functions (tasks 7.2–7.6)', () => {
     info: { fieldName },
     arguments: args,
     identity: identity ?? {
-      sub: 'test-user',
-      claims: { 'custom:organization': 'test-org-a' },
+      sub: "test-user",
+      claims: { "custom:organization": "test-org-a" },
     },
   });
 
   // ─── listToolConfigsRegistry (task 7.2) ─────────────────────
 
-  describe('listToolConfigsRegistry', () => {
-    test('merges Registry and DynamoDB records', async () => {
+  describe("listToolConfigsRegistry", () => {
+    test("merges Registry and DynamoDB records", async () => {
       mockListResources.mockResolvedValue([
-        { recordId: 't1', name: 'Tool1', description: '{}', status: 'APPROVED', customDescriptorContent: JSON.stringify({ orgId: 'test-org-a' }) },
+        {
+          recordId: "t1",
+          name: "Tool1",
+          description: "{}",
+          status: "APPROVED",
+          customDescriptorContent: JSON.stringify({ orgId: "test-org-a" }),
+        },
       ]);
       dynamoMock.on(ScanCommand).resolves({
         Items: [
-          { toolId: 't2', config: { name: 'Tool2' }, state: 'active', orgId: 'test-org-a' },
+          {
+            toolId: "t2",
+            config: { name: "Tool2" },
+            state: "active",
+            orgId: "test-org-a",
+          },
         ],
       });
 
       const result = await listToolConfigsRegistry(eventWithOrg);
       expect(result).toHaveLength(2);
-      expect(result[0].toolId).toBe('t1');
-      expect(result[1].toolId).toBe('t2');
+      expect(result[0].toolId).toBe("t1");
+      expect(result[1].toolId).toBe("t2");
     });
 
-    test('Registry wins on duplicate toolIds', async () => {
+    test("Registry wins on duplicate toolIds", async () => {
       // Updated for 420d0ae name-based dedup: post-420d0ae, registry toolId is
       // a recordId (not the name), so dedupe now keys off config.name. The two
       // rows below share name "SharedTool" across Registry and DDB.
       mockListResources.mockResolvedValue([
-        { recordId: 't1', name: 'SharedTool', description: '{"name":"SharedTool"}', status: 'APPROVED', customDescriptorContent: JSON.stringify({ orgId: 'test-org-a' }) },
+        {
+          recordId: "t1",
+          name: "SharedTool",
+          description: '{"name":"SharedTool"}',
+          status: "APPROVED",
+          customDescriptorContent: JSON.stringify({ orgId: "test-org-a" }),
+        },
       ]);
       dynamoMock.on(ScanCommand).resolves({
         Items: [
-          { toolId: 't1', config: { name: 'SharedTool' }, state: 'active', orgId: 'test-org-a' },
+          {
+            toolId: "t1",
+            config: { name: "SharedTool" },
+            state: "active",
+            orgId: "test-org-a",
+          },
         ],
       });
 
       const result = await listToolConfigsRegistry(eventWithOrg);
       expect(result).toHaveLength(1);
-      expect(result[0].toolId).toBe('t1');
+      expect(result[0].toolId).toBe("t1");
       // The mapped config comes from Registry
       expect(mockMapToToolConfig).toHaveBeenCalled();
     });
 
-    test('returns only DynamoDB records when Registry is empty', async () => {
+    test("returns only DynamoDB records when Registry is empty", async () => {
       mockListResources.mockResolvedValue([]);
       dynamoMock.on(ScanCommand).resolves({
         Items: [
-          { toolId: 't1', config: { name: 'Tool1' }, state: 'active', orgId: 'test-org-a' },
+          {
+            toolId: "t1",
+            config: { name: "Tool1" },
+            state: "active",
+            orgId: "test-org-a",
+          },
         ],
       });
 
       const result = await listToolConfigsRegistry(eventWithOrg);
       expect(result).toHaveLength(1);
-      expect(result[0].toolId).toBe('t1');
+      expect(result[0].toolId).toBe("t1");
     });
 
-    test('returns only Registry records when DynamoDB is empty', async () => {
+    test("returns only Registry records when DynamoDB is empty", async () => {
       mockListResources.mockResolvedValue([
-        { recordId: 't1', name: 'Tool1', description: '{}', status: 'APPROVED', customDescriptorContent: JSON.stringify({ orgId: 'test-org-a' }) },
+        {
+          recordId: "t1",
+          name: "Tool1",
+          description: "{}",
+          status: "APPROVED",
+          customDescriptorContent: JSON.stringify({ orgId: "test-org-a" }),
+        },
       ]);
       dynamoMock.on(ScanCommand).resolves({ Items: [] });
 
@@ -208,373 +261,491 @@ describe('Registry-backed CRUD functions (tasks 7.2–7.6)', () => {
 
   // ─── getToolConfigRegistry (task 7.3) ───────────────────────
 
-  describe('getToolConfigRegistry', () => {
-    test('returns Registry record when found', async () => {
+  describe("getToolConfigRegistry", () => {
+    test("returns Registry record when found", async () => {
       mockGetResource.mockResolvedValue({
-        recordId: 't1', name: 'Tool1', description: '{}', status: 'APPROVED',
-        customDescriptorContent: JSON.stringify({ orgId: 'test-org-a' }),
+        recordId: "t1",
+        name: "Tool1",
+        description: "{}",
+        status: "APPROVED",
+        customDescriptorContent: JSON.stringify({ orgId: "test-org-a" }),
       });
 
-      const result = await getToolConfigRegistry('t1', eventWithOrg);
+      const result = await getToolConfigRegistry("t1", eventWithOrg);
       expect(result).toBeDefined();
-      expect(result!.toolId).toBe('t1');
-      expect(mockGetResource).toHaveBeenCalledWith('tool', 't1');
+      expect(result!.toolId).toBe("t1");
+      expect(mockGetResource).toHaveBeenCalledWith("tool", "t1");
     });
 
-    test('falls back to DynamoDB when not in Registry', async () => {
+    test("falls back to DynamoDB when not in Registry", async () => {
       mockGetResource.mockResolvedValue(null);
       dynamoMock.on(GetCommand).resolves({
-        Item: { toolId: 't1', config: { name: 'Tool1' }, state: 'active', orgId: 'test-org-a' },
+        Item: {
+          toolId: "t1",
+          config: { name: "Tool1" },
+          state: "active",
+          orgId: "test-org-a",
+        },
       });
 
-      const result = await getToolConfigRegistry('t1', eventWithOrg);
+      const result = await getToolConfigRegistry("t1", eventWithOrg);
       expect(result).toBeDefined();
-      expect(result!.toolId).toBe('t1');
+      expect(result!.toolId).toBe("t1");
     });
 
-    test('returns null when not found in either source', async () => {
+    test("returns null when not found in either source", async () => {
       mockGetResource.mockResolvedValue(null);
       dynamoMock.on(GetCommand).resolves({});
 
-      const result = await getToolConfigRegistry('missing', eventWithOrg);
+      const result = await getToolConfigRegistry("missing", eventWithOrg);
       expect(result).toBeNull();
     });
   });
 
   // ─── createToolConfigRegistry (task 7.4) ────────────────────
 
-  describe('createToolConfigRegistry', () => {
+  describe("createToolConfigRegistry", () => {
     const baseRecord = {
-      recordId: 'tool-1',
-      name: 'TestTool',
+      recordId: "tool-1",
+      name: "TestTool",
       description: '{"name":"TestTool"}',
-      status: 'DRAFT',
-      customDescriptorContent: '{}',
-      createdAt: new Date('2025-01-01'),
-      updatedAt: new Date('2025-01-01'),
+      status: "DRAFT",
+      customDescriptorContent: "{}",
+      createdAt: new Date("2025-01-01"),
+      updatedAt: new Date("2025-01-01"),
     };
 
-    test('creates a Registry resource with serialized custom metadata', async () => {
+    test("creates a Registry resource with serialized custom metadata", async () => {
       mockCreateResource.mockResolvedValue(baseRecord);
 
-      await createToolConfigRegistry({
-        toolId: 'tool-1',
-        config: '{"name":"TestTool","description":"A tool for testing"}',
-        state: 'active',
-        categories: ['cat1'],
-        icon: 'icon.png',
-      }, 'unknown', eventWithOrg);
+      await createToolConfigRegistry(
+        {
+          toolId: "tool-1",
+          config: '{"name":"TestTool","description":"A tool for testing"}',
+          state: "active",
+          categories: ["cat1"],
+          icon: "icon.png",
+        },
+        "unknown",
+        eventWithOrg,
+      );
 
       // New contract: customMetadata now carries the full config JSON plus
       // createdBy (defaulted to 'unknown' when no caller id is threaded) and
       // orgId sourced from the JWT claim.
       expect(mockSerializeCustomMetadata).toHaveBeenCalledWith({
-        categories: ['cat1'],
-        icon: 'icon.png',
-        state: 'active',
+        categories: ["cat1"],
+        icon: "icon.png",
+        state: "active",
         integrationBindings: undefined,
         dataStoreBindings: undefined,
         appId: undefined,
         config: '{"name":"TestTool","description":"A tool for testing"}',
-        createdBy: 'unknown',
-        orgId: 'test-org-a',
+        createdBy: "unknown",
+        orgId: "test-org-a",
       });
       // Registry `description` now holds the plain human string, not the
       // full JSON blob.
-      expect(mockCreateResource).toHaveBeenCalledWith('tool', 'tool-1', {
-        name: 'TestTool',
-        description: 'A tool for testing',
+      expect(mockCreateResource).toHaveBeenCalledWith("tool", "tool-1", {
+        name: "TestTool",
+        description: "A tool for testing",
         customMetadata: expect.any(String),
       });
     });
 
-    test('createResource is called with plain description when config.description is absent', async () => {
+    test("createResource is called with plain description when config.description is absent", async () => {
       mockCreateResource.mockResolvedValue(baseRecord);
 
-      await createToolConfigRegistry({
-        toolId: 'tool-1',
-        config: '{"name":"TestTool"}',
-      }, 'unknown', eventWithOrg);
+      await createToolConfigRegistry(
+        {
+          toolId: "tool-1",
+          config: '{"name":"TestTool"}',
+        },
+        "unknown",
+        eventWithOrg,
+      );
 
       // No `description` field in the config → pass empty string, never the
       // full JSON blob.
-      expect(mockCreateResource).toHaveBeenCalledWith('tool', 'tool-1', {
-        name: 'TestTool',
-        description: '',
+      expect(mockCreateResource).toHaveBeenCalledWith("tool", "tool-1", {
+        name: "TestTool",
+        description: "",
         customMetadata: expect.any(String),
       });
     });
 
-    test('threads caller userId into customMetadata.createdBy', async () => {
+    test("threads caller userId into customMetadata.createdBy", async () => {
       mockCreateResource.mockResolvedValue(baseRecord);
 
       await createToolConfigRegistry(
-        { toolId: 'tool-1', config: '{"name":"TestTool"}' },
-        'test-user-abc',
+        { toolId: "tool-1", config: '{"name":"TestTool"}' },
+        "test-user-abc",
         eventWithOrg,
       );
 
       expect(mockSerializeCustomMetadata).toHaveBeenCalledWith(
-        expect.objectContaining({ createdBy: 'test-user-abc' }),
+        expect.objectContaining({ createdBy: "test-user-abc" }),
       );
     });
 
-    test('validates integrationBindings before Registry write', async () => {
+    test("validates integrationBindings before Registry write", async () => {
       await expect(
-        createToolConfigRegistry({
-          toolId: 'tool-1',
-          config: '{"name":"TestTool"}',
-          integrationBindings: [{ integrationType: 'SLACK' }], // missing integrationId
-        }, 'unknown', eventWithOrg),
-      ).rejects.toThrow('integrationBinding missing required field "integrationId"');
+        createToolConfigRegistry(
+          {
+            toolId: "tool-1",
+            config: '{"name":"TestTool"}',
+            integrationBindings: [{ integrationType: "SLACK" }], // missing integrationId
+          },
+          "unknown",
+          eventWithOrg,
+        ),
+      ).rejects.toThrow(
+        'integrationBinding missing required field "integrationId"',
+      );
     });
 
-    test('validates dataStoreBindings before Registry write', async () => {
+    test("validates dataStoreBindings before Registry write", async () => {
       await expect(
-        createToolConfigRegistry({
-          toolId: 'tool-1',
+        createToolConfigRegistry(
+          {
+            toolId: "tool-1",
+            config: '{"name":"TestTool"}',
+            dataStoreBindings: [{ dataStoreId: "ds1" }], // missing dataStoreType
+          },
+          "unknown",
+          eventWithOrg,
+        ),
+      ).rejects.toThrow(
+        'dataStoreBinding missing required field "dataStoreType"',
+      );
+    });
+
+    test("updates status when initial state is provided", async () => {
+      mockCreateResource.mockResolvedValue(baseRecord);
+
+      await createToolConfigRegistry(
+        {
+          toolId: "tool-1",
           config: '{"name":"TestTool"}',
-          dataStoreBindings: [{ dataStoreId: 'ds1' }], // missing dataStoreType
-        }, 'unknown', eventWithOrg),
-      ).rejects.toThrow('dataStoreBinding missing required field "dataStoreType"');
+          state: "active",
+        },
+        "unknown",
+        eventWithOrg,
+      );
+
+      expect(mockToRegistryStatus).toHaveBeenCalledWith("active");
+      expect(mockUpdateResourceStatus).toHaveBeenCalledWith(
+        "tool",
+        "tool-1",
+        "APPROVED",
+      );
     });
 
-    test('updates status when initial state is provided', async () => {
+    test("includes bindings in custom metadata", async () => {
       mockCreateResource.mockResolvedValue(baseRecord);
 
-      await createToolConfigRegistry({
-        toolId: 'tool-1',
-        config: '{"name":"TestTool"}',
-        state: 'active',
-      }, 'unknown', eventWithOrg);
+      await createToolConfigRegistry(
+        {
+          toolId: "tool-1",
+          config: '{"name":"TestTool"}',
+          integrationBindings: [
+            { integrationId: "int1", integrationType: "SLACK" },
+          ],
+          dataStoreBindings: [{ dataStoreId: "ds1", dataStoreType: "S3" }],
+        },
+        "unknown",
+        eventWithOrg,
+      );
 
-      expect(mockToRegistryStatus).toHaveBeenCalledWith('active');
-      expect(mockUpdateResourceStatus).toHaveBeenCalledWith('tool', 'tool-1', 'APPROVED');
+      expect(mockSerializeCustomMetadata).toHaveBeenCalledWith(
+        expect.objectContaining({
+          integrationBindings: [
+            { integrationId: "int1", integrationType: "SLACK" },
+          ],
+          dataStoreBindings: [{ dataStoreId: "ds1", dataStoreType: "S3" }],
+        }),
+      );
     });
 
-    test('includes bindings in custom metadata', async () => {
+    test("returns mapped ToolConfig", async () => {
       mockCreateResource.mockResolvedValue(baseRecord);
 
-      await createToolConfigRegistry({
-        toolId: 'tool-1',
-        config: '{"name":"TestTool"}',
-        integrationBindings: [{ integrationId: 'int1', integrationType: 'SLACK' }],
-        dataStoreBindings: [{ dataStoreId: 'ds1', dataStoreType: 'S3' }],
-      }, 'unknown', eventWithOrg);
-
-      expect(mockSerializeCustomMetadata).toHaveBeenCalledWith(expect.objectContaining({
-        integrationBindings: [{ integrationId: 'int1', integrationType: 'SLACK' }],
-        dataStoreBindings: [{ dataStoreId: 'ds1', dataStoreType: 'S3' }],
-      }));
-    });
-
-    test('returns mapped ToolConfig', async () => {
-      mockCreateResource.mockResolvedValue(baseRecord);
-
-      const result = await createToolConfigRegistry({
-        toolId: 'tool-1',
-        config: '{"name":"TestTool"}',
-      }, 'unknown', eventWithOrg);
+      const result = await createToolConfigRegistry(
+        {
+          toolId: "tool-1",
+          config: '{"name":"TestTool"}',
+        },
+        "unknown",
+        eventWithOrg,
+      );
 
       expect(mockMapToToolConfig).toHaveBeenCalledWith(baseRecord);
-      expect(result.toolId).toBe('tool-1');
+      expect(result.toolId).toBe("tool-1");
     });
 
     // ── Phase-2a: orgId captured from JWT, not from input ──
-    test('(a) orgId captured from the JWT claim and stored in customMetadata', async () => {
+    test("(a) orgId captured from the JWT claim and stored in customMetadata", async () => {
       mockCreateResource.mockResolvedValue(baseRecord);
 
       await createToolConfigRegistry(
-        { toolId: 'tool-1', config: '{"name":"TestTool"}' },
-        'unknown',
+        { toolId: "tool-1", config: '{"name":"TestTool"}' },
+        "unknown",
         eventWithOrg,
       );
 
       expect(mockSerializeCustomMetadata).toHaveBeenCalledWith(
-        expect.objectContaining({ orgId: 'test-org-a' }),
+        expect.objectContaining({ orgId: "test-org-a" }),
       );
     });
 
-    test('throws when caller has no organization claim', async () => {
+    test("throws when caller has no organization claim", async () => {
       await expect(
         createToolConfigRegistry(
-          { toolId: 'tool-1', config: '{"name":"TestTool"}' },
-          'unknown',
+          { toolId: "tool-1", config: '{"name":"TestTool"}' },
+          "unknown",
           {}, // empty event, no identity
         ),
-      ).rejects.toThrow('Cannot determine caller organization');
+      ).rejects.toThrow("Cannot determine caller organization");
       expect(mockCreateResource).not.toHaveBeenCalled();
     });
   });
 
   // ─── updateToolConfigRegistry (task 7.4) ────────────────────
 
-  describe('updateToolConfigRegistry', () => {
+  describe("updateToolConfigRegistry", () => {
     const existingRecord = {
-      recordId: 'tool-1',
-      name: 'ExistingTool',
+      recordId: "tool-1",
+      name: "ExistingTool",
       description: '{"name":"ExistingTool"}',
-      status: 'APPROVED',
+      status: "APPROVED",
       customDescriptorContent: JSON.stringify({
-        categories: ['old-cat'],
-        icon: 'old-icon.png',
-        state: 'active',
-        integrationBindings: [{ integrationId: 'int1', integrationType: 'SLACK' }],
+        categories: ["old-cat"],
+        icon: "old-icon.png",
+        state: "active",
+        orgId: "test-org-a",
+        integrationBindings: [
+          { integrationId: "int1", integrationType: "SLACK" },
+        ],
       }),
-      createdAt: new Date('2025-01-01'),
-      updatedAt: new Date('2025-01-01'),
+      createdAt: new Date("2025-01-01"),
+      updatedAt: new Date("2025-01-01"),
     };
 
     const updatedRecord = {
       ...existingRecord,
-      updatedAt: new Date('2025-01-02'),
+      updatedAt: new Date("2025-01-02"),
     };
 
-    test('throws when tool not found in Registry', async () => {
+    test("throws when tool not found in Registry", async () => {
       mockGetResource.mockResolvedValue(null);
 
       await expect(
-        updateToolConfigRegistry({ toolId: 'missing' }, 'unknown', eventWithOrg),
-      ).rejects.toThrow('Tool config not found: missing');
+        updateToolConfigRegistry(
+          { toolId: "missing" },
+          "unknown",
+          eventWithOrg,
+        ),
+      ).rejects.toThrow("Tool config not found: missing");
     });
 
-    test('updates resource with merged metadata', async () => {
+    test("updates resource with merged metadata", async () => {
       mockGetResource.mockResolvedValue(existingRecord);
       mockUpdateResource.mockResolvedValue(updatedRecord);
 
-      await updateToolConfigRegistry({
-        toolId: 'tool-1',
-        categories: ['new-cat'],
-      }, 'unknown', eventWithOrg);
+      await updateToolConfigRegistry(
+        {
+          toolId: "tool-1",
+          categories: ["new-cat"],
+        },
+        "unknown",
+        eventWithOrg,
+      );
 
-      expect(mockUpdateResource).toHaveBeenCalledWith('tool', 'tool-1', expect.objectContaining({
-        customMetadata: expect.any(String),
-      }));
+      expect(mockUpdateResource).toHaveBeenCalledWith(
+        "tool",
+        "tool-1",
+        expect.objectContaining({
+          customMetadata: expect.any(String),
+        }),
+      );
     });
 
-    test('updates Registry status when state changes', async () => {
+    test("updates Registry status when state changes", async () => {
       mockGetResource.mockResolvedValue(existingRecord);
       mockUpdateResource.mockResolvedValue(updatedRecord);
 
-      await updateToolConfigRegistry({
-        toolId: 'tool-1',
-        state: 'inactive',
-      }, 'unknown', eventWithOrg);
+      await updateToolConfigRegistry(
+        {
+          toolId: "tool-1",
+          state: "inactive",
+        },
+        "unknown",
+        eventWithOrg,
+      );
 
-      expect(mockToRegistryStatus).toHaveBeenCalledWith('inactive');
-      expect(mockUpdateResourceStatus).toHaveBeenCalledWith('tool', 'tool-1', 'DEPRECATED');
+      expect(mockToRegistryStatus).toHaveBeenCalledWith("inactive");
+      expect(mockUpdateResourceStatus).toHaveBeenCalledWith(
+        "tool",
+        "tool-1",
+        "DEPRECATED",
+      );
     });
 
-    test('does not update status when state is unchanged', async () => {
+    test("does not update status when state is unchanged", async () => {
       mockGetResource.mockResolvedValue(existingRecord);
       mockUpdateResource.mockResolvedValue(updatedRecord);
 
-      await updateToolConfigRegistry({
-        toolId: 'tool-1',
-        categories: ['new-cat'],
-      }, 'unknown', eventWithOrg);
+      await updateToolConfigRegistry(
+        {
+          toolId: "tool-1",
+          categories: ["new-cat"],
+        },
+        "unknown",
+        eventWithOrg,
+      );
 
       expect(mockUpdateResourceStatus).not.toHaveBeenCalled();
     });
 
-    test('preserves existing bindings when not provided in input', async () => {
+    test("preserves existing bindings when not provided in input", async () => {
       mockGetResource.mockResolvedValue(existingRecord);
       mockUpdateResource.mockResolvedValue(updatedRecord);
 
-      await updateToolConfigRegistry({
-        toolId: 'tool-1',
-        state: 'inactive',
-      }, 'unknown', eventWithOrg);
+      await updateToolConfigRegistry(
+        {
+          toolId: "tool-1",
+          state: "inactive",
+        },
+        "unknown",
+        eventWithOrg,
+      );
 
       // Should preserve existing integrationBindings from metadata
-      expect(mockSerializeCustomMetadata).toHaveBeenCalledWith(expect.objectContaining({
-        integrationBindings: [{ integrationId: 'int1', integrationType: 'SLACK' }],
-      }));
+      expect(mockSerializeCustomMetadata).toHaveBeenCalledWith(
+        expect.objectContaining({
+          integrationBindings: [
+            { integrationId: "int1", integrationType: "SLACK" },
+          ],
+        }),
+      );
     });
 
-    test('validates new bindings before Registry write', async () => {
+    test("validates new bindings before Registry write", async () => {
       mockGetResource.mockResolvedValue(existingRecord);
 
       await expect(
-        updateToolConfigRegistry({
-          toolId: 'tool-1',
-          integrationBindings: [{ integrationType: 'JIRA' }], // missing integrationId
-        }, 'unknown', eventWithOrg),
-      ).rejects.toThrow('integrationBinding missing required field "integrationId"');
+        updateToolConfigRegistry(
+          {
+            toolId: "tool-1",
+            integrationBindings: [{ integrationType: "JIRA" }], // missing integrationId
+          },
+          "unknown",
+          eventWithOrg,
+        ),
+      ).rejects.toThrow(
+        'integrationBinding missing required field "integrationId"',
+      );
     });
 
-    test('returns mapped ToolConfig', async () => {
+    test("returns mapped ToolConfig", async () => {
       mockGetResource.mockResolvedValue(existingRecord);
       mockUpdateResource.mockResolvedValue(updatedRecord);
 
       // No state change → no refetch, mapToToolConfig receives the
       // updateResource response directly.
-      const result = await updateToolConfigRegistry({
-        toolId: 'tool-1',
-        categories: ['new-cat'],
-      }, 'unknown', eventWithOrg);
+      const result = await updateToolConfigRegistry(
+        {
+          toolId: "tool-1",
+          categories: ["new-cat"],
+        },
+        "unknown",
+        eventWithOrg,
+      );
 
       expect(mockMapToToolConfig).toHaveBeenCalledWith(updatedRecord);
-      expect(result.toolId).toBe('tool-1');
+      expect(result.toolId).toBe("tool-1");
     });
 
-    test('updateResource receives plain description from config.description', async () => {
+    test("updateResource receives plain description from config.description", async () => {
       mockGetResource.mockResolvedValue(existingRecord);
       mockUpdateResource.mockResolvedValue(updatedRecord);
 
-      await updateToolConfigRegistry({
-        toolId: 'tool-1',
-        config: '{"name":"ExistingTool","description":"Updated desc"}',
-      }, 'unknown', eventWithOrg);
+      await updateToolConfigRegistry(
+        {
+          toolId: "tool-1",
+          config: '{"name":"ExistingTool","description":"Updated desc"}',
+        },
+        "unknown",
+        eventWithOrg,
+      );
 
       // Registry `description` now holds only the plain human string, while
       // the full config payload is routed through customMetadata.config.
-      expect(mockUpdateResource).toHaveBeenCalledWith('tool', 'tool-1', expect.objectContaining({
-        name: 'ExistingTool',
-        description: 'Updated desc',
-        customMetadata: expect.any(String),
-      }));
-      expect(mockSerializeCustomMetadata).toHaveBeenCalledWith(expect.objectContaining({
-        config: '{"name":"ExistingTool","description":"Updated desc"}',
-      }));
+      expect(mockUpdateResource).toHaveBeenCalledWith(
+        "tool",
+        "tool-1",
+        expect.objectContaining({
+          name: "ExistingTool",
+          description: "Updated desc",
+          customMetadata: expect.any(String),
+        }),
+      );
+      expect(mockSerializeCustomMetadata).toHaveBeenCalledWith(
+        expect.objectContaining({
+          config: '{"name":"ExistingTool","description":"Updated desc"}',
+        }),
+      );
     });
 
-    test('preserves existing createdBy when updating a record', async () => {
+    test("preserves existing createdBy when updating a record", async () => {
       const recordWithCreator = {
         ...existingRecord,
         customDescriptorContent: JSON.stringify({
-          categories: ['old-cat'],
-          icon: 'old-icon.png',
-          state: 'active',
-          createdBy: 'original-creator',
+          categories: ["old-cat"],
+          icon: "old-icon.png",
+          state: "active",
+          orgId: "test-org-a",
+          createdBy: "original-creator",
         }),
       };
       mockGetResource.mockResolvedValue(recordWithCreator);
       mockUpdateResource.mockResolvedValue(updatedRecord);
 
-      await updateToolConfigRegistry({ toolId: 'tool-1', categories: ['new-cat'] }, 'different-user', eventWithOrg);
+      await updateToolConfigRegistry(
+        { toolId: "tool-1", categories: ["new-cat"] },
+        "different-user",
+        eventWithOrg,
+      );
 
-      expect(mockSerializeCustomMetadata).toHaveBeenCalledWith(expect.objectContaining({
-        createdBy: 'original-creator',
-      }));
+      expect(mockSerializeCustomMetadata).toHaveBeenCalledWith(
+        expect.objectContaining({
+          createdBy: "original-creator",
+        }),
+      );
     });
 
-    test('assigns caller userId to legacy record missing createdBy', async () => {
+    test("assigns caller userId to legacy record missing createdBy", async () => {
       mockGetResource.mockResolvedValue(existingRecord); // no createdBy in existingRecord
       mockUpdateResource.mockResolvedValue(updatedRecord);
 
-      await updateToolConfigRegistry({ toolId: 'tool-1', categories: ['new-cat'] }, 'editor-user', eventWithOrg);
+      await updateToolConfigRegistry(
+        { toolId: "tool-1", categories: ["new-cat"] },
+        "editor-user",
+        eventWithOrg,
+      );
 
-      expect(mockSerializeCustomMetadata).toHaveBeenCalledWith(expect.objectContaining({
-        createdBy: 'editor-user',
-      }));
+      expect(mockSerializeCustomMetadata).toHaveBeenCalledWith(
+        expect.objectContaining({
+          createdBy: "editor-user",
+        }),
+      );
     });
 
-    test('re-fetches resource after updateResourceStatus so returned state reflects post-transition record', async () => {
+    test("re-fetches resource after updateResourceStatus so returned state reflects post-transition record", async () => {
       const refreshedRecord = {
         ...existingRecord,
-        status: 'DEPRECATED',
-        updatedAt: new Date('2025-01-03'),
+        status: "DEPRECATED",
+        updatedAt: new Date("2025-01-03"),
       };
       // First getResource → existing (for merge); Second getResource → refreshed (after status change).
       mockGetResource
@@ -582,11 +753,19 @@ describe('Registry-backed CRUD functions (tasks 7.2–7.6)', () => {
         .mockResolvedValueOnce(refreshedRecord);
       mockUpdateResource.mockResolvedValue(updatedRecord);
 
-      await updateToolConfigRegistry({ toolId: 'tool-1', state: 'inactive' }, 'unknown', eventWithOrg);
+      await updateToolConfigRegistry(
+        { toolId: "tool-1", state: "inactive" },
+        "unknown",
+        eventWithOrg,
+      );
 
       // getResource must be called twice: once before updateResource, once AFTER updateResourceStatus.
       expect(mockGetResource).toHaveBeenCalledTimes(2);
-      expect(mockUpdateResourceStatus).toHaveBeenCalledWith('tool', 'tool-1', 'DEPRECATED');
+      expect(mockUpdateResourceStatus).toHaveBeenCalledWith(
+        "tool",
+        "tool-1",
+        "DEPRECATED",
+      );
       // mapToToolConfig receives the refreshed record (not the stale updatedRecord).
       expect(mockMapToToolConfig).toHaveBeenCalledWith(refreshedRecord);
 
@@ -597,52 +776,89 @@ describe('Registry-backed CRUD functions (tasks 7.2–7.6)', () => {
     });
 
     // ── Phase-2a: update preserves existingMeta.orgId, never derives from input ──
-    test('(b) preserves existingMeta.orgId on update (never replaces it with caller org)', async () => {
+    test("(b) preserves existingMeta.orgId on update for a same-org caller (never replaces it with caller org)", async () => {
       const recordWithOrg = {
         ...existingRecord,
         customDescriptorContent: JSON.stringify({
-          categories: ['c'],
-          icon: '',
-          state: 'active',
-          orgId: 'original-owner-org',
+          categories: ["c"],
+          icon: "",
+          state: "active",
+          orgId: "original-owner-org",
         }),
       };
       mockGetResource.mockResolvedValue(recordWithOrg);
       mockUpdateResource.mockResolvedValue(updatedRecord);
 
       await updateToolConfigRegistry(
-        { toolId: 'tool-1', categories: ['new-cat'] },
-        'unknown',
-        { identity: { claims: { 'custom:organization': 'different-caller-org' } } },
+        { toolId: "tool-1", categories: ["new-cat"] },
+        "unknown",
+        {
+          identity: { claims: { "custom:organization": "original-owner-org" } },
+        },
       );
 
       expect(mockSerializeCustomMetadata).toHaveBeenCalledWith(
-        expect.objectContaining({ orgId: 'original-owner-org' }),
+        expect.objectContaining({ orgId: "original-owner-org" }),
       );
     });
 
-    test('falls back to caller JWT org when legacy record is missing orgId', async () => {
-      // existingRecord has no orgId in customDescriptorContent → legacy path.
-      mockGetResource.mockResolvedValue(existingRecord);
-      mockUpdateResource.mockResolvedValue(updatedRecord);
+    test("(b2) refuses a cross-org caller BEFORE any Registry write, even though existingMeta.orgId would otherwise be preserved (finding 13065e38)", async () => {
+      const recordWithOrg = {
+        ...existingRecord,
+        customDescriptorContent: JSON.stringify({
+          categories: ["c"],
+          icon: "",
+          state: "active",
+          orgId: "original-owner-org",
+        }),
+      };
+      mockGetResource.mockResolvedValue(recordWithOrg);
 
-      await updateToolConfigRegistry(
-        { toolId: 'tool-1', categories: ['new-cat'] },
-        'unknown',
-        eventWithOrg,
-      );
+      await expect(
+        updateToolConfigRegistry(
+          { toolId: "tool-1", categories: ["new-cat"] },
+          "unknown",
+          {
+            identity: {
+              claims: { "custom:organization": "different-caller-org" },
+            },
+          },
+        ),
+      ).rejects.toThrow("Access denied");
+      expect(mockUpdateResource).not.toHaveBeenCalled();
+      expect(mockSerializeCustomMetadata).not.toHaveBeenCalled();
+    });
 
-      expect(mockSerializeCustomMetadata).toHaveBeenCalledWith(
-        expect.objectContaining({ orgId: 'test-org-a' }),
-      );
+    test("fails closed when legacy record is missing orgId, even for a caller with a resolvable org (finding 13065e38)", async () => {
+      // A record whose metadata carries no orgId at all — the fail-closed
+      // acceptance criteria requires this to be refused on update, not
+      // silently adopt the caller's org.
+      const orgLessRecord = {
+        ...existingRecord,
+        customDescriptorContent: JSON.stringify({
+          categories: ["old-cat"],
+          icon: "old-icon.png",
+          state: "active",
+        }),
+      };
+      mockGetResource.mockResolvedValue(orgLessRecord);
+
+      await expect(
+        updateToolConfigRegistry(
+          { toolId: "tool-1", categories: ["new-cat"] },
+          "unknown",
+          eventWithOrg,
+        ),
+      ).rejects.toThrow("Access denied");
+      expect(mockUpdateResource).not.toHaveBeenCalled();
     });
   });
 
   // ─── Legacy fallback & new contract mapping ─────────────────
 
-  describe('mapToToolConfig contract (registry-service)', () => {
+  describe("mapToToolConfig contract (registry-service)", () => {
     const { RegistryService: ActualRegistryService } = jest.requireActual(
-      '../../services/registry-service',
+      "../../services/registry-service",
     );
     let realService: {
       mapToToolConfig: (record: Record<string, unknown>) => { config: string };
@@ -650,47 +866,50 @@ describe('Registry-backed CRUD functions (tasks 7.2–7.6)', () => {
 
     beforeEach(() => {
       realService = new ActualRegistryService({
-        registryId: 'test-registry',
-        region: 'us-east-1',
+        registryId: "test-registry",
+        region: "us-east-1",
       });
     });
 
-    test('new contract: config sourced from customMetadata.config', () => {
+    test("new contract: config sourced from customMetadata.config", () => {
       const record = {
-        recordId: 'tool-new',
-        name: 'NewTool',
-        description: 'A plain human description',
-        status: 'APPROVED',
+        recordId: "tool-new",
+        name: "NewTool",
+        description: "A plain human description",
+        status: "APPROVED",
         customDescriptorContent: JSON.stringify({
-          categories: ['c1'],
-          icon: '',
-          state: 'active',
-          config: '{"name":"NewTool","description":"A plain human description"}',
-          createdBy: 'creator-1',
+          categories: ["c1"],
+          icon: "",
+          state: "active",
+          config:
+            '{"name":"NewTool","description":"A plain human description"}',
+          createdBy: "creator-1",
         }),
-        createdAt: new Date('2025-01-01'),
-        updatedAt: new Date('2025-01-01'),
+        createdAt: new Date("2025-01-01"),
+        updatedAt: new Date("2025-01-01"),
       };
 
       const mapped = realService.mapToToolConfig(record);
       // config comes from meta.config, NOT record.description
-      expect(mapped.config).toBe('{"name":"NewTool","description":"A plain human description"}');
+      expect(mapped.config).toBe(
+        '{"name":"NewTool","description":"A plain human description"}',
+      );
     });
 
-    test('legacy fallback: config sourced from record.description when meta.config is absent', () => {
+    test("legacy fallback: config sourced from record.description when meta.config is absent", () => {
       const record = {
-        recordId: 'tool-legacy',
-        name: 'LegacyTool',
+        recordId: "tool-legacy",
+        name: "LegacyTool",
         description: '{"name":"X"}', // full JSON blob in description — legacy layout
-        status: 'APPROVED',
+        status: "APPROVED",
         customDescriptorContent: JSON.stringify({
           categories: [],
-          icon: '',
-          state: 'active',
+          icon: "",
+          state: "active",
           // no config field
         }),
-        createdAt: new Date('2025-01-01'),
-        updatedAt: new Date('2025-01-01'),
+        createdAt: new Date("2025-01-01"),
+        updatedAt: new Date("2025-01-01"),
       };
 
       const mapped = realService.mapToToolConfig(record);
@@ -700,180 +919,257 @@ describe('Registry-backed CRUD functions (tasks 7.2–7.6)', () => {
 
   // ─── deleteToolConfigRegistry (task 7.4) ────────────────────
 
-  describe('deleteToolConfigRegistry', () => {
-    test('returns success on successful delete', async () => {
+  describe("deleteToolConfigRegistry", () => {
+    test("returns success on successful delete", async () => {
+      mockGetResource.mockResolvedValue({
+        recordId: "tool-1",
+        name: "Tool1",
+        description: "{}",
+        status: "APPROVED",
+        customDescriptorContent: JSON.stringify({ orgId: "test-org-a" }),
+      });
       mockDeleteResource.mockResolvedValue(undefined);
 
-      const result = await deleteToolConfigRegistry('tool-1');
+      const result = await deleteToolConfigRegistry("tool-1", eventWithOrg);
 
-      expect(mockDeleteResource).toHaveBeenCalledWith('tool', 'tool-1');
+      expect(mockDeleteResource).toHaveBeenCalledWith("tool", "tool-1");
       expect(result.success).toBe(true);
-      expect(result.message).toContain('tool-1');
+      expect(result.message).toContain("tool-1");
     });
 
-    test('returns failure when delete throws', async () => {
-      mockDeleteResource.mockRejectedValue(new Error('Registry error'));
+    test("returns failure when delete throws", async () => {
+      mockGetResource.mockResolvedValue({
+        recordId: "tool-1",
+        name: "Tool1",
+        description: "{}",
+        status: "APPROVED",
+        customDescriptorContent: JSON.stringify({ orgId: "test-org-a" }),
+      });
+      mockDeleteResource.mockRejectedValue(new Error("Registry error"));
 
-      const result = await deleteToolConfigRegistry('tool-1');
+      const result = await deleteToolConfigRegistry("tool-1", eventWithOrg);
 
       expect(result.success).toBe(false);
-      expect(result.message).toContain('Failed');
+      expect(result.message).toContain("Failed");
+    });
+
+    test("refuses a cross-org caller BEFORE any Registry delete (finding 13065e38)", async () => {
+      mockGetResource.mockResolvedValue({
+        recordId: "tool-1",
+        name: "Tool1",
+        description: "{}",
+        status: "APPROVED",
+        customDescriptorContent: JSON.stringify({ orgId: "other-org" }),
+      });
+
+      await expect(
+        deleteToolConfigRegistry("tool-1", eventWithOrg),
+      ).rejects.toThrow("Access denied");
+      expect(mockDeleteResource).not.toHaveBeenCalled();
     });
   });
 
   // ─── Handler dispatch (task 7.5) ────────────────────────────
 
-  describe('handler dispatch with REGISTRY_ENABLED=true', () => {
-    test('listToolConfigs dispatches to Registry path', async () => {
+  describe("handler dispatch with REGISTRY_ENABLED=true", () => {
+    test("listToolConfigs dispatches to Registry path", async () => {
       mockListResources.mockResolvedValue([]);
       dynamoMock.on(ScanCommand).resolves({ Items: [] });
 
-      const result = await handler(makeEvent('listToolConfigs', {}));
-      expect(mockListResources).toHaveBeenCalledWith('tool');
+      const result = await handler(makeEvent("listToolConfigs", {}));
+      expect(mockListResources).toHaveBeenCalledWith("tool");
       expect(result).toEqual([]);
     });
 
-    test('getToolConfig dispatches to Registry path', async () => {
+    test("getToolConfig dispatches to Registry path", async () => {
       mockGetResource.mockResolvedValue({
-        recordId: 't1', name: 'Tool1', description: '{}', status: 'APPROVED',
-        customDescriptorContent: JSON.stringify({ orgId: 'test-org-a' }),
+        recordId: "t1",
+        name: "Tool1",
+        description: "{}",
+        status: "APPROVED",
+        customDescriptorContent: JSON.stringify({ orgId: "test-org-a" }),
       });
 
-      const result = await handler(makeEvent('getToolConfig', { toolId: 't1' }));
-      expect(mockGetResource).toHaveBeenCalledWith('tool', 't1');
-      expect(result.toolId).toBe('t1');
+      const result = await handler(
+        makeEvent("getToolConfig", { toolId: "t1" }),
+      );
+      expect(mockGetResource).toHaveBeenCalledWith("tool", "t1");
+      expect(result.toolId).toBe("t1");
     });
 
-    test('listIntegrationOperations still works unchanged', async () => {
-      const result = await handler(makeEvent('listIntegrationOperations', { integrationType: 'SLACK' }));
+    test("listIntegrationOperations still works unchanged", async () => {
+      const result = await handler(
+        makeEvent("listIntegrationOperations", { integrationType: "SLACK" }),
+      );
       expect(Array.isArray(result)).toBe(true);
     });
   });
 
   // ── Phase-2a org scoping via the handler ───────────────────────
-  describe('Phase-2a org scoping (handler)', () => {
-    test('(c) list filters results to caller org', async () => {
+  describe("Phase-2a org scoping (handler)", () => {
+    test("(c) list filters results to caller org", async () => {
       const ours = {
-        recordId: 'tool-a', name: 'OurTool', description: '{}', status: 'APPROVED',
-        customDescriptorContent: JSON.stringify({ orgId: 'test-org-a' }),
+        recordId: "tool-a",
+        name: "OurTool",
+        description: "{}",
+        status: "APPROVED",
+        customDescriptorContent: JSON.stringify({ orgId: "test-org-a" }),
       };
       const theirs = {
-        recordId: 'tool-b', name: 'OtherTool', description: '{}', status: 'APPROVED',
-        customDescriptorContent: JSON.stringify({ orgId: 'other-org' }),
+        recordId: "tool-b",
+        name: "OtherTool",
+        description: "{}",
+        status: "APPROVED",
+        customDescriptorContent: JSON.stringify({ orgId: "other-org" }),
       };
       mockListResources.mockResolvedValue([ours, theirs]);
       dynamoMock.on(ScanCommand).resolves({ Items: [] });
 
-      const result = await handler(makeEvent('listToolConfigs', {}));
+      const result = await handler(makeEvent("listToolConfigs", {}));
       expect(result).toHaveLength(1);
-      expect(result[0].toolId).toBe('tool-a');
+      expect(result[0].toolId).toBe("tool-a");
     });
 
-    test('(d) admin list returns all orgs unfiltered', async () => {
+    test("(d) admin list returns all orgs unfiltered", async () => {
       const ours = {
-        recordId: 'tool-a', name: 'OurTool', description: '{}', status: 'APPROVED',
-        customDescriptorContent: JSON.stringify({ orgId: 'test-org-a' }),
+        recordId: "tool-a",
+        name: "OurTool",
+        description: "{}",
+        status: "APPROVED",
+        customDescriptorContent: JSON.stringify({ orgId: "test-org-a" }),
       };
       const theirs = {
-        recordId: 'tool-b', name: 'OtherTool', description: '{}', status: 'APPROVED',
-        customDescriptorContent: JSON.stringify({ orgId: 'other-org' }),
+        recordId: "tool-b",
+        name: "OtherTool",
+        description: "{}",
+        status: "APPROVED",
+        customDescriptorContent: JSON.stringify({ orgId: "other-org" }),
       };
       mockListResources.mockResolvedValue([ours, theirs]);
       dynamoMock.on(ScanCommand).resolves({ Items: [] });
 
       const adminIdentity = {
-        sub: 'admin',
-        claims: { 'custom:organization': 'admin-home', 'custom:role': 'admin' },
+        sub: "admin",
+        claims: { "custom:organization": "admin-home", "custom:role": "admin" },
       };
-      const result = await handler(makeEvent('listToolConfigs', {}, adminIdentity));
+      const result = await handler(
+        makeEvent("listToolConfigs", {}, adminIdentity),
+      );
       expect(result).toHaveLength(2);
     });
 
-    test('(e) get cross-org surfaces as Not found (null)', async () => {
+    test("(e) get cross-org surfaces as Not found (null)", async () => {
       mockGetResource.mockResolvedValue({
-        recordId: 'tool-x', name: 'X', description: '{}', status: 'APPROVED',
-        customDescriptorContent: JSON.stringify({ orgId: 'other-org' }),
+        recordId: "tool-x",
+        name: "X",
+        description: "{}",
+        status: "APPROVED",
+        customDescriptorContent: JSON.stringify({ orgId: "other-org" }),
       });
       dynamoMock.on(GetCommand).resolves({});
 
-      const result = await handler(makeEvent('getToolConfig', { toolId: 'tool-x' }));
+      const result = await handler(
+        makeEvent("getToolConfig", { toolId: "tool-x" }),
+      );
       expect(result).toBeNull();
     });
 
-    test('(e) admin bypasses cross-org check on get', async () => {
+    test("(e) admin bypasses cross-org check on get", async () => {
       mockGetResource.mockResolvedValue({
-        recordId: 'tool-x', name: 'X', description: '{}', status: 'APPROVED',
-        customDescriptorContent: JSON.stringify({ orgId: 'other-org' }),
+        recordId: "tool-x",
+        name: "X",
+        description: "{}",
+        status: "APPROVED",
+        customDescriptorContent: JSON.stringify({ orgId: "other-org" }),
       });
 
       const adminIdentity = {
-        sub: 'admin',
-        claims: { 'custom:organization': 'admin-home', 'custom:role': 'admin' },
+        sub: "admin",
+        claims: { "custom:organization": "admin-home", "custom:role": "admin" },
       };
-      const result = await handler(makeEvent('getToolConfig', { toolId: 'tool-x' }, adminIdentity));
-      expect(result?.toolId).toBe('tool-x');
-      expect(result?.orgId).toBe('other-org');
+      const result = await handler(
+        makeEvent("getToolConfig", { toolId: "tool-x" }, adminIdentity),
+      );
+      expect(result?.toolId).toBe("tool-x");
+      expect(result?.orgId).toBe("other-org");
     });
 
-    test('list: non-admin without orgId returns empty list', async () => {
-      mockListResources.mockResolvedValue([{
-        recordId: 't1', name: 'T', description: '{}', status: 'APPROVED',
-        customDescriptorContent: JSON.stringify({ orgId: 'test-org-a' }),
-      }]);
+    test("list: non-admin without orgId returns empty list", async () => {
+      mockListResources.mockResolvedValue([
+        {
+          recordId: "t1",
+          name: "T",
+          description: "{}",
+          status: "APPROVED",
+          customDescriptorContent: JSON.stringify({ orgId: "test-org-a" }),
+        },
+      ]);
       dynamoMock.on(ScanCommand).resolves({ Items: [] });
-      const warn = jest.spyOn(console, 'warn').mockImplementation(() => {});
+      const warn = jest.spyOn(console, "warn").mockImplementation(() => {});
 
-      const result = await handler(makeEvent('listToolConfigs', {}, {}));
+      const result = await handler(makeEvent("listToolConfigs", {}, {}));
       expect(result).toEqual([]);
       expect(warn).toHaveBeenCalled();
       warn.mockRestore();
     });
   });
 
-  describe('handler dispatch with REGISTRY_ENABLED=false', () => {
+  describe("handler dispatch with REGISTRY_ENABLED=false", () => {
     beforeEach(() => {
-      process.env.REGISTRY_ENABLED = 'false';
+      process.env.REGISTRY_ENABLED = "false";
     });
 
-    test('listToolConfigs dispatches to DynamoDB path', async () => {
+    test("listToolConfigs dispatches to DynamoDB path", async () => {
       dynamoMock.on(ScanCommand).resolves({
-        Items: [{ toolId: 't1', config: { name: 'Tool1' }, state: 'active' }],
+        Items: [{ toolId: "t1", config: { name: "Tool1" }, state: "active" }],
       });
 
-      const result = await handler(makeEvent('listToolConfigs', {}));
+      const result = await handler(makeEvent("listToolConfigs", {}));
       expect(mockListResources).not.toHaveBeenCalled();
       expect(result).toHaveLength(1);
     });
 
-    test('getToolConfig dispatches to DynamoDB path', async () => {
+    test("getToolConfig dispatches to DynamoDB path", async () => {
       dynamoMock.on(GetCommand).resolves({
-        Item: { toolId: 't1', config: { name: 'Tool1' }, state: 'active' },
+        Item: { toolId: "t1", config: { name: "Tool1" }, state: "active" },
       });
 
-      const result = await handler(makeEvent('getToolConfig', { toolId: 't1' }));
+      const result = await handler(
+        makeEvent("getToolConfig", { toolId: "t1" }),
+      );
       expect(mockGetResource).not.toHaveBeenCalled();
-      expect(result.toolId).toBe('t1');
+      expect(result.toolId).toBe("t1");
     });
   });
 
   // ─── Search handlers (task 7.6) ─────────────────────────────
 
-  describe('searchToolConfigs handler', () => {
-    test('calls searchResources with tool type and returns mapped results', async () => {
+  describe("searchToolConfigs handler", () => {
+    test("calls searchResources with tool type and returns mapped results", async () => {
       mockSearchResources.mockResolvedValue([
-        { recordId: 't1', name: 'Tool1', description: '{}', status: 'APPROVED', customDescriptorContent: '{}' },
+        {
+          recordId: "t1",
+          name: "Tool1",
+          description: "{}",
+          status: "APPROVED",
+          customDescriptorContent: "{}",
+        },
       ]);
 
-      const result = await handler(makeEvent('searchToolConfigs', { query: 'test' }));
-      expect(mockSearchResources).toHaveBeenCalledWith('tool', 'test');
+      const result = await handler(
+        makeEvent("searchToolConfigs", { query: "test" }),
+      );
+      expect(mockSearchResources).toHaveBeenCalledWith("tool", "test");
       expect(result).toHaveLength(1);
-      expect(result[0].toolId).toBe('t1');
+      expect(result[0].toolId).toBe("t1");
     });
 
-    test('returns empty array when no results', async () => {
+    test("returns empty array when no results", async () => {
       mockSearchResources.mockResolvedValue([]);
 
-      const result = await handler(makeEvent('searchToolConfigs', { query: 'nothing' }));
+      const result = await handler(
+        makeEvent("searchToolConfigs", { query: "nothing" }),
+      );
       expect(result).toEqual([]);
     });
   });

--- a/backend/src/lambda/__tests__/tool-config-resolver.property.test.ts
+++ b/backend/src/lambda/__tests__/tool-config-resolver.property.test.ts
@@ -1,45 +1,69 @@
 // Feature: tool-integration-binding, Property 1: ToolConfig Binding Round-Trip
-import * as fc from 'fast-check';
+import * as fc from "fast-check";
 
 // ---- Mock setup ----
 
 const mockDynamoSend = jest.fn();
-jest.mock('@aws-sdk/client-dynamodb', () => ({
+jest.mock("@aws-sdk/client-dynamodb", () => ({
   DynamoDBClient: jest.fn().mockImplementation(() => ({})),
 }));
-jest.mock('@aws-sdk/lib-dynamodb', () => {
-  const actual = jest.requireActual('@aws-sdk/lib-dynamodb');
+jest.mock("@aws-sdk/lib-dynamodb", () => {
+  const actual = jest.requireActual("@aws-sdk/lib-dynamodb");
   return {
     ...actual,
     DynamoDBDocumentClient: {
       from: jest.fn().mockReturnValue({ send: mockDynamoSend }),
     },
-    PutCommand: jest.fn().mockImplementation((input) => ({ _type: 'Put', input })),
-    GetCommand: jest.fn().mockImplementation((input) => ({ _type: 'Get', input })),
-    ScanCommand: jest.fn().mockImplementation((input) => ({ _type: 'Scan', input })),
-    DeleteCommand: jest.fn().mockImplementation((input) => ({ _type: 'Delete', input })),
+    PutCommand: jest
+      .fn()
+      .mockImplementation((input) => ({ _type: "Put", input })),
+    GetCommand: jest
+      .fn()
+      .mockImplementation((input) => ({ _type: "Get", input })),
+    ScanCommand: jest
+      .fn()
+      .mockImplementation((input) => ({ _type: "Scan", input })),
+    DeleteCommand: jest
+      .fn()
+      .mockImplementation((input) => ({ _type: "Delete", input })),
   };
 });
 
 // Set env before import
-process.env.TOOLS_CONFIG_TABLE = 'TestToolsConfigTable';
+process.env.TOOLS_CONFIG_TABLE = "TestToolsConfigTable";
 
 // Import handler after all mocks
-import { handler } from '../tool-config-resolver';
+import { handler } from "../tool-config-resolver";
 
 // ---- Generators ----
 
 const integrationTypeArb = fc.constantFrom(
-  'CONFLUENCE', 'JIRA', 'SLACK', 'SERVICENOW',
-  'ZENDESK', 'PAGERDUTY', 'MICROSOFT',
-  'AWS_LAMBDA', 'AWS_SMITHY', 'MCP_SERVER',
+  "CONFLUENCE",
+  "JIRA",
+  "SLACK",
+  "SERVICENOW",
+  "ZENDESK",
+  "PAGERDUTY",
+  "MICROSOFT",
+  "AWS_LAMBDA",
+  "AWS_SMITHY",
+  "MCP_SERVER",
 );
 
 const dataStoreTypeArb = fc.constantFrom(
-  'S3', 'DYNAMODB', 'RDS_POSTGRESQL', 'RDS_MYSQL',
-  'AURORA_POSTGRESQL', 'AURORA_MYSQL', 'REDSHIFT', 'OPENSEARCH',
-  'NEPTUNE', 'TIMESTREAM', 'ELASTICACHE_REDIS', 'DOCUMENTDB',
-  'KNOWLEDGE_BASE',
+  "S3",
+  "DYNAMODB",
+  "RDS_POSTGRESQL",
+  "RDS_MYSQL",
+  "AURORA_POSTGRESQL",
+  "AURORA_MYSQL",
+  "REDSHIFT",
+  "OPENSEARCH",
+  "NEPTUNE",
+  "TIMESTREAM",
+  "ELASTICACHE_REDIS",
+  "DOCUMENTDB",
+  "KNOWLEDGE_BASE",
 );
 
 const operationIdArb = fc.stringMatching(/^[a-z][a-z_]{2,20}$/);
@@ -62,13 +86,19 @@ interface DataStoreBinding {
 const integrationBindingArb: fc.Arbitrary<IntegrationBinding> = fc.record({
   integrationId: fc.stringMatching(/^int-[a-z0-9]{6,12}$/),
   integrationType: integrationTypeArb,
-  operations: fc.option(fc.array(operationIdArb, { minLength: 1, maxLength: 5 }), { nil: undefined }),
+  operations: fc.option(
+    fc.array(operationIdArb, { minLength: 1, maxLength: 5 }),
+    { nil: undefined },
+  ),
 });
 
 const dataStoreBindingArb: fc.Arbitrary<DataStoreBinding> = fc.record({
   dataStoreId: fc.stringMatching(/^ds-[a-z0-9]{6,12}$/),
   dataStoreType: dataStoreTypeArb,
-  operations: fc.option(fc.array(operationIdArb, { minLength: 1, maxLength: 5 }), { nil: undefined }),
+  operations: fc.option(
+    fc.array(operationIdArb, { minLength: 1, maxLength: 5 }),
+    { nil: undefined },
+  ),
 });
 
 const toolIdArb = fc.stringMatching(/^tool-[a-z0-9]{4,12}$/);
@@ -78,7 +108,7 @@ const toolIdArb = fc.stringMatching(/^tool-[a-z0-9]{4,12}$/);
  * (each command constructor is replaced by `{ _type, input }`).
  */
 interface FakeCommand {
-  _type: 'Put' | 'Get' | 'Scan' | 'Delete';
+  _type: "Put" | "Get" | "Scan" | "Delete";
   input: { Item?: Record<string, unknown> };
 }
 
@@ -92,6 +122,10 @@ function makeEvent(fieldName: string, args: Record<string, unknown>) {
   return {
     info: { fieldName },
     arguments: args,
+    identity: {
+      sub: "property-test-user",
+      claims: { "custom:organization": "property-test-org" },
+    },
   };
 }
 
@@ -110,8 +144,8 @@ beforeEach(() => {
  *
  * **Validates: Requirements 1.1, 1.2, 1.3, 1.5**
  */
-describe('Property 1: ToolConfig Binding Round-Trip', () => {
-  it('createToolConfig followed by getToolConfig returns deeply equal bindings', () => {
+describe("Property 1: ToolConfig Binding Round-Trip", () => {
+  it("createToolConfig followed by getToolConfig returns deeply equal bindings", () => {
     return fc.assert(
       fc.asyncProperty(
         toolIdArb,
@@ -124,17 +158,24 @@ describe('Property 1: ToolConfig Binding Round-Trip', () => {
           let storedItem: Record<string, unknown> | null = null;
 
           mockDynamoSend.mockImplementation((cmd: FakeCommand) => {
-            if (cmd._type === 'Put') {
+            if (cmd._type === "Put") {
               storedItem = { ...cmd.input.Item };
               return Promise.resolve({});
             }
-            if (cmd._type === 'Get') {
-              return Promise.resolve({ Item: storedItem ? { ...storedItem } : undefined });
+            if (cmd._type === "Get") {
+              return Promise.resolve({
+                Item: storedItem ? { ...storedItem } : undefined,
+              });
             }
             return Promise.resolve({});
           });
 
-          const configObj = { name: `tool_${toolId}`, filename: `${toolId}.py`, version: '1', description: 'test' };
+          const configObj = {
+            name: `tool_${toolId}`,
+            filename: `${toolId}.py`,
+            version: "1",
+            description: "test",
+          };
 
           const input: Record<string, unknown> = {
             toolId,
@@ -149,16 +190,20 @@ describe('Property 1: ToolConfig Binding Round-Trip', () => {
           }
 
           // Create the tool config
-          await handler(makeEvent('createToolConfig', { input }));
+          await handler(makeEvent("createToolConfig", { input }));
 
           // Read it back
-          const result = await handler(makeEvent("getToolConfig", { toolId })) as ToolConfigResult;
+          const result = (await handler(
+            makeEvent("getToolConfig", { toolId }),
+          )) as ToolConfigResult;
 
           // Assert bindings round-trip
           if (integrationBindings.length > 0) {
             const expectedIntBindings = integrationBindings.map((b) => ({
               ...b,
-              direction: b.direction ? b.direction.toUpperCase() : 'BIDIRECTIONAL',
+              direction: b.direction
+                ? b.direction.toUpperCase()
+                : "BIDIRECTIONAL",
             }));
             expect(result.integrationBindings).toEqual(expectedIntBindings);
           } else {
@@ -169,16 +214,18 @@ describe('Property 1: ToolConfig Binding Round-Trip', () => {
           if (dataStoreBindings.length > 0) {
             const expectedDsBindings = dataStoreBindings.map((b) => ({
               ...b,
-              direction: b.direction ? b.direction.toUpperCase() : 'BIDIRECTIONAL',
+              direction: b.direction
+                ? b.direction.toUpperCase()
+                : "BIDIRECTIONAL",
             }));
             expect(result.dataStoreBindings).toEqual(expectedDsBindings);
           } else {
             // When no bindings provided, should be null or undefined (backward compat)
             expect(result.dataStoreBindings ?? null).toBeNull();
           }
-        }
+        },
       ),
-      { numRuns: 100 }
+      { numRuns: 100 },
     );
   });
 });
@@ -194,161 +241,210 @@ describe('Property 1: ToolConfig Binding Round-Trip', () => {
  *
  * **Validates: Requirements 1.4**
  */
-describe('Property 2: Partial Update Preserves Unrelated Bindings', () => {
-  it('updating only integrationBindings preserves dataStoreBindings', () => {
+describe("Property 2: Partial Update Preserves Unrelated Bindings", () => {
+  it("updating only integrationBindings preserves dataStoreBindings", () => {
     return fc.assert(
       fc.asyncProperty(
         toolIdArb,
         fc.array(integrationBindingArb, { minLength: 1, maxLength: 4 }),
         fc.array(dataStoreBindingArb, { minLength: 1, maxLength: 4 }),
         fc.array(integrationBindingArb, { minLength: 1, maxLength: 4 }),
-        async (toolId, originalIntBindings, originalDsBindings, updatedIntBindings) => {
+        async (
+          toolId,
+          originalIntBindings,
+          originalDsBindings,
+          updatedIntBindings,
+        ) => {
           mockDynamoSend.mockReset();
 
           // In-memory store keyed by toolId
           let storedItem: Record<string, unknown> | null = null;
 
           mockDynamoSend.mockImplementation((cmd: FakeCommand) => {
-            if (cmd._type === 'Put') {
+            if (cmd._type === "Put") {
               storedItem = { ...cmd.input.Item };
               return Promise.resolve({});
             }
-            if (cmd._type === 'Get') {
+            if (cmd._type === "Get") {
               // Return a deep copy so mutations don't leak
               return Promise.resolve({
-                Item: storedItem ? JSON.parse(JSON.stringify(storedItem)) : undefined,
+                Item: storedItem
+                  ? JSON.parse(JSON.stringify(storedItem))
+                  : undefined,
               });
             }
             return Promise.resolve({});
           });
 
-          const configObj = { name: `tool_${toolId}`, filename: `${toolId}.py`, version: '1', description: 'test' };
+          const configObj = {
+            name: `tool_${toolId}`,
+            filename: `${toolId}.py`,
+            version: "1",
+            description: "test",
+          };
 
           // Step 1: Create with both binding types
-          await handler(makeEvent('createToolConfig', {
-            input: {
-              toolId,
-              config: JSON.stringify(configObj),
-              integrationBindings: originalIntBindings,
-              dataStoreBindings: originalDsBindings,
-            },
-          }));
+          await handler(
+            makeEvent("createToolConfig", {
+              input: {
+                toolId,
+                config: JSON.stringify(configObj),
+                integrationBindings: originalIntBindings,
+                dataStoreBindings: originalDsBindings,
+              },
+            }),
+          );
 
           // Step 2: Update only integrationBindings (omit dataStoreBindings from input)
-          await handler(makeEvent('updateToolConfig', {
-            input: {
-              toolId,
-              integrationBindings: updatedIntBindings,
-            },
-          }));
+          await handler(
+            makeEvent("updateToolConfig", {
+              input: {
+                toolId,
+                integrationBindings: updatedIntBindings,
+              },
+            }),
+          );
 
           // Step 3: Read back and verify
-          const result = await handler(makeEvent("getToolConfig", { toolId })) as ToolConfigResult;
+          const result = (await handler(
+            makeEvent("getToolConfig", { toolId }),
+          )) as ToolConfigResult;
 
           // integrationBindings should reflect the update
           const expectedUpdatedInt = updatedIntBindings.map((b) => ({
             ...b,
-            direction: b.direction ? b.direction.toUpperCase() : 'BIDIRECTIONAL',
+            direction: b.direction
+              ? b.direction.toUpperCase()
+              : "BIDIRECTIONAL",
           }));
           expect(result.integrationBindings).toEqual(expectedUpdatedInt);
 
           // dataStoreBindings should be preserved unchanged
           const expectedOriginalDs = originalDsBindings.map((b) => ({
             ...b,
-            direction: b.direction ? b.direction.toUpperCase() : 'BIDIRECTIONAL',
+            direction: b.direction
+              ? b.direction.toUpperCase()
+              : "BIDIRECTIONAL",
           }));
           expect(result.dataStoreBindings).toEqual(expectedOriginalDs);
-        }
+        },
       ),
-      { numRuns: 100 }
+      { numRuns: 100 },
     );
   });
 
-  it('updating only dataStoreBindings preserves integrationBindings', () => {
+  it("updating only dataStoreBindings preserves integrationBindings", () => {
     return fc.assert(
       fc.asyncProperty(
         toolIdArb,
         fc.array(integrationBindingArb, { minLength: 1, maxLength: 4 }),
         fc.array(dataStoreBindingArb, { minLength: 1, maxLength: 4 }),
         fc.array(dataStoreBindingArb, { minLength: 1, maxLength: 4 }),
-        async (toolId, originalIntBindings, originalDsBindings, updatedDsBindings) => {
+        async (
+          toolId,
+          originalIntBindings,
+          originalDsBindings,
+          updatedDsBindings,
+        ) => {
           mockDynamoSend.mockReset();
 
           let storedItem: Record<string, unknown> | null = null;
 
           mockDynamoSend.mockImplementation((cmd: FakeCommand) => {
-            if (cmd._type === 'Put') {
+            if (cmd._type === "Put") {
               storedItem = { ...cmd.input.Item };
               return Promise.resolve({});
             }
-            if (cmd._type === 'Get') {
+            if (cmd._type === "Get") {
               return Promise.resolve({
-                Item: storedItem ? JSON.parse(JSON.stringify(storedItem)) : undefined,
+                Item: storedItem
+                  ? JSON.parse(JSON.stringify(storedItem))
+                  : undefined,
               });
             }
             return Promise.resolve({});
           });
 
-          const configObj = { name: `tool_${toolId}`, filename: `${toolId}.py`, version: '1', description: 'test' };
+          const configObj = {
+            name: `tool_${toolId}`,
+            filename: `${toolId}.py`,
+            version: "1",
+            description: "test",
+          };
 
           // Step 1: Create with both binding types
-          await handler(makeEvent('createToolConfig', {
-            input: {
-              toolId,
-              config: JSON.stringify(configObj),
-              integrationBindings: originalIntBindings,
-              dataStoreBindings: originalDsBindings,
-            },
-          }));
+          await handler(
+            makeEvent("createToolConfig", {
+              input: {
+                toolId,
+                config: JSON.stringify(configObj),
+                integrationBindings: originalIntBindings,
+                dataStoreBindings: originalDsBindings,
+              },
+            }),
+          );
 
           // Step 2: Update only dataStoreBindings (omit integrationBindings from input)
-          await handler(makeEvent('updateToolConfig', {
-            input: {
-              toolId,
-              dataStoreBindings: updatedDsBindings,
-            },
-          }));
+          await handler(
+            makeEvent("updateToolConfig", {
+              input: {
+                toolId,
+                dataStoreBindings: updatedDsBindings,
+              },
+            }),
+          );
 
           // Step 3: Read back and verify
-          const result = await handler(makeEvent("getToolConfig", { toolId })) as ToolConfigResult;
+          const result = (await handler(
+            makeEvent("getToolConfig", { toolId }),
+          )) as ToolConfigResult;
 
           // dataStoreBindings should reflect the update
           const expectedUpdatedDs = updatedDsBindings.map((b) => ({
             ...b,
-            direction: b.direction ? b.direction.toUpperCase() : 'BIDIRECTIONAL',
+            direction: b.direction
+              ? b.direction.toUpperCase()
+              : "BIDIRECTIONAL",
           }));
           expect(result.dataStoreBindings).toEqual(expectedUpdatedDs);
 
           // integrationBindings should be preserved unchanged
           const expectedOriginalInt = originalIntBindings.map((b) => ({
             ...b,
-            direction: b.direction ? b.direction.toUpperCase() : 'BIDIRECTIONAL',
+            direction: b.direction
+              ? b.direction.toUpperCase()
+              : "BIDIRECTIONAL",
           }));
           expect(result.integrationBindings).toEqual(expectedOriginalInt);
-        }
+        },
       ),
-      { numRuns: 100 }
+      { numRuns: 100 },
     );
   });
 });
 
-
 // Feature: datastore-integration-pipeline, Property 3: Direction Field Round-Trip
 // Validates: Requirements 8.1, 8.2, 8.5
 
-const directionArb = fc.constantFrom('INPUT', 'OUTPUT', 'BIDIRECTIONAL');
+const directionArb = fc.constantFrom("INPUT", "OUTPUT", "BIDIRECTIONAL");
 
 const integrationBindingWithDirectionArb = fc.record({
   integrationId: fc.stringMatching(/^int-[a-z0-9]{6,12}$/),
   integrationType: integrationTypeArb,
-  operations: fc.option(fc.array(operationIdArb, { minLength: 1, maxLength: 5 }), { nil: undefined }),
+  operations: fc.option(
+    fc.array(operationIdArb, { minLength: 1, maxLength: 5 }),
+    { nil: undefined },
+  ),
   direction: directionArb,
 });
 
 const dataStoreBindingWithDirectionArb = fc.record({
   dataStoreId: fc.stringMatching(/^ds-[a-z0-9]{6,12}$/),
   dataStoreType: dataStoreTypeArb,
-  operations: fc.option(fc.array(operationIdArb, { minLength: 1, maxLength: 5 }), { nil: undefined }),
+  operations: fc.option(
+    fc.array(operationIdArb, { minLength: 1, maxLength: 5 }),
+    { nil: undefined },
+  ),
   direction: directionArb,
 });
 
@@ -363,70 +459,102 @@ const dataStoreBindingWithDirectionArb = fc.record({
  *
  * **Validates: Requirements 8.1, 8.2, 8.5**
  */
-describe('Property 3: Direction Field Round-Trip', () => {
-  it('createToolConfig followed by getToolConfig returns bindings with direction fields deeply equal to the original input', () => {
+describe("Property 3: Direction Field Round-Trip", () => {
+  it("createToolConfig followed by getToolConfig returns bindings with direction fields deeply equal to the original input", () => {
     return fc.assert(
       fc.asyncProperty(
         toolIdArb,
-        fc.array(integrationBindingWithDirectionArb, { minLength: 1, maxLength: 4 }),
-        fc.array(dataStoreBindingWithDirectionArb, { minLength: 1, maxLength: 4 }),
+        fc.array(integrationBindingWithDirectionArb, {
+          minLength: 1,
+          maxLength: 4,
+        }),
+        fc.array(dataStoreBindingWithDirectionArb, {
+          minLength: 1,
+          maxLength: 4,
+        }),
         async (toolId, integrationBindings, dataStoreBindings) => {
           mockDynamoSend.mockReset();
 
           let storedItem: Record<string, unknown> | null = null;
 
           mockDynamoSend.mockImplementation((cmd: FakeCommand) => {
-            if (cmd._type === 'Put') {
+            if (cmd._type === "Put") {
               storedItem = JSON.parse(JSON.stringify(cmd.input.Item));
               return Promise.resolve({});
             }
-            if (cmd._type === 'Get') {
+            if (cmd._type === "Get") {
               return Promise.resolve({
-                Item: storedItem ? JSON.parse(JSON.stringify(storedItem)) : undefined,
+                Item: storedItem
+                  ? JSON.parse(JSON.stringify(storedItem))
+                  : undefined,
               });
             }
             return Promise.resolve({});
           });
 
-          const configObj = { name: `tool_${toolId}`, filename: `${toolId}.py`, version: '1', description: 'test' };
+          const configObj = {
+            name: `tool_${toolId}`,
+            filename: `${toolId}.py`,
+            version: "1",
+            description: "test",
+          };
 
           // Create with directional bindings
-          await handler(makeEvent('createToolConfig', {
-            input: {
-              toolId,
-              config: JSON.stringify(configObj),
-              integrationBindings,
-              dataStoreBindings,
-            },
-          }));
+          await handler(
+            makeEvent("createToolConfig", {
+              input: {
+                toolId,
+                config: JSON.stringify(configObj),
+                integrationBindings,
+                dataStoreBindings,
+              },
+            }),
+          );
 
           // Read back
-          const result = await handler(makeEvent("getToolConfig", { toolId })) as ToolConfigResult;
+          const result = (await handler(
+            makeEvent("getToolConfig", { toolId }),
+          )) as ToolConfigResult;
 
           // Assert integration bindings direction round-trip
           expect(result.integrationBindings).toBeDefined();
-          expect(result.integrationBindings).toHaveLength(integrationBindings.length);
+          expect(result.integrationBindings).toHaveLength(
+            integrationBindings.length,
+          );
           for (let i = 0; i < integrationBindings.length; i++) {
-            expect(result.integrationBindings[i].direction).toBe(integrationBindings[i].direction);
-            expect(result.integrationBindings[i].integrationId).toBe(integrationBindings[i].integrationId);
-            expect(result.integrationBindings[i].integrationType).toBe(integrationBindings[i].integrationType);
+            expect(result.integrationBindings[i].direction).toBe(
+              integrationBindings[i].direction,
+            );
+            expect(result.integrationBindings[i].integrationId).toBe(
+              integrationBindings[i].integrationId,
+            );
+            expect(result.integrationBindings[i].integrationType).toBe(
+              integrationBindings[i].integrationType,
+            );
           }
 
           // Assert data store bindings direction round-trip
           expect(result.dataStoreBindings).toBeDefined();
-          expect(result.dataStoreBindings).toHaveLength(dataStoreBindings.length);
+          expect(result.dataStoreBindings).toHaveLength(
+            dataStoreBindings.length,
+          );
           for (let i = 0; i < dataStoreBindings.length; i++) {
-            expect(result.dataStoreBindings[i].direction).toBe(dataStoreBindings[i].direction);
-            expect(result.dataStoreBindings[i].dataStoreId).toBe(dataStoreBindings[i].dataStoreId);
-            expect(result.dataStoreBindings[i].dataStoreType).toBe(dataStoreBindings[i].dataStoreType);
+            expect(result.dataStoreBindings[i].direction).toBe(
+              dataStoreBindings[i].direction,
+            );
+            expect(result.dataStoreBindings[i].dataStoreId).toBe(
+              dataStoreBindings[i].dataStoreId,
+            );
+            expect(result.dataStoreBindings[i].dataStoreType).toBe(
+              dataStoreBindings[i].dataStoreType,
+            );
           }
-        }
+        },
       ),
-      { numRuns: 100 }
+      { numRuns: 100 },
     );
   });
 });
-
 
 // Feature: datastore-integration-pipeline, Property 4: Direction Field Backward Compatibility
 // Validates: Requirements 8.5, 8.6
@@ -440,7 +568,7 @@ describe('Property 3: Direction Field Round-Trip', () => {
  *
  * **Validates: Requirements 8.5, 8.6**
  */
-describe('Property 4: Direction Field Backward Compatibility', () => {
+describe("Property 4: Direction Field Backward Compatibility", () => {
   it('getToolConfig returns direction "bidirectional" for legacy bindings that lack a direction field', () => {
     return fc.assert(
       fc.asyncProperty(
@@ -462,17 +590,22 @@ describe('Property 4: Direction Field Backward Compatibility', () => {
 
           const legacyItem: Record<string, unknown> = {
             toolId,
-            config: { name: `tool_${toolId}`, filename: `${toolId}.py`, version: '1', description: 'test' },
-            state: 'active',
+            config: {
+              name: `tool_${toolId}`,
+              filename: `${toolId}.py`,
+              version: "1",
+              description: "test",
+            },
+            state: "active",
             categories: [],
             integrationBindings: legacyIntBindings,
             dataStoreBindings: legacyDsBindings,
-            createdAt: '2025-01-01T00:00:00Z',
-            updatedAt: '2025-01-01T00:00:00Z',
+            createdAt: "2025-01-01T00:00:00Z",
+            updatedAt: "2025-01-01T00:00:00Z",
           };
 
           mockDynamoSend.mockImplementation((cmd: FakeCommand) => {
-            if (cmd._type === 'Get') {
+            if (cmd._type === "Get") {
               return Promise.resolve({
                 Item: JSON.parse(JSON.stringify(legacyItem)),
               });
@@ -480,24 +613,30 @@ describe('Property 4: Direction Field Backward Compatibility', () => {
             return Promise.resolve({});
           });
 
-          const result = await handler(makeEvent("getToolConfig", { toolId })) as ToolConfigResult;
+          const result = (await handler(
+            makeEvent("getToolConfig", { toolId }),
+          )) as ToolConfigResult;
 
           // Every integration binding should have direction = 'bidirectional'
           expect(result.integrationBindings).toBeDefined();
-          expect(result.integrationBindings).toHaveLength(legacyIntBindings.length);
+          expect(result.integrationBindings).toHaveLength(
+            legacyIntBindings.length,
+          );
           for (const binding of result.integrationBindings) {
-            expect(binding.direction).toBe('BIDIRECTIONAL');
+            expect(binding.direction).toBe("BIDIRECTIONAL");
           }
 
           // Every data store binding should have direction = 'bidirectional'
           expect(result.dataStoreBindings).toBeDefined();
-          expect(result.dataStoreBindings).toHaveLength(legacyDsBindings.length);
+          expect(result.dataStoreBindings).toHaveLength(
+            legacyDsBindings.length,
+          );
           for (const binding of result.dataStoreBindings) {
-            expect(binding.direction).toBe('BIDIRECTIONAL');
+            expect(binding.direction).toBe("BIDIRECTIONAL");
           }
-        }
+        },
       ),
-      { numRuns: 100 }
+      { numRuns: 100 },
     );
   });
 });

--- a/backend/src/lambda/__tests__/tool-config-resolver.test.ts
+++ b/backend/src/lambda/__tests__/tool-config-resolver.test.ts
@@ -1,113 +1,153 @@
 /**
  * Tests for tool-config-resolver Lambda
  */
-import { DynamoDBDocumentClient, GetCommand, PutCommand, ScanCommand, DeleteCommand } from '@aws-sdk/lib-dynamodb';
-import { mockClient } from 'aws-sdk-client-mock';
+import {
+  DynamoDBDocumentClient,
+  GetCommand,
+  PutCommand,
+  ScanCommand,
+  DeleteCommand,
+} from "@aws-sdk/lib-dynamodb";
+import { mockClient } from "aws-sdk-client-mock";
 
 const dynamoMock = mockClient(DynamoDBDocumentClient);
 
-import { handler } from '../tool-config-resolver';
+import { handler } from "../tool-config-resolver";
 
-describe('tool-config-resolver', () => {
+describe("tool-config-resolver", () => {
   beforeEach(() => {
     dynamoMock.reset();
-    process.env.TOOLS_CONFIG_TABLE = 'test-tools-config';
+    process.env.TOOLS_CONFIG_TABLE = "test-tools-config";
   });
 
   afterEach(() => {
     delete process.env.TOOLS_CONFIG_TABLE;
   });
 
-  const makeEvent = (fieldName: string, args: Record<string, unknown>) => ({
+  const makeEvent = (
+    fieldName: string,
+    args: Record<string, unknown>,
+    identity?: Record<string, unknown>,
+  ) => ({
     info: { fieldName },
     arguments: args,
+    identity: identity ?? {
+      sub: "test-user",
+      claims: { "custom:organization": "test-org-a" },
+    },
   });
 
-  describe('listToolConfigs', () => {
-    test('returns all tool configs', async () => {
+  describe("listToolConfigs", () => {
+    test("returns all tool configs", async () => {
       dynamoMock.on(ScanCommand).resolves({
-        Items: [
-          { toolId: 't1', config: { name: 'Tool1' }, state: 'active' },
-        ],
+        Items: [{ toolId: "t1", config: { name: "Tool1" }, state: "active" }],
       });
 
-      const result = await handler(makeEvent('listToolConfigs', {}));
+      const result = await handler(makeEvent("listToolConfigs", {}));
       expect(result).toHaveLength(1);
-      expect(result[0].toolId).toBe('t1');
-      expect(typeof result[0].config).toBe('string');
+      expect(result[0].toolId).toBe("t1");
+      expect(typeof result[0].config).toBe("string");
     });
 
-    test('returns empty array when no tools exist', async () => {
+    test("returns empty array when no tools exist", async () => {
       dynamoMock.on(ScanCommand).resolves({ Items: [] });
-      const result = await handler(makeEvent('listToolConfigs', {}));
+      const result = await handler(makeEvent("listToolConfigs", {}));
       expect(result).toEqual([]);
     });
   });
 
-  describe('getToolConfig', () => {
-    test('returns tool when found', async () => {
+  describe("getToolConfig", () => {
+    test("returns tool when found", async () => {
       dynamoMock.on(GetCommand).resolves({
-        Item: { toolId: 't1', config: { name: 'Tool1' }, state: 'active' },
+        Item: { toolId: "t1", config: { name: "Tool1" }, state: "active" },
       });
 
-      const result = await handler(makeEvent('getToolConfig', { toolId: 't1' }));
+      const result = await handler(
+        makeEvent("getToolConfig", { toolId: "t1" }),
+      );
       expect(result).toBeDefined();
-      expect(result!.toolId).toBe('t1');
+      expect(result!.toolId).toBe("t1");
     });
 
-    test('returns null when not found', async () => {
+    test("returns null when not found", async () => {
       dynamoMock.on(GetCommand).resolves({});
-      const result = await handler(makeEvent('getToolConfig', { toolId: 'missing' }));
+      const result = await handler(
+        makeEvent("getToolConfig", { toolId: "missing" }),
+      );
       expect(result).toBeNull();
     });
   });
 
-  describe('createToolConfig', () => {
-    test('creates tool config', async () => {
+  describe("createToolConfig", () => {
+    test("creates tool config", async () => {
       dynamoMock.on(PutCommand).resolves({});
 
-      const result = await handler(makeEvent('createToolConfig', {
-        input: { toolId: 'new-tool', config: '{"name":"New"}' },
-      }));
+      const result = await handler(
+        makeEvent("createToolConfig", {
+          input: { toolId: "new-tool", config: '{"name":"New"}' },
+        }),
+      );
 
-      expect(result.toolId).toBe('new-tool');
+      expect(result.toolId).toBe("new-tool");
       expect(result.createdAt).toBeDefined();
     });
   });
 
-  describe('updateToolConfig', () => {
-    test('throws when tool not found', async () => {
+  describe("updateToolConfig", () => {
+    test("throws when tool not found", async () => {
       dynamoMock.on(GetCommand).resolves({});
 
       await expect(
-        handler(makeEvent('updateToolConfig', { input: { toolId: 'missing' } }))
-      ).rejects.toThrow('Tool config not found');
+        handler(
+          makeEvent("updateToolConfig", { input: { toolId: "missing" } }),
+        ),
+      ).rejects.toThrow("Tool config not found");
     });
 
-    test('updates existing tool config', async () => {
+    test("updates existing tool config", async () => {
       dynamoMock.on(GetCommand).resolves({
-        Item: { toolId: 't1', config: '{"old":true}', state: 'active', createdAt: '2025-01-01' },
+        Item: {
+          toolId: "t1",
+          orgId: "test-org-a",
+          config: '{"old":true}',
+          state: "active",
+          createdAt: "2025-01-01",
+        },
       });
       dynamoMock.on(PutCommand).resolves({});
 
-      const result = await handler(makeEvent('updateToolConfig', {
-        input: { toolId: 't1', config: '{"new":true}' },
-      }));
+      const result = await handler(
+        makeEvent("updateToolConfig", {
+          input: { toolId: "t1", config: '{"new":true}' },
+        }),
+      );
 
       expect(JSON.parse(result.config)).toEqual({ new: true });
     });
   });
 
-  describe('deleteToolConfig', () => {
-    test('returns success on delete', async () => {
+  describe("deleteToolConfig", () => {
+    test("returns success on delete", async () => {
+      dynamoMock.on(GetCommand).resolves({
+        Item: {
+          toolId: "t1",
+          orgId: "test-org-a",
+          config: "{}",
+          state: "active",
+        },
+      });
       dynamoMock.on(DeleteCommand).resolves({});
 
-      const result = await handler(makeEvent('deleteToolConfig', { toolId: 't1' }));
+      const result = await handler(
+        makeEvent("deleteToolConfig", { toolId: "t1" }),
+      );
       expect(result.success).toBe(true);
     });
   });
 
-  test('throws on unknown field', async () => {
-    await expect(handler(makeEvent('unknownField', {}))).rejects.toThrow('Unknown field');
+  test("throws on unknown field", async () => {
+    await expect(handler(makeEvent("unknownField", {}))).rejects.toThrow(
+      "Unknown field",
+    );
   });
 });

--- a/backend/src/lambda/tool-config-resolver.ts
+++ b/backend/src/lambda/tool-config-resolver.ts
@@ -12,7 +12,11 @@ import {
   type ToolCustomMetadata,
   type ListResourcesOptions,
 } from "../services/registry-service";
-import { extractOrgFromEvent, isAdminFromEvent } from "../utils/auth-event";
+import {
+  extractOrgFromEvent,
+  isAdminFromEvent,
+  assertRowOrg,
+} from "../utils/auth-event";
 
 const client = new DynamoDBClient({});
 const docClient = DynamoDBDocumentClient.from(client);
@@ -310,6 +314,7 @@ export const handler = async (
             )
           : await createToolConfig(
               event.arguments.input as ToolConfigMutationInput,
+              event,
             );
 
       case "updateToolConfig":
@@ -321,12 +326,16 @@ export const handler = async (
             )
           : await updateToolConfig(
               event.arguments.input as ToolConfigMutationInput,
+              event,
             );
 
       case "deleteToolConfig":
         return registryEnabled
-          ? await deleteToolConfigRegistry(event.arguments.toolId as string)
-          : await deleteToolConfig(event.arguments.toolId as string);
+          ? await deleteToolConfigRegistry(
+              event.arguments.toolId as string,
+              event,
+            )
+          : await deleteToolConfig(event.arguments.toolId as string, event);
 
       case "listIntegrationOperations":
         return getOperations(event.arguments.integrationType as string);
@@ -574,6 +583,13 @@ export async function updateToolConfigRegistry(
     orgId: undefined,
   });
 
+  // Org scoping (finding 13065e38): reconcile the record's orgId against
+  // the caller BEFORE any Registry write. Mirrors datastore-resolver.ts's
+  // updateDataStore gate (finding ca76d041) — fetch-then-verify via the
+  // shared assertRowOrg helper, admin bypass included, fail closed on a
+  // missing/unresolvable org on either side.
+  await assertRowOrg({ orgId: existingMeta.orgId }, event);
+
   // Preserve existing orgId; fall back to caller for legacy records.
   // Never derive orgId from input — that field is backend-owned.
   const preservedOrgId =
@@ -673,8 +689,22 @@ export async function updateToolConfigRegistry(
  */
 export async function deleteToolConfigRegistry(
   toolId: string,
+  event?: OrgScopedEvent,
 ): Promise<{ success: boolean; message?: string }> {
   const registryService = getRegistryService();
+
+  // Org scoping (finding 13065e38): fetch-then-verify BEFORE the Registry
+  // delete. A missing record still fails closed via assertRowOrg (no orgId
+  // to reconcile against), rather than silently no-op'ing past the check.
+  const existing = await registryService.getResource("tool", toolId);
+  const existingMeta = existing
+    ? registryService.deserializeCustomMetadata<{ orgId?: string }>(
+        existing.customDescriptorContent ?? null,
+        { orgId: undefined },
+      )
+    : { orgId: undefined };
+  await assertRowOrg({ orgId: existingMeta.orgId }, event);
+
   try {
     await registryService.deleteResource("tool", toolId);
     return {
@@ -765,6 +795,7 @@ async function getToolConfig(toolId: string): Promise<ToolConfig | null> {
 
 async function createToolConfig(
   input: ToolConfigMutationInput,
+  event?: OrgScopedEvent,
 ): Promise<ToolConfig> {
   const now = new Date().toISOString();
   const config =
@@ -778,9 +809,19 @@ async function createToolConfig(
     validateDataStoreBindings(input.dataStoreBindings);
   }
 
+  // Org scoping (finding 13065e38): ToolConfigMutationInput carries no
+  // client-supplied orgId field at all, so there is no client value to
+  // reject — but leaving this hardcoded to "" (as before) permanently
+  // orphans every legacy-created row from the assertRowOrg gate now
+  // guarding updateToolConfig/deleteToolConfig (a row with no orgId always
+  // fails closed). Derive orgId server-side from the caller, exactly like
+  // createToolConfigRegistry already does, so newly-created legacy rows
+  // remain updatable/deletable by their owning org.
+  const orgId = event !== undefined ? await extractOrgFromEvent(event) : null;
+
   const toolConfig: ToolConfig = {
     toolId: input.toolId,
-    orgId: "",
+    orgId: orgId ?? "",
     config,
     state: input.state || "active",
     categories: input.categories || [],
@@ -826,11 +867,18 @@ async function createToolConfig(
 
 async function updateToolConfig(
   input: ToolConfigMutationInput,
+  event?: OrgScopedEvent,
 ): Promise<ToolConfig> {
   const existing = await getToolConfig(input.toolId);
   if (!existing) {
     throw new Error(`Tool config not found: ${input.toolId}`);
   }
+
+  // Org scoping (finding 13065e38): reconcile the row's orgId against the
+  // caller BEFORE any write. Mirrors datastore-resolver.ts's updateDataStore
+  // gate (finding ca76d041) — fetch-then-verify, admin bypass, fail closed
+  // on a missing/unresolvable org on either side.
+  await assertRowOrg(existing, event);
 
   // Validate bindings before persistence
   if (input.integrationBindings && Array.isArray(input.integrationBindings)) {
@@ -915,7 +963,13 @@ async function updateToolConfig(
 
 async function deleteToolConfig(
   toolId: string,
+  event?: OrgScopedEvent,
 ): Promise<{ success: boolean; message?: string }> {
+  // Org scoping (finding 13065e38): fetch-then-verify BEFORE the delete.
+  // A missing row fails closed via assertRowOrg (no orgId to reconcile).
+  const existing = await getToolConfig(toolId);
+  await assertRowOrg(existing, event);
+
   try {
     await docClient.send(
       new DeleteCommand({


### PR DESCRIPTION
## Summary

`tool-config-resolver`'s read operations were organization-filtered, but its mutations were not: `updateToolConfig` and `deleteToolConfig` acted on a client-supplied tool id with no organization reconciliation. Any authenticated user of any organization could rewrite or destroy another tenant's tool configuration, including its bindings to datastores and integrations, which carry credential references. Destructive and reachable by a non-admin.

The same defect existed on the Registry path, not just the two operations named in the finding, so **four** mutations are now guarded:

- `updateToolConfig`, `deleteToolConfig`, `updateToolConfigRegistry`, `deleteToolConfigRegistry` - each fetch-then-verify via the shared `assertRowOrg` before any `PutCommand`, `DeleteCommand`, `updateResource` or `deleteResource`, with the admin bypass
preserved
- Fails closed on absent identity, unresolvable organization, missing row, and a row lacking `orgId`
- Reads were already organization-filtered and are unchanged; `ListIntegrationOperations` and
`searchToolConfigs` are non-tenant

Mirrors the datastore remediation exactly rather than introducing a new pattern.

## Incidental defect found and fixed

Legacy `createToolConfig` wrote `orgId` as an empty string unconditionally. Every row it created would therefore have been orphaned from the gate added here - cross-tenant callers refused, but so would the legitimate owner, with rows unreachable by any organization check. It now derives the organization server-side from the caller, matching its Registry-path sibling. Its input carries no client `orgId`, so the reject-the-mismatch convention had nothing to reject and was correctly not applied.

## Guard

A fifth dispatch-derived gate-enumeration guard covers this module, adapted for its dual `registryEnabled ? X : Y` dispatch shape so **both** callees per gated case are checked for event plumbing and gate ordering. Guarding only one branch of that ternary would have left half the surface open while appearing covered.

## Testing

- Cross-org callers refused on update and delete with mocks recording zero writes and zero deletes; same-org succeeds; credential references never exposed on a refused path
- Fail-closed cases probed individually
- Executed bite proof with byte-identical restore; the enumeration guard proven to bite on a stripped identity read
- Several pre-existing tests encoded the vulnerable behaviour - notably one asserting a cross-org update silently preserved the row's `orgId` - and were corrected to assert rejection. This is the fifth module in this series where the suite documented the gap
- tsc, lint exit 0; 138 targeted tests; all five enumeration guards 66; full backend jest 7325
- CI-equivalent synth with cdk-nag **enabled** and `ENVIRONMENT=test`: clean. No IAM or CDK change, so no suppression or rail-6 allowlist entry was needed, and all seven `split:gates` rails pass