### PR TITLE
fix(security): reconcile project org access in the ADR resolver

### DIFF
--- a/backend/lib/governance-stack.ts
+++ b/backend/lib/governance-stack.ts
@@ -773,6 +773,11 @@ exports.handler = async (event) => {
           ADRS_TABLE: props.adrsTable.tableName,
           ADR_REOPEN_ATTEMPTS_TABLE: props.adrReopenAttemptsTable.tableName,
           EVENT_BUS_NAME: props.agentEventBus.eventBusName,
+          // finding 677c1a6c: assertProjectOrgAccess reads PROJECTS_TABLE
+          // to reconcile the caller's org against the ADR's owning project
+          // before any write/read. Read-only — this resolver never writes
+          // Projects.
+          PROJECTS_TABLE: props.projectsTable.tableName,
         },
         timeout: Duration.seconds(30),
         logGroup: new logs.LogGroup(this, "ADRResolverFunctionLogs", {
@@ -785,6 +790,9 @@ exports.handler = async (event) => {
     props.adrsTable.grantReadWriteData(adrResolverFunction);
     props.adrReopenAttemptsTable.grantReadWriteData(adrResolverFunction);
     props.agentEventBus.grantPutEventsTo(adrResolverFunction);
+    // finding 677c1a6c: read-only grant for the project-org reconciliation
+    // gate (assertProjectOrgAccess). Least privilege — no write access.
+    props.projectsTable.grantReadData(adrResolverFunction);
 
     const adrDataSourceRole = new iam.Role(this, "ADRDataSourceRole", {
       assumedBy: new iam.ServicePrincipal("appsync.amazonaws.com"),

--- a/backend/src/lambda/__tests__/adr-resolver-dispatch-gate-enumeration.test.ts
+++ b/backend/src/lambda/__tests__/adr-resolver-dispatch-gate-enumeration.test.ts
@@ -1,0 +1,289 @@
+/**
+ * Enumeration-completeness guard for adr-resolver.ts's dispatch switch
+ * (finding 677c1a6c — the sixth instance of the class-closing move started
+ * by registry-agent-record-resolver-dispatch-gate-enumeration.test.ts and
+ * continued by app-publish-handler-dispatch-gate-enumeration.test.ts /
+ * user-management-resolver-dispatch-gate-enumeration.test.ts /
+ * agent-code-resolver-dispatch-gate-enumeration.test.ts /
+ * tool-config-resolver-dispatch-gate-enumeration.test.ts).
+ *
+ * Root defect closed by finding 677c1a6c: createADR/getADR/
+ * listADRsForProject (and the other adr-resolver mutations reachable via
+ * this dispatch) gated only on hasPermission('adr:create'/'adr:reopen')
+ * and trusted the client-supplied projectId with NO project-to-
+ * organization reconciliation — a permitted user of one org could create
+ * ADRs against, or read/list ADRs belonging to, another org's project.
+ * The fix threads an OPTIONAL `event` parameter through every exported
+ * function; the dispatch handler always supplies it, and each function
+ * calls the shared `assertProjectOrgAccess` gate before any write (create/
+ * supersede/reopen/lock) or before returning any data (get/list) — as an
+ * ADDITIONAL check, not a replacement for hasPermission('adr:create'),
+ * which remains in force.
+ *
+ * This handler's dispatch cases delegate to a DIRECT `await <fn>(...)`
+ * call (not a dual registry/legacy path like tool-config-resolver), so
+ * this guard's parser extracts ONE call site per case and verifies that
+ * callee's own function body actually threads `event` to the handler AND
+ * contains an `assertProjectOrgAccess(` call.
+ */
+import * as fs from "fs";
+import * as path from "path";
+
+const HANDLER_PATH = path.join(__dirname, "..", "adr-resolver.ts");
+
+function extractDispatchCases(source: string): string[] {
+  const switchStart = source.indexOf("switch (fieldName)");
+  if (switchStart === -1) {
+    throw new Error(
+      "Could not locate `switch (fieldName)` in adr-resolver.ts — " +
+        "dispatch structure changed; update this guard's parsing.",
+    );
+  }
+  const defaultIdx = source.indexOf("default:", switchStart);
+  if (defaultIdx === -1) {
+    throw new Error(
+      "Could not locate the dispatch switch's `default:` case — " +
+        "update this guard's parsing.",
+    );
+  }
+  const switchBody = source.slice(switchStart, defaultIdx);
+  const caseRe = /case\s+['"]([^'"]+)['"]\s*:/g;
+  const cases: string[] = [];
+  let m: RegExpExecArray | null;
+  while ((m = caseRe.exec(switchBody)) !== null) {
+    cases.push(m[1]);
+  }
+  return cases;
+}
+
+/** Slices out a single `case '<fieldName>': ... case` (or default) block. */
+function extractCaseBody(source: string, fieldName: string): string {
+  const switchStart = source.indexOf("switch (fieldName)");
+  const defaultIdx = source.indexOf("default:", switchStart);
+  const switchBody = source.slice(switchStart, defaultIdx);
+
+  const caseIdx =
+    switchBody.indexOf(`case '${fieldName}'`) !== -1
+      ? switchBody.indexOf(`case '${fieldName}'`)
+      : switchBody.indexOf(`case "${fieldName}"`);
+  if (caseIdx === -1) {
+    throw new Error(`Could not locate case '${fieldName}' in dispatch switch`);
+  }
+  const nextCaseIdx = switchBody.indexOf("case ", caseIdx + 1);
+  return switchBody.slice(
+    caseIdx,
+    nextCaseIdx === -1 ? undefined : nextCaseIdx,
+  );
+}
+
+/** Extracts every `await <fnName>(` call site name inside a case body. */
+function extractCallSiteNames(caseBody: string): string[] {
+  const callRe = /await\s+([A-Za-z0-9_]+)\s*\(/g;
+  const names: string[] = [];
+  let m: RegExpExecArray | null;
+  while ((m = callRe.exec(caseBody)) !== null) {
+    names.push(m[1]);
+  }
+  return names;
+}
+
+/**
+ * Extracts a top-level `(export )?async function <name>(...) { ... }` body
+ * by brace-counting from the function keyword, matching the parameter
+ * list's closing paren first (return-type annotations here are simple
+ * `Promise<ADR>` / `Promise<ADR | null>` / `Promise<ADR[]>` shapes with no
+ * nested braces, so the body's opening brace is simply the first `{` after
+ * the parameter list closes).
+ */
+function extractFunctionBody(source: string, fnName: string): string {
+  const declRe = new RegExp(
+    `(?:export\\s+)?async function ${fnName}\\b\\s*\\(`,
+  );
+  const declMatch = declRe.exec(source);
+  if (!declMatch) {
+    throw new Error(
+      `Could not locate function declaration for '${fnName}' in adr-resolver.ts`,
+    );
+  }
+  const paramsOpenIdx = source.indexOf("(", declMatch.index);
+  let parenDepth = 0;
+  let j = paramsOpenIdx;
+  for (; j < source.length; j++) {
+    if (source[j] === "(") parenDepth++;
+    else if (source[j] === ")") {
+      parenDepth--;
+      if (parenDepth === 0) break;
+    }
+  }
+  const bodyStart = source.indexOf("{", j);
+  let depth = 0;
+  let i = bodyStart;
+  for (; i < source.length; i++) {
+    if (source[i] === "{") depth++;
+    else if (source[i] === "}") {
+      depth--;
+      if (depth === 0) break;
+    }
+  }
+  return source.slice(bodyStart, i + 1);
+}
+
+const GATE_CALL_RE = /assertProjectOrgAccess\s*\(/;
+const EVENT_PARAM_RE = /event\?\s*:\s*unknown/;
+
+/**
+ * Every op on this dispatch surface calls assertProjectOrgAccess in its own
+ * function body (createADR, supersedeADR, reopenADR, getADR,
+ * listADRsForProject). `lockADR` is NOT reachable from this dispatch (no
+ * top-level GraphQL mutation exposes it per its own docblock) so it is not
+ * a dispatch case and is intentionally absent from both lists — it is
+ * covered by unit tests in adr-resolver.test.ts / adr-resolver-org-
+ * scoping.test.ts directly instead.
+ */
+const GATED_OPS: Record<string, { fn: string }> = {
+  createADR: { fn: "createADR" },
+  supersedeADR: { fn: "supersedeADR" },
+  reopenADR: { fn: "reopenADR" },
+  getADR: { fn: "getADR" },
+  listADRsForProject: { fn: "listADRsForProject" },
+};
+
+/**
+ * No case on this dispatch surface is legitimately exempt — every op reads
+ * or writes governance data scoped to a projectId, so every op must
+ * reconcile the caller's org. Kept as an empty object (rather than omitted)
+ * so the "every case is accounted for" test below has a home to point at
+ * if a genuinely exempt case is ever added.
+ */
+const EXEMPT_OPS: Record<string, string> = {};
+
+describe("adr-resolver — dispatch enumeration completeness", () => {
+  const source = fs.readFileSync(HANDLER_PATH, "utf-8");
+  const cases = extractDispatchCases(source);
+
+  test("the dispatch switch actually has cases to check (sanity check on the parser itself)", () => {
+    expect(cases.length).toBeGreaterThanOrEqual(5);
+    expect(cases).toEqual(
+      expect.arrayContaining([
+        "createADR",
+        "supersedeADR",
+        "reopenADR",
+        "getADR",
+        "listADRsForProject",
+      ]),
+    );
+  });
+
+  test("every dispatch case is accounted for in GATED_OPS or EXEMPT_OPS", () => {
+    const unaccounted = cases.filter(
+      (c) => !(c in GATED_OPS) && !(c in EXEMPT_OPS),
+    );
+    expect(unaccounted).toEqual([]);
+  });
+
+  test("GATED_OPS and EXEMPT_OPS do not both claim the same op", () => {
+    const overlap = Object.keys(GATED_OPS).filter((k) => k in EXEMPT_OPS);
+    expect(overlap).toEqual([]);
+  });
+
+  test("no GATED_OPS/EXEMPT_OPS entry references a case that no longer exists in the switch", () => {
+    const known = new Set(cases);
+    const staleGated = Object.keys(GATED_OPS).filter((k) => !known.has(k));
+    const staleExempt = Object.keys(EXEMPT_OPS).filter((k) => !known.has(k));
+    expect(staleGated).toEqual([]);
+    expect(staleExempt).toEqual([]);
+  });
+
+  test("lockADR is not a dispatch case (documented as internal-only) and is absent from both lists", () => {
+    expect(cases).not.toContain("lockADR");
+    expect("lockADR" in GATED_OPS).toBe(false);
+    expect("lockADR" in EXEMPT_OPS).toBe(false);
+  });
+
+  describe.each(Object.entries(GATED_OPS))(
+    "GATED_OPS['%s'] dispatches to a function that threads `event` and calls assertProjectOrgAccess",
+    (fieldName, meta) => {
+      test(`${fieldName}'s case dispatches to ${meta.fn}`, () => {
+        const caseBody = extractCaseBody(source, fieldName);
+        const callSites = extractCallSiteNames(caseBody);
+        expect(callSites).toContain(meta.fn);
+      });
+
+      test(`${fieldName}'s case passes \`event\` as the final argument to ${meta.fn}`, () => {
+        const caseBody = extractCaseBody(source, fieldName);
+        const callRe = new RegExp(
+          `${meta.fn}\\s*\\([^;]*?\\bevent\\b[^;]*?\\)`,
+        );
+        expect(callRe.test(caseBody)).toBe(true);
+      });
+
+      test(`${meta.fn}'s declaration accepts an optional \`event?: unknown\` parameter`, () => {
+        const declRe = new RegExp(
+          `(?:export\\s+)?async function ${meta.fn}\\b\\s*\\(([^)]*)\\)`,
+        );
+        const m = declRe.exec(source);
+        expect(m).not.toBeNull();
+        expect(EVENT_PARAM_RE.test((m as RegExpExecArray)[1])).toBe(true);
+      });
+
+      test(`${meta.fn}'s function body contains an assertProjectOrgAccess call`, () => {
+        const body = extractFunctionBody(source, meta.fn);
+        expect(GATE_CALL_RE.test(body)).toBe(true);
+      });
+    },
+  );
+
+  describe("write-path ops gate BEFORE their DynamoDB write side effect", () => {
+    test("createADR's gate call precedes its PutCommand", () => {
+      const body = extractFunctionBody(source, "createADR");
+      const gateIdx = body.search(GATE_CALL_RE);
+      const putIdx = body.indexOf("new PutCommand(");
+      expect(gateIdx).toBeGreaterThan(-1);
+      expect(putIdx).toBeGreaterThan(-1);
+      expect(gateIdx).toBeLessThan(putIdx);
+    });
+
+    test("supersedeADR's gate call precedes its UpdateCommand", () => {
+      const body = extractFunctionBody(source, "supersedeADR");
+      const gateIdx = body.search(GATE_CALL_RE);
+      const updateIdx = body.indexOf("new UpdateCommand(");
+      expect(gateIdx).toBeGreaterThan(-1);
+      expect(updateIdx).toBeGreaterThan(-1);
+      expect(gateIdx).toBeLessThan(updateIdx);
+    });
+
+    test("reopenADR's gate call precedes its audit-table PutCommand (Step 2)", () => {
+      const body = extractFunctionBody(source, "reopenADR");
+      const gateIdx = body.search(GATE_CALL_RE);
+      const auditPutIdx = body.indexOf("new PutCommand(");
+      expect(gateIdx).toBeGreaterThan(-1);
+      expect(auditPutIdx).toBeGreaterThan(-1);
+      expect(gateIdx).toBeLessThan(auditPutIdx);
+    });
+  });
+
+  describe("read-path ops return nothing before the gate resolves", () => {
+    test("getADR's gate call precedes its `return adr` statement", () => {
+      const body = extractFunctionBody(source, "getADR");
+      const gateIdx = body.search(GATE_CALL_RE);
+      const returnIdx = body.lastIndexOf("return adr;");
+      expect(gateIdx).toBeGreaterThan(-1);
+      expect(returnIdx).toBeGreaterThan(-1);
+      expect(gateIdx).toBeLessThan(returnIdx);
+    });
+
+    test("listADRsForProject's gate call precedes its QueryCommand (no foreign-data read at all)", () => {
+      const body = extractFunctionBody(source, "listADRsForProject");
+      const gateIdx = body.search(GATE_CALL_RE);
+      const queryIdx = body.indexOf("new QueryCommand(");
+      expect(gateIdx).toBeGreaterThan(-1);
+      expect(queryIdx).toBeGreaterThan(-1);
+      expect(gateIdx).toBeLessThan(queryIdx);
+    });
+  });
+
+  test("handler's hasPermission('adr:create') check is not removed by this fix (additive, not a replacement)", () => {
+    expect(source).toMatch(/hasPermission\(authContext, ['"]adr:create['"]\)/);
+    expect(source).toMatch(/hasPermission\(authContext, ['"]adr:reopen['"]\)/);
+  });
+});

--- a/backend/src/lambda/__tests__/adr-resolver-org-scoping.test.ts
+++ b/backend/src/lambda/__tests__/adr-resolver-org-scoping.test.ts
@@ -1,0 +1,345 @@
+/**
+ * Org-scoping tests for adr-resolver (finding 677c1a6c).
+ *
+ * DEFECT: createADR/getADR/listADRsForProject (and the other adr-resolver
+ * mutations) gated only on hasPermission('adr:create'/'adr:reopen') and
+ * trusted the client-supplied projectId with no project-to-organization
+ * reconciliation — a permitted user of one org could create/read/list ADRs
+ * against another org's project.
+ *
+ * FIX: assertProjectOrgAccess(projectId, event) is threaded through every
+ * op as an ADDITIONAL, optional-event gate (hasPermission stays). The
+ * dispatch handler always supplies `event`; internal/system callers
+ * (project-resolver's phase guard, program-review-resolver,
+ * agent-import-resolver's SYSTEM_IMPORT_ADR_AUTHOR path) call the exported
+ * functions directly with no event and are therefore unaffected — they
+ * already operate on a projectId they resolved through their own path.
+ *
+ * Acceptance (from the task):
+ *  - cross-org caller refused on create, read, and list; zero writes and
+ *    zero reads of foreign data recorded by the mocks
+ *  - same-org caller WITH adr:create succeeds
+ *  - same-org caller WITHOUT adr:create is still refused on create (the org
+ *    check is additive, not a replacement for hasPermission)
+ */
+import {
+  DynamoDBDocumentClient,
+  GetCommand,
+  PutCommand,
+  QueryCommand,
+} from "@aws-sdk/lib-dynamodb";
+import {
+  EventBridgeClient,
+  PutEventsCommand,
+} from "@aws-sdk/client-eventbridge";
+import { mockClient } from "aws-sdk-client-mock";
+import type { AuthContext } from "../../types";
+
+const ddbMock = mockClient(DynamoDBDocumentClient);
+const ebMock = mockClient(EventBridgeClient);
+
+process.env.ADRS_TABLE = "citadel-adrs-test";
+process.env.ADR_REOPEN_ATTEMPTS_TABLE = "citadel-adr-reopen-attempts-test";
+process.env.EVENT_BUS_NAME = "citadel-agents-test";
+process.env.PROJECTS_TABLE = "citadel-projects-test";
+
+import {
+  createADR,
+  getADR,
+  listADRsForProject,
+  handler,
+  type ADRInput,
+} from "../adr-resolver";
+import { __resetGovernanceNotifierForTest } from "../../utils/notifier-base";
+import { ProjectOrgAccessError } from "../../utils/project-org-access";
+
+function mockAuthContextFor(role: "architect" | "developer"): AuthContext {
+  return { userId: `user-${role}`, username: role, groups: [], roles: [role] };
+}
+
+function baseInput(overrides: Record<string, unknown> = {}): ADRInput {
+  return {
+    projectId: "proj-1",
+    title: "Use PostgreSQL over MySQL",
+    decision: "Adopt PostgreSQL 16 for all services.",
+    reasoning: "Stronger type system, JSONB support, mature RLS.",
+    constraints: [],
+    alternativesConsidered: [],
+    revisitConditions: [],
+    sourceRoundIds: [],
+    ...overrides,
+  } as unknown as ADRInput;
+}
+
+function crossOrgEvent(
+  fieldName: string,
+  args: Record<string, unknown>,
+  role: "architect" | "developer" = "architect",
+) {
+  return {
+    info: { fieldName },
+    arguments: args,
+    identity: {
+      sub: `user-${role}-org-b`,
+      username: role,
+      "custom:role": role,
+      "custom:organization": "org-b",
+    },
+  };
+}
+
+function sameOrgEvent(
+  fieldName: string,
+  args: Record<string, unknown>,
+  role: "architect" | "developer" = "architect",
+) {
+  return {
+    info: { fieldName },
+    arguments: args,
+    identity: {
+      sub: `user-${role}-org-a`,
+      username: role,
+      "custom:role": role,
+      "custom:organization": "org-a",
+    },
+  };
+}
+
+describe("adr-resolver — project-org scoping (finding 677c1a6c)", () => {
+  beforeEach(() => {
+    ddbMock.reset();
+    ebMock.reset();
+    ebMock
+      .on(PutEventsCommand)
+      .resolves({ FailedEntryCount: 0, Entries: [{ EventId: "evt-1" }] });
+    __resetGovernanceNotifierForTest();
+  });
+
+  function stubProject(organization = "org-a", owner = "someone-else") {
+    ddbMock
+      .on(GetCommand, {
+        TableName: "citadel-projects-test",
+        Key: { id: "proj-1" },
+      })
+      .resolves({ Item: { id: "proj-1", owner, organization } });
+  }
+
+  // ── createADR ────────────────────────────────────────────────────────
+
+  describe("createADR", () => {
+    test("cross-org caller with adr:create is refused; zero PutCommand to ADRS_TABLE", async () => {
+      stubProject("org-a");
+      const auth = mockAuthContextFor("architect");
+      const event = crossOrgEvent("createADR", {});
+
+      await expect(createADR(baseInput(), auth, event)).rejects.toBeInstanceOf(
+        ProjectOrgAccessError,
+      );
+
+      const adrPuts = ddbMock
+        .commandCalls(PutCommand)
+        .filter((c) => c.args[0].input.TableName === "citadel-adrs-test");
+      expect(adrPuts).toHaveLength(0);
+    });
+
+    test("same-org caller with adr:create succeeds", async () => {
+      stubProject("org-a");
+      ddbMock.on(PutCommand).resolves({});
+      const auth = mockAuthContextFor("architect");
+      const event = sameOrgEvent("createADR", {});
+
+      const adr = await createADR(baseInput(), auth, event);
+      expect(adr.status).toBe("PROPOSED");
+
+      const adrPuts = ddbMock
+        .commandCalls(PutCommand)
+        .filter((c) => c.args[0].input.TableName === "citadel-adrs-test");
+      expect(adrPuts).toHaveLength(1);
+    });
+
+    test("same-org caller WITHOUT adr:create is still refused (permission check not replaced)", async () => {
+      stubProject("org-a");
+      const auth = mockAuthContextFor("developer");
+      const event = sameOrgEvent("createADR", {}, "developer");
+
+      await expect(createADR(baseInput(), auth, event)).rejects.toThrow(
+        /UnauthorizedError/,
+      );
+      const adrPuts = ddbMock
+        .commandCalls(PutCommand)
+        .filter((c) => c.args[0].input.TableName === "citadel-adrs-test");
+      expect(adrPuts).toHaveLength(0);
+    });
+
+    test("internal caller with no event (system/legacy call) is unaffected by the org gate", async () => {
+      ddbMock.on(PutCommand).resolves({});
+      const auth = mockAuthContextFor("architect");
+      const adr = await createADR(baseInput(), auth);
+      expect(adr.status).toBe("PROPOSED");
+      // No project lookup should even be attempted with no event supplied.
+      const projectGets = ddbMock
+        .commandCalls(GetCommand)
+        .filter((c) => c.args[0].input.TableName === "citadel-projects-test");
+      expect(projectGets).toHaveLength(0);
+    });
+  });
+
+  // ── getADR ───────────────────────────────────────────────────────────
+
+  describe("getADR", () => {
+    const existing = {
+      adrId: "adr-1",
+      projectId: "proj-1",
+      status: "PROPOSED",
+      version: 1,
+      title: "t",
+      sourceRoundIds: [],
+    };
+
+    test("cross-org caller is refused and the ADR is never returned", async () => {
+      ddbMock
+        .on(GetCommand, {
+          TableName: "citadel-adrs-test",
+          Key: { adrId: "adr-1" },
+        })
+        .resolves({ Item: existing });
+      stubProject("org-a");
+      const event = crossOrgEvent("getADR", { adrId: "adr-1" });
+
+      await expect(getADR("adr-1", event)).rejects.toBeInstanceOf(
+        ProjectOrgAccessError,
+      );
+    });
+
+    test("same-org caller can read the ADR", async () => {
+      ddbMock
+        .on(GetCommand, {
+          TableName: "citadel-adrs-test",
+          Key: { adrId: "adr-1" },
+        })
+        .resolves({ Item: existing });
+      stubProject("org-a");
+      const event = sameOrgEvent("getADR", { adrId: "adr-1" });
+
+      const adr = await getADR("adr-1", event);
+      expect(adr).toEqual(existing);
+    });
+
+    test("nonexistent ADR still returns null (ordering: fetch first, no crash on missing row)", async () => {
+      ddbMock.on(GetCommand).resolves({});
+      const event = sameOrgEvent("getADR", { adrId: "missing" });
+      const adr = await getADR("missing", event);
+      expect(adr).toBeNull();
+    });
+
+    test("internal caller with no event is unaffected", async () => {
+      ddbMock
+        .on(GetCommand, {
+          TableName: "citadel-adrs-test",
+          Key: { adrId: "adr-1" },
+        })
+        .resolves({ Item: existing });
+      const adr = await getADR("adr-1");
+      expect(adr).toEqual(existing);
+      const projectGets = ddbMock
+        .commandCalls(GetCommand)
+        .filter((c) => c.args[0].input.TableName === "citadel-projects-test");
+      expect(projectGets).toHaveLength(0);
+    });
+  });
+
+  // ── listADRsForProject ───────────────────────────────────────────────
+
+  describe("listADRsForProject", () => {
+    test("cross-org caller is refused; zero QueryCommand against ADRS_TABLE (no foreign-data read)", async () => {
+      stubProject("org-a");
+      const event = crossOrgEvent("listADRsForProject", {
+        projectId: "proj-1",
+      });
+
+      await expect(listADRsForProject("proj-1", event)).rejects.toBeInstanceOf(
+        ProjectOrgAccessError,
+      );
+      const adrQueries = ddbMock
+        .commandCalls(QueryCommand)
+        .filter((c) => c.args[0].input.TableName === "citadel-adrs-test");
+      expect(adrQueries).toHaveLength(0);
+    });
+
+    test("same-org caller can list", async () => {
+      stubProject("org-a");
+      ddbMock
+        .on(QueryCommand, { TableName: "citadel-adrs-test" })
+        .resolves({ Items: [] });
+      const event = sameOrgEvent("listADRsForProject", { projectId: "proj-1" });
+
+      const adrs = await listADRsForProject("proj-1", event);
+      expect(adrs).toEqual([]);
+    });
+
+    test("internal caller with no event is unaffected", async () => {
+      ddbMock.on(QueryCommand).resolves({ Items: [] });
+      const adrs = await listADRsForProject("proj-1");
+      expect(adrs).toEqual([]);
+      const projectGets = ddbMock
+        .commandCalls(GetCommand)
+        .filter((c) => c.args[0].input.TableName === "citadel-projects-test");
+      expect(projectGets).toHaveLength(0);
+    });
+  });
+
+  // ── handler dispatch always threads event ───────────────────────────
+
+  describe("handler dispatch threads event into the org gate", () => {
+    test("createADR via handler: cross-org caller refused", async () => {
+      stubProject("org-a");
+      await expect(
+        handler(crossOrgEvent("createADR", { input: baseInput() })),
+      ).rejects.toThrow(/Access denied/);
+    });
+
+    test("getADR via handler: cross-org caller refused", async () => {
+      const existing = {
+        adrId: "adr-1",
+        projectId: "proj-1",
+        status: "PROPOSED",
+        version: 1,
+        title: "t",
+        sourceRoundIds: [],
+      };
+      ddbMock
+        .on(GetCommand, {
+          TableName: "citadel-adrs-test",
+          Key: { adrId: "adr-1" },
+        })
+        .resolves({ Item: existing });
+      stubProject("org-a");
+      await expect(
+        handler(crossOrgEvent("getADR", { adrId: "adr-1" })),
+      ).rejects.toThrow(/Access denied/);
+    });
+
+    test("listADRsForProject via handler: cross-org caller refused", async () => {
+      stubProject("org-a");
+      await expect(
+        handler(crossOrgEvent("listADRsForProject", { projectId: "proj-1" })),
+      ).rejects.toThrow(/Access denied/);
+    });
+
+    test("createADR via handler: same-org caller with permission succeeds", async () => {
+      stubProject("org-a");
+      ddbMock.on(PutCommand).resolves({});
+      const result = (await handler(
+        sameOrgEvent("createADR", { input: baseInput() }),
+      )) as { status: string };
+      expect(result.status).toBe("PROPOSED");
+    });
+
+    test("createADR via handler: same-org caller without permission refused", async () => {
+      stubProject("org-a");
+      await expect(
+        handler(sameOrgEvent("createADR", { input: baseInput() }, "developer")),
+      ).rejects.toThrow(/UnauthorizedError/);
+    });
+  });
+});

--- a/backend/src/lambda/__tests__/adr-resolver.test.ts
+++ b/backend/src/lambda/__tests__/adr-resolver.test.ts
@@ -14,19 +14,29 @@
  * - Property tests: ADR_TRANSITIONS matrix via LifecycleManager;
  * createADR always returns status=PROPOSED and version=1.
  */
-import { DynamoDBDocumentClient, GetCommand, PutCommand, UpdateCommand, QueryCommand } from '@aws-sdk/lib-dynamodb';
-import { EventBridgeClient, PutEventsCommand } from '@aws-sdk/client-eventbridge';
-import { mockClient } from 'aws-sdk-client-mock';
-import * as fc from 'fast-check';
-import type { AuthContext } from '../../types';
+import {
+  DynamoDBDocumentClient,
+  GetCommand,
+  PutCommand,
+  UpdateCommand,
+  QueryCommand,
+} from "@aws-sdk/lib-dynamodb";
+import {
+  EventBridgeClient,
+  PutEventsCommand,
+} from "@aws-sdk/client-eventbridge";
+import { mockClient } from "aws-sdk-client-mock";
+import * as fc from "fast-check";
+import type { AuthContext } from "../../types";
 
 const ddbMock = mockClient(DynamoDBDocumentClient);
 const ebMock = mockClient(EventBridgeClient);
 
 // Env must be set before importing the module under test.
-process.env.ADRS_TABLE = 'citadel-adrs-test';
-process.env.ADR_REOPEN_ATTEMPTS_TABLE = 'citadel-adr-reopen-attempts-test';
-process.env.EVENT_BUS_NAME = 'citadel-agents-test';
+process.env.ADRS_TABLE = "citadel-adrs-test";
+process.env.ADR_REOPEN_ATTEMPTS_TABLE = "citadel-adr-reopen-attempts-test";
+process.env.EVENT_BUS_NAME = "citadel-agents-test";
+process.env.PROJECTS_TABLE = "citadel-projects-test";
 
 import {
   createADR,
@@ -37,14 +47,14 @@ import {
   supersedeADR,
   handler,
   type ADRInput,
-} from '../adr-resolver';
-import { __resetGovernanceNotifierForTest } from '../../utils/notifier-base';
-import { LifecycleManager, ADR_TRANSITIONS } from '../../adapters/lifecycle';
+} from "../adr-resolver";
+import { __resetGovernanceNotifierForTest } from "../../utils/notifier-base";
+import { LifecycleManager, ADR_TRANSITIONS } from "../../adapters/lifecycle";
 
 // Role-based AuthContext helper. The production auth.ts grants adr:create to
 // the 'architect' role (landed in commit ffa887f). 'developer' has
 // no ADR permissions.
-function mockAuthContextFor(role: 'architect' | 'developer'): AuthContext {
+function mockAuthContextFor(role: "architect" | "developer"): AuthContext {
   return {
     userId: `user-${role}`,
     username: role,
@@ -55,63 +65,69 @@ function mockAuthContextFor(role: 'architect' | 'developer'): AuthContext {
 
 function baseInput(overrides: Record<string, unknown> = {}): ADRInput {
   return {
-    projectId: 'proj-1',
-    title: 'Use PostgreSQL over MySQL',
-    decision: 'Adopt PostgreSQL 16 for all services.',
-    reasoning: 'Stronger type system, JSONB support, mature RLS.',
-    constraints: ['Must support RDS', 'Must support PITR'],
-    alternativesConsidered: ['MySQL 8', 'Aurora Serverless'],
-    revisitConditions: ['Team skills shift', 'Vendor contract change'],
-    sourceRoundIds: ['round-1'],
+    projectId: "proj-1",
+    title: "Use PostgreSQL over MySQL",
+    decision: "Adopt PostgreSQL 16 for all services.",
+    reasoning: "Stronger type system, JSONB support, mature RLS.",
+    constraints: ["Must support RDS", "Must support PITR"],
+    alternativesConsidered: ["MySQL 8", "Aurora Serverless"],
+    revisitConditions: ["Team skills shift", "Vendor contract change"],
+    sourceRoundIds: ["round-1"],
     ...overrides,
   } as unknown as ADRInput;
 }
 
-describe('adr-resolver', () => {
+describe("adr-resolver", () => {
   beforeEach(() => {
     ddbMock.reset();
     ebMock.reset();
-    ebMock.on(PutEventsCommand).resolves({ FailedEntryCount: 0, Entries: [{ EventId: 'evt-1' }] });
+    ebMock
+      .on(PutEventsCommand)
+      .resolves({ FailedEntryCount: 0, Entries: [{ EventId: "evt-1" }] });
     __resetGovernanceNotifierForTest();
   });
 
   // ── createADR ─────────────────────────────────────────────────────────
 
-  describe('createADR', () => {
-    test('happy path with mandatory + optional fields returns PROPOSED v1 ISO-8601 createdAt', async () => {
+  describe("createADR", () => {
+    test("happy path with mandatory + optional fields returns PROPOSED v1 ISO-8601 createdAt", async () => {
       ddbMock.on(PutCommand).resolves({});
-      const auth = mockAuthContextFor('architect');
+      const auth = mockAuthContextFor("architect");
       const input = baseInput({
-        severity: 'HIGH',
-        affectsModules: ['billing', 'auth'],
-        reviewers: ['user-2', 'user-3'],
+        severity: "HIGH",
+        affectsModules: ["billing", "auth"],
+        reviewers: ["user-2", "user-3"],
       });
 
       const adr = await createADR(input, auth);
 
-      expect(adr.status).toBe('PROPOSED');
+      expect(adr.status).toBe("PROPOSED");
       expect(adr.version).toBe(1);
-      expect(adr.createdAt).toMatch(/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3}Z$/);
-      expect(adr.createdBy).toBe('user-architect');
+      expect(adr.createdAt).toMatch(
+        /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3}Z$/,
+      );
+      expect(adr.createdBy).toBe("user-architect");
       expect(adr.adrId).toMatch(/^[0-9a-f-]{36}$/i);
-      expect(adr.severity).toBe('HIGH');
-      expect(adr.affectsModules).toEqual(['billing', 'auth']);
-      expect(adr.reviewers).toEqual(['user-2', 'user-3']);
-      expect(adr.sourceRoundIds).toEqual(['round-1']);
+      expect(adr.severity).toBe("HIGH");
+      expect(adr.affectsModules).toEqual(["billing", "auth"]);
+      expect(adr.reviewers).toEqual(["user-2", "user-3"]);
+      expect(adr.sourceRoundIds).toEqual(["round-1"]);
 
       const puts = ddbMock.commandCalls(PutCommand);
       expect(puts).toHaveLength(1);
-      expect(puts[0].args[0].input.TableName).toBe('citadel-adrs-test');
-      expect(puts[0].args[0].input.ConditionExpression).toBe('attribute_not_exists(adrId)');
+      expect(puts[0].args[0].input.TableName).toBe("citadel-adrs-test");
+      expect(puts[0].args[0].input.ConditionExpression).toBe(
+        "attribute_not_exists(adrId)",
+      );
     });
 
-    test('happy path with only mandatory fields leaves optional fields undefined', async () => {
+    test("happy path with only mandatory fields leaves optional fields undefined", async () => {
       ddbMock.on(PutCommand).resolves({});
-      const auth = mockAuthContextFor('architect');
+      const auth = mockAuthContextFor("architect");
 
       const adr = await createADR(baseInput(), auth);
 
-      expect(adr.status).toBe('PROPOSED');
+      expect(adr.status).toBe("PROPOSED");
       expect(adr.version).toBe(1);
       expect(adr.severity).toBeUndefined();
       expect(adr.affectsModules).toBeUndefined();
@@ -120,58 +136,65 @@ describe('adr-resolver', () => {
       expect(adr.supersededBy).toBeUndefined();
     });
 
-    test('rejects caller without adr:create permission and issues no PutCommand', async () => {
+    test("rejects caller without adr:create permission and issues no PutCommand", async () => {
       ddbMock.on(PutCommand).resolves({});
-      const auth = mockAuthContextFor('developer');
+      const auth = mockAuthContextFor("developer");
 
-      await expect(createADR(baseInput(), auth)).rejects.toThrow(/UnauthorizedError/);
+      await expect(createADR(baseInput(), auth)).rejects.toThrow(
+        /UnauthorizedError/,
+      );
       expect(ddbMock.commandCalls(PutCommand)).toHaveLength(0);
     });
 
-    test('rejects missing decision as ValidationError', async () => {
-      const auth = mockAuthContextFor('architect');
+    test("rejects missing decision as ValidationError", async () => {
+      const auth = mockAuthContextFor("architect");
       await expect(
-        createADR(baseInput({ decision: '' }), auth)
+        createADR(baseInput({ decision: "" }), auth),
       ).rejects.toThrow(/ValidationError.*decision/);
       expect(ddbMock.commandCalls(PutCommand)).toHaveLength(0);
     });
 
-    test('rejects missing reasoning as ValidationError', async () => {
-      const auth = mockAuthContextFor('architect');
+    test("rejects missing reasoning as ValidationError", async () => {
+      const auth = mockAuthContextFor("architect");
       await expect(
-        createADR(baseInput({ reasoning: '' }), auth)
+        createADR(baseInput({ reasoning: "" }), auth),
       ).rejects.toThrow(/ValidationError.*reasoning/);
     });
 
-    test('rejects non-array constraints as ValidationError', async () => {
-      const auth = mockAuthContextFor('architect');
+    test("rejects non-array constraints as ValidationError", async () => {
+      const auth = mockAuthContextFor("architect");
       await expect(
-        createADR(baseInput({ constraints: 'not-an-array' }), auth)
+        createADR(baseInput({ constraints: "not-an-array" }), auth),
       ).rejects.toThrow(/ValidationError.*array/);
     });
   });
 
   // ── lockADR ───────────────────────────────────────────────────────────
 
-  describe('lockADR', () => {
-    test('PROPOSED -> LOCKED emits governance.adr.locked with sourceRoundIds passthrough', async () => {
+  describe("lockADR", () => {
+    test("PROPOSED -> LOCKED emits governance.adr.locked with sourceRoundIds passthrough", async () => {
       const existing = {
-        adrId: 'adr-1',
-        projectId: 'proj-1',
-        title: 'Use PostgreSQL',
-        status: 'PROPOSED',
+        adrId: "adr-1",
+        projectId: "proj-1",
+        title: "Use PostgreSQL",
+        status: "PROPOSED",
         version: 1,
-        sourceRoundIds: ['round-1', 'round-2'],
+        sourceRoundIds: ["round-1", "round-2"],
       };
       ddbMock.on(GetCommand).resolves({ Item: existing });
       ddbMock.on(UpdateCommand).resolves({
-        Attributes: {...existing, status: 'LOCKED', version: 2, lockedAt: '2026-04-30T00:00:00.000Z' },
+        Attributes: {
+          ...existing,
+          status: "LOCKED",
+          version: 2,
+          lockedAt: "2026-04-30T00:00:00.000Z",
+        },
       });
 
-      const auth = mockAuthContextFor('architect');
-      const locked = await lockADR('adr-1', auth);
+      const auth = mockAuthContextFor("architect");
+      const locked = await lockADR("adr-1", auth);
 
-      expect(locked.status).toBe('LOCKED');
+      expect(locked.status).toBe("LOCKED");
       expect(locked.version).toBe(2);
       expect(locked.lockedAt).toBeDefined();
 
@@ -183,259 +206,430 @@ describe('adr-resolver', () => {
       const ebCalls = ebMock.commandCalls(PutEventsCommand);
       expect(ebCalls).toHaveLength(1);
       const entry = ebCalls[0].args[0].input.Entries![0];
-      expect(entry.DetailType).toBe('governance.adr.locked');
+      expect(entry.DetailType).toBe("governance.adr.locked");
       const detail = JSON.parse(entry.Detail!);
-      expect(detail.adrId).toBe('adr-1');
-      expect(detail.projectId).toBe('proj-1');
-      expect(detail.title).toBe('Use PostgreSQL');
-      expect(detail.sourceRoundIds).toEqual(['round-1', 'round-2']);
+      expect(detail.adrId).toBe("adr-1");
+      expect(detail.projectId).toBe("proj-1");
+      expect(detail.title).toBe("Use PostgreSQL");
+      expect(detail.sourceRoundIds).toEqual(["round-1", "round-2"]);
     });
 
-    test('already-LOCKED is an idempotent early-return: no Update, no EventBridge emission', async () => {
+    test("already-LOCKED is an idempotent early-return: no Update, no EventBridge emission", async () => {
       // Design choice (documented in lockADR source): if the ADR is already
       // LOCKED we short-circuit BEFORE the lifecycle check and BEFORE the DDB
       // update, so we never bump the version and never re-emit the event.
       const alreadyLocked = {
-        adrId: 'adr-1',
-        projectId: 'proj-1',
-        title: 'Use PostgreSQL',
-        status: 'LOCKED',
+        adrId: "adr-1",
+        projectId: "proj-1",
+        title: "Use PostgreSQL",
+        status: "LOCKED",
         version: 5,
-        sourceRoundIds: ['round-1'],
-        lockedAt: '2026-04-29T00:00:00.000Z',
+        sourceRoundIds: ["round-1"],
+        lockedAt: "2026-04-29T00:00:00.000Z",
       };
       ddbMock.on(GetCommand).resolves({ Item: alreadyLocked });
 
-      const auth = mockAuthContextFor('architect');
-      const result = await lockADR('adr-1', auth);
+      const auth = mockAuthContextFor("architect");
+      const result = await lockADR("adr-1", auth);
 
       expect(result).toEqual(alreadyLocked);
       expect(ddbMock.commandCalls(UpdateCommand)).toHaveLength(0);
       expect(ebMock.commandCalls(PutEventsCommand)).toHaveLength(0);
     });
 
-    test('non-existent ADR throws', async () => {
+    test("non-existent ADR throws", async () => {
       ddbMock.on(GetCommand).resolves({});
-      const auth = mockAuthContextFor('architect');
-      await expect(lockADR('missing', auth)).rejects.toThrow(/not found/);
+      const auth = mockAuthContextFor("architect");
+      await expect(lockADR("missing", auth)).rejects.toThrow(/not found/);
     });
 
-    test('rejects caller without adr:create permission', async () => {
-      const auth = mockAuthContextFor('developer');
-      await expect(lockADR('adr-1', auth)).rejects.toThrow(/UnauthorizedError/);
+    test("rejects caller without adr:create permission", async () => {
+      const auth = mockAuthContextFor("developer");
+      await expect(lockADR("adr-1", auth)).rejects.toThrow(/UnauthorizedError/);
       expect(ddbMock.commandCalls(GetCommand)).toHaveLength(0);
     });
   });
 
   // ── supersedeADR ──────────────────────────────────────────────────────
 
-  describe('supersedeADR', () => {
-    test('happy path: old ADR PROPOSED -> SUPERSEDED, version bumps, supersededBy set', async () => {
-      const oldAdr = { adrId: 'adr-old', projectId: 'proj-1', status: 'PROPOSED', version: 3, title: 'old', sourceRoundIds: ['r1'] };
-      const newAdr = { adrId: 'adr-new', projectId: 'proj-1', status: 'PROPOSED', version: 1, title: 'new', sourceRoundIds: ['r2'] };
+  describe("supersedeADR", () => {
+    test("happy path: old ADR PROPOSED -> SUPERSEDED, version bumps, supersededBy set", async () => {
+      const oldAdr = {
+        adrId: "adr-old",
+        projectId: "proj-1",
+        status: "PROPOSED",
+        version: 3,
+        title: "old",
+        sourceRoundIds: ["r1"],
+      };
+      const newAdr = {
+        adrId: "adr-new",
+        projectId: "proj-1",
+        status: "PROPOSED",
+        version: 1,
+        title: "new",
+        sourceRoundIds: ["r2"],
+      };
       ddbMock
-        .on(GetCommand, { TableName: 'citadel-adrs-test', Key: { adrId: 'adr-old' } })
+        .on(GetCommand, {
+          TableName: "citadel-adrs-test",
+          Key: { adrId: "adr-old" },
+        })
         .resolves({ Item: oldAdr })
-        .on(GetCommand, { TableName: 'citadel-adrs-test', Key: { adrId: 'adr-new' } })
+        .on(GetCommand, {
+          TableName: "citadel-adrs-test",
+          Key: { adrId: "adr-new" },
+        })
         .resolves({ Item: newAdr });
       ddbMock.on(UpdateCommand).resolves({
-        Attributes: {...oldAdr, status: 'SUPERSEDED', version: 4, supersededBy: 'adr-new' },
+        Attributes: {
+          ...oldAdr,
+          status: "SUPERSEDED",
+          version: 4,
+          supersededBy: "adr-new",
+        },
       });
 
-      const auth = mockAuthContextFor('architect');
-      const result = await supersedeADR('adr-old', 'adr-new', auth);
+      const auth = mockAuthContextFor("architect");
+      const result = await supersedeADR("adr-old", "adr-new", auth);
 
-      expect(result.status).toBe('SUPERSEDED');
+      expect(result.status).toBe("SUPERSEDED");
       expect(result.version).toBe(4);
-      expect(result.supersededBy).toBe('adr-new');
+      expect(result.supersededBy).toBe("adr-new");
 
       const updates = ddbMock.commandCalls(UpdateCommand);
       expect(updates).toHaveLength(1);
       const input = updates[0].args[0].input;
       expect(input.ConditionExpression).toMatch(/version/);
-      expect(input.ExpressionAttributeValues![':currentVersion']).toBe(3);
-      expect(input.ExpressionAttributeValues![':newVersion']).toBe(4);
+      expect(input.ExpressionAttributeValues![":currentVersion"]).toBe(3);
+      expect(input.ExpressionAttributeValues![":newVersion"]).toBe(4);
     });
 
-    test('rejects cross-project supersede as ValidationError', async () => {
-      const oldAdr = { adrId: 'adr-old', projectId: 'proj-A', status: 'PROPOSED', version: 1, title: 'old', sourceRoundIds: [] };
-      const newAdr = { adrId: 'adr-new', projectId: 'proj-B', status: 'PROPOSED', version: 1, title: 'new', sourceRoundIds: [] };
+    test("rejects cross-project supersede as ValidationError", async () => {
+      const oldAdr = {
+        adrId: "adr-old",
+        projectId: "proj-A",
+        status: "PROPOSED",
+        version: 1,
+        title: "old",
+        sourceRoundIds: [],
+      };
+      const newAdr = {
+        adrId: "adr-new",
+        projectId: "proj-B",
+        status: "PROPOSED",
+        version: 1,
+        title: "new",
+        sourceRoundIds: [],
+      };
       ddbMock
-        .on(GetCommand, { TableName: 'citadel-adrs-test', Key: { adrId: 'adr-old' } })
+        .on(GetCommand, {
+          TableName: "citadel-adrs-test",
+          Key: { adrId: "adr-old" },
+        })
         .resolves({ Item: oldAdr })
-        .on(GetCommand, { TableName: 'citadel-adrs-test', Key: { adrId: 'adr-new' } })
+        .on(GetCommand, {
+          TableName: "citadel-adrs-test",
+          Key: { adrId: "adr-new" },
+        })
         .resolves({ Item: newAdr });
 
-      const auth = mockAuthContextFor('architect');
-      await expect(
-        supersedeADR('adr-old', 'adr-new', auth)
-      ).rejects.toThrow(/ValidationError.*same projectId/);
+      const auth = mockAuthContextFor("architect");
+      await expect(supersedeADR("adr-old", "adr-new", auth)).rejects.toThrow(
+        /ValidationError.*same projectId/,
+      );
       expect(ddbMock.commandCalls(UpdateCommand)).toHaveLength(0);
     });
 
-    test('stale version (ConditionalCheckFailedException) propagates', async () => {
-      const oldAdr = { adrId: 'adr-old', projectId: 'proj-1', status: 'PROPOSED', version: 3, title: 'old', sourceRoundIds: [] };
-      const newAdr = { adrId: 'adr-new', projectId: 'proj-1', status: 'PROPOSED', version: 1, title: 'new', sourceRoundIds: [] };
+    test("stale version (ConditionalCheckFailedException) propagates", async () => {
+      const oldAdr = {
+        adrId: "adr-old",
+        projectId: "proj-1",
+        status: "PROPOSED",
+        version: 3,
+        title: "old",
+        sourceRoundIds: [],
+      };
+      const newAdr = {
+        adrId: "adr-new",
+        projectId: "proj-1",
+        status: "PROPOSED",
+        version: 1,
+        title: "new",
+        sourceRoundIds: [],
+      };
       ddbMock
-        .on(GetCommand, { TableName: 'citadel-adrs-test', Key: { adrId: 'adr-old' } })
+        .on(GetCommand, {
+          TableName: "citadel-adrs-test",
+          Key: { adrId: "adr-old" },
+        })
         .resolves({ Item: oldAdr })
-        .on(GetCommand, { TableName: 'citadel-adrs-test', Key: { adrId: 'adr-new' } })
+        .on(GetCommand, {
+          TableName: "citadel-adrs-test",
+          Key: { adrId: "adr-new" },
+        })
         .resolves({ Item: newAdr });
-      const ccfError = new Error('The conditional request failed');
-      ccfError.name = 'ConditionalCheckFailedException';
+      const ccfError = new Error("The conditional request failed");
+      ccfError.name = "ConditionalCheckFailedException";
       ddbMock.on(UpdateCommand).rejects(ccfError);
 
-      const auth = mockAuthContextFor('architect');
-      await expect(
-        supersedeADR('adr-old', 'adr-new', auth)
-      ).rejects.toThrow(/conditional/i);
+      const auth = mockAuthContextFor("architect");
+      await expect(supersedeADR("adr-old", "adr-new", auth)).rejects.toThrow(
+        /conditional/i,
+      );
     });
 
-    test('rejects invalid lifecycle transition from SUPERSEDED', async () => {
-      const oldAdr = { adrId: 'adr-old', projectId: 'proj-1', status: 'SUPERSEDED', version: 2, title: 'old', sourceRoundIds: [] };
-      const newAdr = { adrId: 'adr-new', projectId: 'proj-1', status: 'PROPOSED', version: 1, title: 'new', sourceRoundIds: [] };
+    test("rejects invalid lifecycle transition from SUPERSEDED", async () => {
+      const oldAdr = {
+        adrId: "adr-old",
+        projectId: "proj-1",
+        status: "SUPERSEDED",
+        version: 2,
+        title: "old",
+        sourceRoundIds: [],
+      };
+      const newAdr = {
+        adrId: "adr-new",
+        projectId: "proj-1",
+        status: "PROPOSED",
+        version: 1,
+        title: "new",
+        sourceRoundIds: [],
+      };
       ddbMock
-        .on(GetCommand, { TableName: 'citadel-adrs-test', Key: { adrId: 'adr-old' } })
+        .on(GetCommand, {
+          TableName: "citadel-adrs-test",
+          Key: { adrId: "adr-old" },
+        })
         .resolves({ Item: oldAdr })
-        .on(GetCommand, { TableName: 'citadel-adrs-test', Key: { adrId: 'adr-new' } })
+        .on(GetCommand, {
+          TableName: "citadel-adrs-test",
+          Key: { adrId: "adr-new" },
+        })
         .resolves({ Item: newAdr });
 
-      const auth = mockAuthContextFor('architect');
-      await expect(
-        supersedeADR('adr-old', 'adr-new', auth)
-      ).rejects.toThrow(/Invalid status transition/);
+      const auth = mockAuthContextFor("architect");
+      await expect(supersedeADR("adr-old", "adr-new", auth)).rejects.toThrow(
+        /Invalid status transition/,
+      );
     });
   });
 
   // ── getADR / listADRsForProject ───────────────────────────────────────
 
-  describe('getADR', () => {
-    test('returns null for unknown adrId', async () => {
+  describe("getADR", () => {
+    test("returns null for unknown adrId", async () => {
       ddbMock.on(GetCommand).resolves({});
-      const adr = await getADR('missing');
+      const adr = await getADR("missing");
       expect(adr).toBeNull();
     });
 
-    test('returns the ADR when present', async () => {
-      const existing = { adrId: 'adr-1', projectId: 'proj-1', status: 'PROPOSED', version: 1, title: 't', sourceRoundIds: [] };
+    test("returns the ADR when present", async () => {
+      const existing = {
+        adrId: "adr-1",
+        projectId: "proj-1",
+        status: "PROPOSED",
+        version: 1,
+        title: "t",
+        sourceRoundIds: [],
+      };
       ddbMock.on(GetCommand).resolves({ Item: existing });
-      const adr = await getADR('adr-1');
+      const adr = await getADR("adr-1");
       expect(adr).toEqual(existing);
     });
   });
 
-  describe('listADRsForProject', () => {
-    test('returns [] when project has no ADRs and queries the project-index GSI', async () => {
+  describe("listADRsForProject", () => {
+    test("returns [] when project has no ADRs and queries the project-index GSI", async () => {
       ddbMock.on(QueryCommand).resolves({ Items: [] });
-      const adrs = await listADRsForProject('proj-none');
+      const adrs = await listADRsForProject("proj-none");
       expect(adrs).toEqual([]);
       const calls = ddbMock.commandCalls(QueryCommand);
       expect(calls).toHaveLength(1);
-      expect(calls[0].args[0].input.IndexName).toBe('project-index');
-      expect(calls[0].args[0].input.KeyConditionExpression).toBe('projectId = :pid');
+      expect(calls[0].args[0].input.IndexName).toBe("project-index");
+      expect(calls[0].args[0].input.KeyConditionExpression).toBe(
+        "projectId = :pid",
+      );
     });
 
-    test('returns items when project has ADRs', async () => {
+    test("returns items when project has ADRs", async () => {
       const items = [
-        { adrId: 'a1', projectId: 'proj-1', status: 'LOCKED', version: 2, title: 't1', sourceRoundIds: [] },
-        { adrId: 'a2', projectId: 'proj-1', status: 'PROPOSED', version: 1, title: 't2', sourceRoundIds: [] },
+        {
+          adrId: "a1",
+          projectId: "proj-1",
+          status: "LOCKED",
+          version: 2,
+          title: "t1",
+          sourceRoundIds: [],
+        },
+        {
+          adrId: "a2",
+          projectId: "proj-1",
+          status: "PROPOSED",
+          version: 1,
+          title: "t2",
+          sourceRoundIds: [],
+        },
       ];
       ddbMock.on(QueryCommand).resolves({ Items: items });
-      const adrs = await listADRsForProject('proj-1');
+      const adrs = await listADRsForProject("proj-1");
       expect(adrs).toEqual(items);
     });
   });
 
   // ── handler (field dispatch) ──────────────────────────────────────────
 
-  describe('handler dispatch', () => {
-    function makeEvent(fieldName: string, args: Record<string, unknown>, role: 'architect' | 'developer' = 'architect') {
+  describe("handler dispatch", () => {
+    // finding 677c1a6c: handler dispatch now threads `event` into the
+    // project-org gate, so every dispatch test needs a project record whose
+    // organization matches the caller's `custom:organization` claim.
+    beforeEach(() => {
+      ddbMock
+        .on(GetCommand, {
+          TableName: "citadel-projects-test",
+          Key: { id: "proj-1" },
+        })
+        .resolves({
+          Item: {
+            id: "proj-1",
+            owner: "someone-else",
+            organization: "org-shared",
+          },
+        });
+    });
+
+    function makeEvent(
+      fieldName: string,
+      args: Record<string, unknown>,
+      role: "architect" | "developer" = "architect",
+    ) {
       return {
         info: { fieldName },
         arguments: args,
         identity: {
           sub: `user-${role}`,
           username: role,
-          'custom:role': role,
+          "custom:role": role,
+          "custom:organization": "org-shared",
         },
       };
     }
 
-    test('createADR dispatch routes to createADR function and enforces permission', async () => {
+    test("createADR dispatch routes to createADR function and enforces permission", async () => {
       ddbMock.on(PutCommand).resolves({});
-      const result = (await handler(makeEvent('createADR', { input: baseInput() }))) as {
+      const result = (await handler(
+        makeEvent("createADR", { input: baseInput() }),
+      )) as {
         status: string;
         version: number;
       };
-      expect(result.status).toBe('PROPOSED');
+      expect(result.status).toBe("PROPOSED");
       expect(result.version).toBe(1);
     });
 
-    test('getADR dispatch', async () => {
-      const existing = { adrId: 'adr-1', projectId: 'proj-1', status: 'PROPOSED', version: 1, title: 't', sourceRoundIds: [] };
-      ddbMock.on(GetCommand).resolves({ Item: existing });
-      const result = await handler(makeEvent('getADR', { adrId: 'adr-1' }));
+    test("getADR dispatch", async () => {
+      const existing = {
+        adrId: "adr-1",
+        projectId: "proj-1",
+        status: "PROPOSED",
+        version: 1,
+        title: "t",
+        sourceRoundIds: [],
+      };
+      ddbMock
+        .on(GetCommand, {
+          TableName: "citadel-adrs-test",
+          Key: { adrId: "adr-1" },
+        })
+        .resolves({ Item: existing });
+      const result = await handler(makeEvent("getADR", { adrId: "adr-1" }));
       expect(result).toEqual(existing);
     });
 
-    test('listADRsForProject dispatch', async () => {
+    test("listADRsForProject dispatch", async () => {
       ddbMock.on(QueryCommand).resolves({ Items: [] });
-      const result = await handler(makeEvent('listADRsForProject', { projectId: 'proj-1' }));
+      const result = await handler(
+        makeEvent("listADRsForProject", { projectId: "proj-1" }),
+      );
       expect(result).toEqual([]);
     });
 
-    test('unknown field throws', async () => {
-      await expect(handler(makeEvent('notAField', {}))).rejects.toThrow(/Unsupported field/);
+    test("unknown field throws", async () => {
+      await expect(handler(makeEvent("notAField", {}))).rejects.toThrow(
+        /Unsupported field/,
+      );
     });
 
-    test('developer role cannot create ADR', async () => {
+    test("developer role cannot create ADR", async () => {
       await expect(
-        handler(makeEvent('createADR', { input: baseInput() }, 'developer'))
+        handler(makeEvent("createADR", { input: baseInput() }, "developer")),
       ).rejects.toThrow(/UnauthorizedError/);
     });
   });
 
   // ── Property tests ────────────────────────────────────────────────────
 
-  describe('property: ADR_TRANSITIONS via LifecycleManager', () => {
+  describe("property: ADR_TRANSITIONS via LifecycleManager", () => {
     const lifecycle = new LifecycleManager(ADR_TRANSITIONS);
-    const STATUSES = ['PROPOSED', 'LOCKED', 'SUPERSEDED', 'REOPENED'];
+    const STATUSES = ["PROPOSED", "LOCKED", "SUPERSEDED", "REOPENED"];
     const MATRIX: Record<string, string[]> = {
-      PROPOSED: ['LOCKED', 'SUPERSEDED'],
-      LOCKED: ['SUPERSEDED', 'REOPENED'],
-      REOPENED: ['LOCKED'],
+      PROPOSED: ["LOCKED", "SUPERSEDED"],
+      LOCKED: ["SUPERSEDED", "REOPENED"],
+      REOPENED: ["LOCKED"],
       SUPERSEDED: [],
     };
 
-    test('random (from, to) pairs respect the matrix and same-state idempotence', () => {
+    test("random (from, to) pairs respect the matrix and same-state idempotence", () => {
       const statusArb = fc.constantFrom(...STATUSES);
       fc.assert(
         fc.property(statusArb, statusArb, (from, to) => {
           const expected = from === to || MATRIX[from].includes(to);
           expect(lifecycle.isValidTransition(from, to)).toBe(expected);
         }),
-        { numRuns: 100 }
+        { numRuns: 100 },
       );
     });
   });
 
-  describe('property: createADR always returns PROPOSED v1', () => {
-    test('for 100 random valid inputs, status=PROPOSED and version=1', async () => {
+  describe("property: createADR always returns PROPOSED v1", () => {
+    test("for 100 random valid inputs, status=PROPOSED and version=1", async () => {
       ddbMock.on(PutCommand).resolves({});
-      const auth = mockAuthContextFor('architect');
+      const auth = mockAuthContextFor("architect");
 
       const titleArb = fc.string({ minLength: 1, maxLength: 80 });
       const bodyArb = fc.string({ minLength: 1, maxLength: 500 });
-      const listArb = fc.array(fc.string({ minLength: 1, maxLength: 50 }), { minLength: 0, maxLength: 5 });
-      const severityArb = fc.option(fc.constantFrom('LOW', 'MEDIUM', 'HIGH', 'CRITICAL'), { nil: undefined });
+      const listArb = fc.array(fc.string({ minLength: 1, maxLength: 50 }), {
+        minLength: 0,
+        maxLength: 5,
+      });
+      const severityArb = fc.option(
+        fc.constantFrom("LOW", "MEDIUM", "HIGH", "CRITICAL"),
+        { nil: undefined },
+      );
 
       await fc.assert(
         fc.asyncProperty(
-          titleArb, bodyArb, bodyArb, listArb, listArb, listArb, listArb, severityArb,
-          async (title, decision, reasoning, constraints, alternatives, revisits, sourceRoundIds, severity) => {
+          titleArb,
+          bodyArb,
+          bodyArb,
+          listArb,
+          listArb,
+          listArb,
+          listArb,
+          severityArb,
+          async (
+            title,
+            decision,
+            reasoning,
+            constraints,
+            alternatives,
+            revisits,
+            sourceRoundIds,
+            severity,
+          ) => {
             ddbMock.resetHistory();
             const input = {
-              projectId: 'proj-p',
+              projectId: "proj-p",
               title,
               decision,
               reasoning,
@@ -446,13 +640,15 @@ describe('adr-resolver', () => {
               severity,
             };
             const adr = await createADR(input, auth);
-            expect(adr.status).toBe('PROPOSED');
+            expect(adr.status).toBe("PROPOSED");
             expect(adr.version).toBe(1);
             expect(adr.adrId).toMatch(/^[0-9a-f-]{36}$/i);
-            expect(adr.createdAt).toMatch(/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3}Z$/);
-          }
+            expect(adr.createdAt).toMatch(
+              /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3}Z$/,
+            );
+          },
         ),
-        { numRuns: 100 }
+        { numRuns: 100 },
       );
     });
   });
@@ -466,15 +662,17 @@ describe('adr-resolver', () => {
   // pre-audit input-shape validation (step 0), which rejects malformed
   // payloads to keep the audit table clean.
 
-  describe('reopenADR — audit-before-auth', () => {
-    const AUDIT_TABLE = 'citadel-adr-reopen-attempts-test';
-    const ADRS_TABLE = 'citadel-adrs-test';
+  describe("reopenADR — audit-before-auth", () => {
+    const AUDIT_TABLE = "citadel-adr-reopen-attempts-test";
+    const ADRS_TABLE = "citadel-adrs-test";
 
     // Helper: auth context for any governance-relevant role (adds
     // project_manager + developer to the existing architect/developer
     // helper above, since grants adr:reopen to architect AND
     // project_manager per QT1-5).
-    function auditAuthContextFor(role: 'architect' | 'project_manager' | 'developer'): AuthContext {
+    function auditAuthContextFor(
+      role: "architect" | "project_manager" | "developer",
+    ): AuthContext {
       return {
         userId: `user-${role}`,
         username: role,
@@ -498,59 +696,67 @@ describe('adr-resolver', () => {
 
     function lockedAdr(overrides: Partial<Record<string, unknown>> = {}) {
       return {
-        adrId: 'adr-1',
-        projectId: 'proj-1',
-        title: 'Adopt PostgreSQL',
-        status: 'LOCKED',
+        adrId: "adr-1",
+        projectId: "proj-1",
+        title: "Adopt PostgreSQL",
+        status: "LOCKED",
         version: 3,
-        sourceRoundIds: ['r1'],
-        lockedAt: '2026-04-29T00:00:00.000Z',
+        sourceRoundIds: ["r1"],
+        lockedAt: "2026-04-29T00:00:00.000Z",
         ...overrides,
       };
     }
 
-    test('1. denied user: audit row written as PENDING→DENIED, event emitted, then throws', async () => {
+    test("1. denied user: audit row written as PENDING→DENIED, event emitted, then throws", async () => {
       // Fail path must still produce: 1 PutCommand(PENDING) then 1
       // UpdateCommand(DENIED) then 1 PutEvents.
       ddbMock.on(GetCommand).resolves({ Item: lockedAdr() });
       ddbMock.on(PutCommand).resolves({});
       ddbMock.on(UpdateCommand).resolves({});
 
-      const auth = auditAuthContextFor('developer');
+      const auth = auditAuthContextFor("developer");
       await expect(
-        reopenADR('adr-1', 'Reopen for clause X', true, 'scope expanded', auth)
+        reopenADR("adr-1", "Reopen for clause X", true, "scope expanded", auth),
       ).rejects.toThrow(/UnauthorizedError.*adr:reopen/);
 
       const { puts, updates } = auditCommands();
       expect(puts).toHaveLength(1);
       expect(puts[0].args[0].input.TableName).toBe(AUDIT_TABLE);
-      expect(puts[0].args[0].input.ConditionExpression).toMatch(/attribute_not_exists\(attemptId\)/);
+      expect(puts[0].args[0].input.ConditionExpression).toMatch(
+        /attribute_not_exists\(attemptId\)/,
+      );
       const pendingRow = puts[0].args[0].input.Item as Record<string, unknown>;
-      expect(pendingRow.authResult).toBe('PENDING');
-      expect(pendingRow.adrId).toBe('adr-1');
-      expect(pendingRow.projectId).toBe('proj-1');
-      expect(pendingRow.attemptedBy).toBe('user-developer');
-      expect(pendingRow.attemptedAt).toMatch(/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3}Z$/);
-      expect(pendingRow.proposedChange).toBe('Reopen for clause X');
+      expect(pendingRow.authResult).toBe("PENDING");
+      expect(pendingRow.adrId).toBe("adr-1");
+      expect(pendingRow.projectId).toBe("proj-1");
+      expect(pendingRow.attemptedBy).toBe("user-developer");
+      expect(pendingRow.attemptedAt).toMatch(
+        /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3}Z$/,
+      );
+      expect(pendingRow.proposedChange).toBe("Reopen for clause X");
       expect(pendingRow.revisitConditionMatched).toBe(true);
-      expect(pendingRow.reason).toBe('scope expanded');
+      expect(pendingRow.reason).toBe("scope expanded");
 
       expect(updates).toHaveLength(1);
       expect(updates[0].args[0].input.TableName).toBe(AUDIT_TABLE);
-      expect(updates[0].args[0].input.ExpressionAttributeValues![':ar']).toBe('DENIED');
-      expect(updates[0].args[0].input.Key).toEqual({ attemptId: pendingRow.attemptId });
+      expect(updates[0].args[0].input.ExpressionAttributeValues![":ar"]).toBe(
+        "DENIED",
+      );
+      expect(updates[0].args[0].input.Key).toEqual({
+        attemptId: pendingRow.attemptId,
+      });
 
       // Event IS emitted on denied path (downstream alerting relies on this).
       const ebCalls = ebMock.commandCalls(PutEventsCommand);
       expect(ebCalls).toHaveLength(1);
       const entry = ebCalls[0].args[0].input.Entries![0];
-      expect(entry.DetailType).toBe('governance.adr.reopen.attempted');
+      expect(entry.DetailType).toBe("governance.adr.reopen.attempted");
       const detail = JSON.parse(entry.Detail!);
-      expect(detail.authResult).toBe('DENIED');
-      expect(detail.attemptedBy).toBe('user-developer');
+      expect(detail.authResult).toBe("DENIED");
+      expect(detail.attemptedBy).toBe("user-developer");
     });
 
-    test('2. architect on LOCKED ADR succeeds: audit row PENDING→ALLOWED, ADR transitions to REOPENED', async () => {
+    test("2. architect on LOCKED ADR succeeds: audit row PENDING→ALLOWED, ADR transitions to REOPENED", async () => {
       const locked = lockedAdr();
       ddbMock.on(GetCommand).resolves({ Item: locked });
       ddbMock.on(PutCommand).resolves({});
@@ -558,58 +764,88 @@ describe('adr-resolver', () => {
         .on(UpdateCommand, { TableName: AUDIT_TABLE })
         .resolves({})
         .on(UpdateCommand, { TableName: ADRS_TABLE })
-        .resolves({ Attributes: {...locked, status: 'REOPENED', version: 4 } });
+        .resolves({
+          Attributes: { ...locked, status: "REOPENED", version: 4 },
+        });
 
-      const auth = auditAuthContextFor('architect');
-      const result = await reopenADR('adr-1', 'Need to rethink clause Y', true, 'vendor contract change', auth);
+      const auth = auditAuthContextFor("architect");
+      const result = await reopenADR(
+        "adr-1",
+        "Need to rethink clause Y",
+        true,
+        "vendor contract change",
+        auth,
+      );
 
-      expect(result.status).toBe('REOPENED');
+      expect(result.status).toBe("REOPENED");
       expect(result.version).toBe(4);
 
       const { puts, updates } = auditCommands();
       expect(puts).toHaveLength(1);
-      expect((puts[0].args[0].input.Item as Record<string, unknown>).authResult).toBe('PENDING');
+      expect(
+        (puts[0].args[0].input.Item as Record<string, unknown>).authResult,
+      ).toBe("PENDING");
       expect(updates).toHaveLength(1);
-      expect(updates[0].args[0].input.ExpressionAttributeValues![':ar']).toBe('ALLOWED');
+      expect(updates[0].args[0].input.ExpressionAttributeValues![":ar"]).toBe(
+        "ALLOWED",
+      );
 
       // ADR-table update asserts optimistic lock on version.
       const adrUpdates = ddbMock
         .commandCalls(UpdateCommand)
         .filter((c) => c.args[0].input.TableName === ADRS_TABLE);
       expect(adrUpdates).toHaveLength(1);
-      expect(adrUpdates[0].args[0].input.ConditionExpression).toMatch(/version/);
-      expect(adrUpdates[0].args[0].input.ExpressionAttributeValues![':currentVersion']).toBe(3);
-      expect(adrUpdates[0].args[0].input.ExpressionAttributeValues![':newVersion']).toBe(4);
-      expect(adrUpdates[0].args[0].input.ExpressionAttributeValues![':newStatus']).toBe('REOPENED');
+      expect(adrUpdates[0].args[0].input.ConditionExpression).toMatch(
+        /version/,
+      );
+      expect(
+        adrUpdates[0].args[0].input.ExpressionAttributeValues![
+          ":currentVersion"
+        ],
+      ).toBe(3);
+      expect(
+        adrUpdates[0].args[0].input.ExpressionAttributeValues![":newVersion"],
+      ).toBe(4);
+      expect(
+        adrUpdates[0].args[0].input.ExpressionAttributeValues![":newStatus"],
+      ).toBe("REOPENED");
 
       const ebCalls = ebMock.commandCalls(PutEventsCommand);
       expect(ebCalls).toHaveLength(1);
       const detail = JSON.parse(ebCalls[0].args[0].input.Entries![0].Detail!);
-      expect(detail.authResult).toBe('ALLOWED');
-      expect(detail.projectId).toBe('proj-1');
-      expect(detail.adrId).toBe('adr-1');
+      expect(detail.authResult).toBe("ALLOWED");
+      expect(detail.projectId).toBe("proj-1");
+      expect(detail.adrId).toBe("adr-1");
       expect(detail.revisitConditionMatched).toBe(true);
     });
 
-    test('3. architect on non-LOCKED (PROPOSED) ADR: audit row stays ALLOWED with transitionError populated, event emitted, ValidationError thrown', async () => {
-      const proposed = lockedAdr({ status: 'PROPOSED' });
+    test("3. architect on non-LOCKED (PROPOSED) ADR: audit row stays ALLOWED with transitionError populated, event emitted, ValidationError thrown", async () => {
+      const proposed = lockedAdr({ status: "PROPOSED" });
       ddbMock.on(GetCommand).resolves({ Item: proposed });
       ddbMock.on(PutCommand).resolves({});
       ddbMock.on(UpdateCommand).resolves({});
 
-      const auth = auditAuthContextFor('architect');
-      await expect(
-        reopenADR('adr-1', 'p', false, 'r', auth)
-      ).rejects.toThrow(/Invalid status transition/);
+      const auth = auditAuthContextFor("architect");
+      await expect(reopenADR("adr-1", "p", false, "r", auth)).rejects.toThrow(
+        /Invalid status transition/,
+      );
 
       const { puts, updates } = auditCommands();
       expect(puts).toHaveLength(1);
-      expect((puts[0].args[0].input.Item as Record<string, unknown>).authResult).toBe('PENDING');
+      expect(
+        (puts[0].args[0].input.Item as Record<string, unknown>).authResult,
+      ).toBe("PENDING");
       // Two audit-table updates: first ALLOWED, then transitionError.
       expect(updates).toHaveLength(2);
-      expect(updates[0].args[0].input.ExpressionAttributeValues![':ar']).toBe('ALLOWED');
-      expect(updates[1].args[0].input.UpdateExpression).toMatch(/transitionError/);
-      expect(updates[1].args[0].input.ExpressionAttributeValues![':te']).toMatch(/Invalid status transition/);
+      expect(updates[0].args[0].input.ExpressionAttributeValues![":ar"]).toBe(
+        "ALLOWED",
+      );
+      expect(updates[1].args[0].input.UpdateExpression).toMatch(
+        /transitionError/,
+      );
+      expect(
+        updates[1].args[0].input.ExpressionAttributeValues![":te"],
+      ).toMatch(/Invalid status transition/);
       // No ADR-table write.
       const adrUpdates = ddbMock
         .commandCalls(UpdateCommand)
@@ -617,95 +853,112 @@ describe('adr-resolver', () => {
       expect(adrUpdates).toHaveLength(0);
       // Event IS emitted — between auth-update and lifecycle validation.
       expect(ebMock.commandCalls(PutEventsCommand)).toHaveLength(1);
-      const detail = JSON.parse(ebMock.commandCalls(PutEventsCommand)[0].args[0].input.Entries![0].Detail!);
-      expect(detail.authResult).toBe('ALLOWED');
+      const detail = JSON.parse(
+        ebMock.commandCalls(PutEventsCommand)[0].args[0].input.Entries![0]
+          .Detail!,
+      );
+      expect(detail.authResult).toBe("ALLOWED");
     });
 
-    test('4. architect on non-existent ADR: audit row written with projectId empty, authResult ALLOWED, then throws ADR-not-found', async () => {
+    test("4. architect on non-existent ADR: audit row written with projectId empty, authResult ALLOWED, then throws ADR-not-found", async () => {
       ddbMock.on(GetCommand).resolves({});
       ddbMock.on(PutCommand).resolves({});
       ddbMock.on(UpdateCommand).resolves({});
 
-      const auth = auditAuthContextFor('architect');
+      const auth = auditAuthContextFor("architect");
       await expect(
-        reopenADR('ghost-adr', 'p', true, 'r', auth)
+        reopenADR("ghost-adr", "p", true, "r", auth),
       ).rejects.toThrow(/ADR not found: ghost-adr/);
 
       const { puts, updates } = auditCommands();
       expect(puts).toHaveLength(1);
       const row = puts[0].args[0].input.Item as Record<string, unknown>;
-      expect(row.adrId).toBe('ghost-adr');
-      expect(row.projectId).toBe('');
-      expect(row.authResult).toBe('PENDING');
+      expect(row.adrId).toBe("ghost-adr");
+      expect(row.projectId).toBe("");
+      expect(row.authResult).toBe("PENDING");
       expect(updates).toHaveLength(1);
-      expect(updates[0].args[0].input.ExpressionAttributeValues![':ar']).toBe('ALLOWED');
+      expect(updates[0].args[0].input.ExpressionAttributeValues![":ar"]).toBe(
+        "ALLOWED",
+      );
       expect(ebMock.commandCalls(PutEventsCommand)).toHaveLength(1);
     });
 
-    test('5. non-existent ADR with denied user: audit row DENIED, UnauthorizedError wins over ADR-not-found', async () => {
+    test("5. non-existent ADR with denied user: audit row DENIED, UnauthorizedError wins over ADR-not-found", async () => {
       ddbMock.on(GetCommand).resolves({});
       ddbMock.on(PutCommand).resolves({});
       ddbMock.on(UpdateCommand).resolves({});
 
-      const auth = auditAuthContextFor('developer');
+      const auth = auditAuthContextFor("developer");
       await expect(
-        reopenADR('ghost-adr', 'p', true, 'r', auth)
+        reopenADR("ghost-adr", "p", true, "r", auth),
       ).rejects.toThrow(/UnauthorizedError/);
       // Specifically NOT the 'ADR not found' error.
       await expect(
-        reopenADR('ghost-adr', 'p', true, 'r', auth)
+        reopenADR("ghost-adr", "p", true, "r", auth),
       ).rejects.not.toThrow(/ADR not found/);
 
-      const puts = ddbMock.commandCalls(PutCommand).filter((c) => c.args[0].input.TableName === AUDIT_TABLE);
-      const updates = ddbMock.commandCalls(UpdateCommand).filter((c) => c.args[0].input.TableName === AUDIT_TABLE);
+      const puts = ddbMock
+        .commandCalls(PutCommand)
+        .filter((c) => c.args[0].input.TableName === AUDIT_TABLE);
+      const updates = ddbMock
+        .commandCalls(UpdateCommand)
+        .filter((c) => c.args[0].input.TableName === AUDIT_TABLE);
       expect(puts.length).toBeGreaterThanOrEqual(1);
-      expect(updates.some((c) => c.args[0].input.ExpressionAttributeValues![':ar'] === 'DENIED')).toBe(true);
+      expect(
+        updates.some(
+          (c) => c.args[0].input.ExpressionAttributeValues![":ar"] === "DENIED",
+        ),
+      ).toBe(true);
     });
 
-    test('6. invalid input (non-string proposedChange) with architect: ValidationError BEFORE any DDB write', async () => {
-      const auth = auditAuthContextFor('architect');
+    test("6. invalid input (non-string proposedChange) with architect: ValidationError BEFORE any DDB write", async () => {
+      const auth = auditAuthContextFor("architect");
       await expect(
-        reopenADR('adr-1', 123 as unknown as string, true, 'r', auth)
+        reopenADR("adr-1", 123 as unknown as string, true, "r", auth),
       ).rejects.toThrow(/ValidationError.*proposedChange/);
       // Zero writes to the audit table.
-      expect(ddbMock.commandCalls(PutCommand).filter((c) => c.args[0].input.TableName === AUDIT_TABLE)).toHaveLength(0);
+      expect(
+        ddbMock
+          .commandCalls(PutCommand)
+          .filter((c) => c.args[0].input.TableName === AUDIT_TABLE),
+      ).toHaveLength(0);
       expect(ddbMock.commandCalls(UpdateCommand)).toHaveLength(0);
       // And zero GetCommands too — we abort before any DDB contact.
       expect(ddbMock.commandCalls(GetCommand)).toHaveLength(0);
     });
 
-    test('7. invalid input (non-string reason): ValidationError before audit', async () => {
-      const auth = auditAuthContextFor('architect');
+    test("7. invalid input (non-string reason): ValidationError before audit", async () => {
+      const auth = auditAuthContextFor("architect");
       await expect(
-        reopenADR('adr-1', 'p', true, 123 as unknown as string, auth)
+        reopenADR("adr-1", "p", true, 123 as unknown as string, auth),
       ).rejects.toThrow(/ValidationError.*reason/);
       expect(ddbMock.commandCalls(PutCommand)).toHaveLength(0);
     });
 
-    test('8. invalid input (non-boolean revisitConditionMatched): ValidationError before audit', async () => {
-      const auth = auditAuthContextFor('architect');
+    test("8. invalid input (non-boolean revisitConditionMatched): ValidationError before audit", async () => {
+      const auth = auditAuthContextFor("architect");
       await expect(
-        reopenADR('adr-1', 'p', 'yes' as unknown as boolean, 'r', auth)
+        reopenADR("adr-1", "p", "yes" as unknown as boolean, "r", auth),
       ).rejects.toThrow(/ValidationError.*revisitConditionMatched/);
       expect(ddbMock.commandCalls(PutCommand)).toHaveLength(0);
     });
 
-    test('9. concurrent reopen (stale version): ConditionalCheckFailedException propagates, audit row stays ALLOWED', async () => {
+    test("9. concurrent reopen (stale version): ConditionalCheckFailedException propagates, audit row stays ALLOWED", async () => {
       const locked = lockedAdr();
       ddbMock.on(GetCommand).resolves({ Item: locked });
       ddbMock.on(PutCommand).resolves({});
-      const ccf = new Error('The conditional request failed');
-      ccf.name = 'ConditionalCheckFailedException';
+      const ccf = new Error("The conditional request failed");
+      ccf.name = "ConditionalCheckFailedException";
       ddbMock
         .on(UpdateCommand, { TableName: AUDIT_TABLE })
         .resolves({})
         .on(UpdateCommand, { TableName: ADRS_TABLE })
         .rejects(ccf);
 
-      const auth = auditAuthContextFor('architect');
-      await expect(
-        reopenADR('adr-1', 'p', true, 'r', auth)
-      ).rejects.toThrow(/conditional/i);
+      const auth = auditAuthContextFor("architect");
+      await expect(reopenADR("adr-1", "p", true, "r", auth)).rejects.toThrow(
+        /conditional/i,
+      );
 
       const { puts, updates } = auditCommands();
       expect(puts).toHaveLength(1);
@@ -713,10 +966,12 @@ describe('adr-resolver', () => {
       // populated here because the failure happened in the ADRS_TABLE
       // update, not in LifecycleManager.validateTransition.
       expect(updates).toHaveLength(1);
-      expect(updates[0].args[0].input.ExpressionAttributeValues![':ar']).toBe('ALLOWED');
+      expect(updates[0].args[0].input.ExpressionAttributeValues![":ar"]).toBe(
+        "ALLOWED",
+      );
     });
 
-    test('10. project_manager role is permitted: happy path identical to architect', async () => {
+    test("10. project_manager role is permitted: happy path identical to architect", async () => {
       const locked = lockedAdr();
       ddbMock.on(GetCommand).resolves({ Item: locked });
       ddbMock.on(PutCommand).resolves({});
@@ -724,40 +979,49 @@ describe('adr-resolver', () => {
         .on(UpdateCommand, { TableName: AUDIT_TABLE })
         .resolves({})
         .on(UpdateCommand, { TableName: ADRS_TABLE })
-        .resolves({ Attributes: {...locked, status: 'REOPENED', version: 4 } });
+        .resolves({
+          Attributes: { ...locked, status: "REOPENED", version: 4 },
+        });
 
-      const auth = auditAuthContextFor('project_manager');
-      const result = await reopenADR('adr-1', 'p', true, 'r', auth);
-      expect(result.status).toBe('REOPENED');
+      const auth = auditAuthContextFor("project_manager");
+      const result = await reopenADR("adr-1", "p", true, "r", auth);
+      expect(result.status).toBe("REOPENED");
 
       const { puts, updates } = auditCommands();
       expect(puts).toHaveLength(1);
-      expect(updates[0].args[0].input.ExpressionAttributeValues![':ar']).toBe('ALLOWED');
+      expect(updates[0].args[0].input.ExpressionAttributeValues![":ar"]).toBe(
+        "ALLOWED",
+      );
       expect(ebMock.commandCalls(PutEventsCommand)).toHaveLength(1);
     });
 
-    test('11. developer role is denied (same as test 1 but explicit)', async () => {
+    test("11. developer role is denied (same as test 1 but explicit)", async () => {
       ddbMock.on(GetCommand).resolves({ Item: lockedAdr() });
       ddbMock.on(PutCommand).resolves({});
       ddbMock.on(UpdateCommand).resolves({});
 
-      const auth = auditAuthContextFor('developer');
-      await expect(
-        reopenADR('adr-1', 'p', true, 'r', auth)
-      ).rejects.toThrow(/UnauthorizedError.*adr:reopen/);
+      const auth = auditAuthContextFor("developer");
+      await expect(reopenADR("adr-1", "p", true, "r", auth)).rejects.toThrow(
+        /UnauthorizedError.*adr:reopen/,
+      );
       const updates = ddbMock
         .commandCalls(UpdateCommand)
         .filter((c) => c.args[0].input.TableName === AUDIT_TABLE);
-      expect(updates[0].args[0].input.ExpressionAttributeValues![':ar']).toBe('DENIED');
+      expect(updates[0].args[0].input.ExpressionAttributeValues![":ar"]).toBe(
+        "DENIED",
+      );
     });
 
-    test('12. property: for every invocation that passes input validation, at least one PutCommand was issued to the audit table', async () => {
-      const roleArb = fc.constantFrom<'architect' | 'project_manager' | 'developer'>(
-        'architect',
-        'project_manager',
-        'developer',
+    test("12. property: for every invocation that passes input validation, at least one PutCommand was issued to the audit table", async () => {
+      const roleArb = fc.constantFrom<
+        "architect" | "project_manager" | "developer"
+      >("architect", "project_manager", "developer");
+      const statusArb = fc.constantFrom(
+        "PROPOSED",
+        "LOCKED",
+        "SUPERSEDED",
+        "REOPENED",
       );
-      const statusArb = fc.constantFrom('PROPOSED', 'LOCKED', 'SUPERSEDED', 'REOPENED');
       const revisitArb = fc.boolean();
       // Bounded strings so the structural validation always passes.
       const strArb = fc.string({ minLength: 0, maxLength: 50 });
@@ -766,29 +1030,45 @@ describe('adr-resolver', () => {
 
       await fc.assert(
         fc.asyncProperty(
-          roleArb, statusArb, revisitArb, strArb, strArb, existsArb,
+          roleArb,
+          statusArb,
+          revisitArb,
+          strArb,
+          strArb,
+          existsArb,
           async (role, status, revisit, proposed, reason, exists) => {
             ddbMock.reset();
             ebMock.reset();
-            ebMock.on(PutEventsCommand).resolves({ FailedEntryCount: 0, Entries: [{ EventId: 'e' }] });
+            ebMock
+              .on(PutEventsCommand)
+              .resolves({ FailedEntryCount: 0, Entries: [{ EventId: "e" }] });
             __resetGovernanceNotifierForTest();
 
-            ddbMock.on(GetCommand).resolves(exists? { Item: lockedAdr({ status }) }: {});
+            ddbMock
+              .on(GetCommand)
+              .resolves(exists ? { Item: lockedAdr({ status }) } : {});
             ddbMock.on(PutCommand).resolves({});
-            const succeedOnAdrUpdate = exists && status === 'LOCKED' && role!== 'developer';
+            const succeedOnAdrUpdate =
+              exists && status === "LOCKED" && role !== "developer";
             ddbMock
               .on(UpdateCommand, { TableName: AUDIT_TABLE })
               .resolves({})
               .on(UpdateCommand, { TableName: ADRS_TABLE })
               .resolves(
                 succeedOnAdrUpdate
-                  ? { Attributes: {...lockedAdr({ status }), status: 'REOPENED', version: 4 } }
+                  ? {
+                      Attributes: {
+                        ...lockedAdr({ status }),
+                        status: "REOPENED",
+                        version: 4,
+                      },
+                    }
                   : {},
               );
 
             const auth = auditAuthContextFor(role);
             try {
-              await reopenADR('adr-1', proposed, revisit, reason, auth);
+              await reopenADR("adr-1", proposed, revisit, reason, auth);
             } catch {
               // Expected on many branches.
             }
@@ -798,14 +1078,17 @@ describe('adr-resolver', () => {
               .filter((c) => c.args[0].input.TableName === AUDIT_TABLE);
             expect(auditPuts.length).toBeGreaterThanOrEqual(1);
             // And the row is PENDING at insert-time.
-            expect((auditPuts[0].args[0].input.Item as Record<string, unknown>).authResult).toBe('PENDING');
+            expect(
+              (auditPuts[0].args[0].input.Item as Record<string, unknown>)
+                .authResult,
+            ).toBe("PENDING");
           },
         ),
         { numRuns: 100 },
       );
     });
 
-    test('13. emit payload shape: Detail contains exactly {projectId, adrId, revisitConditionMatched, attemptedBy, authResult, timestamp} (correlationId optional)', async () => {
+    test("13. emit payload shape: Detail contains exactly {projectId, adrId, revisitConditionMatched, attemptedBy, authResult, timestamp} (correlationId optional)", async () => {
       const locked = lockedAdr();
       ddbMock.on(GetCommand).resolves({ Item: locked });
       ddbMock.on(PutCommand).resolves({});
@@ -813,34 +1096,38 @@ describe('adr-resolver', () => {
         .on(UpdateCommand, { TableName: AUDIT_TABLE })
         .resolves({})
         .on(UpdateCommand, { TableName: ADRS_TABLE })
-        .resolves({ Attributes: {...locked, status: 'REOPENED', version: 4 } });
+        .resolves({
+          Attributes: { ...locked, status: "REOPENED", version: 4 },
+        });
 
-      const auth = auditAuthContextFor('architect');
-      await reopenADR('adr-1', 'p', true, 'r', auth);
+      const auth = auditAuthContextFor("architect");
+      await reopenADR("adr-1", "p", true, "r", auth);
 
       const ebCalls = ebMock.commandCalls(PutEventsCommand);
       expect(ebCalls).toHaveLength(1);
       const entry = ebCalls[0].args[0].input.Entries![0];
-      expect(entry.Source).toBe('citadel.backend');
-      expect(entry.DetailType).toBe('governance.adr.reopen.attempted');
+      expect(entry.Source).toBe("citadel.backend");
+      expect(entry.DetailType).toBe("governance.adr.reopen.attempted");
       const detail = JSON.parse(entry.Detail!);
       // Required keys present.
-      expect(detail.projectId).toBe('proj-1');
-      expect(detail.adrId).toBe('adr-1');
+      expect(detail.projectId).toBe("proj-1");
+      expect(detail.adrId).toBe("adr-1");
       expect(detail.revisitConditionMatched).toBe(true);
-      expect(detail.attemptedBy).toBe('user-architect');
-      expect(detail.authResult).toBe('ALLOWED');
-      expect(detail.timestamp).toMatch(/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3}Z$/);
+      expect(detail.attemptedBy).toBe("user-architect");
+      expect(detail.authResult).toBe("ALLOWED");
+      expect(detail.timestamp).toMatch(
+        /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3}Z$/,
+      );
       // No extra keys besides the allowed set (correlationId is permitted
       // but optional — omitted here since we didn't pass one).
       const allowed = new Set([
-        'projectId',
-        'adrId',
-        'revisitConditionMatched',
-        'attemptedBy',
-        'authResult',
-        'timestamp',
-        'correlationId',
+        "projectId",
+        "adrId",
+        "revisitConditionMatched",
+        "attemptedBy",
+        "authResult",
+        "timestamp",
+        "correlationId",
       ]);
       for (const key of Object.keys(detail)) {
         expect(allowed.has(key)).toBe(true);
@@ -850,32 +1137,64 @@ describe('adr-resolver', () => {
 
   // ── reopenADR dispatch via handler ────────────────────────────────────
 
-  describe('handler dispatch: reopenADR', () => {
-    test('reopenADR dispatches to the resolver with architect auth and returns REOPENED', async () => {
+  describe("handler dispatch: reopenADR", () => {
+    test("reopenADR dispatches to the resolver with architect auth and returns REOPENED", async () => {
       const locked = {
-        adrId: 'adr-1',
-        projectId: 'proj-1',
-        title: 't',
-        status: 'LOCKED',
+        adrId: "adr-1",
+        projectId: "proj-1",
+        title: "t",
+        status: "LOCKED",
         version: 3,
         sourceRoundIds: [],
-        lockedAt: '2026-04-29T00:00:00.000Z',
+        lockedAt: "2026-04-29T00:00:00.000Z",
       };
-      ddbMock.on(GetCommand).resolves({ Item: locked });
+      ddbMock
+        .on(GetCommand, {
+          TableName: "citadel-adrs-test",
+          Key: { adrId: "adr-1" },
+        })
+        .resolves({ Item: locked });
+      ddbMock
+        .on(GetCommand, {
+          TableName: "citadel-projects-test",
+          Key: { id: "proj-1" },
+        })
+        .resolves({
+          Item: {
+            id: "proj-1",
+            owner: "someone-else",
+            organization: "org-shared",
+          },
+        });
       ddbMock.on(PutCommand).resolves({});
       ddbMock
-        .on(UpdateCommand, { TableName: 'citadel-adr-reopen-attempts-test' })
+        .on(UpdateCommand, { TableName: "citadel-adr-reopen-attempts-test" })
         .resolves({})
-        .on(UpdateCommand, { TableName: 'citadel-adrs-test' })
-        .resolves({ Attributes: {...locked, status: 'REOPENED', version: 4 } });
+        .on(UpdateCommand, { TableName: "citadel-adrs-test" })
+        .resolves({
+          Attributes: { ...locked, status: "REOPENED", version: 4 },
+        });
 
       const event = {
-        info: { fieldName: 'reopenADR' },
-        arguments: { adrId: 'adr-1', proposedChange: 'p', revisitConditionMatched: true, reason: 'r' },
-        identity: { sub: 'user-architect', username: 'architect', 'custom:role': 'architect' },
+        info: { fieldName: "reopenADR" },
+        arguments: {
+          adrId: "adr-1",
+          proposedChange: "p",
+          revisitConditionMatched: true,
+          reason: "r",
+        },
+        identity: {
+          sub: "user-architect",
+          username: "architect",
+          "custom:role": "architect",
+          "custom:organization": "org-shared",
+        },
       };
-      const result = (await handler(event)) as { status: string; version: number };
-      expect(result.status).toBe('REOPENED');
+      const result = (await handler(event)) as {
+        status: string;
+        version: number;
+      };
+      expect(result.status).toBe("REOPENED");
       expect(result.version).toBe(4);
     });
   });

--- a/backend/src/lambda/adr-resolver.ts
+++ b/backend/src/lambda/adr-resolver.ts
@@ -15,26 +15,77 @@
  * read that tries to lock or supersede an ADR that was concurrently mutated
  * is rejected with ConditionalCheckFailedException — the invariant required
  * by QT3-2.
+ *
+ * ## Per-operation disposition (finding 677c1a6c)
+ *
+ * DEFECT: every op below gated only on hasPermission('adr:create'/
+ * 'adr:reopen') and trusted the client-supplied/fetched projectId with NO
+ * project-to-organization reconciliation. FIX: `assertProjectOrgAccess`
+ * (backend/src/utils/project-org-access.ts) is threaded through every
+ * exported function as an OPTIONAL trailing `event` parameter — additive
+ * to hasPermission, never a replacement. `handler` always supplies `event`
+ * (every real AppSync invocation is gated); internal/system callers that
+ * invoke these functions directly with no `event` (project-resolver.ts's
+ * phase guard, program-review-resolver.ts, agent-import-resolver.ts's
+ * SYSTEM_IMPORT_ADR_AUTHOR path) are unaffected, since they already
+ * establish their own right to the projectId before calling in.
+ *
+ *  - createADR       — GATED. hasPermission('adr:create') unchanged; org
+ *                       check on input.projectId runs immediately after
+ *                       and BEFORE the PutCommand.
+ *  - supersedeADR     — GATED. hasPermission('adr:create') unchanged; org
+ *                       check runs on the (already-validated-equal)
+ *                       shared projectId of both ADRs, after the
+ *                       cross-project ValidationError check and BEFORE the
+ *                       UpdateCommand that flips oldAdr to SUPERSEDED.
+ *  - reopenADR        — GATED. hasPermission('adr:reopen') unchanged; org
+ *                       check runs right after Step 1 fetches the ADR (so
+ *                       it has a projectId to reconcile) and BEFORE Step
+ *                       2's audit-row PutCommand — a cross-org caller
+ *                       never gets an audit row written for a foreign
+ *                       project's ADR. Does not disturb audit-before-auth
+ *                       ordering for callers who pass the org gate.
+ *  - lockADR          — GATED (not a dispatch case — see below). org check
+ *                       runs after the fetch and BEFORE the idempotent-
+ *                       LOCKED early-return, so a cross-org caller cannot
+ *                       observe even that shortcut for a foreign ADR.
+ *  - getADR           — GATED. Fetch-then-verify: the projectId to
+ *                       reconcile comes from the FETCHED record (adrId is
+ *                       the only client-supplied key), so the row is read
+ *                       from DynamoDB but the org check runs BEFORE the ADR
+ *                       is returned to the caller — nothing is handed back
+ *                       before the check passes.
+ *  - listADRsForProject — GATED. org check on the client-supplied
+ *                       projectId runs BEFORE the QueryCommand, so a
+ *                       cross-org caller never triggers a read of another
+ *                       tenant's ADR rows at all.
+ *
+ * lockADR is intentionally NOT a dispatch `case` (no top-level GraphQL
+ * mutation exposes it, per its own docblock) — it is still gated (called
+ * by integration tests / future lifecycle-coordinating stories) but is
+ * exercised via direct unit tests rather than the dispatch-enumeration
+ * guard's case-derived list.
  */
-import { DynamoDBClient } from '@aws-sdk/client-dynamodb';
+import { DynamoDBClient } from "@aws-sdk/client-dynamodb";
 import {
   DynamoDBDocumentClient,
   GetCommand,
   PutCommand,
   UpdateCommand,
   QueryCommand,
-} from '@aws-sdk/lib-dynamodb';
-import { v4 as uuidv4 } from 'uuid';
-import { LifecycleManager, ADR_TRANSITIONS } from '../adapters/lifecycle';
-import { emitGovernanceEvent } from '../utils/notifier-base';
-import { hasPermission } from '../utils/auth';
+} from "@aws-sdk/lib-dynamodb";
+import { v4 as uuidv4 } from "uuid";
+import { LifecycleManager, ADR_TRANSITIONS } from "../adapters/lifecycle";
+import { emitGovernanceEvent } from "../utils/notifier-base";
+import { hasPermission } from "../utils/auth";
+import { assertProjectOrgAccess } from "../utils/project-org-access";
 import type {
   AuthContext,
   ADRReopenAttempt,
   AuthResultLiteral,
   GovernanceEventIdentity,
   GovernanceResolverEvent,
-} from '../types';
+} from "../types";
 
 const dynamoClient = new DynamoDBClient({});
 const docClient = DynamoDBDocumentClient.from(dynamoClient);
@@ -42,8 +93,9 @@ const ADRS_TABLE = process.env.ADRS_TABLE!;
 const ADR_REOPEN_ATTEMPTS_TABLE = process.env.ADR_REOPEN_ATTEMPTS_TABLE!;
 const adrLifecycle = new LifecycleManager(ADR_TRANSITIONS);
 
-export type ADRStatusLiteral = 'PROPOSED' | 'LOCKED' | 'SUPERSEDED' | 'REOPENED';
-export type ADRSeverityLiteral = 'LOW' | 'MEDIUM' | 'HIGH' | 'CRITICAL';
+export type ADRStatusLiteral =
+  "PROPOSED" | "LOCKED" | "SUPERSEDED" | "REOPENED";
+export type ADRSeverityLiteral = "LOW" | "MEDIUM" | "HIGH" | "CRITICAL";
 
 export interface ADRInput {
   projectId: string;
@@ -85,11 +137,11 @@ type ADRResolverEvent = GovernanceResolverEvent<ADRResolverArguments>;
 
 function authContextFromEvent(event: ADRResolverEvent): AuthContext {
   const identity: GovernanceEventIdentity = event?.identity || {};
-  const claimRole = identity['custom:role'] ?? identity.claims?.['custom:role'];
+  const claimRole = identity["custom:role"] ?? identity.claims?.["custom:role"];
   return {
-    userId: identity.sub || identity.username || 'anonymous',
+    userId: identity.sub || identity.username || "anonymous",
     username: identity.username,
-    groups: identity['cognito:groups'] || [],
+    groups: identity["cognito:groups"] || [],
     roles: claimRole ? [claimRole] : [],
   };
 }
@@ -99,23 +151,42 @@ function authContextFromEvent(event: ADRResolverEvent): AuthContext {
  * be weaponised to exfiltrate long payloads. Non-string values pass through.
  */
 function sanitizeForLog(input: unknown): unknown {
-  if (!input || typeof input !== 'object') return input;
+  if (!input || typeof input !== "object") return input;
   const out: Record<string, unknown> = {};
   for (const [k, v] of Object.entries(input as Record<string, unknown>)) {
-    out[k] = typeof v === 'string' && v.length > 200 ? v.slice(0, 200) + '…' : v;
+    out[k] =
+      typeof v === "string" && v.length > 200 ? v.slice(0, 200) + "…" : v;
   }
   return out;
 }
 
-export async function createADR(input: ADRInput, authContext: AuthContext): Promise<ADR> {
-  if (!hasPermission(authContext, 'adr:create')) {
-    throw new Error('UnauthorizedError: adr:create permission required');
+/**
+ * `event` is OPTIONAL and additive to `hasPermission('adr:create')`, never a
+ * replacement for it (finding 677c1a6c). When supplied — i.e. every real
+ * AppSync invocation, via `handler` — the caller's organization is
+ * reconciled against `input.projectId`'s owning organization BEFORE any
+ * write, closing the cross-tenant ADR-creation hole. When omitted, this is
+ * an internal/system call (project-resolver's phase guard,
+ * agent-import-resolver's SYSTEM_IMPORT_ADR_AUTHOR path) that has already
+ * established its own right to operate on the given projectId — those call
+ * sites are unaffected.
+ */
+export async function createADR(
+  input: ADRInput,
+  authContext: AuthContext,
+  event?: unknown,
+): Promise<ADR> {
+  if (!hasPermission(authContext, "adr:create")) {
+    throw new Error("UnauthorizedError: adr:create permission required");
+  }
+  if (event !== undefined) {
+    await assertProjectOrgAccess(input.projectId, event);
   }
   if (!input.decision) {
-    throw new Error('ValidationError: decision is required');
+    throw new Error("ValidationError: decision is required");
   }
   if (!input.reasoning) {
-    throw new Error('ValidationError: reasoning is required');
+    throw new Error("ValidationError: reasoning is required");
   }
   if (
     !Array.isArray(input.constraints) ||
@@ -123,11 +194,11 @@ export async function createADR(input: ADRInput, authContext: AuthContext): Prom
     !Array.isArray(input.revisitConditions)
   ) {
     throw new Error(
-      'ValidationError: constraints, alternativesConsidered, revisitConditions must be arrays'
+      "ValidationError: constraints, alternativesConsidered, revisitConditions must be arrays",
     );
   }
   if (!Array.isArray(input.sourceRoundIds)) {
-    throw new Error('ValidationError: sourceRoundIds must be an array');
+    throw new Error("ValidationError: sourceRoundIds must be an array");
   }
 
   const adr: ADR = {
@@ -143,7 +214,7 @@ export async function createADR(input: ADRInput, authContext: AuthContext): Prom
     affectsModules: input.affectsModules,
     reviewers: input.reviewers,
     sourceRoundIds: input.sourceRoundIds,
-    status: 'PROPOSED',
+    status: "PROPOSED",
     version: 1,
     createdAt: new Date().toISOString(),
     createdBy: authContext.userId,
@@ -153,38 +224,71 @@ export async function createADR(input: ADRInput, authContext: AuthContext): Prom
     new PutCommand({
       TableName: ADRS_TABLE,
       Item: adr,
-      ConditionExpression: 'attribute_not_exists(adrId)',
-    })
+      ConditionExpression: "attribute_not_exists(adrId)",
+    }),
   );
   return adr;
 }
 
-export async function getADR(adrId: string): Promise<ADR | null> {
+/**
+ * `event` is OPTIONAL (see createADR's docblock for the rationale). When
+ * supplied, the org check runs AFTER the row is fetched (the projectId to
+ * reconcile against comes from the fetched record, not a caller-supplied
+ * argument) and BEFORE the ADR is returned to the caller — nothing is
+ * handed back before the check passes.
+ */
+export async function getADR(
+  adrId: string,
+  event?: unknown,
+): Promise<ADR | null> {
   const res = await docClient.send(
-    new GetCommand({ TableName: ADRS_TABLE, Key: { adrId } })
+    new GetCommand({ TableName: ADRS_TABLE, Key: { adrId } }),
   );
-  return (res.Item as ADR | undefined) ?? null;
+  const adr = (res.Item as ADR | undefined) ?? null;
+  if (adr && event !== undefined) {
+    await assertProjectOrgAccess(adr.projectId, event);
+  }
+  return adr;
 }
 
-export async function listADRsForProject(projectId: string): Promise<ADR[]> {
+/**
+ * `event` is OPTIONAL (see createADR's docblock). When supplied, the org
+ * check runs BEFORE the QueryCommand against ADRS_TABLE, so a cross-org
+ * caller never triggers a read of another tenant's ADR rows at all.
+ */
+export async function listADRsForProject(
+  projectId: string,
+  event?: unknown,
+): Promise<ADR[]> {
+  if (event !== undefined) {
+    await assertProjectOrgAccess(projectId, event);
+  }
   const res = await docClient.send(
     new QueryCommand({
       TableName: ADRS_TABLE,
-      IndexName: 'project-index',
-      KeyConditionExpression: 'projectId = :pid',
-      ExpressionAttributeValues: { ':pid': projectId },
-    })
+      IndexName: "project-index",
+      KeyConditionExpression: "projectId = :pid",
+      ExpressionAttributeValues: { ":pid": projectId },
+    }),
   );
   return (res.Items as ADR[] | undefined) ?? [];
 }
 
+/**
+ * `event` is OPTIONAL (see createADR's docblock). When supplied, both ADRs'
+ * shared projectId (already validated equal below) is org-checked BEFORE
+ * the UpdateCommand that flips oldAdr to SUPERSEDED.
+ */
 export async function supersedeADR(
   oldAdrId: string,
   newAdrId: string,
-  authContext: AuthContext
+  authContext: AuthContext,
+  event?: unknown,
 ): Promise<ADR> {
-  if (!hasPermission(authContext, 'adr:create')) {
-    throw new Error('UnauthorizedError: adr:create permission required to supersede');
+  if (!hasPermission(authContext, "adr:create")) {
+    throw new Error(
+      "UnauthorizedError: adr:create permission required to supersede",
+    );
   }
   const oldAdr = await getADR(oldAdrId);
   if (!oldAdr) throw new Error(`ADR not found: ${oldAdrId}`);
@@ -192,20 +296,23 @@ export async function supersedeADR(
   if (!newAdr) throw new Error(`ADR not found: ${newAdrId}`);
   if (oldAdr.projectId !== newAdr.projectId) {
     throw new Error(
-      'ValidationError: superseding ADR must belong to the same projectId'
+      "ValidationError: superseding ADR must belong to the same projectId",
     );
+  }
+  if (event !== undefined) {
+    await assertProjectOrgAccess(oldAdr.projectId, event);
   }
   // Guard: an already-SUPERSEDED ADR is terminal; it cannot be superseded
   // again even though LifecycleManager's same-state idempotence would
   // otherwise accept SUPERSEDED -> SUPERSEDED. Re-supersession would
   // overwrite supersededBy and break the ADR history chain.
-  if (oldAdr.status === 'SUPERSEDED') {
+  if (oldAdr.status === "SUPERSEDED") {
     throw new Error(
       `Invalid status transition: ${oldAdr.status} → SUPERSEDED. ` +
-        'ADR is already superseded and is terminal.'
+        "ADR is already superseded and is terminal.",
     );
   }
-  adrLifecycle.validateTransition(oldAdr.status, 'SUPERSEDED');
+  adrLifecycle.validateTransition(oldAdr.status, "SUPERSEDED");
 
   const currentVersion = oldAdr.version;
   const res = await docClient.send(
@@ -213,17 +320,17 @@ export async function supersedeADR(
       TableName: ADRS_TABLE,
       Key: { adrId: oldAdrId },
       UpdateExpression:
-        'SET #status =:newStatus, supersededBy =:newAdrId, #version = :newVersion',
-      ConditionExpression: '#version = :currentVersion',
-      ExpressionAttributeNames: { '#status': 'status', '#version': 'version' },
+        "SET #status =:newStatus, supersededBy =:newAdrId, #version = :newVersion",
+      ConditionExpression: "#version = :currentVersion",
+      ExpressionAttributeNames: { "#status": "status", "#version": "version" },
       ExpressionAttributeValues: {
-        ':newStatus': 'SUPERSEDED',
-        ':newAdrId': newAdrId,
-        ':newVersion': currentVersion + 1,
-        ':currentVersion': currentVersion,
+        ":newStatus": "SUPERSEDED",
+        ":newAdrId": newAdrId,
+        ":newVersion": currentVersion + 1,
+        ":currentVersion": currentVersion,
       },
-      ReturnValues: 'ALL_NEW',
-    })
+      ReturnValues: "ALL_NEW",
+    }),
   );
   return res.Attributes as ADR;
 }
@@ -251,6 +358,15 @@ export async function supersedeADR(
  * enforces the types, so a failure here indicates a caller bypassing the
  * schema (direct Lambda invoke, test harness, etc.), not a user action
  * that deserves non-repudiation.
+ *
+ * `event` is OPTIONAL (see createADR's docblock). When supplied, the org
+ * check runs immediately after Step 1 fetches the ADR (so it has a
+ * projectId to reconcile) and BEFORE Step 2's audit-row write — a cross-org
+ * caller never gets an audit row for a foreign project's ADR, matching the
+ * "zero writes... of foreign data" acceptance bar. This does not disturb
+ * the audit-before-auth ordering for a same-org caller: the audit write
+ * still precedes the adr:reopen permission check for every request that
+ * passes the org gate.
  */
 export async function reopenADR(
   adrId: string,
@@ -258,16 +374,19 @@ export async function reopenADR(
   revisitConditionMatched: boolean,
   reason: string,
   authContext: AuthContext,
+  event?: unknown,
 ): Promise<ADR> {
   // Step 0: validate input shape (pre-audit — see docblock).
-  if (typeof proposedChange !== 'string') {
-    throw new Error('ValidationError: proposedChange must be a string');
+  if (typeof proposedChange !== "string") {
+    throw new Error("ValidationError: proposedChange must be a string");
   }
-  if (typeof reason !== 'string') {
-    throw new Error('ValidationError: reason must be a string');
+  if (typeof reason !== "string") {
+    throw new Error("ValidationError: reason must be a string");
   }
-  if (typeof revisitConditionMatched !== 'boolean') {
-    throw new Error('ValidationError: revisitConditionMatched must be a boolean');
+  if (typeof revisitConditionMatched !== "boolean") {
+    throw new Error(
+      "ValidationError: revisitConditionMatched must be a boolean",
+    );
   }
 
   // Step 1: lookup the ADR so we can stamp projectId onto the audit row
@@ -275,7 +394,14 @@ export async function reopenADR(
   // still audit the attempt with projectId='' so the audit trail records
   // who tried and when.
   const adr = await getADR(adrId);
-  const projectId = adr?.projectId ?? '';
+  const projectId = adr?.projectId ?? "";
+
+  // Step 1b: org gate. Only enforceable when the ADR (and therefore a
+  // projectId) exists — a missing ADR has no project to reconcile against,
+  // so it falls through to the existing audit-then-not-found path below.
+  if (adr && event !== undefined) {
+    await assertProjectOrgAccess(projectId, event);
+  }
 
   // Step 2: write audit row with authResult='PENDING' BEFORE the permission
   // check. This is the critical audit-before-auth ordering.
@@ -290,43 +416,43 @@ export async function reopenADR(
     proposedChange,
     revisitConditionMatched,
     reason,
-    authResult: 'PENDING',
+    authResult: "PENDING",
   };
   await docClient.send(
     new PutCommand({
       TableName: ADR_REOPEN_ATTEMPTS_TABLE,
       Item: auditRow,
-      ConditionExpression: 'attribute_not_exists(attemptId)',
-    })
+      ConditionExpression: "attribute_not_exists(attemptId)",
+    }),
   );
 
   // Step 3: NOW check the Cognito permission.
-  const authorised = hasPermission(authContext, 'adr:reopen');
-  const authResult: AuthResultLiteral = authorised ? 'ALLOWED' : 'DENIED';
+  const authorised = hasPermission(authContext, "adr:reopen");
+  const authResult: AuthResultLiteral = authorised ? "ALLOWED" : "DENIED";
 
   // Step 4: update the audit row to reflect the auth outcome.
   await docClient.send(
     new UpdateCommand({
       TableName: ADR_REOPEN_ATTEMPTS_TABLE,
       Key: { attemptId },
-      UpdateExpression: 'SET authResult = :ar',
-      ExpressionAttributeValues: { ':ar': authResult },
-    })
+      UpdateExpression: "SET authResult = :ar",
+      ExpressionAttributeValues: { ":ar": authResult },
+    }),
   );
 
   // Step 5: emit governance.adr.reopen.attempted regardless of outcome.
   // Downstream alerting on DENIED counts relies on both branches emitting.
-  await emitGovernanceEvent('governance.adr.reopen.attempted', {
+  await emitGovernanceEvent("governance.adr.reopen.attempted", {
     projectId,
     adrId,
     revisitConditionMatched,
     attemptedBy: authContext.userId,
-    authResult: authorised ? 'ALLOWED' : 'DENIED',
+    authResult: authorised ? "ALLOWED" : "DENIED",
   });
 
   // Step 6: if auth denied, throw. Audit row is already persisted + emitted.
   if (!authorised) {
-    throw new Error('UnauthorizedError: adr:reopen permission required');
+    throw new Error("UnauthorizedError: adr:reopen permission required");
   }
 
   // Step 7: if the ADR did not exist, surface that AFTER auditing the
@@ -340,16 +466,16 @@ export async function reopenADR(
   // ValidationError propagates and the audit row remains ALLOWED with
   // transitionError populated.
   try {
-    adrLifecycle.validateTransition(adr.status, 'REOPENED');
+    adrLifecycle.validateTransition(adr.status, "REOPENED");
   } catch (err) {
     const msg = (err as Error)?.message ?? String(err);
     await docClient.send(
       new UpdateCommand({
         TableName: ADR_REOPEN_ATTEMPTS_TABLE,
         Key: { attemptId },
-        UpdateExpression: 'SET transitionError = :te',
-        ExpressionAttributeValues: { ':te': msg },
-      })
+        UpdateExpression: "SET transitionError = :te",
+        ExpressionAttributeValues: { ":te": msg },
+      }),
     );
     throw err;
   }
@@ -364,16 +490,16 @@ export async function reopenADR(
     new UpdateCommand({
       TableName: ADRS_TABLE,
       Key: { adrId },
-      UpdateExpression: 'SET #status = :newStatus, #version = :newVersion',
-      ConditionExpression: '#version = :currentVersion',
-      ExpressionAttributeNames: { '#status': 'status', '#version': 'version' },
+      UpdateExpression: "SET #status = :newStatus, #version = :newVersion",
+      ConditionExpression: "#version = :currentVersion",
+      ExpressionAttributeNames: { "#status": "status", "#version": "version" },
       ExpressionAttributeValues: {
-        ':newStatus': 'REOPENED',
-        ':newVersion': currentVersion + 1,
-        ':currentVersion': currentVersion,
+        ":newStatus": "REOPENED",
+        ":newVersion": currentVersion + 1,
+        ":currentVersion": currentVersion,
       },
-      ReturnValues: 'ALL_NEW',
-    })
+      ReturnValues: "ALL_NEW",
+    }),
   );
 
   return res.Attributes as ADR;
@@ -391,15 +517,30 @@ export async function reopenADR(
  * validateTransition (which accepts same-state) would either re-emit or
  * fight the optimistic-lock ConditionExpression depending on the retry
  * pattern — early-return is the simpler, safer choice per QT3-5 review.
+ *
+ * `event` is OPTIONAL (see createADR's docblock). When supplied, the org
+ * check runs after the fetch (needs the ADR's projectId) and BEFORE the
+ * idempotent-LOCKED early-return / lifecycle validation / UpdateCommand —
+ * a cross-org caller cannot even observe the idempotent "already locked"
+ * shortcut for a foreign ADR.
  */
-export async function lockADR(adrId: string, authContext: AuthContext): Promise<ADR> {
-  if (!hasPermission(authContext, 'adr:create')) {
-    throw new Error('UnauthorizedError: adr:create permission required to lock');
+export async function lockADR(
+  adrId: string,
+  authContext: AuthContext,
+  event?: unknown,
+): Promise<ADR> {
+  if (!hasPermission(authContext, "adr:create")) {
+    throw new Error(
+      "UnauthorizedError: adr:create permission required to lock",
+    );
   }
   const adr = await getADR(adrId);
   if (!adr) throw new Error(`ADR not found: ${adrId}`);
-  if (adr.status === 'LOCKED') return adr;
-  adrLifecycle.validateTransition(adr.status, 'LOCKED');
+  if (event !== undefined) {
+    await assertProjectOrgAccess(adr.projectId, event);
+  }
+  if (adr.status === "LOCKED") return adr;
+  adrLifecycle.validateTransition(adr.status, "LOCKED");
 
   const currentVersion = adr.version;
   const res = await docClient.send(
@@ -407,20 +548,20 @@ export async function lockADR(adrId: string, authContext: AuthContext): Promise<
       TableName: ADRS_TABLE,
       Key: { adrId },
       UpdateExpression:
-        'SET #status = :newStatus, lockedAt = :lockedAt, #version = :newVersion',
-      ConditionExpression: '#version = :currentVersion',
-      ExpressionAttributeNames: { '#status': 'status', '#version': 'version' },
+        "SET #status = :newStatus, lockedAt = :lockedAt, #version = :newVersion",
+      ConditionExpression: "#version = :currentVersion",
+      ExpressionAttributeNames: { "#status": "status", "#version": "version" },
       ExpressionAttributeValues: {
-        ':newStatus': 'LOCKED',
-        ':lockedAt': new Date().toISOString(),
-        ':newVersion': currentVersion + 1,
-        ':currentVersion': currentVersion,
+        ":newStatus": "LOCKED",
+        ":lockedAt": new Date().toISOString(),
+        ":newVersion": currentVersion + 1,
+        ":currentVersion": currentVersion,
       },
-      ReturnValues: 'ALL_NEW',
-    })
+      ReturnValues: "ALL_NEW",
+    }),
   );
   const locked = res.Attributes as ADR;
-  await emitGovernanceEvent('governance.adr.locked', {
+  await emitGovernanceEvent("governance.adr.locked", {
     projectId: locked.projectId,
     adrId: locked.adrId,
     title: locked.title,
@@ -434,31 +575,37 @@ export const handler = async (event: ADRResolverEvent): Promise<unknown> => {
   const authContext = authContextFromEvent(event);
   try {
     switch (fieldName) {
-      case 'createADR':
-        return await createADR(event.arguments.input as ADRInput, authContext);
-      case 'supersedeADR':
+      case "createADR":
+        return await createADR(
+          event.arguments.input as ADRInput,
+          authContext,
+          event,
+        );
+      case "supersedeADR":
         return await supersedeADR(
           event.arguments.oldAdrId,
           event.arguments.newAdrId,
-          authContext
+          authContext,
+          event,
         );
-      case 'reopenADR':
+      case "reopenADR":
         return await reopenADR(
           event.arguments.adrId,
           event.arguments.proposedChange,
           event.arguments.revisitConditionMatched,
           event.arguments.reason,
           authContext,
+          event,
         );
-      case 'getADR':
-        return await getADR(event.arguments.adrId);
-      case 'listADRsForProject':
-        return await listADRsForProject(event.arguments.projectId);
+      case "getADR":
+        return await getADR(event.arguments.adrId, event);
+      case "listADRsForProject":
+        return await listADRsForProject(event.arguments.projectId, event);
       default:
         throw new Error(`Unsupported field: ${fieldName}`);
     }
   } catch (err: unknown) {
-    console.error('adr-resolver error', {
+    console.error("adr-resolver error", {
       fieldName,
       message: err instanceof Error ? err.message : undefined,
       args: sanitizeForLog(event?.arguments),

--- a/backend/src/utils/__tests__/project-org-access.test.ts
+++ b/backend/src/utils/__tests__/project-org-access.test.ts
@@ -1,0 +1,145 @@
+/**
+ * Unit tests for assertProjectOrgAccess (finding 677c1a6c).
+ *
+ * assertProjectOrgAccess is the shared project-to-organization join used by
+ * adr-resolver (pilot) and, in follow-on findings, the other governance
+ * modules (execspec, program-review, interrogation-round,
+ * agent-design-assessment). It reuses project-resolver.getProject's own
+ * "may access this project" semantics — project.owner === callerId OR
+ * (callerOrg && project.organization === callerOrg) — rather than inventing
+ * a second definition, and preserves the admin-bypass convention used by the
+ * sibling helpers (assertRowOrg, assertManifestAccess).
+ *
+ * Fail-closed matrix under test: absent identity, unresolvable caller org,
+ * missing project, and a project whose organization cannot be determined
+ * (no organization attribute and caller is not the owner) all THROW rather
+ * than defaulting to allow.
+ */
+import { DynamoDBDocumentClient, GetCommand } from "@aws-sdk/lib-dynamodb";
+import { mockClient } from "aws-sdk-client-mock";
+
+process.env.PROJECTS_TABLE = "citadel-projects-test";
+
+const ddbMock = mockClient(DynamoDBDocumentClient);
+
+import {
+  assertProjectOrgAccess,
+  ProjectOrgAccessError,
+} from "../project-org-access";
+
+describe("assertProjectOrgAccess", () => {
+  beforeEach(() => {
+    ddbMock.reset();
+  });
+
+  test("resolves when caller org matches project.organization", async () => {
+    ddbMock.on(GetCommand).resolves({
+      Item: { id: "proj-1", owner: "owner-1", organization: "org-a" },
+    });
+    const event = { identity: { sub: "u1", "custom:organization": "org-a" } };
+    await expect(
+      assertProjectOrgAccess("proj-1", event),
+    ).resolves.toBeUndefined();
+  });
+
+  test("resolves when caller is the project owner, even if org claim differs", async () => {
+    ddbMock.on(GetCommand).resolves({
+      Item: { id: "proj-1", owner: "u1", organization: "org-a" },
+    });
+    const event = { identity: { sub: "u1", "custom:organization": "org-b" } };
+    await expect(
+      assertProjectOrgAccess("proj-1", event),
+    ).resolves.toBeUndefined();
+  });
+
+  test("throws ProjectOrgAccessError when caller org differs from project org and caller is not owner", async () => {
+    ddbMock.on(GetCommand).resolves({
+      Item: { id: "proj-1", owner: "owner-1", organization: "org-a" },
+    });
+    const event = { identity: { sub: "u2", "custom:organization": "org-b" } };
+    await expect(
+      assertProjectOrgAccess("proj-1", event),
+    ).rejects.toBeInstanceOf(ProjectOrgAccessError);
+  });
+
+  test("fails closed when identity is absent from the event", async () => {
+    ddbMock.on(GetCommand).resolves({
+      Item: { id: "proj-1", owner: "owner-1", organization: "org-a" },
+    });
+    await expect(assertProjectOrgAccess("proj-1", {})).rejects.toBeInstanceOf(
+      ProjectOrgAccessError,
+    );
+    // No accidental fall-through to a bare truthy check — assert no read
+    // was ever attempted before we can even resolve identity? Actually a
+    // Get IS issued (we need the project to check owner), so instead assert
+    // the specific failure mode: rejects, does not resolve.
+  });
+
+  test("fails closed when the caller's organization cannot be resolved and caller is not owner", async () => {
+    ddbMock.on(GetCommand).resolves({
+      Item: { id: "proj-1", owner: "owner-1", organization: "org-a" },
+    });
+    // No custom:organization claim, no USER_POOL_ID configured -> null org.
+    const event = { identity: { sub: "u2" } };
+    await expect(
+      assertProjectOrgAccess("proj-1", event),
+    ).rejects.toBeInstanceOf(ProjectOrgAccessError);
+  });
+
+  test("fails closed when the project does not exist", async () => {
+    ddbMock.on(GetCommand).resolves({});
+    const event = { identity: { sub: "u1", "custom:organization": "org-a" } };
+    await expect(
+      assertProjectOrgAccess("proj-missing", event),
+    ).rejects.toBeInstanceOf(ProjectOrgAccessError);
+  });
+
+  test("fails closed when the project has no organization attribute and caller is not the owner", async () => {
+    ddbMock.on(GetCommand).resolves({
+      Item: { id: "proj-1", owner: "owner-1" }, // no organization field
+    });
+    const event = { identity: { sub: "u2", "custom:organization": "org-a" } };
+    await expect(
+      assertProjectOrgAccess("proj-1", event),
+    ).rejects.toBeInstanceOf(ProjectOrgAccessError);
+  });
+
+  test("admin bypasses the org check entirely, even for a cross-org project", async () => {
+    ddbMock.on(GetCommand).resolves({
+      Item: { id: "proj-1", owner: "owner-1", organization: "org-a" },
+    });
+    const event = {
+      identity: { sub: "admin-1", "custom:role": "admin" },
+    };
+    await expect(
+      assertProjectOrgAccess("proj-1", event),
+    ).resolves.toBeUndefined();
+  });
+
+  test("admin bypass does not require a DynamoDB read of the project at all", async () => {
+    // Sanity: the admin bypass short-circuits before the fetch, matching
+    // assertRowOrg's isAdminFromEvent(event) early-return convention.
+    ddbMock.on(GetCommand).rejects(new Error("should not be called"));
+    const event = { identity: { sub: "admin-1", "custom:role": "admin" } };
+    await expect(
+      assertProjectOrgAccess("proj-1", event),
+    ).resolves.toBeUndefined();
+    expect(ddbMock.commandCalls(GetCommand)).toHaveLength(0);
+  });
+
+  test("ProjectOrgAccessError carries an Access denied message", async () => {
+    ddbMock.on(GetCommand).resolves({});
+    const event = { identity: { sub: "u1", "custom:organization": "org-a" } };
+    await expect(assertProjectOrgAccess("proj-x", event)).rejects.toThrow(
+      /Access denied/,
+    );
+  });
+
+  test("fails closed when projectId is empty", async () => {
+    const event = { identity: { sub: "u1", "custom:organization": "org-a" } };
+    await expect(assertProjectOrgAccess("", event)).rejects.toBeInstanceOf(
+      ProjectOrgAccessError,
+    );
+    expect(ddbMock.commandCalls(GetCommand)).toHaveLength(0);
+  });
+});

--- a/backend/src/utils/project-org-access.ts
+++ b/backend/src/utils/project-org-access.ts
@@ -1,0 +1,121 @@
+/**
+ * Shared project-to-organization reconciliation gate (finding 677c1a6c).
+ *
+ * `assertProjectOrgAccess(projectId, event)` is the pilot piece for the
+ * governance-module family: adr-resolver is the first caller; execspec,
+ * program-review, interrogation-round, and agent-design-assessment are
+ * expected to adopt it in follow-on findings, since their triage entries
+ * describe the identical shape (client-supplied projectId -> key op, no
+ * project-to-organization reconciliation).
+ *
+ * This deliberately reuses project-resolver.ts's OWN "may access this
+ * project" semantics rather than inventing a second definition:
+ *
+ *   hasAccess = project.owner === callerId
+ *            || (callerOrg && project.organization === callerOrg)
+ *
+ * (see `getProject` in project-resolver.ts). project.organization is the
+ * server-derived tenant boundary stamped onto the row at createProject time
+ * from the caller's `custom:organization` claim (or DEFAULT_ORGANIZATION) —
+ * never a client-suppliable value. project-resolver.ts is not imported
+ * here to avoid pulling its EventBridge/S3/lifecycle dependencies into
+ * every governance module; instead the identical GetCommand-against-
+ * PROJECTS_TABLE shape used there (and by agent-resolver.ts, which performs
+ * the same read-the-parent-project join) is duplicated at the single-row
+ * level.
+ *
+ * Fail-closed matrix (mirrors assertRowOrg / assertManifestAccess):
+ *  - absent/unresolvable caller identity            -> deny
+ *  - unresolvable caller organization (and not owner) -> deny
+ *  - missing project                                 -> deny
+ *  - project whose organization cannot be determined
+ *    (no `organization` attribute) and caller is not the owner -> deny
+ *
+ * Admin bypass is preserved via `isAdminFromEvent`, matching the sibling
+ * helpers' convention exactly (short-circuits BEFORE the DynamoDB read, so
+ * an admin's request never even needs the row to exist).
+ */
+import { DynamoDBClient } from "@aws-sdk/client-dynamodb";
+import { DynamoDBDocumentClient, GetCommand } from "@aws-sdk/lib-dynamodb";
+import { getUserId } from "./appsync";
+import { extractOrgFromEvent, isAdminFromEvent } from "./auth-event";
+
+const dynamoClient = new DynamoDBClient({});
+const docClient = DynamoDBDocumentClient.from(dynamoClient);
+
+/**
+ * Thrown by {@link assertProjectOrgAccess} on any denial. Callers should let
+ * this propagate (fail closed) rather than catching and continuing — same
+ * contract as {@link CrossOrgAccessError} from auth-event.ts.
+ */
+export class ProjectOrgAccessError extends Error {
+  constructor(message = "Access denied") {
+    super(message);
+    this.name = "ProjectOrgAccessError";
+  }
+}
+
+interface ProjectOrgRow {
+  id?: string;
+  owner?: unknown;
+  organization?: unknown;
+}
+
+/**
+ * Asserts the caller may access `projectId`, reconciling it against the
+ * caller's organization the same way project-resolver.getProject does.
+ * Throws {@link ProjectOrgAccessError} on any denial; resolves silently on
+ * success. Must be called BEFORE any write or before returning any data
+ * derived from the project's governance sub-resources (ADRs, exec specs,
+ * rounds, assessments).
+ */
+export async function assertProjectOrgAccess(
+  projectId: string,
+  event: unknown,
+): Promise<void> {
+  if (isAdminFromEvent(event)) {
+    return;
+  }
+
+  if (typeof projectId !== "string" || projectId.length === 0) {
+    throw new ProjectOrgAccessError();
+  }
+
+  const callerId = getUserId(
+    (event as { identity?: Parameters<typeof getUserId>[0] })?.identity,
+  );
+  if (!callerId || callerId === "anonymous") {
+    throw new ProjectOrgAccessError();
+  }
+
+  const projectsTable = process.env.PROJECTS_TABLE;
+  if (!projectsTable) {
+    // No table configured means we cannot verify anything — fail closed
+    // rather than silently allowing every caller through.
+    throw new ProjectOrgAccessError();
+  }
+
+  const result = await docClient.send(
+    new GetCommand({
+      TableName: projectsTable,
+      Key: { id: projectId },
+    }),
+  );
+
+  const project = result.Item as ProjectOrgRow | undefined;
+  if (!project) {
+    throw new ProjectOrgAccessError();
+  }
+
+  if (project.owner === callerId) {
+    return;
+  }
+
+  const callerOrg = await extractOrgFromEvent(event);
+  const projectOrg =
+    typeof project.organization === "string" ? project.organization : undefined;
+
+  if (!callerOrg || !projectOrg || callerOrg !== projectOrg) {
+    throw new ProjectOrgAccessError();
+  }
+}


### PR DESCRIPTION
## Summary
`adr-resolver` gated only on `hasPermission('adricreate')` and then trusted the client-supplied `projectId`; `getADR` was a bare key get and `listADRsForProject` a bare query. A permitted user of one organization could therefore create ADRs against another organization's project and read their decision records. ADRs are the governance audit trail the platform presents as authoritative, so cross-tenant write here corrupts evidence.

Every operation is now gated, with `hasPermission` retained as an **additional** check rather than replaced:
- `createADR` before the write; `supersedeADR` before its update
- `getADR` fetch-then-verify, with nothing returned before the check
- `ListARsForProject` before the query, so no foreign rows are read at all
- `reopenADR` before the audit-row write, preserving the existing audit-before-auth ordering for callers who pass
- `lockADR` gated too, though no GraphQL mutation currently exposes it

## Shared helper, built for reuse

`assertProjectOrgAccess(projectId, event)` reuses `getProject`'s **exact** rule - owner matches the caller, or the project's organization matches the caller's server-derived organization - with the admin bypass convention already used by `assertRowOrg` and `assertManifestAccess`. It fails closed on absent identity, unresolvable caller organization, missing project, or a project with no organization attribute.

Worth flagging: the finding proposed a `Project.owner` → `lookupUserOrganization` join. **That pattern does not exist in the code** - `project.organization` is already the server-derived tenant field. Four more governance modules will consume this helper, so defining a second, weaker notion of project access here would have propagated it across the family.

The `event` parameter is optional and trailing, so internal callers (the project-resolver phase guard, program-review, and agent-import's system ADR author) are unaffected.

## Infrastructure gap found and fixed

The ADR Lambda had **no `PROJECTS_TABLE` grant**, so the organization join could not have
worked at all. `grantReadData` plus the environment variable were added in a separate commit. This is the third security fix in this series that required closing an infrastructure gap first.

## Testing

- Cross-org refusals on create, read and list, proven against two seeded organizations so absence is meaningful
- Permission enforcement verified independently: a same-org caller without `adr:create` is still refused
- Fail-closed proven by **mutation**, not assertion: replacing the throw with a return failed six tests
- Executed bite proof: with the gate removed, the cross-org `createADR` writes the full ADR (verbatim payload captured); restored byte-identically
- Sixth dispatch-derived gate-enumeration guard added, itself proven to bite
- tsc, lint exit 0; 168 targeted tests; all six enumeration guards; full backend jest 7383; CI-equivalent synth with nag enabled clean; all `split:gates` rails pass

## Notes

- Pilot for the governance family. `execspec`, `program-review`, `interrogation-round` and
`agent-design-assessment` now consume this helper - the transcript writes in `interrogation-round` and the foreign `PROJECTS`-row mutation in `agent-design-assessment` are remaining cases