### PR TITLE
fix(security): reconcile project org access across governance modules

### DIFF
--- a/backend/lib/governance-stack.ts
+++ b/backend/lib/governance-stack.ts
@@ -2597,6 +2597,11 @@ exports.handler = async (event) => {
           AGENT_DESIGN_ASSESSMENTS_TABLE:
             props.agentDesignAssessmentsTable.tableName,
           ENVIRONMENT: props.environment,
+          // finding 2c262386: assertProjectOrgAccess reads PROJECTS_TABLE
+          // to reconcile the caller's org against the reviewed project
+          // before any evidence read/write. Read-only — this resolver
+          // never writes Projects.
+          PROJECTS_TABLE: props.projectsTable.tableName,
         },
         timeout: cdk.Duration.seconds(30),
         logGroup: new logs.LogGroup(this, "ProgramReviewResolverFunctionLogs", {
@@ -2615,6 +2620,9 @@ exports.handler = async (event) => {
     props.agentDesignAssessmentsTable.grantReadData(
       programReviewResolverFunction,
     );
+    // finding 2c262386: read-only grant for the project-org reconciliation
+    // gate (assertProjectOrgAccess). Least privilege — no write access.
+    props.projectsTable.grantReadData(programReviewResolverFunction);
 
     const programReviewDataSourceRole = new iam.Role(
       this,

--- a/backend/lib/governance-stack.ts
+++ b/backend/lib/governance-stack.ts
@@ -893,6 +893,11 @@ exports.handler = async (event) => {
         environment: {
           EXECUTION_SPECS_TABLE: props.executionSpecificationsTable.tableName,
           EVENT_BUS_NAME: props.agentEventBus.eventBusName,
+          // finding 2c262386: assertProjectOrgAccess reads PROJECTS_TABLE
+          // to reconcile the caller's org against the exec spec's owning
+          // project before any read/write. Read-only — this resolver
+          // never writes Projects.
+          PROJECTS_TABLE: props.projectsTable.tableName,
         },
         timeout: cdk.Duration.seconds(30),
         logGroup: new logs.LogGroup(this, "ExecSpecResolverFunctionLogs", {
@@ -906,6 +911,9 @@ exports.handler = async (event) => {
       execSpecResolverFunction,
     );
     props.agentEventBus.grantPutEventsTo(execSpecResolverFunction);
+    // finding 2c262386: read-only grant for the project-org reconciliation
+    // gate (assertProjectOrgAccess). Least privilege — no write access.
+    props.projectsTable.grantReadData(execSpecResolverFunction);
 
     const execSpecDataSourceRole = new iam.Role(
       this,

--- a/backend/lib/governance-stack.ts
+++ b/backend/lib/governance-stack.ts
@@ -2301,6 +2301,11 @@ exports.handler = async (event) => {
           INTERROGATION_ROUNDS_TABLE: props.interrogationRoundsTable.tableName,
           GOVERNANCE_TRANSCRIPTS_BUCKET: governanceTranscriptsBucket.bucketName,
           EVENT_BUS_NAME: props.agentEventBus.eventBusName,
+          // finding 2c262386: assertProjectOrgAccess reads PROJECTS_TABLE
+          // to reconcile the caller's org against the round's owning
+          // project before any read/write. Read-only — this resolver
+          // never writes Projects.
+          PROJECTS_TABLE: props.projectsTable.tableName,
         },
         timeout: cdk.Duration.seconds(30),
         logGroup: new logs.LogGroup(
@@ -2322,6 +2327,9 @@ exports.handler = async (event) => {
       interrogationRoundResolverFunction,
     );
     props.agentEventBus.grantPutEventsTo(interrogationRoundResolverFunction);
+    // finding 2c262386: read-only grant for the project-org reconciliation
+    // gate (assertProjectOrgAccess). Least privilege — no write access.
+    props.projectsTable.grantReadData(interrogationRoundResolverFunction);
 
     const interrogationRoundDataSourceRole = new iam.Role(
       this,

--- a/backend/src/lambda/__tests__/agent-design-assessment-resolver-dispatch-gate-enumeration.test.ts
+++ b/backend/src/lambda/__tests__/agent-design-assessment-resolver-dispatch-gate-enumeration.test.ts
@@ -1,0 +1,217 @@
+/**
+ * Enumeration-completeness guard for agent-design-assessment-resolver.ts's
+ * dispatch switch (finding 2c262386 — module 2/4, guard 8 in the series).
+ *
+ * Root defect closed by finding 2c262386 (this module): submitAgentDesign
+ * Assessment's TransactWriteCommand mutates BOTH the assessments row AND
+ * another organization's citadel-projects row (archetype/
+ * archetypeConfidence/archetypeStatus) with NO project-to-organization
+ * reconciliation of the client-supplied projectId. The fix threads an
+ * OPTIONAL `event` parameter through every exported function; the
+ * dispatch handler always supplies it. For submitAgentDesignAssessment
+ * specifically, this guard also asserts the gate call precedes the
+ * TransactWriteCommand construction — i.e. it gates the WHOLE transaction,
+ * not one leg of it.
+ */
+import * as fs from "fs";
+import * as path from "path";
+
+const HANDLER_PATH = path.join(
+  __dirname,
+  "..",
+  "agent-design-assessment-resolver.ts",
+);
+
+function extractDispatchCases(source: string): string[] {
+  const switchStart = source.indexOf("switch (fieldName)");
+  if (switchStart === -1) {
+    throw new Error(
+      "Could not locate `switch (fieldName)` in agent-design-assessment-resolver.ts — " +
+        "dispatch structure changed; update this guard's parsing.",
+    );
+  }
+  const defaultIdx = source.indexOf("default:", switchStart);
+  if (defaultIdx === -1) {
+    throw new Error(
+      "Could not locate the dispatch switch's `default:` case — " +
+        "update this guard's parsing.",
+    );
+  }
+  const switchBody = source.slice(switchStart, defaultIdx);
+  const caseRe = /case\s+['"]([^'"]+)['"]\s*:/g;
+  const cases: string[] = [];
+  let m: RegExpExecArray | null;
+  while ((m = caseRe.exec(switchBody)) !== null) {
+    cases.push(m[1]);
+  }
+  return cases;
+}
+
+function extractCaseBody(source: string, fieldName: string): string {
+  const switchStart = source.indexOf("switch (fieldName)");
+  const defaultIdx = source.indexOf("default:", switchStart);
+  const switchBody = source.slice(switchStart, defaultIdx);
+
+  const caseIdx =
+    switchBody.indexOf(`case '${fieldName}'`) !== -1
+      ? switchBody.indexOf(`case '${fieldName}'`)
+      : switchBody.indexOf(`case "${fieldName}"`);
+  if (caseIdx === -1) {
+    throw new Error(`Could not locate case '${fieldName}' in dispatch switch`);
+  }
+  const nextCaseIdx = switchBody.indexOf("case ", caseIdx + 1);
+  return switchBody.slice(
+    caseIdx,
+    nextCaseIdx === -1 ? undefined : nextCaseIdx,
+  );
+}
+
+function extractCallSiteNames(caseBody: string): string[] {
+  const callRe = /await\s+([A-Za-z0-9_]+)\s*\(/g;
+  const names: string[] = [];
+  let m: RegExpExecArray | null;
+  while ((m = callRe.exec(caseBody)) !== null) {
+    names.push(m[1]);
+  }
+  return names;
+}
+
+function extractFunctionBody(source: string, fnName: string): string {
+  const declRe = new RegExp(
+    `(?:export\\s+)?async function ${fnName}\\b\\s*\\(`,
+  );
+  const declMatch = declRe.exec(source);
+  if (!declMatch) {
+    throw new Error(
+      `Could not locate function declaration for '${fnName}' in agent-design-assessment-resolver.ts`,
+    );
+  }
+  const paramsOpenIdx = source.indexOf("(", declMatch.index);
+  let parenDepth = 0;
+  let j = paramsOpenIdx;
+  for (; j < source.length; j++) {
+    if (source[j] === "(") parenDepth++;
+    else if (source[j] === ")") {
+      parenDepth--;
+      if (parenDepth === 0) break;
+    }
+  }
+  const bodyStart = source.indexOf("{", j);
+  let depth = 0;
+  let i = bodyStart;
+  for (; i < source.length; i++) {
+    if (source[i] === "{") depth++;
+    else if (source[i] === "}") {
+      depth--;
+      if (depth === 0) break;
+    }
+  }
+  return source.slice(bodyStart, i + 1);
+}
+
+const GATE_CALL_RE = /assertProjectOrgAccess\s*\(/;
+const EVENT_PARAM_RE = /event\?\s*:\s*unknown/;
+
+const GATED_OPS: Record<string, { fn: string }> = {
+  startAgentDesignAssessment: { fn: "startAgentDesignAssessment" },
+  submitAgentDesignAssessment: { fn: "submitAgentDesignAssessment" },
+  getAgentDesignAssessment: { fn: "getAgentDesignAssessment" },
+};
+
+const EXEMPT_OPS: Record<string, string> = {};
+
+describe("agent-design-assessment-resolver — dispatch enumeration completeness", () => {
+  const source = fs.readFileSync(HANDLER_PATH, "utf-8");
+  const cases = extractDispatchCases(source);
+
+  test("the dispatch switch actually has cases to check (sanity check on the parser itself)", () => {
+    expect(cases.length).toBeGreaterThanOrEqual(3);
+    expect(cases).toEqual(expect.arrayContaining(Object.keys(GATED_OPS)));
+  });
+
+  test("every dispatch case is accounted for in GATED_OPS or EXEMPT_OPS", () => {
+    const unaccounted = cases.filter(
+      (c) => !(c in GATED_OPS) && !(c in EXEMPT_OPS),
+    );
+    expect(unaccounted).toEqual([]);
+  });
+
+  test("GATED_OPS and EXEMPT_OPS do not both claim the same op", () => {
+    const overlap = Object.keys(GATED_OPS).filter((k) => k in EXEMPT_OPS);
+    expect(overlap).toEqual([]);
+  });
+
+  test("no GATED_OPS/EXEMPT_OPS entry references a case that no longer exists in the switch", () => {
+    const known = new Set(cases);
+    const staleGated = Object.keys(GATED_OPS).filter((k) => !known.has(k));
+    const staleExempt = Object.keys(EXEMPT_OPS).filter((k) => !known.has(k));
+    expect(staleGated).toEqual([]);
+    expect(staleExempt).toEqual([]);
+  });
+
+  describe.each(Object.entries(GATED_OPS))(
+    "GATED_OPS['%s'] dispatches to a function that threads `event` and calls assertProjectOrgAccess",
+    (fieldName, meta) => {
+      test(`${fieldName}'s case dispatches to ${meta.fn}`, () => {
+        const caseBody = extractCaseBody(source, fieldName);
+        const callSites = extractCallSiteNames(caseBody);
+        expect(callSites).toContain(meta.fn);
+      });
+
+      test(`${fieldName}'s case passes \`event\` as an argument to ${meta.fn}`, () => {
+        const caseBody = extractCaseBody(source, fieldName);
+        const callRe = new RegExp(
+          `${meta.fn}\\s*\\([^;]*?\\bevent\\b[^;]*?\\)`,
+        );
+        expect(callRe.test(caseBody)).toBe(true);
+      });
+
+      test(`${meta.fn}'s declaration accepts an optional \`event?: unknown\` parameter`, () => {
+        const declRe = new RegExp(
+          `(?:export\\s+)?async function ${meta.fn}\\b\\s*\\(([^)]*)\\)`,
+        );
+        const m = declRe.exec(source);
+        expect(m).not.toBeNull();
+        expect(EVENT_PARAM_RE.test((m as RegExpExecArray)[1])).toBe(true);
+      });
+
+      test(`${meta.fn}'s function body contains an assertProjectOrgAccess call`, () => {
+        const body = extractFunctionBody(source, meta.fn);
+        expect(GATE_CALL_RE.test(body)).toBe(true);
+      });
+    },
+  );
+
+  test("submitAgentDesignAssessment's gate call precedes the TransactWriteCommand construction (gates the WHOLE transaction, not one leg)", () => {
+    const body = extractFunctionBody(source, "submitAgentDesignAssessment");
+    const gateIdx = body.search(GATE_CALL_RE);
+    const transactIdx = body.indexOf("new TransactWriteCommand(");
+    expect(gateIdx).toBeGreaterThan(-1);
+    expect(transactIdx).toBeGreaterThan(-1);
+    expect(gateIdx).toBeLessThan(transactIdx);
+  });
+
+  test("startAgentDesignAssessment's gate call precedes its PutCommand", () => {
+    const body = extractFunctionBody(source, "startAgentDesignAssessment");
+    const gateIdx = body.search(GATE_CALL_RE);
+    const putIdx = body.indexOf("new PutCommand(");
+    expect(gateIdx).toBeGreaterThan(-1);
+    expect(putIdx).toBeGreaterThan(-1);
+    expect(gateIdx).toBeLessThan(putIdx);
+  });
+
+  test("getAgentDesignAssessment's gate call precedes its `return row` statement", () => {
+    const body = extractFunctionBody(source, "getAgentDesignAssessment");
+    const gateIdx = body.search(GATE_CALL_RE);
+    const returnIdx = body.lastIndexOf("return row;");
+    expect(gateIdx).toBeGreaterThan(-1);
+    expect(returnIdx).toBeGreaterThan(-1);
+    expect(gateIdx).toBeLessThan(returnIdx);
+  });
+
+  test("handler's hasPermission('assessment:submit') check is not removed by this fix (additive, not a replacement)", () => {
+    expect(source).toMatch(
+      /hasPermission\(authContext, ['"]assessment:submit['"]\)/,
+    );
+  });
+});

--- a/backend/src/lambda/__tests__/agent-design-assessment-resolver-org-scoping.test.ts
+++ b/backend/src/lambda/__tests__/agent-design-assessment-resolver-org-scoping.test.ts
@@ -1,0 +1,411 @@
+/**
+ * Org-scoping tests for agent-design-assessment-resolver (finding 2c262386,
+ * module 2/4).
+ *
+ * DEFECT: startAgentDesignAssessment / submitAgentDesignAssessment /
+ * getAgentDesignAssessment gated only on hasPermission('assessment:submit')
+ * (mutations) and trusted the client-supplied projectId with NO project-to-
+ * organization reconciliation. submitAgentDesignAssessment is the sharpest:
+ * it performs a TransactWriteCommand that mutates BOTH the assessments row
+ * AND another organization's citadel-projects row (archetype/
+ * archetypeConfidence/archetypeStatus) — a cross-org write into a foreign
+ * PROJECTS record via the same transaction that touches the assessments
+ * table.
+ *
+ * FIX: assertProjectOrgAccess(projectId, event) — the SAME shared helper
+ * from PR 142 / finding 677c1a6c — is threaded through every exported
+ * function as an ADDITIONAL, optional `event` parameter. Critically for
+ * submitAgentDesignAssessment, the gate is placed BEFORE the
+ * TransactWriteCommand is constructed at all — it must precede the WHOLE
+ * transaction, not one leg of it, so a cross-org caller triggers zero
+ * transaction commits (not even a partial/rolled-back one).
+ *
+ * Acceptance:
+ *  - cross-org caller refused on start/submit/get; zero writes, zero
+ *    transaction commits, zero foreign reads
+ *  - same-org caller WITH assessment:submit succeeds
+ *  - same-org caller WITHOUT assessment:submit is still refused (additive)
+ */
+import {
+  DynamoDBDocumentClient,
+  GetCommand,
+  PutCommand,
+  TransactWriteCommand,
+} from "@aws-sdk/lib-dynamodb";
+import {
+  EventBridgeClient,
+  PutEventsCommand,
+} from "@aws-sdk/client-eventbridge";
+import { mockClient } from "aws-sdk-client-mock";
+import type { AuthContext } from "../../types";
+import { ProjectArchetypeStatus } from "../../types";
+
+const ddbMock = mockClient(DynamoDBDocumentClient);
+const ebMock = mockClient(EventBridgeClient);
+
+process.env.AGENT_DESIGN_ASSESSMENTS_TABLE =
+  "citadel-agent-design-assessments-test";
+process.env.PROJECTS_TABLE = "citadel-projects-test";
+process.env.EVENT_BUS_NAME = "citadel-agents-test";
+
+import {
+  startAgentDesignAssessment,
+  getAgentDesignAssessment,
+  submitAgentDesignAssessment,
+  handler,
+} from "../agent-design-assessment-resolver";
+import { __resetGovernanceNotifierForTest } from "../../utils/notifier-base";
+import { ProjectOrgAccessError } from "../../utils/project-org-access";
+
+function mockAuthContextFor(role: "architect" | "developer"): AuthContext {
+  return { userId: `user-${role}`, username: role, groups: [], roles: [role] };
+}
+
+function crossOrgEvent(
+  fieldName: string,
+  args: Record<string, unknown>,
+  role: "architect" | "developer" = "architect",
+) {
+  return {
+    info: { fieldName },
+    arguments: args,
+    identity: {
+      sub: `user-${role}-org-b`,
+      username: role,
+      "custom:role": role,
+      "custom:organization": "org-b",
+    },
+  };
+}
+
+function sameOrgEvent(
+  fieldName: string,
+  args: Record<string, unknown>,
+  role: "architect" | "developer" = "architect",
+) {
+  return {
+    info: { fieldName },
+    arguments: args,
+    identity: {
+      sub: `user-${role}-org-a`,
+      username: role,
+      "custom:role": role,
+      "custom:organization": "org-a",
+    },
+  };
+}
+
+function validSubmitInput(overrides: Record<string, unknown> = {}) {
+  return {
+    projectId: "proj-1",
+    archetype: "AGENTIC_WORKFLOW",
+    archetypeConfidence: 0.9,
+    dimensionRanking: [
+      { dimension: "CODE", rank: 1, rationale: "r1" },
+      { dimension: "DATA", rank: 2, rationale: "r2" },
+      { dimension: "INTEGRATION", rank: 3, rationale: "r3" },
+      { dimension: "INFRASTRUCTURE", rank: 4, rationale: "r4" },
+    ],
+    accessibleDataSources: ["s3"],
+    primaryRiskAreas: ["security"],
+    ...overrides,
+  };
+}
+
+const existingRow = {
+  projectId: "proj-1",
+  archetype: null,
+  archetypeConfidence: null,
+  archetypeStatus: ProjectArchetypeStatus.PENDING,
+  dimensionRanking: [],
+  accessibleDataSources: [],
+  primaryRiskAreas: [],
+  completedAt: null,
+  completedBy: null,
+  createdAt: "2024-01-01T00:00:00.000Z",
+  updatedAt: "2024-01-01T00:00:00.000Z",
+};
+
+describe("agent-design-assessment-resolver — project-org scoping (finding 2c262386)", () => {
+  beforeEach(() => {
+    ddbMock.reset();
+    ebMock.reset();
+    ebMock
+      .on(PutEventsCommand)
+      .resolves({ FailedEntryCount: 0, Entries: [{ EventId: "evt-1" }] });
+    __resetGovernanceNotifierForTest();
+  });
+
+  function stubProject(organization = "org-a", owner = "someone-else") {
+    ddbMock
+      .on(GetCommand, {
+        TableName: "citadel-projects-test",
+        Key: { id: "proj-1" },
+      })
+      .resolves({ Item: { id: "proj-1", owner, organization } });
+  }
+
+  function stubAssessment(overrides: Record<string, unknown> = {}) {
+    ddbMock
+      .on(GetCommand, {
+        TableName: "citadel-agent-design-assessments-test",
+        Key: { projectId: "proj-1" },
+      })
+      .resolves({ Item: { ...existingRow, ...overrides } });
+  }
+
+  // ── startAgentDesignAssessment ───────────────────────────────────────
+
+  describe("startAgentDesignAssessment", () => {
+    test("cross-org caller refused; zero PutCommand to assessments table", async () => {
+      stubProject("org-a");
+      const auth = mockAuthContextFor("architect");
+      const event = crossOrgEvent("startAgentDesignAssessment", {
+        projectId: "proj-1",
+      });
+
+      await expect(
+        startAgentDesignAssessment("proj-1", auth, event),
+      ).rejects.toBeInstanceOf(ProjectOrgAccessError);
+
+      const puts = ddbMock
+        .commandCalls(PutCommand)
+        .filter(
+          (c) =>
+            c.args[0].input.TableName ===
+            "citadel-agent-design-assessments-test",
+        );
+      expect(puts).toHaveLength(0);
+    });
+
+    test("same-org caller with assessment:submit succeeds", async () => {
+      stubProject("org-a");
+      ddbMock.on(PutCommand).resolves({});
+      const auth = mockAuthContextFor("architect");
+      const event = sameOrgEvent("startAgentDesignAssessment", {
+        projectId: "proj-1",
+      });
+
+      const row = await startAgentDesignAssessment("proj-1", auth, event);
+      expect(row.archetypeStatus).toBe(ProjectArchetypeStatus.PENDING);
+    });
+
+    test("same-org caller WITHOUT assessment:submit is still refused (additive)", async () => {
+      stubProject("org-a");
+      const auth = mockAuthContextFor("developer");
+      const event = sameOrgEvent(
+        "startAgentDesignAssessment",
+        { projectId: "proj-1" },
+        "developer",
+      );
+
+      await expect(
+        startAgentDesignAssessment("proj-1", auth, event),
+      ).rejects.toThrow(/UnauthorizedError/);
+      const puts = ddbMock
+        .commandCalls(PutCommand)
+        .filter(
+          (c) =>
+            c.args[0].input.TableName ===
+            "citadel-agent-design-assessments-test",
+        );
+      expect(puts).toHaveLength(0);
+    });
+  });
+
+  // ── getAgentDesignAssessment (fetch-then-verify read) ────────────────
+
+  describe("getAgentDesignAssessment", () => {
+    test("cross-org caller refused; row never returned", async () => {
+      stubAssessment();
+      stubProject("org-a");
+      const event = crossOrgEvent("getAgentDesignAssessment", {
+        projectId: "proj-1",
+      });
+
+      await expect(
+        getAgentDesignAssessment("proj-1", event),
+      ).rejects.toBeInstanceOf(ProjectOrgAccessError);
+    });
+
+    test("same-org caller can read", async () => {
+      stubAssessment();
+      stubProject("org-a");
+      const event = sameOrgEvent("getAgentDesignAssessment", {
+        projectId: "proj-1",
+      });
+
+      const row = await getAgentDesignAssessment("proj-1", event);
+      expect(row?.projectId).toBe("proj-1");
+    });
+
+    test("nonexistent row still returns null (fetch first, no crash)", async () => {
+      ddbMock.on(GetCommand).resolves({});
+      const event = sameOrgEvent("getAgentDesignAssessment", {
+        projectId: "missing",
+      });
+      const row = await getAgentDesignAssessment("missing", event);
+      expect(row).toBeNull();
+    });
+  });
+
+  // ── submitAgentDesignAssessment (TransactWrite — sharpest op) ────────
+
+  describe("submitAgentDesignAssessment", () => {
+    test("cross-org caller refused; ZERO TransactWriteCommand issued at all (gate precedes the whole transaction, not one leg)", async () => {
+      stubAssessment();
+      stubProject("org-a");
+      const auth = mockAuthContextFor("architect");
+      const event = crossOrgEvent("submitAgentDesignAssessment", {});
+
+      await expect(
+        submitAgentDesignAssessment(validSubmitInput() as never, auth, event),
+      ).rejects.toBeInstanceOf(ProjectOrgAccessError);
+
+      expect(ddbMock.commandCalls(TransactWriteCommand)).toHaveLength(0);
+      expect(ebMock.commandCalls(PutEventsCommand)).toHaveLength(0);
+    });
+
+    test("cross-org caller refused; the foreign PROJECTS row is never mutated", async () => {
+      stubAssessment();
+      stubProject("org-a");
+      const auth = mockAuthContextFor("architect");
+      const event = crossOrgEvent("submitAgentDesignAssessment", {});
+
+      await expect(
+        submitAgentDesignAssessment(validSubmitInput() as never, auth, event),
+      ).rejects.toBeInstanceOf(ProjectOrgAccessError);
+
+      // No transaction means no leg of it touched PROJECTS_TABLE either.
+      const transactCalls = ddbMock.commandCalls(TransactWriteCommand);
+      const projectsLegs = transactCalls.flatMap((c) =>
+        (c.args[0].input.TransactItems ?? []).filter(
+          (item) => item.Update?.TableName === "citadel-projects-test",
+        ),
+      );
+      expect(projectsLegs).toHaveLength(0);
+    });
+
+    test("same-org caller with assessment:submit succeeds; transaction commits", async () => {
+      stubAssessment();
+      stubProject("org-a");
+      ddbMock.on(TransactWriteCommand).resolves({});
+      // getAgentDesignAssessment is called again after commit (Step 6) —
+      // stub returns a completed row on the second call.
+      ddbMock
+        .on(GetCommand, {
+          TableName: "citadel-agent-design-assessments-test",
+          Key: { projectId: "proj-1" },
+        })
+        .resolvesOnce({ Item: existingRow })
+        .resolves({
+          Item: {
+            ...existingRow,
+            archetype: "AGENTIC_WORKFLOW",
+            archetypeStatus: ProjectArchetypeStatus.CLASSIFIED,
+            completedAt: "2024-06-01T00:00:00.000Z",
+          },
+        });
+      const auth = mockAuthContextFor("architect");
+      const event = sameOrgEvent("submitAgentDesignAssessment", {});
+
+      const result = await submitAgentDesignAssessment(
+        validSubmitInput() as never,
+        auth,
+        event,
+      );
+      expect(result.archetypeStatus).toBe(ProjectArchetypeStatus.CLASSIFIED);
+      expect(ddbMock.commandCalls(TransactWriteCommand)).toHaveLength(1);
+    });
+
+    test("same-org caller WITHOUT assessment:submit is still refused (additive, zero transaction)", async () => {
+      stubAssessment();
+      stubProject("org-a");
+      const auth = mockAuthContextFor("developer");
+      const event = sameOrgEvent(
+        "submitAgentDesignAssessment",
+        {},
+        "developer",
+      );
+
+      await expect(
+        submitAgentDesignAssessment(validSubmitInput() as never, auth, event),
+      ).rejects.toThrow(/UnauthorizedError/);
+      expect(ddbMock.commandCalls(TransactWriteCommand)).toHaveLength(0);
+    });
+
+    test("fetch-then-verify ordering: org check runs after fetching the existing row but before the transaction", async () => {
+      stubAssessment();
+      stubProject("org-b"); // caller is org-a -> cross-org
+      const auth = mockAuthContextFor("architect");
+      const event = sameOrgEvent("submitAgentDesignAssessment", {});
+
+      await expect(
+        submitAgentDesignAssessment(validSubmitInput() as never, auth, event),
+      ).rejects.toBeInstanceOf(ProjectOrgAccessError);
+      expect(ddbMock.commandCalls(TransactWriteCommand)).toHaveLength(0);
+    });
+  });
+
+  // ── handler dispatch always threads event ───────────────────────────
+
+  describe("handler dispatch threads event into the org gate", () => {
+    test("submitAgentDesignAssessment via handler: cross-org caller refused, zero transaction", async () => {
+      stubAssessment();
+      stubProject("org-a");
+      await expect(
+        handler(
+          crossOrgEvent("submitAgentDesignAssessment", validSubmitInput()),
+        ),
+      ).rejects.toThrow(/Access denied/);
+      expect(ddbMock.commandCalls(TransactWriteCommand)).toHaveLength(0);
+    });
+
+    test("startAgentDesignAssessment via handler: cross-org caller refused", async () => {
+      stubProject("org-a");
+      await expect(
+        handler(
+          crossOrgEvent("startAgentDesignAssessment", { projectId: "proj-1" }),
+        ),
+      ).rejects.toThrow(/Access denied/);
+    });
+
+    test("submitAgentDesignAssessment via handler: same-org caller with permission succeeds", async () => {
+      stubAssessment();
+      stubProject("org-a");
+      ddbMock.on(TransactWriteCommand).resolves({});
+      ddbMock
+        .on(GetCommand, {
+          TableName: "citadel-agent-design-assessments-test",
+          Key: { projectId: "proj-1" },
+        })
+        .resolvesOnce({ Item: existingRow })
+        .resolves({
+          Item: {
+            ...existingRow,
+            archetype: "AGENTIC_WORKFLOW",
+            archetypeStatus: ProjectArchetypeStatus.CLASSIFIED,
+            completedAt: "2024-06-01T00:00:00.000Z",
+          },
+        });
+      const result = (await handler(
+        sameOrgEvent("submitAgentDesignAssessment", validSubmitInput()),
+      )) as { archetypeStatus: string };
+      expect(result.archetypeStatus).toBe(ProjectArchetypeStatus.CLASSIFIED);
+    });
+
+    test("submitAgentDesignAssessment via handler: same-org caller without permission refused", async () => {
+      stubAssessment();
+      stubProject("org-a");
+      await expect(
+        handler(
+          sameOrgEvent(
+            "submitAgentDesignAssessment",
+            validSubmitInput(),
+            "developer",
+          ),
+        ),
+      ).rejects.toThrow(/UnauthorizedError/);
+    });
+  });
+});

--- a/backend/src/lambda/__tests__/agent-design-assessment-resolver.test.ts
+++ b/backend/src/lambda/__tests__/agent-design-assessment-resolver.test.ts
@@ -29,11 +29,14 @@ import {
   GetCommand,
   PutCommand,
   TransactWriteCommand,
-} from '@aws-sdk/lib-dynamodb';
-import { EventBridgeClient, PutEventsCommand } from '@aws-sdk/client-eventbridge';
-import { mockClient } from 'aws-sdk-client-mock';
-import * as fc from 'fast-check';
-import type { AuthContext } from '../../types';
+} from "@aws-sdk/lib-dynamodb";
+import {
+  EventBridgeClient,
+  PutEventsCommand,
+} from "@aws-sdk/client-eventbridge";
+import { mockClient } from "aws-sdk-client-mock";
+import * as fc from "fast-check";
+import type { AuthContext } from "../../types";
 
 // ── Auth mock ─────────────────────────────────────────────────────────
 // Track B is landing `assessment:submit` on architect + project_manager in
@@ -41,13 +44,13 @@ import type { AuthContext } from '../../types';
 // permission helper: `architect` and `project_manager` and `admin` hold
 // `assessment:submit`, `developer` does not. This matches the intended
 // auth.ts rolePermissions table.
-jest.mock('../../utils/auth', () => ({
+jest.mock("../../utils/auth", () => ({
   hasPermission: (authContext: AuthContext, permission: string): boolean => {
-    if (authContext.roles?.includes('admin')) return true;
+    if (authContext.roles?.includes("admin")) return true;
     const grants: Record<string, string[]> = {
-      architect: ['assessment:submit', 'project:read'],
-      project_manager: ['assessment:submit', 'project:read'],
-      developer: ['project:read'],
+      architect: ["assessment:submit", "project:read"],
+      project_manager: ["assessment:submit", "project:read"],
+      developer: ["project:read"],
     };
     for (const role of authContext.roles || []) {
       if ((grants[role] || []).includes(permission)) return true;
@@ -61,17 +64,18 @@ const ebMock = mockClient(EventBridgeClient);
 
 // Env MUST be set before importing the module under test — the resolver
 // captures process.env at module load time.
-process.env.AGENT_DESIGN_ASSESSMENTS_TABLE = 'citadel-agent-design-assessments-test';
-process.env.PROJECTS_TABLE = 'citadel-projects-test';
-process.env.EVENT_BUS_NAME = 'citadel-agents-test';
+process.env.AGENT_DESIGN_ASSESSMENTS_TABLE =
+  "citadel-agent-design-assessments-test";
+process.env.PROJECTS_TABLE = "citadel-projects-test";
+process.env.EVENT_BUS_NAME = "citadel-agents-test";
 
 import {
   startAgentDesignAssessment,
   submitAgentDesignAssessment,
   getAgentDesignAssessment,
   handler,
-} from '../agent-design-assessment-resolver';
-import { __resetGovernanceNotifierForTest } from '../../utils/notifier-base';
+} from "../agent-design-assessment-resolver";
+import { __resetGovernanceNotifierForTest } from "../../utils/notifier-base";
 import {
   GovernanceArchetype,
   ProjectArchetypeStatus,
@@ -79,13 +83,13 @@ import {
   type SubmitAgentDesignAssessmentInput,
   type DimensionComplexityInput,
   type AgentDesignAssessment,
-} from '../../types';
+} from "../../types";
 
-const ASSESS_TABLE = 'citadel-agent-design-assessments-test';
-const PROJECTS_TABLE = 'citadel-projects-test';
+const ASSESS_TABLE = "citadel-agent-design-assessments-test";
+const PROJECTS_TABLE = "citadel-projects-test";
 
 function authContextFor(
-  role: 'architect' | 'developer' | 'project_manager' | 'admin',
+  role: "architect" | "developer" | "project_manager" | "admin",
 ): AuthContext {
   return {
     userId: `user-${role}`,
@@ -97,10 +101,10 @@ function authContextFor(
 
 function validRanking(): DimensionComplexityInput[] {
   return [
-    { dimension: 'CODE', rank: 1, rationale: 'core modernisation path' },
-    { dimension: 'DATA', rank: 2, rationale: 'schema migration needed' },
-    { dimension: 'INTEGRATION', rank: 3, rationale: 'a few legacy hooks' },
-    { dimension: 'INFRASTRUCTURE', rank: 4, rationale: 'greenfield AWS' },
+    { dimension: "CODE", rank: 1, rationale: "core modernisation path" },
+    { dimension: "DATA", rank: 2, rationale: "schema migration needed" },
+    { dimension: "INTEGRATION", rank: 3, rationale: "a few legacy hooks" },
+    { dimension: "INFRASTRUCTURE", rank: 4, rationale: "greenfield AWS" },
   ];
 }
 
@@ -108,12 +112,12 @@ function validInput(
   overrides: Partial<SubmitAgentDesignAssessmentInput> = {},
 ): SubmitAgentDesignAssessmentInput {
   return {
-    projectId: 'proj-1',
+    projectId: "proj-1",
     archetype: GovernanceArchetype.MONOLITHIC_DB,
     archetypeConfidence: 0.9,
     dimensionRanking: validRanking(),
-    accessibleDataSources: ['postgres-prod'],
-    primaryRiskAreas: ['data-migration'],
+    accessibleDataSources: ["postgres-prod"],
+    primaryRiskAreas: ["data-migration"],
     ...overrides,
   };
 }
@@ -122,7 +126,7 @@ function existingAssessment(
   overrides: Partial<AgentDesignAssessment> = {},
 ): AgentDesignAssessment {
   return {
-    projectId: 'proj-1',
+    projectId: "proj-1",
     archetype: null,
     archetypeConfidence: null,
     archetypeStatus: ProjectArchetypeStatus.PENDING,
@@ -131,8 +135,8 @@ function existingAssessment(
     primaryRiskAreas: [],
     completedAt: null,
     completedBy: null,
-    createdAt: '2026-04-30T00:00:00.000Z',
-    updatedAt: '2026-04-30T00:00:00.000Z',
+    createdAt: "2026-04-30T00:00:00.000Z",
+    updatedAt: "2026-04-30T00:00:00.000Z",
     ...overrides,
   };
 }
@@ -143,35 +147,35 @@ function completedAssessment(): AgentDesignAssessment {
     archetypeConfidence: 0.9,
     archetypeStatus: ProjectArchetypeStatus.CLASSIFIED,
     dimensionRanking: validRanking().map((d) => ({ ...d })),
-    accessibleDataSources: ['postgres-prod'],
-    primaryRiskAreas: ['data-migration'],
-    completedAt: '2026-04-30T01:00:00.000Z',
-    completedBy: 'user-architect',
-    updatedAt: '2026-04-30T01:00:00.000Z',
+    accessibleDataSources: ["postgres-prod"],
+    primaryRiskAreas: ["data-migration"],
+    completedAt: "2026-04-30T01:00:00.000Z",
+    completedBy: "user-architect",
+    updatedAt: "2026-04-30T01:00:00.000Z",
   });
 }
 
-describe('agent-design-assessment-resolver', () => {
+describe("agent-design-assessment-resolver", () => {
   beforeEach(() => {
     ddbMock.reset();
     ebMock.reset();
     ebMock.on(PutEventsCommand).resolves({
       FailedEntryCount: 0,
-      Entries: [{ EventId: 'evt-1' }],
+      Entries: [{ EventId: "evt-1" }],
     });
     __resetGovernanceNotifierForTest();
   });
 
   // ── startAgentDesignAssessment ────────────────────────────────────────
 
-  describe('startAgentDesignAssessment', () => {
-    test('1. happy path: persists PENDING row with ISO-8601 timestamps and ConditionExpression attribute_not_exists(projectId)', async () => {
+  describe("startAgentDesignAssessment", () => {
+    test("1. happy path: persists PENDING row with ISO-8601 timestamps and ConditionExpression attribute_not_exists(projectId)", async () => {
       ddbMock.on(PutCommand).resolves({});
-      const auth = authContextFor('architect');
+      const auth = authContextFor("architect");
 
-      const row = await startAgentDesignAssessment('proj-1', auth);
+      const row = await startAgentDesignAssessment("proj-1", auth);
 
-      expect(row.projectId).toBe('proj-1');
+      expect(row.projectId).toBe("proj-1");
       expect(row.archetype).toBeNull();
       expect(row.archetypeConfidence).toBeNull();
       expect(row.archetypeStatus).toBe(ProjectArchetypeStatus.PENDING);
@@ -180,70 +184,74 @@ describe('agent-design-assessment-resolver', () => {
       expect(row.primaryRiskAreas).toEqual([]);
       expect(row.completedAt).toBeNull();
       expect(row.completedBy).toBeNull();
-      expect(row.createdAt).toMatch(/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3}Z$/);
-      expect(row.updatedAt).toMatch(/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3}Z$/);
+      expect(row.createdAt).toMatch(
+        /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3}Z$/,
+      );
+      expect(row.updatedAt).toMatch(
+        /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3}Z$/,
+      );
 
       const puts = ddbMock.commandCalls(PutCommand);
       expect(puts).toHaveLength(1);
       expect(puts[0].args[0].input.TableName).toBe(ASSESS_TABLE);
       expect(puts[0].args[0].input.ConditionExpression).toBe(
-        'attribute_not_exists(projectId)',
+        "attribute_not_exists(projectId)",
       );
       expect(puts[0].args[0].input.Item).toMatchObject({
-        projectId: 'proj-1',
-        archetypeStatus: 'PENDING',
+        projectId: "proj-1",
+        archetypeStatus: "PENDING",
       });
     });
 
-    test('2. project_manager also allowed (assessment:submit grant on architect + project_manager)', async () => {
+    test("2. project_manager also allowed (assessment:submit grant on architect + project_manager)", async () => {
       ddbMock.on(PutCommand).resolves({});
-      const auth = authContextFor('project_manager');
-      const row = await startAgentDesignAssessment('proj-2', auth);
-      expect(row.projectId).toBe('proj-2');
+      const auth = authContextFor("project_manager");
+      const row = await startAgentDesignAssessment("proj-2", auth);
+      expect(row.projectId).toBe("proj-2");
       expect(ddbMock.commandCalls(PutCommand)).toHaveLength(1);
     });
 
-    test('3. developer denied: UnauthorizedError, no DDB write', async () => {
+    test("3. developer denied: UnauthorizedError, no DDB write", async () => {
       ddbMock.on(PutCommand).resolves({});
-      const auth = authContextFor('developer');
-      await expect(
-        startAgentDesignAssessment('proj-1', auth),
-      ).rejects.toThrow(/UnauthorizedError.*assessment:submit/);
+      const auth = authContextFor("developer");
+      await expect(startAgentDesignAssessment("proj-1", auth)).rejects.toThrow(
+        /UnauthorizedError.*assessment:submit/,
+      );
       expect(ddbMock.commandCalls(PutCommand)).toHaveLength(0);
     });
 
-    test('4. empty projectId → ValidationError, no DDB write', async () => {
-      const auth = authContextFor('architect');
-      await expect(startAgentDesignAssessment('', auth)).rejects.toThrow(
+    test("4. empty projectId → ValidationError, no DDB write", async () => {
+      const auth = authContextFor("architect");
+      await expect(startAgentDesignAssessment("", auth)).rejects.toThrow(
         /ValidationError.*projectId/,
       );
       expect(ddbMock.commandCalls(PutCommand)).toHaveLength(0);
     });
 
-    test('5. ConditionalCheckFailedException from pre-existing row propagates', async () => {
-      const ccf = new Error('The conditional request failed');
-      ccf.name = 'ConditionalCheckFailedException';
+    test("5. ConditionalCheckFailedException from pre-existing row propagates", async () => {
+      const ccf = new Error("The conditional request failed");
+      ccf.name = "ConditionalCheckFailedException";
       ddbMock.on(PutCommand).rejects(ccf);
-      const auth = authContextFor('architect');
-      await expect(
-        startAgentDesignAssessment('proj-1', auth),
-      ).rejects.toThrow(/conditional/i);
+      const auth = authContextFor("architect");
+      await expect(startAgentDesignAssessment("proj-1", auth)).rejects.toThrow(
+        /conditional/i,
+      );
     });
   });
 
   // ── getAgentDesignAssessment ──────────────────────────────────────────
 
-  describe('getAgentDesignAssessment', () => {
-    test('6. returns null when missing', async () => {
+  describe("getAgentDesignAssessment", () => {
+    test("6. returns null when missing", async () => {
       ddbMock.on(GetCommand).resolves({ Item: undefined });
-      const result = await getAgentDesignAssessment('proj-missing');
+      const result = await getAgentDesignAssessment("proj-missing");
       expect(result).toBeNull();
     });
 
-    test('7. returns Item when present', async () => {
+    test("7. returns Item when present", async () => {
       const existing = existingAssessment();
       ddbMock.on(GetCommand).resolves({ Item: existing });
-      const result = await getAgentDesignAssessment('proj-1');
+      const result = await getAgentDesignAssessment("proj-1");
       expect(result).toEqual(existing);
       const gets = ddbMock.commandCalls(GetCommand);
       expect(gets).toHaveLength(1);
@@ -253,9 +261,9 @@ describe('agent-design-assessment-resolver', () => {
 
   // ── submitAgentDesignAssessment — perm gate ───────────────────────────
 
-  describe('submitAgentDesignAssessment — perm gate', () => {
-    test('8. developer denied BEFORE any DDB access', async () => {
-      const auth = authContextFor('developer');
+  describe("submitAgentDesignAssessment — perm gate", () => {
+    test("8. developer denied BEFORE any DDB access", async () => {
+      const auth = authContextFor("developer");
       await expect(
         submitAgentDesignAssessment(validInput(), auth),
       ).rejects.toThrow(/UnauthorizedError.*assessment:submit/);
@@ -266,24 +274,26 @@ describe('agent-design-assessment-resolver', () => {
 
   // ── submitAgentDesignAssessment — validation branches ─────────────────
 
-  describe('submitAgentDesignAssessment — validation', () => {
-    test('9. dimensionRanking length != 4 rejected', async () => {
-      const auth = authContextFor('architect');
-      const input = validInput({ dimensionRanking: validRanking().slice(0, 3) });
+  describe("submitAgentDesignAssessment — validation", () => {
+    test("9. dimensionRanking length != 4 rejected", async () => {
+      const auth = authContextFor("architect");
+      const input = validInput({
+        dimensionRanking: validRanking().slice(0, 3),
+      });
       await expect(submitAgentDesignAssessment(input, auth)).rejects.toThrow(
         /ValidationError.*dimensionRanking.*exactly 4/,
       );
       expect(ddbMock.commandCalls(GetCommand)).toHaveLength(0);
     });
 
-    test('10. duplicate ranks (1,1,2,3) rejected', async () => {
-      const auth = authContextFor('architect');
+    test("10. duplicate ranks (1,1,2,3) rejected", async () => {
+      const auth = authContextFor("architect");
       const input = validInput({
         dimensionRanking: [
-          { dimension: 'CODE', rank: 1, rationale: 'ok' },
-          { dimension: 'DATA', rank: 1, rationale: 'ok' },
-          { dimension: 'INTEGRATION', rank: 2, rationale: 'ok' },
-          { dimension: 'INFRASTRUCTURE', rank: 3, rationale: 'ok' },
+          { dimension: "CODE", rank: 1, rationale: "ok" },
+          { dimension: "DATA", rank: 1, rationale: "ok" },
+          { dimension: "INTEGRATION", rank: 2, rationale: "ok" },
+          { dimension: "INFRASTRUCTURE", rank: 3, rationale: "ok" },
         ],
       });
       await expect(submitAgentDesignAssessment(input, auth)).rejects.toThrow(
@@ -291,14 +301,14 @@ describe('agent-design-assessment-resolver', () => {
       );
     });
 
-    test('11. missing rank 4 (ranks 1,2,3,5) rejected', async () => {
-      const auth = authContextFor('architect');
+    test("11. missing rank 4 (ranks 1,2,3,5) rejected", async () => {
+      const auth = authContextFor("architect");
       const input = validInput({
         dimensionRanking: [
-          { dimension: 'CODE', rank: 1, rationale: 'ok' },
-          { dimension: 'DATA', rank: 2, rationale: 'ok' },
-          { dimension: 'INTEGRATION', rank: 3, rationale: 'ok' },
-          { dimension: 'INFRASTRUCTURE', rank: 5, rationale: 'ok' },
+          { dimension: "CODE", rank: 1, rationale: "ok" },
+          { dimension: "DATA", rank: 2, rationale: "ok" },
+          { dimension: "INTEGRATION", rank: 3, rationale: "ok" },
+          { dimension: "INFRASTRUCTURE", rank: 5, rationale: "ok" },
         ],
       });
       await expect(submitAgentDesignAssessment(input, auth)).rejects.toThrow(
@@ -306,14 +316,14 @@ describe('agent-design-assessment-resolver', () => {
       );
     });
 
-    test('12. wrong dimension set (CODE duplicated, INFRASTRUCTURE missing) rejected', async () => {
-      const auth = authContextFor('architect');
+    test("12. wrong dimension set (CODE duplicated, INFRASTRUCTURE missing) rejected", async () => {
+      const auth = authContextFor("architect");
       const input = validInput({
         dimensionRanking: [
-          { dimension: 'CODE', rank: 1, rationale: 'ok' },
-          { dimension: 'CODE', rank: 2, rationale: 'ok' },
-          { dimension: 'DATA', rank: 3, rationale: 'ok' },
-          { dimension: 'INTEGRATION', rank: 4, rationale: 'ok' },
+          { dimension: "CODE", rank: 1, rationale: "ok" },
+          { dimension: "CODE", rank: 2, rationale: "ok" },
+          { dimension: "DATA", rank: 3, rationale: "ok" },
+          { dimension: "INTEGRATION", rank: 4, rationale: "ok" },
         ],
       });
       await expect(submitAgentDesignAssessment(input, auth)).rejects.toThrow(
@@ -321,30 +331,30 @@ describe('agent-design-assessment-resolver', () => {
       );
     });
 
-    test('13. empty accessibleDataSources rejected', async () => {
-      const auth = authContextFor('architect');
+    test("13. empty accessibleDataSources rejected", async () => {
+      const auth = authContextFor("architect");
       const input = validInput({ accessibleDataSources: [] });
       await expect(submitAgentDesignAssessment(input, auth)).rejects.toThrow(
         /ValidationError.*accessibleDataSources/,
       );
     });
 
-    test('14. empty primaryRiskAreas rejected', async () => {
-      const auth = authContextFor('architect');
+    test("14. empty primaryRiskAreas rejected", async () => {
+      const auth = authContextFor("architect");
       const input = validInput({ primaryRiskAreas: [] });
       await expect(submitAgentDesignAssessment(input, auth)).rejects.toThrow(
         /ValidationError.*primaryRiskAreas/,
       );
     });
 
-    test('15. empty rationale (whitespace only) rejected', async () => {
-      const auth = authContextFor('architect');
+    test("15. empty rationale (whitespace only) rejected", async () => {
+      const auth = authContextFor("architect");
       const input = validInput({
         dimensionRanking: [
-          { dimension: 'CODE', rank: 1, rationale: '   ' },
-          { dimension: 'DATA', rank: 2, rationale: 'ok' },
-          { dimension: 'INTEGRATION', rank: 3, rationale: 'ok' },
-          { dimension: 'INFRASTRUCTURE', rank: 4, rationale: 'ok' },
+          { dimension: "CODE", rank: 1, rationale: "   " },
+          { dimension: "DATA", rank: 2, rationale: "ok" },
+          { dimension: "INTEGRATION", rank: 3, rationale: "ok" },
+          { dimension: "INFRASTRUCTURE", rank: 4, rationale: "ok" },
         ],
       });
       await expect(submitAgentDesignAssessment(input, auth)).rejects.toThrow(
@@ -355,18 +365,20 @@ describe('agent-design-assessment-resolver', () => {
 
   // ── submitAgentDesignAssessment — lifecycle guards ────────────────────
 
-  describe('submitAgentDesignAssessment — lifecycle guards', () => {
-    test('16. assessment not started (GetCommand returns null) → throws', async () => {
-      const auth = authContextFor('architect');
+  describe("submitAgentDesignAssessment — lifecycle guards", () => {
+    test("16. assessment not started (GetCommand returns null) → throws", async () => {
+      const auth = authContextFor("architect");
       ddbMock.on(GetCommand).resolves({ Item: undefined });
       await expect(
         submitAgentDesignAssessment(validInput(), auth),
-      ).rejects.toThrow(/AgentDesignAssessment not found.*startAgentDesignAssessment/);
+      ).rejects.toThrow(
+        /AgentDesignAssessment not found.*startAgentDesignAssessment/,
+      );
       expect(ddbMock.commandCalls(TransactWriteCommand)).toHaveLength(0);
     });
 
-    test('17. re-submission on completed assessment (completedAt !== null) → throws, no TransactWrite', async () => {
-      const auth = authContextFor('architect');
+    test("17. re-submission on completed assessment (completedAt !== null) → throws, no TransactWrite", async () => {
+      const auth = authContextFor("architect");
       ddbMock.on(GetCommand).resolves({ Item: completedAssessment() });
       await expect(
         submitAgentDesignAssessment(validInput(), auth),
@@ -378,9 +390,9 @@ describe('agent-design-assessment-resolver', () => {
 
   // ── submitAgentDesignAssessment — happy path ──────────────────────────
 
-  describe('submitAgentDesignAssessment — happy path', () => {
-    test('18. emits EXACTLY one TransactWriteCommand with 2 items spanning both tables + governance.archetype.classified', async () => {
-      const auth = authContextFor('architect');
+  describe("submitAgentDesignAssessment — happy path", () => {
+    test("18. emits EXACTLY one TransactWriteCommand with 2 items spanning both tables + governance.archetype.classified", async () => {
+      const auth = authContextFor("architect");
       // First Get: existing PENDING row. Second Get: post-commit re-fetch.
       const pending = existingAssessment();
       const postCommit = completedAssessment();
@@ -395,7 +407,7 @@ describe('agent-design-assessment-resolver', () => {
       // Result is the post-commit row.
       expect(result.archetype).toBe(GovernanceArchetype.MONOLITHIC_DB);
       expect(result.archetypeStatus).toBe(ProjectArchetypeStatus.CLASSIFIED);
-      expect(result.completedBy).toBe('user-architect');
+      expect(result.completedBy).toBe("user-architect");
 
       // Exactly one TransactWriteCommand.
       const tx = ddbMock.commandCalls(TransactWriteCommand);
@@ -421,9 +433,9 @@ describe('agent-design-assessment-resolver', () => {
       const ebCalls = ebMock.commandCalls(PutEventsCommand);
       expect(ebCalls).toHaveLength(1);
       const entry = ebCalls[0].args[0].input.Entries![0];
-      expect(entry.DetailType).toBe('governance.archetype.classified');
+      expect(entry.DetailType).toBe("governance.archetype.classified");
       const detail = JSON.parse(entry.Detail!);
-      expect(detail.projectId).toBe('proj-1');
+      expect(detail.projectId).toBe("proj-1");
       expect(detail.archetype).toBe(GovernanceArchetype.MONOLITHIC_DB);
       // `confidence` is the field name in the typed DetailPayloadOf
       // map in notifier-base.ts (reconciled). The resolver passes
@@ -432,8 +444,8 @@ describe('agent-design-assessment-resolver', () => {
       expect(detail.confidence).toBe(0.9);
     });
 
-    test('19. ProjectsTable update writes the archetype back (mirror-write)', async () => {
-      const auth = authContextFor('architect');
+    test("19. ProjectsTable update writes the archetype back (mirror-write)", async () => {
+      const auth = authContextFor("architect");
       ddbMock
         .on(GetCommand)
         .resolvesOnce({ Item: existingAssessment() })
@@ -442,13 +454,14 @@ describe('agent-design-assessment-resolver', () => {
 
       await submitAgentDesignAssessment(validInput(), auth);
 
-      const items = ddbMock.commandCalls(TransactWriteCommand)[0].args[0].input
-        .TransactItems!;
+      const items =
+        ddbMock.commandCalls(TransactWriteCommand)[0].args[0].input
+          .TransactItems!;
       const projectsUpdate = items.find(
         (i) => i.Update?.TableName === PROJECTS_TABLE,
       );
       expect(projectsUpdate).toBeDefined();
-      expect(projectsUpdate!.Update!.Key).toEqual({ id: 'proj-1' });
+      expect(projectsUpdate!.Update!.Key).toEqual({ id: "proj-1" });
       const values = projectsUpdate!.Update!.ExpressionAttributeValues!;
       // Find the value corresponding to archetype in the UpdateExpression.
       const archetypeValue = Object.entries(values).find(
@@ -461,8 +474,8 @@ describe('agent-design-assessment-resolver', () => {
       expect(statusValue).toBeDefined();
     });
 
-    test('20. archetypeConfidence defaults to 1.0 when omitted', async () => {
-      const auth = authContextFor('architect');
+    test("20. archetypeConfidence defaults to 1.0 when omitted", async () => {
+      const auth = authContextFor("architect");
       ddbMock
         .on(GetCommand)
         .resolvesOnce({ Item: existingAssessment() })
@@ -484,58 +497,95 @@ describe('agent-design-assessment-resolver', () => {
 
   // ── handler dispatch ──────────────────────────────────────────────────
 
-  describe('handler dispatch', () => {
+  describe("handler dispatch", () => {
+    // finding 2c262386: handler dispatch now threads `event` into the
+    // project-org gate, so every dispatch test needs a project record
+    // whose organization matches the caller's `custom:organization` claim.
+    beforeEach(() => {
+      ddbMock
+        .on(GetCommand, {
+          TableName: "citadel-projects-test",
+          Key: { id: "proj-1" },
+        })
+        .resolves({
+          Item: {
+            id: "proj-1",
+            owner: "someone-else",
+            organization: "org-shared",
+          },
+        });
+    });
+
     function event(
       fieldName: string,
       args: Record<string, unknown>,
-      role: 'architect' | 'developer' = 'architect',
+      role: "architect" | "developer" = "architect",
     ): Record<string, unknown> {
       return {
         info: { fieldName },
         arguments: args,
-        identity: { sub: `user-${role}`, username: role, 'custom:role': role },
+        identity: {
+          sub: `user-${role}`,
+          username: role,
+          "custom:role": role,
+          "custom:organization": "org-shared",
+        },
       };
     }
 
-    test('21. dispatches startAgentDesignAssessment', async () => {
+    test("21. dispatches startAgentDesignAssessment", async () => {
       ddbMock.on(PutCommand).resolves({});
       const result = (await handler(
-        event('startAgentDesignAssessment', { projectId: 'proj-1' }),
+        event("startAgentDesignAssessment", { projectId: "proj-1" }),
       )) as { projectId: string; archetypeStatus: string };
-      expect(result.projectId).toBe('proj-1');
-      expect(result.archetypeStatus).toBe('PENDING');
+      expect(result.projectId).toBe("proj-1");
+      expect(result.archetypeStatus).toBe("PENDING");
     });
 
-    test('22. dispatches getAgentDesignAssessment', async () => {
-      ddbMock.on(GetCommand).resolves({ Item: existingAssessment() });
-      const result = (await handler(
-        event('getAgentDesignAssessment', { projectId: 'proj-1' }, 'developer'),
-      )) as { projectId: string } | null;
-      expect(result?.projectId).toBe('proj-1');
-    });
-
-    test('23. dispatches submitAgentDesignAssessment with full input object', async () => {
+    test("22. dispatches getAgentDesignAssessment", async () => {
       ddbMock
-        .on(GetCommand)
+        .on(GetCommand, {
+          TableName: "citadel-agent-design-assessments-test",
+          Key: { projectId: "proj-1" },
+        })
+        .resolves({ Item: existingAssessment() });
+      const result = (await handler(
+        event("getAgentDesignAssessment", { projectId: "proj-1" }, "developer"),
+      )) as { projectId: string } | null;
+      expect(result?.projectId).toBe("proj-1");
+    });
+
+    test("23. dispatches submitAgentDesignAssessment with full input object", async () => {
+      ddbMock
+        .on(GetCommand, {
+          TableName: "citadel-agent-design-assessments-test",
+          Key: { projectId: "proj-1" },
+        })
         .resolvesOnce({ Item: existingAssessment() })
         .resolvesOnce({ Item: completedAssessment() });
       ddbMock.on(TransactWriteCommand).resolves({});
-      const result = (await handler(event('submitAgentDesignAssessment', validInput()))) as {
+      const result = (await handler(
+        event("submitAgentDesignAssessment", validInput()),
+      )) as {
         archetypeStatus: string;
       };
-      expect(result.archetypeStatus).toBe('CLASSIFIED');
+      expect(result.archetypeStatus).toBe("CLASSIFIED");
     });
 
-    test('24. unknown fieldName throws', async () => {
-      await expect(
-        handler(event('bogusField', {})),
-      ).rejects.toThrow(/Unknown fieldName.*bogusField/);
+    test("24. unknown fieldName throws", async () => {
+      await expect(handler(event("bogusField", {}))).rejects.toThrow(
+        /Unknown fieldName.*bogusField/,
+      );
     });
 
-    test('25. handler honours auth gate on write fields (developer denied)', async () => {
+    test("25. handler honours auth gate on write fields (developer denied)", async () => {
       await expect(
         handler(
-          event('startAgentDesignAssessment', { projectId: 'proj-1' }, 'developer'),
+          event(
+            "startAgentDesignAssessment",
+            { projectId: "proj-1" },
+            "developer",
+          ),
         ),
       ).rejects.toThrow(/UnauthorizedError/);
     });
@@ -543,22 +593,22 @@ describe('agent-design-assessment-resolver', () => {
 
   // ── Property test: resolver validator matches schema allowlist ────────
 
-  describe('property: submitAgentDesignAssessment validator (200 iters)', () => {
-    test('26. ValidationError iff ranking is not a permutation of the 4 dimensions with ranks = {1,2,3,4}', async () => {
+  describe("property: submitAgentDesignAssessment validator (200 iters)", () => {
+    test("26. ValidationError iff ranking is not a permutation of the 4 dimensions with ranks = {1,2,3,4}", async () => {
       const dimensionArb = fc.constantFrom<FourDimensionLiteral>(
-        'CODE',
-        'DATA',
-        'INTEGRATION',
-        'INFRASTRUCTURE',
+        "CODE",
+        "DATA",
+        "INTEGRATION",
+        "INFRASTRUCTURE",
       );
       // QB-003-1: use bounded simple rationale strings to avoid ReDoS-risk
       // payloads in redactPII.
       const rationaleArb = fc.constantFrom(
-        'core work',
-        'some data',
-        'small scope',
-        'integration point',
-        'simple',
+        "core work",
+        "some data",
+        "small scope",
+        "integration point",
+        "simple",
       );
       const entryArb = fc.record({
         dimension: dimensionArb,
@@ -568,10 +618,10 @@ describe('agent-design-assessment-resolver', () => {
       const rankingArb = fc.array(entryArb, { minLength: 0, maxLength: 8 });
 
       const FOUR = new Set<FourDimensionLiteral>([
-        'CODE',
-        'DATA',
-        'INTEGRATION',
-        'INFRASTRUCTURE',
+        "CODE",
+        "DATA",
+        "INTEGRATION",
+        "INFRASTRUCTURE",
       ]);
 
       await fc.assert(
@@ -582,7 +632,7 @@ describe('agent-design-assessment-resolver', () => {
           ebMock.reset();
           ebMock.on(PutEventsCommand).resolves({
             FailedEntryCount: 0,
-            Entries: [{ EventId: 'evt-prop' }],
+            Entries: [{ EventId: "evt-prop" }],
           });
           __resetGovernanceNotifierForTest();
 
@@ -598,7 +648,8 @@ describe('agent-design-assessment-resolver', () => {
           const validLength = ranking.length === 4;
           const ranks = ranking.map((r) => r.rank).sort((a, b) => a - b);
           const validRanks =
-            validLength && JSON.stringify(ranks) === JSON.stringify([1, 2, 3, 4]);
+            validLength &&
+            JSON.stringify(ranks) === JSON.stringify([1, 2, 3, 4]);
           const dims = new Set(ranking.map((r) => r.dimension));
           const validDims =
             validLength &&
@@ -606,16 +657,17 @@ describe('agent-design-assessment-resolver', () => {
             [...FOUR].every((d) => dims.has(d));
           const validRationales =
             validLength && ranking.every((r) => r.rationale.trim().length > 0);
-          const isValid = validLength && validRanks && validDims && validRationales;
+          const isValid =
+            validLength && validRanks && validDims && validRationales;
 
-          const auth = authContextFor('architect');
+          const auth = authContextFor("architect");
           const input: SubmitAgentDesignAssessmentInput = {
-            projectId: 'proj-prop',
+            projectId: "proj-prop",
             archetype: GovernanceArchetype.MONOLITHIC_DB,
             archetypeConfidence: 0.8,
             dimensionRanking: ranking,
-            accessibleDataSources: ['src-1'],
-            primaryRiskAreas: ['risk-1'],
+            accessibleDataSources: ["src-1"],
+            primaryRiskAreas: ["risk-1"],
           };
 
           if (isValid) {

--- a/backend/src/lambda/__tests__/execspec-resolver-dispatch-gate-enumeration.test.ts
+++ b/backend/src/lambda/__tests__/execspec-resolver-dispatch-gate-enumeration.test.ts
@@ -1,0 +1,285 @@
+/**
+ * Enumeration-completeness guard for execspec-resolver.ts's dispatch switch
+ * (finding 2c262386 — module 1/4, guard 7 in the series continued from
+ * adr-resolver-dispatch-gate-enumeration.test.ts / finding 677c1a6c).
+ *
+ * Root defect closed by finding 2c262386 (this module): approve/revise/
+ * submit/reject ExecutionSpecification (and the get/list queries) gated
+ * only on hasPermission('spec:approve') and trusted the client-supplied/
+ * fetched projectId with NO project-to-organization reconciliation — an
+ * architect in one org could approve or rewrite another org's governance
+ * execution spec by specId. The fix threads an OPTIONAL `event` parameter
+ * through every exported function; the dispatch handler always supplies
+ * it, and each function calls the shared `assertProjectOrgAccess` gate
+ * before any write or before returning any data — as an ADDITIONAL check,
+ * not a replacement for hasPermission('spec:approve'), which remains in
+ * force.
+ *
+ * This handler's dispatch cases delegate to a DIRECT `await <fn>(...)`
+ * call, so this guard's parser extracts ONE call site per case and
+ * verifies that callee's own function body actually threads `event` to
+ * the handler AND contains an `assertProjectOrgAccess(` call.
+ */
+import * as fs from 'fs';
+import * as path from 'path';
+
+const HANDLER_PATH = path.join(__dirname, '..', 'execspec-resolver.ts');
+
+function extractDispatchCases(source: string): string[] {
+  const switchStart = source.indexOf('switch (fieldName)');
+  if (switchStart === -1) {
+    throw new Error(
+      'Could not locate `switch (fieldName)` in execspec-resolver.ts — ' +
+        "dispatch structure changed; update this guard's parsing.",
+    );
+  }
+  const defaultIdx = source.indexOf('default:', switchStart);
+  if (defaultIdx === -1) {
+    throw new Error(
+      "Could not locate the dispatch switch's `default:` case — " +
+        "update this guard's parsing.",
+    );
+  }
+  const switchBody = source.slice(switchStart, defaultIdx);
+  const caseRe = /case\s+['"]([^'"]+)['"]\s*:/g;
+  const cases: string[] = [];
+  let m: RegExpExecArray | null;
+  while ((m = caseRe.exec(switchBody)) !== null) {
+    cases.push(m[1]);
+  }
+  return cases;
+}
+
+/** Slices out a single `case '<fieldName>': ... case` (or default) block. */
+function extractCaseBody(source: string, fieldName: string): string {
+  const switchStart = source.indexOf('switch (fieldName)');
+  const defaultIdx = source.indexOf('default:', switchStart);
+  const switchBody = source.slice(switchStart, defaultIdx);
+
+  const caseIdx =
+    switchBody.indexOf(`case '${fieldName}'`) !== -1
+      ? switchBody.indexOf(`case '${fieldName}'`)
+      : switchBody.indexOf(`case "${fieldName}"`);
+  if (caseIdx === -1) {
+    throw new Error(`Could not locate case '${fieldName}' in dispatch switch`);
+  }
+  const nextCaseIdx = switchBody.indexOf('case ', caseIdx + 1);
+  return switchBody.slice(
+    caseIdx,
+    nextCaseIdx === -1 ? undefined : nextCaseIdx,
+  );
+}
+
+/** Extracts every `await <fnName>(` call site name inside a case body. */
+function extractCallSiteNames(caseBody: string): string[] {
+  const callRe = /await\s+([A-Za-z0-9_]+)\s*\(/g;
+  const names: string[] = [];
+  let m: RegExpExecArray | null;
+  while ((m = callRe.exec(caseBody)) !== null) {
+    names.push(m[1]);
+  }
+  return names;
+}
+
+/**
+ * Extracts a top-level `export async function <name>(...) { ... }` body by
+ * brace-counting from the function keyword, matching the parameter list's
+ * closing paren first.
+ */
+function extractFunctionBody(source: string, fnName: string): string {
+  const declRe = new RegExp(
+    `(?:export\\s+)?async function ${fnName}\\b\\s*\\(`,
+  );
+  const declMatch = declRe.exec(source);
+  if (!declMatch) {
+    throw new Error(
+      `Could not locate function declaration for '${fnName}' in execspec-resolver.ts`,
+    );
+  }
+  const paramsOpenIdx = source.indexOf('(', declMatch.index);
+  let parenDepth = 0;
+  let j = paramsOpenIdx;
+  for (; j < source.length; j++) {
+    if (source[j] === '(') parenDepth++;
+    else if (source[j] === ')') {
+      parenDepth--;
+      if (parenDepth === 0) break;
+    }
+  }
+  const bodyStart = source.indexOf('{', j);
+  let depth = 0;
+  let i = bodyStart;
+  for (; i < source.length; i++) {
+    if (source[i] === '{') depth++;
+    else if (source[i] === '}') {
+      depth--;
+      if (depth === 0) break;
+    }
+  }
+  return source.slice(bodyStart, i + 1);
+}
+
+const GATE_CALL_RE = /assertProjectOrgAccess\s*\(/;
+const EVENT_PARAM_RE = /event\?\s*:\s*unknown/;
+
+/**
+ * Every op on this dispatch surface calls assertProjectOrgAccess in its own
+ * function body.
+ */
+const GATED_OPS: Record<string, { fn: string }> = {
+  createExecutionSpecification: { fn: 'createExecutionSpecification' },
+  submitExecutionSpecification: { fn: 'submitExecutionSpecification' },
+  approveExecutionSpecification: { fn: 'approveExecutionSpecification' },
+  rejectExecutionSpecification: { fn: 'rejectExecutionSpecification' },
+  reviseExecutionSpecification: { fn: 'reviseExecutionSpecification' },
+  getExecutionSpecification: { fn: 'getExecutionSpecification' },
+  listExecutionSpecifications: { fn: 'listExecutionSpecifications' },
+};
+
+/**
+ * No case on this dispatch surface is legitimately exempt — every op reads
+ * or writes governance data scoped to a projectId, so every op must
+ * reconcile the caller's org.
+ */
+const EXEMPT_OPS: Record<string, string> = {};
+
+describe('execspec-resolver — dispatch enumeration completeness', () => {
+  const source = fs.readFileSync(HANDLER_PATH, 'utf-8');
+  const cases = extractDispatchCases(source);
+
+  test('the dispatch switch actually has cases to check (sanity check on the parser itself)', () => {
+    expect(cases.length).toBeGreaterThanOrEqual(7);
+    expect(cases).toEqual(
+      expect.arrayContaining(Object.keys(GATED_OPS)),
+    );
+  });
+
+  test('every dispatch case is accounted for in GATED_OPS or EXEMPT_OPS', () => {
+    const unaccounted = cases.filter(
+      (c) => !(c in GATED_OPS) && !(c in EXEMPT_OPS),
+    );
+    expect(unaccounted).toEqual([]);
+  });
+
+  test('GATED_OPS and EXEMPT_OPS do not both claim the same op', () => {
+    const overlap = Object.keys(GATED_OPS).filter((k) => k in EXEMPT_OPS);
+    expect(overlap).toEqual([]);
+  });
+
+  test('no GATED_OPS/EXEMPT_OPS entry references a case that no longer exists in the switch', () => {
+    const known = new Set(cases);
+    const staleGated = Object.keys(GATED_OPS).filter((k) => !known.has(k));
+    const staleExempt = Object.keys(EXEMPT_OPS).filter((k) => !known.has(k));
+    expect(staleGated).toEqual([]);
+    expect(staleExempt).toEqual([]);
+  });
+
+  describe.each(Object.entries(GATED_OPS))(
+    "GATED_OPS['%s'] dispatches to a function that threads `event` and calls assertProjectOrgAccess",
+    (fieldName, meta) => {
+      test(`${fieldName}'s case dispatches to ${meta.fn}`, () => {
+        const caseBody = extractCaseBody(source, fieldName);
+        const callSites = extractCallSiteNames(caseBody);
+        expect(callSites).toContain(meta.fn);
+      });
+
+      test(`${fieldName}'s case passes \`event\` as an argument to ${meta.fn}`, () => {
+        const caseBody = extractCaseBody(source, fieldName);
+        const callRe = new RegExp(
+          `${meta.fn}\\s*\\([^;]*?\\bevent\\b[^;]*?\\)`,
+        );
+        expect(callRe.test(caseBody)).toBe(true);
+      });
+
+      test(`${meta.fn}'s declaration accepts an optional \`event?: unknown\` parameter`, () => {
+        const declRe = new RegExp(
+          `(?:export\\s+)?async function ${meta.fn}\\b\\s*\\(([^)]*)\\)`,
+        );
+        const m = declRe.exec(source);
+        expect(m).not.toBeNull();
+        expect(EVENT_PARAM_RE.test((m as RegExpExecArray)[1])).toBe(true);
+      });
+
+      test(`${meta.fn}'s function body contains an assertProjectOrgAccess call`, () => {
+        const body = extractFunctionBody(source, meta.fn);
+        expect(GATE_CALL_RE.test(body)).toBe(true);
+      });
+    },
+  );
+
+  describe('write-path ops gate BEFORE their DynamoDB write side effect', () => {
+    test("createExecutionSpecification's gate call precedes its PutCommand", () => {
+      const body = extractFunctionBody(source, 'createExecutionSpecification');
+      const gateIdx = body.search(GATE_CALL_RE);
+      const putIdx = body.indexOf('new PutCommand(');
+      expect(gateIdx).toBeGreaterThan(-1);
+      expect(putIdx).toBeGreaterThan(-1);
+      expect(gateIdx).toBeLessThan(putIdx);
+    });
+
+    test("approveExecutionSpecification's gate call precedes its updateStatus call (sharpest op)", () => {
+      const body = extractFunctionBody(source, 'approveExecutionSpecification');
+      const gateIdx = body.search(GATE_CALL_RE);
+      const updateIdx = body.indexOf('updateStatus(');
+      expect(gateIdx).toBeGreaterThan(-1);
+      expect(updateIdx).toBeGreaterThan(-1);
+      expect(gateIdx).toBeLessThan(updateIdx);
+    });
+
+    test("reviseExecutionSpecification's gate call precedes its updateStatus call", () => {
+      const body = extractFunctionBody(source, 'reviseExecutionSpecification');
+      const gateIdx = body.search(GATE_CALL_RE);
+      const updateIdx = body.indexOf('updateStatus(');
+      expect(gateIdx).toBeGreaterThan(-1);
+      expect(updateIdx).toBeGreaterThan(-1);
+      expect(gateIdx).toBeLessThan(updateIdx);
+    });
+
+    test("submitExecutionSpecification's gate call precedes its updateStatus call", () => {
+      const body = extractFunctionBody(source, 'submitExecutionSpecification');
+      const gateIdx = body.search(GATE_CALL_RE);
+      const updateIdx = body.indexOf('updateStatus(');
+      expect(gateIdx).toBeGreaterThan(-1);
+      expect(updateIdx).toBeGreaterThan(-1);
+      expect(gateIdx).toBeLessThan(updateIdx);
+    });
+
+    test("rejectExecutionSpecification's gate call precedes its updateStatus call, but follows the pre-existing audit-before-auth emit", () => {
+      const body = extractFunctionBody(source, 'rejectExecutionSpecification');
+      const gateIdx = body.search(GATE_CALL_RE);
+      const updateIdx = body.indexOf('updateStatus(');
+      const emitIdx = body.indexOf('emitGovernanceEvent(');
+      expect(gateIdx).toBeGreaterThan(-1);
+      expect(updateIdx).toBeGreaterThan(-1);
+      expect(emitIdx).toBeGreaterThan(-1);
+      // Gate must come AFTER the audit emit (preserving audit-before-auth)
+      // and BEFORE the terminal write.
+      expect(emitIdx).toBeLessThan(gateIdx);
+      expect(gateIdx).toBeLessThan(updateIdx);
+    });
+  });
+
+  describe('read-path ops return/query nothing before the gate resolves', () => {
+    test("getExecutionSpecification's gate call precedes its `return spec` statement", () => {
+      const body = extractFunctionBody(source, 'getExecutionSpecification');
+      const gateIdx = body.search(GATE_CALL_RE);
+      const returnIdx = body.lastIndexOf('return spec;');
+      expect(gateIdx).toBeGreaterThan(-1);
+      expect(returnIdx).toBeGreaterThan(-1);
+      expect(gateIdx).toBeLessThan(returnIdx);
+    });
+
+    test("listExecutionSpecifications's gate call precedes its QueryCommand (no foreign-data read at all)", () => {
+      const body = extractFunctionBody(source, 'listExecutionSpecifications');
+      const gateIdx = body.search(GATE_CALL_RE);
+      const queryIdx = body.indexOf('new QueryCommand(');
+      expect(gateIdx).toBeGreaterThan(-1);
+      expect(queryIdx).toBeGreaterThan(-1);
+      expect(gateIdx).toBeLessThan(queryIdx);
+    });
+  });
+
+  test("handler's hasPermission('spec:approve') check is not removed by this fix (additive, not a replacement)", () => {
+    expect(source).toMatch(/hasPermission\(authContext, ['"]spec:approve['"]\)/);
+  });
+});

--- a/backend/src/lambda/__tests__/execspec-resolver-org-scoping.test.ts
+++ b/backend/src/lambda/__tests__/execspec-resolver-org-scoping.test.ts
@@ -1,0 +1,527 @@
+/**
+ * Org-scoping tests for execspec-resolver (finding 2c262386, module 1/4).
+ *
+ * DEFECT: approveExecutionSpecification / reviseExecutionSpecification (and
+ * every other exported op) gated only on hasPermission('spec:approve') and
+ * trusted the fetched specId's projectId with NO project-to-organization
+ * reconciliation — an architect in org A could approve or rewrite org B's
+ * governance execution spec by specId.
+ *
+ * FIX: assertProjectOrgAccess(projectId, event) — the SAME shared helper
+ * from PR 142 / finding 677c1a6c, reused verbatim (no variant) — is
+ * threaded through every exported function as an ADDITIONAL, optional
+ * `event` parameter. The dispatch handler always supplies `event`.
+ * hasPermission('spec:approve') remains in force, unchanged.
+ *
+ * Acceptance:
+ *  - cross-org caller refused on create/submit/approve/reject/revise/get/
+ *    list; zero writes to EXECUTION_SPECS_TABLE, zero foreign reads
+ *  - same-org caller WITH spec:approve succeeds
+ *  - same-org caller WITHOUT spec:approve is still refused (additive, not
+ *    a replacement)
+ *  - approveExecutionSpecification's own docblock states "Permission check
+ *    FIRST — no DDB access, no event, before any state work" — this
+ *    ordering (permission, then fetch, then org-check, then write) must be
+ *    preserved, not replaced by audit-before-auth (no such ordering exists
+ *    in this module — see note in the reject test below).
+ */
+import {
+  DynamoDBDocumentClient,
+  GetCommand,
+  PutCommand,
+  UpdateCommand,
+  QueryCommand,
+} from "@aws-sdk/lib-dynamodb";
+import { EventBridgeClient, PutEventsCommand } from "@aws-sdk/client-eventbridge";
+import { mockClient } from "aws-sdk-client-mock";
+import type { AuthContext } from "../../types";
+
+const ddbMock = mockClient(DynamoDBDocumentClient);
+const ebMock = mockClient(EventBridgeClient);
+
+process.env.EXECUTION_SPECS_TABLE = "citadel-execution-specs-test";
+process.env.EVENT_BUS_NAME = "citadel-agents-test";
+process.env.PROJECTS_TABLE = "citadel-projects-test";
+
+import {
+  createExecutionSpecification,
+  submitExecutionSpecification,
+  approveExecutionSpecification,
+  rejectExecutionSpecification,
+  reviseExecutionSpecification,
+  getExecutionSpecification,
+  listExecutionSpecifications,
+  handler,
+} from "../execspec-resolver";
+import { __resetGovernanceNotifierForTest } from "../../utils/notifier-base";
+import { ProjectOrgAccessError } from "../../utils/project-org-access";
+
+function mockAuthContextFor(role: "architect" | "developer"): AuthContext {
+  return { userId: `user-${role}`, username: role, groups: [], roles: [role] };
+}
+
+const VALID_NARRATIVE =
+  "s3://citadel-governance-transcripts-test-123456789012-us-east-1/projects/proj-1/spec.md";
+
+function baseCreateInput(overrides: Record<string, unknown> = {}) {
+  return {
+    projectId: "proj-1",
+    sourceAdrIds: ["adr-1"],
+    structuredPayload: "{}",
+    narrativeS3Uri: VALID_NARRATIVE,
+    ...overrides,
+  };
+}
+
+function crossOrgEvent(
+  fieldName: string,
+  args: Record<string, unknown>,
+  role: "architect" | "developer" = "architect",
+) {
+  return {
+    info: { fieldName },
+    arguments: args,
+    identity: {
+      sub: `user-${role}-org-b`,
+      username: role,
+      "custom:role": role,
+      "custom:organization": "org-b",
+    },
+  };
+}
+
+function sameOrgEvent(
+  fieldName: string,
+  args: Record<string, unknown>,
+  role: "architect" | "developer" = "architect",
+) {
+  return {
+    info: { fieldName },
+    arguments: args,
+    identity: {
+      sub: `user-${role}-org-a`,
+      username: role,
+      "custom:role": role,
+      "custom:organization": "org-a",
+    },
+  };
+}
+
+const existingSpec = {
+  specId: "spec-1",
+  projectId: "proj-1",
+  sourceAdrIds: ["adr-1"],
+  structuredPayload: "{}",
+  narrativeS3Uri: VALID_NARRATIVE,
+  status: "DRAFT",
+  version: 1,
+  createdAt: "2024-01-01T00:00:00.000Z",
+  createdBy: "someone",
+};
+
+describe("execspec-resolver — project-org scoping (finding 2c262386)", () => {
+  beforeEach(() => {
+    ddbMock.reset();
+    ebMock.reset();
+    ebMock
+      .on(PutEventsCommand)
+      .resolves({ FailedEntryCount: 0, Entries: [{ EventId: "evt-1" }] });
+    __resetGovernanceNotifierForTest();
+  });
+
+  function stubProject(organization = "org-a", owner = "someone-else") {
+    ddbMock
+      .on(GetCommand, {
+        TableName: "citadel-projects-test",
+        Key: { id: "proj-1" },
+      })
+      .resolves({ Item: { id: "proj-1", owner, organization } });
+  }
+
+  function stubSpec(status = "DRAFT", version = 1) {
+    ddbMock
+      .on(GetCommand, {
+        TableName: "citadel-execution-specs-test",
+        Key: { specId: "spec-1" },
+      })
+      .resolves({ Item: { ...existingSpec, status, version } });
+  }
+
+  // ── createExecutionSpecification ────────────────────────────────────
+
+  describe("createExecutionSpecification", () => {
+    test("cross-org caller refused; zero PutCommand to EXECUTION_SPECS_TABLE", async () => {
+      stubProject("org-a");
+      const auth = mockAuthContextFor("architect");
+      const event = crossOrgEvent("createExecutionSpecification", {});
+
+      await expect(
+        createExecutionSpecification(baseCreateInput(), auth, event),
+      ).rejects.toBeInstanceOf(ProjectOrgAccessError);
+
+      const puts = ddbMock
+        .commandCalls(PutCommand)
+        .filter(
+          (c) => c.args[0].input.TableName === "citadel-execution-specs-test",
+        );
+      expect(puts).toHaveLength(0);
+    });
+
+    test("same-org caller with spec:approve succeeds", async () => {
+      stubProject("org-a");
+      ddbMock.on(PutCommand).resolves({});
+      const auth = mockAuthContextFor("architect");
+      const event = sameOrgEvent("createExecutionSpecification", {});
+
+      const spec = await createExecutionSpecification(
+        baseCreateInput(),
+        auth,
+        event,
+      );
+      expect(spec.status).toBe("DRAFT");
+    });
+
+    test("same-org caller WITHOUT spec:approve is still refused (additive, not replaced)", async () => {
+      stubProject("org-a");
+      const auth = mockAuthContextFor("developer");
+      const event = sameOrgEvent(
+        "createExecutionSpecification",
+        {},
+        "developer",
+      );
+
+      await expect(
+        createExecutionSpecification(baseCreateInput(), auth, event),
+      ).rejects.toThrow(/UnauthorizedError/);
+      const puts = ddbMock
+        .commandCalls(PutCommand)
+        .filter(
+          (c) => c.args[0].input.TableName === "citadel-execution-specs-test",
+        );
+      expect(puts).toHaveLength(0);
+    });
+  });
+
+  // ── approveExecutionSpecification (sharpest op) ─────────────────────
+
+  describe("approveExecutionSpecification", () => {
+    test("cross-org caller refused; zero UpdateCommand, zero governance event emitted", async () => {
+      stubSpec("PENDING_REVIEW");
+      stubProject("org-a");
+      const auth = mockAuthContextFor("architect");
+      const event = crossOrgEvent("approveExecutionSpecification", {
+        specId: "spec-1",
+      });
+
+      await expect(
+        approveExecutionSpecification("spec-1", auth, event),
+      ).rejects.toBeInstanceOf(ProjectOrgAccessError);
+
+      expect(ddbMock.commandCalls(UpdateCommand)).toHaveLength(0);
+      expect(ebMock.commandCalls(PutEventsCommand)).toHaveLength(0);
+    });
+
+    test("same-org caller with spec:approve succeeds and state transitions to APPROVED", async () => {
+      stubSpec("PENDING_REVIEW");
+      stubProject("org-a");
+      ddbMock.on(UpdateCommand).resolves({
+        Attributes: { ...existingSpec, status: "APPROVED", version: 2 },
+      });
+      const auth = mockAuthContextFor("architect");
+      const event = sameOrgEvent("approveExecutionSpecification", {
+        specId: "spec-1",
+      });
+
+      const result = await approveExecutionSpecification("spec-1", auth, event);
+      expect(result.status).toBe("APPROVED");
+    });
+
+    test("same-org caller WITHOUT spec:approve is still refused", async () => {
+      stubSpec("PENDING_REVIEW");
+      stubProject("org-a");
+      const auth = mockAuthContextFor("developer");
+      const event = sameOrgEvent(
+        "approveExecutionSpecification",
+        { specId: "spec-1" },
+        "developer",
+      );
+
+      await expect(
+        approveExecutionSpecification("spec-1", auth, event),
+      ).rejects.toThrow(/UnauthorizedError/);
+      expect(ddbMock.commandCalls(UpdateCommand)).toHaveLength(0);
+    });
+
+    test("fetch-then-verify ordering: org check runs before the UpdateCommand", async () => {
+      // spec is fetched (specId is the only client arg — projectId comes
+      // from the fetched record), THEN the org check must run BEFORE any
+      // write mutates spec state.
+      stubSpec("PENDING_REVIEW");
+      stubProject("org-b"); // caller is org-a in sameOrgEvent below -> cross-org
+      const auth = mockAuthContextFor("architect");
+      const event = sameOrgEvent("approveExecutionSpecification", {
+        specId: "spec-1",
+      });
+
+      await expect(
+        approveExecutionSpecification("spec-1", auth, event),
+      ).rejects.toBeInstanceOf(ProjectOrgAccessError);
+      expect(ddbMock.commandCalls(UpdateCommand)).toHaveLength(0);
+    });
+  });
+
+  // ── reviseExecutionSpecification ────────────────────────────────────
+
+  describe("reviseExecutionSpecification", () => {
+    test("cross-org caller refused; zero UpdateCommand (rewrite blocked)", async () => {
+      stubSpec("REJECTED");
+      stubProject("org-a");
+      const auth = mockAuthContextFor("architect");
+      const event = crossOrgEvent("reviseExecutionSpecification", {
+        specId: "spec-1",
+        input: { structuredPayload: "{}", narrativeS3Uri: VALID_NARRATIVE },
+      });
+
+      await expect(
+        reviseExecutionSpecification(
+          "spec-1",
+          { structuredPayload: "{}", narrativeS3Uri: VALID_NARRATIVE },
+          auth,
+          event,
+        ),
+      ).rejects.toBeInstanceOf(ProjectOrgAccessError);
+      expect(ddbMock.commandCalls(UpdateCommand)).toHaveLength(0);
+    });
+
+    test("same-org caller with spec:approve succeeds", async () => {
+      stubSpec("REJECTED");
+      stubProject("org-a");
+      ddbMock.on(UpdateCommand).resolves({
+        Attributes: { ...existingSpec, status: "DRAFT", version: 2 },
+      });
+      const auth = mockAuthContextFor("architect");
+      const event = sameOrgEvent("reviseExecutionSpecification", {
+        specId: "spec-1",
+      });
+
+      const result = await reviseExecutionSpecification(
+        "spec-1",
+        { structuredPayload: "{}", narrativeS3Uri: VALID_NARRATIVE },
+        auth,
+        event,
+      );
+      expect(result.status).toBe("DRAFT");
+    });
+  });
+
+  // ── submitExecutionSpecification ────────────────────────────────────
+
+  describe("submitExecutionSpecification", () => {
+    test("cross-org caller refused; zero UpdateCommand", async () => {
+      stubSpec("DRAFT");
+      stubProject("org-a");
+      const auth = mockAuthContextFor("architect");
+      const event = crossOrgEvent("submitExecutionSpecification", {
+        specId: "spec-1",
+      });
+
+      await expect(
+        submitExecutionSpecification("spec-1", auth, event),
+      ).rejects.toBeInstanceOf(ProjectOrgAccessError);
+      expect(ddbMock.commandCalls(UpdateCommand)).toHaveLength(0);
+    });
+  });
+
+  // ── rejectExecutionSpecification ────────────────────────────────────
+  // NOTE ON AUDIT ORDERING: this module's own docblock documents an
+  // audit-before-auth pattern (structured console.log lines) for
+  // rejectExecutionSpecification, matching the "QT3-3" convention used by
+  // adr-resolver's reopenADR. Unlike reopenADR, this module does NOT
+  // persist the audit line to a dedicated DynamoDB audit table — it is a
+  // CloudWatch console.log side-effect, not a write our mocks can observe.
+  // The org gate must run AFTER hasPermission (auth) has fired  and
+  // must NOT be placed ahead of the existing audit-before-auth console.log
+  // lines, since those must fire for every attempt regardless of the org
+  // outcome (matching reopenADR's "audit row exists ∀ invocation"
+  // invariant intent). The gate is inserted immediately after the spec is
+  // fetched and BEFORE the terminal DDB UpdateCommand — i.e. after the
+  // existing audit-then-auth-then-emit sequence, preserving that ordering.
+  describe("rejectExecutionSpecification", () => {
+    test("cross-org caller refused; zero UpdateCommand (terminal REJECTED state never written for foreign spec)", async () => {
+      stubSpec("PENDING_REVIEW");
+      stubProject("org-a");
+      const auth = mockAuthContextFor("architect");
+      const event = crossOrgEvent("rejectExecutionSpecification", {
+        specId: "spec-1",
+        reason: "not viable",
+      });
+
+      await expect(
+        rejectExecutionSpecification("spec-1", "not viable", auth, event),
+      ).rejects.toBeInstanceOf(ProjectOrgAccessError);
+      expect(ddbMock.commandCalls(UpdateCommand)).toHaveLength(0);
+    });
+
+    test("audit-before-auth ordering preserved: governance.specification.rejected still emits on DENIED same-org attempts", async () => {
+      stubSpec("PENDING_REVIEW");
+      stubProject("org-a");
+      const auth = mockAuthContextFor("developer");
+      const event = sameOrgEvent(
+        "rejectExecutionSpecification",
+        { specId: "spec-1", reason: "x" },
+        "developer",
+      );
+
+      await expect(
+        rejectExecutionSpecification("spec-1", "x", auth, event),
+      ).rejects.toThrow(/UnauthorizedError/);
+      // The existing audit-before-auth emit must still fire for a
+      // same-org DENIED attempt — this fix must not disturb that ordering.
+      expect(ebMock.commandCalls(PutEventsCommand).length).toBeGreaterThan(0);
+    });
+
+    test("same-org caller with spec:approve succeeds", async () => {
+      stubSpec("PENDING_REVIEW");
+      stubProject("org-a");
+      ddbMock.on(UpdateCommand).resolves({
+        Attributes: { ...existingSpec, status: "REJECTED", version: 2 },
+      });
+      const auth = mockAuthContextFor("architect");
+      const event = sameOrgEvent("rejectExecutionSpecification", {
+        specId: "spec-1",
+        reason: "not viable",
+      });
+
+      const result = await rejectExecutionSpecification(
+        "spec-1",
+        "not viable",
+        auth,
+        event,
+      );
+      expect(result.status).toBe("REJECTED");
+    });
+  });
+
+  // ── getExecutionSpecification (fetch-then-verify read) ──────────────
+
+  describe("getExecutionSpecification", () => {
+    test("cross-org caller refused; spec never returned", async () => {
+      stubSpec("DRAFT");
+      stubProject("org-a");
+      const event = crossOrgEvent("getExecutionSpecification", {
+        specId: "spec-1",
+      });
+
+      await expect(
+        getExecutionSpecification("spec-1", event),
+      ).rejects.toBeInstanceOf(ProjectOrgAccessError);
+    });
+
+    test("same-org caller can read", async () => {
+      stubSpec("DRAFT");
+      stubProject("org-a");
+      const event = sameOrgEvent("getExecutionSpecification", {
+        specId: "spec-1",
+      });
+
+      const spec = await getExecutionSpecification("spec-1", event);
+      expect(spec?.specId).toBe("spec-1");
+    });
+
+    test("nonexistent spec still returns null (fetch first, no crash on missing row)", async () => {
+      ddbMock.on(GetCommand).resolves({});
+      const event = sameOrgEvent("getExecutionSpecification", {
+        specId: "missing",
+      });
+      const spec = await getExecutionSpecification("missing", event);
+      expect(spec).toBeNull();
+    });
+  });
+
+  // ── listExecutionSpecifications ─────────────────────────────────────
+
+  describe("listExecutionSpecifications", () => {
+    test("cross-org caller refused; zero QueryCommand against EXECUTION_SPECS_TABLE", async () => {
+      stubProject("org-a");
+      const event = crossOrgEvent("listExecutionSpecifications", {
+        projectId: "proj-1",
+      });
+
+      await expect(
+        listExecutionSpecifications("proj-1", event),
+      ).rejects.toBeInstanceOf(ProjectOrgAccessError);
+      const queries = ddbMock
+        .commandCalls(QueryCommand)
+        .filter(
+          (c) => c.args[0].input.TableName === "citadel-execution-specs-test",
+        );
+      expect(queries).toHaveLength(0);
+    });
+
+    test("same-org caller can list", async () => {
+      stubProject("org-a");
+      ddbMock
+        .on(QueryCommand, { TableName: "citadel-execution-specs-test" })
+        .resolves({ Items: [] });
+      const event = sameOrgEvent("listExecutionSpecifications", {
+        projectId: "proj-1",
+      });
+
+      const specs = await listExecutionSpecifications("proj-1", event);
+      expect(specs).toEqual([]);
+    });
+  });
+
+  // ── handler dispatch always threads event ───────────────────────────
+
+  describe("handler dispatch threads event into the org gate for every case", () => {
+    test("approveExecutionSpecification via handler: cross-org caller refused", async () => {
+      stubSpec("PENDING_REVIEW");
+      stubProject("org-a");
+      await expect(
+        handler(
+          crossOrgEvent("approveExecutionSpecification", { specId: "spec-1" }),
+        ),
+      ).rejects.toThrow(/Access denied/);
+    });
+
+    test("reviseExecutionSpecification via handler: cross-org caller refused", async () => {
+      stubSpec("REJECTED");
+      stubProject("org-a");
+      await expect(
+        handler(
+          crossOrgEvent("reviseExecutionSpecification", {
+            specId: "spec-1",
+            input: { structuredPayload: "{}", narrativeS3Uri: VALID_NARRATIVE },
+          }),
+        ),
+      ).rejects.toThrow(/Access denied/);
+    });
+
+    test("approveExecutionSpecification via handler: same-org caller with permission succeeds", async () => {
+      stubSpec("PENDING_REVIEW");
+      stubProject("org-a");
+      ddbMock.on(UpdateCommand).resolves({
+        Attributes: { ...existingSpec, status: "APPROVED", version: 2 },
+      });
+      const result = (await handler(
+        sameOrgEvent("approveExecutionSpecification", { specId: "spec-1" }),
+      )) as { status: string };
+      expect(result.status).toBe("APPROVED");
+    });
+
+    test("approveExecutionSpecification via handler: same-org caller without permission refused", async () => {
+      stubSpec("PENDING_REVIEW");
+      stubProject("org-a");
+      await expect(
+        handler(
+          sameOrgEvent(
+            "approveExecutionSpecification",
+            { specId: "spec-1" },
+            "developer",
+          ),
+        ),
+      ).rejects.toThrow(/UnauthorizedError/);
+    });
+  });
+});

--- a/backend/src/lambda/__tests__/execspec-resolver.test.ts
+++ b/backend/src/lambda/__tests__/execspec-resolver.test.ts
@@ -34,6 +34,7 @@ const ebMock = mockClient(EventBridgeClient);
 // Env must be set before importing the module under test.
 process.env.EXECUTION_SPECS_TABLE = 'citadel-execution-specifications-test';
 process.env.EVENT_BUS_NAME = 'citadel-agents-test';
+process.env.PROJECTS_TABLE = 'citadel-projects-test';
 
 import {
   createExecutionSpecification,
@@ -637,6 +638,24 @@ describe('execspec-resolver', () => {
   // ── handler dispatch ──────────────────────────────────────────────────
 
   describe('handler dispatch', () => {
+    // finding 2c262386: handler dispatch now threads `event` into the
+    // project-org gate, so every dispatch test needs a project record whose
+    // organization matches the caller's `custom:organization` claim.
+    beforeEach(() => {
+      ddbMock
+        .on(GetCommand, {
+          TableName: 'citadel-projects-test',
+          Key: { id: 'proj-1' },
+        })
+        .resolves({
+          Item: {
+            id: 'proj-1',
+            owner: 'someone-else',
+            organization: 'org-shared',
+          },
+        });
+    });
+
     function makeEvent(
       fieldName: string,
       args: Record<string, unknown>,
@@ -649,6 +668,7 @@ describe('execspec-resolver', () => {
           sub: `user-${role}`,
           username: role,
           'custom:role': role,
+          'custom:organization': 'org-shared',
         },
       };
     }
@@ -663,7 +683,12 @@ describe('execspec-resolver', () => {
     });
 
     test('getExecutionSpecification dispatch', async () => {
-      ddbMock.on(GetCommand).resolves({ Item: existingSpec() });
+      ddbMock
+        .on(GetCommand, {
+          TableName: 'citadel-execution-specifications-test',
+          Key: { specId: 'spec-1' },
+        })
+        .resolves({ Item: existingSpec() });
       const result = (await handler(
         makeEvent('getExecutionSpecification', { specId: 'spec-1' }),
       )) as { specId: string };

--- a/backend/src/lambda/__tests__/interrogation-round-resolver-dispatch-gate-enumeration.test.ts
+++ b/backend/src/lambda/__tests__/interrogation-round-resolver-dispatch-gate-enumeration.test.ts
@@ -1,0 +1,259 @@
+/**
+ * Enumeration-completeness guard for interrogation-round-resolver.ts's
+ * dispatch switch (finding 2c262386 — module 3/4, guard 9 in the series).
+ *
+ * Root defect closed by finding 2c262386 (this module): stabiliseRound
+ * writes a governance transcript to S3 (encrypted, carries PII) and sets
+ * TERMINAL state (STABILISED) on a foreign round, gated only on
+ * hasPermission('adr:create') with no project-to-organization
+ * reconciliation of the client-supplied projectId. The fix threads an
+ * OPTIONAL `event` parameter through every exported function; the
+ * dispatch handler always supplies it. This guard also asserts
+ * stabiliseRound's gate call precedes BOTH the S3 PutObjectCommand AND the
+ * idempotent-STABILISED early-return.
+ */
+import * as fs from "fs";
+import * as path from "path";
+
+const HANDLER_PATH = path.join(
+  __dirname,
+  "..",
+  "interrogation-round-resolver.ts",
+);
+
+function extractDispatchCases(source: string): string[] {
+  const switchStart = source.indexOf("switch (fieldName)");
+  if (switchStart === -1) {
+    throw new Error(
+      "Could not locate `switch (fieldName)` in interrogation-round-resolver.ts — " +
+        "dispatch structure changed; update this guard's parsing.",
+    );
+  }
+  const defaultIdx = source.indexOf("default:", switchStart);
+  if (defaultIdx === -1) {
+    throw new Error(
+      "Could not locate the dispatch switch's `default:` case — " +
+        "update this guard's parsing.",
+    );
+  }
+  const switchBody = source.slice(switchStart, defaultIdx);
+  const caseRe = /case\s+['"]([^'"]+)['"]\s*:/g;
+  const cases: string[] = [];
+  let m: RegExpExecArray | null;
+  while ((m = caseRe.exec(switchBody)) !== null) {
+    cases.push(m[1]);
+  }
+  return cases;
+}
+
+function extractCaseBody(source: string, fieldName: string): string {
+  const switchStart = source.indexOf("switch (fieldName)");
+  const defaultIdx = source.indexOf("default:", switchStart);
+  const switchBody = source.slice(switchStart, defaultIdx);
+
+  const caseIdx =
+    switchBody.indexOf(`case '${fieldName}'`) !== -1
+      ? switchBody.indexOf(`case '${fieldName}'`)
+      : switchBody.indexOf(`case "${fieldName}"`);
+  if (caseIdx === -1) {
+    throw new Error(`Could not locate case '${fieldName}' in dispatch switch`);
+  }
+  const nextCaseIdx = switchBody.indexOf("case ", caseIdx + 1);
+  return switchBody.slice(
+    caseIdx,
+    nextCaseIdx === -1 ? undefined : nextCaseIdx,
+  );
+}
+
+function extractCallSiteNames(caseBody: string): string[] {
+  const callRe = /await\s+([A-Za-z0-9_]+)\s*\(/g;
+  const names: string[] = [];
+  let m: RegExpExecArray | null;
+  while ((m = callRe.exec(caseBody)) !== null) {
+    names.push(m[1]);
+  }
+  return names;
+}
+
+function extractFunctionBody(source: string, fnName: string): string {
+  const declRe = new RegExp(
+    `(?:export\\s+)?async function ${fnName}\\b\\s*\\(`,
+  );
+  const declMatch = declRe.exec(source);
+  if (!declMatch) {
+    throw new Error(
+      `Could not locate function declaration for '${fnName}' in interrogation-round-resolver.ts`,
+    );
+  }
+  const paramsOpenIdx = source.indexOf("(", declMatch.index);
+  let parenDepth = 0;
+  let j = paramsOpenIdx;
+  for (; j < source.length; j++) {
+    if (source[j] === "(") parenDepth++;
+    else if (source[j] === ")") {
+      parenDepth--;
+      if (parenDepth === 0) break;
+    }
+  }
+  const bodyStart = source.indexOf("{", j);
+  let depth = 0;
+  let i = bodyStart;
+  for (; i < source.length; i++) {
+    if (source[i] === "{") depth++;
+    else if (source[i] === "}") {
+      depth--;
+      if (depth === 0) break;
+    }
+  }
+  return source.slice(bodyStart, i + 1);
+}
+
+const GATE_CALL_RE = /assertProjectOrgAccess\s*\(/;
+const EVENT_PARAM_RE = /event\?\s*:\s*unknown/;
+
+const GATED_OPS: Record<string, { fn: string }> = {
+  startInterrogationRound: { fn: "startInterrogationRound" },
+  injectConstraints: { fn: "injectConstraints" },
+  stabiliseRound: { fn: "stabiliseRound" },
+  getInterrogationRound: { fn: "getInterrogationRound" },
+  listInterrogationRounds: { fn: "listInterrogationRounds" },
+};
+
+const EXEMPT_OPS: Record<string, string> = {};
+
+describe("interrogation-round-resolver — dispatch enumeration completeness", () => {
+  const source = fs.readFileSync(HANDLER_PATH, "utf-8");
+  const cases = extractDispatchCases(source);
+
+  test("the dispatch switch actually has cases to check (sanity check on the parser itself)", () => {
+    expect(cases.length).toBeGreaterThanOrEqual(5);
+    expect(cases).toEqual(expect.arrayContaining(Object.keys(GATED_OPS)));
+  });
+
+  test("every dispatch case is accounted for in GATED_OPS or EXEMPT_OPS", () => {
+    const unaccounted = cases.filter(
+      (c) => !(c in GATED_OPS) && !(c in EXEMPT_OPS),
+    );
+    expect(unaccounted).toEqual([]);
+  });
+
+  test("GATED_OPS and EXEMPT_OPS do not both claim the same op", () => {
+    const overlap = Object.keys(GATED_OPS).filter((k) => k in EXEMPT_OPS);
+    expect(overlap).toEqual([]);
+  });
+
+  test("no GATED_OPS/EXEMPT_OPS entry references a case that no longer exists in the switch", () => {
+    const known = new Set(cases);
+    const staleGated = Object.keys(GATED_OPS).filter((k) => !known.has(k));
+    const staleExempt = Object.keys(EXEMPT_OPS).filter((k) => !known.has(k));
+    expect(staleGated).toEqual([]);
+    expect(staleExempt).toEqual([]);
+  });
+
+  describe.each(Object.entries(GATED_OPS))(
+    "GATED_OPS['%s'] dispatches to a function that threads `event` and calls assertProjectOrgAccess",
+    (fieldName, meta) => {
+      test(`${fieldName}'s case dispatches to ${meta.fn}`, () => {
+        const caseBody = extractCaseBody(source, fieldName);
+        const callSites = extractCallSiteNames(caseBody);
+        expect(callSites).toContain(meta.fn);
+      });
+
+      test(`${fieldName}'s case passes \`event\` as an argument to ${meta.fn}`, () => {
+        const caseBody = extractCaseBody(source, fieldName);
+        const callRe = new RegExp(
+          `${meta.fn}\\s*\\([^;]*?\\bevent\\b[^;]*?\\)`,
+        );
+        expect(callRe.test(caseBody)).toBe(true);
+      });
+
+      test(`${meta.fn}'s declaration accepts an optional \`event?: unknown\` parameter`, () => {
+        const declRe = new RegExp(
+          `(?:export\\s+)?async function ${meta.fn}\\b\\s*\\(([^)]*)\\)`,
+        );
+        const m = declRe.exec(source);
+        expect(m).not.toBeNull();
+        expect(EVENT_PARAM_RE.test((m as RegExpExecArray)[1])).toBe(true);
+      });
+
+      test(`${meta.fn}'s function body contains an assertProjectOrgAccess call`, () => {
+        const body = extractFunctionBody(source, meta.fn);
+        expect(GATE_CALL_RE.test(body)).toBe(true);
+      });
+    },
+  );
+
+  describe("stabiliseRound gates before every state-changing side effect", () => {
+    test("stabiliseRound's gate call precedes the idempotent-STABILISED early-return", () => {
+      const body = extractFunctionBody(source, "stabiliseRound");
+      const gateIdx = body.search(GATE_CALL_RE);
+      const earlyReturnMatch =
+        /current\.status\s*===\s*['"]STABILISED['"]/.exec(body);
+      expect(gateIdx).toBeGreaterThan(-1);
+      expect(earlyReturnMatch).not.toBeNull();
+      expect(gateIdx).toBeLessThan((earlyReturnMatch as RegExpExecArray).index);
+    });
+
+    test("stabiliseRound's gate call precedes the S3 PutObjectCommand (transcript write)", () => {
+      const body = extractFunctionBody(source, "stabiliseRound");
+      const gateIdx = body.search(GATE_CALL_RE);
+      const putObjectIdx = body.indexOf("new PutObjectCommand(");
+      expect(gateIdx).toBeGreaterThan(-1);
+      expect(putObjectIdx).toBeGreaterThan(-1);
+      expect(gateIdx).toBeLessThan(putObjectIdx);
+    });
+
+    test("stabiliseRound's gate call precedes the terminal UpdateCommand", () => {
+      const body = extractFunctionBody(source, "stabiliseRound");
+      const gateIdx = body.search(GATE_CALL_RE);
+      const updateIdx = body.indexOf("new UpdateCommand(");
+      expect(gateIdx).toBeGreaterThan(-1);
+      expect(updateIdx).toBeGreaterThan(-1);
+      expect(gateIdx).toBeLessThan(updateIdx);
+    });
+  });
+
+  describe("other write-path ops gate BEFORE their DynamoDB write side effect", () => {
+    test("startInterrogationRound's gate call precedes its PutCommand", () => {
+      const body = extractFunctionBody(source, "startInterrogationRound");
+      const gateIdx = body.search(GATE_CALL_RE);
+      const putIdx = body.indexOf("new PutCommand(");
+      expect(gateIdx).toBeGreaterThan(-1);
+      expect(putIdx).toBeGreaterThan(-1);
+      expect(gateIdx).toBeLessThan(putIdx);
+    });
+
+    test("injectConstraints's gate call precedes its UpdateCommand", () => {
+      const body = extractFunctionBody(source, "injectConstraints");
+      const gateIdx = body.search(GATE_CALL_RE);
+      const updateIdx = body.indexOf("new UpdateCommand(");
+      expect(gateIdx).toBeGreaterThan(-1);
+      expect(updateIdx).toBeGreaterThan(-1);
+      expect(gateIdx).toBeLessThan(updateIdx);
+    });
+  });
+
+  describe("read-path ops return/query nothing before the gate resolves", () => {
+    test("getInterrogationRound's gate call precedes its `return round` statement", () => {
+      const body = extractFunctionBody(source, "getInterrogationRound");
+      const gateIdx = body.search(GATE_CALL_RE);
+      const returnIdx = body.lastIndexOf("return round;");
+      expect(gateIdx).toBeGreaterThan(-1);
+      expect(returnIdx).toBeGreaterThan(-1);
+      expect(gateIdx).toBeLessThan(returnIdx);
+    });
+
+    test("listInterrogationRounds's gate call precedes its QueryCommand (no foreign-data read at all)", () => {
+      const body = extractFunctionBody(source, "listInterrogationRounds");
+      const gateIdx = body.search(GATE_CALL_RE);
+      const queryIdx = body.indexOf("new QueryCommand(");
+      expect(gateIdx).toBeGreaterThan(-1);
+      expect(queryIdx).toBeGreaterThan(-1);
+      expect(gateIdx).toBeLessThan(queryIdx);
+    });
+  });
+
+  test("handler's hasPermission('adr:create') check is not removed by this fix (additive, not a replacement)", () => {
+    expect(source).toMatch(/hasPermission\(authContext, ['"]adr:create['"]\)/);
+  });
+});

--- a/backend/src/lambda/__tests__/interrogation-round-resolver-org-scoping.test.ts
+++ b/backend/src/lambda/__tests__/interrogation-round-resolver-org-scoping.test.ts
@@ -1,0 +1,511 @@
+/**
+ * Org-scoping tests for interrogation-round-resolver (finding 2c262386,
+ * module 3/4).
+ *
+ * DEFECT: startInterrogationRound / injectConstraints / stabiliseRound
+ * gated only on hasPermission('adr:create') and trusted the client-
+ * supplied projectId with NO project-to-organization reconciliation.
+ * stabiliseRound is the sharpest op: it writes a governance transcript to
+ * S3 (encrypted because it carries PII, via redactPII + SSE-KMS) and sets
+ * TERMINAL state (STABILISED) on a foreign round — a cross-org caller
+ * could write a PII-bearing transcript into another org's governance
+ * namespace and drive their round to a terminal state.
+ *
+ * FIX: assertProjectOrgAccess(projectId, event) — the SAME shared helper
+ * from PR 142 / finding 677c1a6c — is threaded through every exported
+ * function as an ADDITIONAL, optional `event` parameter. For
+ * stabiliseRound, the gate runs after the round is fetched (fetch-then-
+ * verify — roundN/projectId are the only client args, but the row itself
+ * must exist to be gated meaningfully) and BEFORE the idempotent-
+ * STABILISED early-return, BEFORE the S3 PutObjectCommand, and BEFORE the
+ * terminal UpdateCommand / governance event emission.
+ *
+ * Acceptance:
+ *  - cross-org caller refused on start/inject/stabilise/get/list; zero
+ *    writes, zero S3 PutObject (zero transcript writes), zero foreign
+ *    reads returned
+ *  - same-org caller WITH adr:create succeeds
+ *  - same-org caller WITHOUT adr:create is still refused (additive)
+ */
+import {
+  DynamoDBDocumentClient,
+  GetCommand,
+  PutCommand,
+  UpdateCommand,
+  QueryCommand,
+} from "@aws-sdk/lib-dynamodb";
+import { S3Client, PutObjectCommand } from "@aws-sdk/client-s3";
+import {
+  EventBridgeClient,
+  PutEventsCommand,
+} from "@aws-sdk/client-eventbridge";
+import { mockClient } from "aws-sdk-client-mock";
+import type { AuthContext } from "../../types";
+
+const ddbMock = mockClient(DynamoDBDocumentClient);
+const s3Mock = mockClient(S3Client);
+const ebMock = mockClient(EventBridgeClient);
+
+process.env.INTERROGATION_ROUNDS_TABLE = "citadel-interrogation-rounds-test";
+process.env.GOVERNANCE_TRANSCRIPTS_BUCKET =
+  "citadel-governance-transcripts-test";
+process.env.EVENT_BUS_NAME = "citadel-agents-test";
+process.env.PROJECTS_TABLE = "citadel-projects-test";
+
+import {
+  startInterrogationRound,
+  injectConstraints,
+  stabiliseRound,
+  getInterrogationRound,
+  listInterrogationRounds,
+  handler,
+} from "../interrogation-round-resolver";
+import { __resetGovernanceNotifierForTest } from "../../utils/notifier-base";
+import { ProjectOrgAccessError } from "../../utils/project-org-access";
+
+function mockAuthContextFor(role: "architect" | "developer"): AuthContext {
+  return { userId: `user-${role}`, username: role, groups: [], roles: [role] };
+}
+
+function crossOrgEvent(
+  fieldName: string,
+  args: Record<string, unknown>,
+  role: "architect" | "developer" = "architect",
+) {
+  return {
+    info: { fieldName },
+    arguments: args,
+    identity: {
+      sub: `user-${role}-org-b`,
+      username: role,
+      "custom:role": role,
+      "custom:organization": "org-b",
+    },
+  };
+}
+
+function sameOrgEvent(
+  fieldName: string,
+  args: Record<string, unknown>,
+  role: "architect" | "developer" = "architect",
+) {
+  return {
+    info: { fieldName },
+    arguments: args,
+    identity: {
+      sub: `user-${role}-org-a`,
+      username: role,
+      "custom:role": role,
+      "custom:organization": "org-a",
+    },
+  };
+}
+
+const existingRound = {
+  projectId: "proj-1",
+  roundN: 1,
+  transcriptS3Uri:
+    "s3://citadel-governance-transcripts-test/projects/proj-1/rounds/1.jsonl",
+  status: "IN_PROGRESS",
+  startedAt: "2024-01-01T00:00:00.000Z",
+};
+
+describe("interrogation-round-resolver — project-org scoping (finding 2c262386)", () => {
+  beforeEach(() => {
+    ddbMock.reset();
+    s3Mock.reset();
+    ebMock.reset();
+    ebMock
+      .on(PutEventsCommand)
+      .resolves({ FailedEntryCount: 0, Entries: [{ EventId: "evt-1" }] });
+    s3Mock.on(PutObjectCommand).resolves({});
+    __resetGovernanceNotifierForTest();
+  });
+
+  function stubProject(organization = "org-a", owner = "someone-else") {
+    ddbMock
+      .on(GetCommand, {
+        TableName: "citadel-projects-test",
+        Key: { id: "proj-1" },
+      })
+      .resolves({ Item: { id: "proj-1", owner, organization } });
+  }
+
+  function stubRound(overrides: Record<string, unknown> = {}) {
+    ddbMock
+      .on(GetCommand, {
+        TableName: "citadel-interrogation-rounds-test",
+        Key: { projectId: "proj-1", roundN: 1 },
+      })
+      .resolves({ Item: { ...existingRound, ...overrides } });
+  }
+
+  // ── startInterrogationRound ──────────────────────────────────────────
+
+  describe("startInterrogationRound", () => {
+    test("cross-org caller refused; zero PutCommand to rounds table", async () => {
+      stubProject("org-a");
+      const auth = mockAuthContextFor("architect");
+      const event = crossOrgEvent("startInterrogationRound", {
+        projectId: "proj-1",
+        roundN: 1,
+      });
+
+      await expect(
+        startInterrogationRound("proj-1", 1, auth, event),
+      ).rejects.toBeInstanceOf(ProjectOrgAccessError);
+
+      const puts = ddbMock
+        .commandCalls(PutCommand)
+        .filter(
+          (c) =>
+            c.args[0].input.TableName === "citadel-interrogation-rounds-test",
+        );
+      expect(puts).toHaveLength(0);
+    });
+
+    test("same-org caller with adr:create succeeds", async () => {
+      stubProject("org-a");
+      ddbMock.on(PutCommand).resolves({});
+      const auth = mockAuthContextFor("architect");
+      const event = sameOrgEvent("startInterrogationRound", {
+        projectId: "proj-1",
+        roundN: 1,
+      });
+
+      const round = await startInterrogationRound("proj-1", 1, auth, event);
+      expect(round.status).toBe("IN_PROGRESS");
+    });
+
+    test("same-org caller WITHOUT adr:create is still refused (additive)", async () => {
+      stubProject("org-a");
+      const auth = mockAuthContextFor("developer");
+      const event = sameOrgEvent(
+        "startInterrogationRound",
+        { projectId: "proj-1", roundN: 1 },
+        "developer",
+      );
+
+      await expect(
+        startInterrogationRound("proj-1", 1, auth, event),
+      ).rejects.toThrow(/UnauthorizedError/);
+      const puts = ddbMock
+        .commandCalls(PutCommand)
+        .filter(
+          (c) =>
+            c.args[0].input.TableName === "citadel-interrogation-rounds-test",
+        );
+      expect(puts).toHaveLength(0);
+    });
+  });
+
+  // ── injectConstraints ─────────────────────────────────────────────────
+
+  describe("injectConstraints", () => {
+    test("cross-org caller refused; zero UpdateCommand", async () => {
+      stubRound("IN_PROGRESS");
+      stubProject("org-a");
+      const auth = mockAuthContextFor("architect");
+      const event = crossOrgEvent("injectConstraints", {
+        projectId: "proj-1",
+        roundN: 1,
+        constraints: ["c1"],
+      });
+
+      await expect(
+        injectConstraints("proj-1", 1, ["c1"], auth, event),
+      ).rejects.toBeInstanceOf(ProjectOrgAccessError);
+      expect(ddbMock.commandCalls(UpdateCommand)).toHaveLength(0);
+    });
+
+    test("same-org caller with adr:create succeeds", async () => {
+      stubRound("IN_PROGRESS");
+      stubProject("org-a");
+      ddbMock.on(UpdateCommand).resolves({
+        Attributes: { ...existingRound, status: "AWAITING_CONSTRAINTS" },
+      });
+      const auth = mockAuthContextFor("architect");
+      const event = sameOrgEvent("injectConstraints", {
+        projectId: "proj-1",
+        roundN: 1,
+        constraints: ["c1"],
+      });
+
+      const round = await injectConstraints("proj-1", 1, ["c1"], auth, event);
+      expect(round.status).toBe("AWAITING_CONSTRAINTS");
+    });
+  });
+
+  // ── stabiliseRound (sharpest op: transcript write + terminal state) ──
+
+  describe("stabiliseRound", () => {
+    test("cross-org caller refused; zero S3 PutObject (zero transcript writes)", async () => {
+      stubRound("IN_PROGRESS");
+      stubProject("org-a");
+      const auth = mockAuthContextFor("architect");
+      const event = crossOrgEvent("stabiliseRound", {
+        projectId: "proj-1",
+        roundN: 1,
+      });
+
+      await expect(
+        stabiliseRound(
+          "proj-1",
+          1,
+          [{ role: "user", content: "hello" }],
+          "summary",
+          auth,
+          event,
+        ),
+      ).rejects.toBeInstanceOf(ProjectOrgAccessError);
+
+      expect(s3Mock.commandCalls(PutObjectCommand)).toHaveLength(0);
+    });
+
+    test("cross-org caller refused; zero UpdateCommand (terminal STABILISED state never set on foreign round)", async () => {
+      stubRound("IN_PROGRESS");
+      stubProject("org-a");
+      const auth = mockAuthContextFor("architect");
+      const event = crossOrgEvent("stabiliseRound", {
+        projectId: "proj-1",
+        roundN: 1,
+      });
+
+      await expect(
+        stabiliseRound(
+          "proj-1",
+          1,
+          [{ role: "user", content: "hello" }],
+          "summary",
+          auth,
+          event,
+        ),
+      ).rejects.toBeInstanceOf(ProjectOrgAccessError);
+
+      expect(ddbMock.commandCalls(UpdateCommand)).toHaveLength(0);
+      expect(ebMock.commandCalls(PutEventsCommand)).toHaveLength(0);
+    });
+
+    test("cross-org caller refused even when the round is already STABILISED (idempotent early-return does not bypass the gate)", async () => {
+      stubRound("STABILISED");
+      stubProject("org-a");
+      const auth = mockAuthContextFor("architect");
+      const event = crossOrgEvent("stabiliseRound", {
+        projectId: "proj-1",
+        roundN: 1,
+      });
+
+      await expect(
+        stabiliseRound(
+          "proj-1",
+          1,
+          [{ role: "user", content: "hello" }],
+          "summary",
+          auth,
+          event,
+        ),
+      ).rejects.toBeInstanceOf(ProjectOrgAccessError);
+      expect(s3Mock.commandCalls(PutObjectCommand)).toHaveLength(0);
+    });
+
+    test("same-org caller with adr:create succeeds; transcript written and round transitions to STABILISED", async () => {
+      stubRound("IN_PROGRESS");
+      stubProject("org-a");
+      ddbMock.on(UpdateCommand).resolves({
+        Attributes: { ...existingRound, status: "STABILISED" },
+      });
+      const auth = mockAuthContextFor("architect");
+      const event = sameOrgEvent("stabiliseRound", {
+        projectId: "proj-1",
+        roundN: 1,
+      });
+
+      const round = await stabiliseRound(
+        "proj-1",
+        1,
+        [{ role: "user", content: "hello" }],
+        "summary",
+        auth,
+        event,
+      );
+      expect(round.status).toBe("STABILISED");
+      expect(s3Mock.commandCalls(PutObjectCommand)).toHaveLength(1);
+    });
+
+    test("same-org caller WITHOUT adr:create is still refused; zero transcript write", async () => {
+      stubRound("IN_PROGRESS");
+      stubProject("org-a");
+      const auth = mockAuthContextFor("developer");
+      const event = sameOrgEvent(
+        "stabiliseRound",
+        { projectId: "proj-1", roundN: 1 },
+        "developer",
+      );
+
+      await expect(
+        stabiliseRound(
+          "proj-1",
+          1,
+          [{ role: "user", content: "hello" }],
+          "summary",
+          auth,
+          event,
+        ),
+      ).rejects.toThrow(/UnauthorizedError/);
+      expect(s3Mock.commandCalls(PutObjectCommand)).toHaveLength(0);
+    });
+
+    test("fetch-then-verify ordering: org check runs after fetching the round but before any write", async () => {
+      stubRound("IN_PROGRESS");
+      stubProject("org-b"); // caller is org-a -> cross-org
+      const auth = mockAuthContextFor("architect");
+      const event = sameOrgEvent("stabiliseRound", {
+        projectId: "proj-1",
+        roundN: 1,
+      });
+
+      await expect(
+        stabiliseRound(
+          "proj-1",
+          1,
+          [{ role: "user", content: "hello" }],
+          "summary",
+          auth,
+          event,
+        ),
+      ).rejects.toBeInstanceOf(ProjectOrgAccessError);
+      expect(s3Mock.commandCalls(PutObjectCommand)).toHaveLength(0);
+      expect(ddbMock.commandCalls(UpdateCommand)).toHaveLength(0);
+    });
+  });
+
+  // ── getInterrogationRound (fetch-then-verify read) ───────────────────
+
+  describe("getInterrogationRound", () => {
+    test("cross-org caller refused; round never returned", async () => {
+      stubRound();
+      stubProject("org-a");
+      const event = crossOrgEvent("getInterrogationRound", {
+        projectId: "proj-1",
+        roundN: 1,
+      });
+
+      await expect(
+        getInterrogationRound("proj-1", 1, event),
+      ).rejects.toBeInstanceOf(ProjectOrgAccessError);
+    });
+
+    test("same-org caller can read", async () => {
+      stubRound();
+      stubProject("org-a");
+      const event = sameOrgEvent("getInterrogationRound", {
+        projectId: "proj-1",
+        roundN: 1,
+      });
+
+      const round = await getInterrogationRound("proj-1", 1, event);
+      expect(round?.projectId).toBe("proj-1");
+    });
+
+    test("nonexistent round still returns null (fetch first, no crash)", async () => {
+      ddbMock.on(GetCommand).resolves({});
+      const event = sameOrgEvent("getInterrogationRound", {
+        projectId: "missing",
+        roundN: 1,
+      });
+      const round = await getInterrogationRound("missing", 1, event);
+      expect(round).toBeNull();
+    });
+  });
+
+  // ── listInterrogationRounds ───────────────────────────────────────────
+
+  describe("listInterrogationRounds", () => {
+    test("cross-org caller refused; zero QueryCommand against rounds table", async () => {
+      stubProject("org-a");
+      const event = crossOrgEvent("listInterrogationRounds", {
+        projectId: "proj-1",
+      });
+
+      await expect(
+        listInterrogationRounds("proj-1", event),
+      ).rejects.toBeInstanceOf(ProjectOrgAccessError);
+      const queries = ddbMock
+        .commandCalls(QueryCommand)
+        .filter(
+          (c) =>
+            c.args[0].input.TableName === "citadel-interrogation-rounds-test",
+        );
+      expect(queries).toHaveLength(0);
+    });
+
+    test("same-org caller can list", async () => {
+      stubProject("org-a");
+      ddbMock
+        .on(QueryCommand, { TableName: "citadel-interrogation-rounds-test" })
+        .resolves({ Items: [] });
+      const event = sameOrgEvent("listInterrogationRounds", {
+        projectId: "proj-1",
+      });
+
+      const rounds = await listInterrogationRounds("proj-1", event);
+      expect(rounds).toEqual([]);
+    });
+  });
+
+  // ── handler dispatch always threads event ───────────────────────────
+
+  describe("handler dispatch threads event into the org gate", () => {
+    test("stabiliseRound via handler: cross-org caller refused, zero transcript write", async () => {
+      stubRound("IN_PROGRESS");
+      stubProject("org-a");
+      await expect(
+        handler(
+          crossOrgEvent("stabiliseRound", {
+            projectId: "proj-1",
+            roundN: 1,
+            transcript: [{ role: "user", content: "hi" }],
+            stabilisedSummary: "s",
+          }),
+        ),
+      ).rejects.toThrow(/Access denied/);
+      expect(s3Mock.commandCalls(PutObjectCommand)).toHaveLength(0);
+    });
+
+    test("stabiliseRound via handler: same-org caller with permission succeeds", async () => {
+      stubRound("IN_PROGRESS");
+      stubProject("org-a");
+      ddbMock.on(UpdateCommand).resolves({
+        Attributes: { ...existingRound, status: "STABILISED" },
+      });
+      const result = (await handler(
+        sameOrgEvent("stabiliseRound", {
+          projectId: "proj-1",
+          roundN: 1,
+          transcript: [{ role: "user", content: "hi" }],
+          stabilisedSummary: "s",
+        }),
+      )) as { status: string };
+      expect(result.status).toBe("STABILISED");
+    });
+
+    test("stabiliseRound via handler: same-org caller without permission refused", async () => {
+      stubRound("IN_PROGRESS");
+      stubProject("org-a");
+      await expect(
+        handler(
+          sameOrgEvent(
+            "stabiliseRound",
+            {
+              projectId: "proj-1",
+              roundN: 1,
+              transcript: [{ role: "user", content: "hi" }],
+              stabilisedSummary: "s",
+            },
+            "developer",
+          ),
+        ),
+      ).rejects.toThrow(/UnauthorizedError/);
+    });
+  });
+});

--- a/backend/src/lambda/__tests__/interrogation-round-resolver.test.ts
+++ b/backend/src/lambda/__tests__/interrogation-round-resolver.test.ts
@@ -27,12 +27,15 @@ import {
   PutCommand,
   UpdateCommand,
   QueryCommand,
-} from '@aws-sdk/lib-dynamodb';
-import { S3Client, PutObjectCommand } from '@aws-sdk/client-s3';
-import { EventBridgeClient, PutEventsCommand } from '@aws-sdk/client-eventbridge';
-import { mockClient } from 'aws-sdk-client-mock';
-import * as fc from 'fast-check';
-import type { AuthContext } from '../../types';
+} from "@aws-sdk/lib-dynamodb";
+import { S3Client, PutObjectCommand } from "@aws-sdk/client-s3";
+import {
+  EventBridgeClient,
+  PutEventsCommand,
+} from "@aws-sdk/client-eventbridge";
+import { mockClient } from "aws-sdk-client-mock";
+import * as fc from "fast-check";
+import type { AuthContext } from "../../types";
 
 const ddbMock = mockClient(DynamoDBDocumentClient);
 const s3Mock = mockClient(S3Client);
@@ -40,9 +43,11 @@ const ebMock = mockClient(EventBridgeClient);
 
 // Env must be set BEFORE importing the module under test — the resolver
 // captures process.env at module load time.
-process.env.INTERROGATION_ROUNDS_TABLE = 'citadel-interrogation-rounds-test';
-process.env.GOVERNANCE_TRANSCRIPTS_BUCKET = 'citadel-governance-transcripts-test';
-process.env.EVENT_BUS_NAME = 'citadel-agents-test';
+process.env.INTERROGATION_ROUNDS_TABLE = "citadel-interrogation-rounds-test";
+process.env.GOVERNANCE_TRANSCRIPTS_BUCKET =
+  "citadel-governance-transcripts-test";
+process.env.EVENT_BUS_NAME = "citadel-agents-test";
+process.env.PROJECTS_TABLE = "citadel-projects-test";
 
 import {
   startInterrogationRound,
@@ -52,10 +57,10 @@ import {
   listInterrogationRounds,
   handler,
   type InterrogationRound,
-} from '../interrogation-round-resolver';
-import { __resetGovernanceNotifierForTest } from '../../utils/notifier-base';
+} from "../interrogation-round-resolver";
+import { __resetGovernanceNotifierForTest } from "../../utils/notifier-base";
 
-function mockAuthContextFor(role: 'architect' | 'developer'): AuthContext {
+function mockAuthContextFor(role: "architect" | "developer"): AuthContext {
   return {
     userId: `user-${role}`,
     username: role,
@@ -64,88 +69,92 @@ function mockAuthContextFor(role: 'architect' | 'developer'): AuthContext {
   };
 }
 
-function baseRow(overrides: Partial<InterrogationRound> = {}): InterrogationRound {
+function baseRow(
+  overrides: Partial<InterrogationRound> = {},
+): InterrogationRound {
   return {
-    projectId: 'proj-1',
+    projectId: "proj-1",
     roundN: 1,
     transcriptS3Uri:
-      's3://citadel-governance-transcripts-test/projects/proj-1/rounds/1.jsonl',
-    status: 'IN_PROGRESS',
-    startedAt: '2026-04-30T00:00:00.000Z',
+      "s3://citadel-governance-transcripts-test/projects/proj-1/rounds/1.jsonl",
+    status: "IN_PROGRESS",
+    startedAt: "2026-04-30T00:00:00.000Z",
     ...overrides,
   };
 }
 
-describe('interrogation-round-resolver', () => {
+describe("interrogation-round-resolver", () => {
   beforeEach(() => {
     ddbMock.reset();
     s3Mock.reset();
     ebMock.reset();
     ebMock
       .on(PutEventsCommand)
-      .resolves({ FailedEntryCount: 0, Entries: [{ EventId: 'evt-1' }] });
+      .resolves({ FailedEntryCount: 0, Entries: [{ EventId: "evt-1" }] });
     s3Mock.on(PutObjectCommand).resolves({ ETag: '"abc"' });
     __resetGovernanceNotifierForTest();
   });
 
   // ── startInterrogationRound ─────────────────────────────────────────
 
-  describe('startInterrogationRound', () => {
-    test('writes DDB row with IN_PROGRESS, deterministic S3 URI, and emits governance.round.started', async () => {
+  describe("startInterrogationRound", () => {
+    test("writes DDB row with IN_PROGRESS, deterministic S3 URI, and emits governance.round.started", async () => {
       ddbMock.on(PutCommand).resolves({});
-      const auth = mockAuthContextFor('architect');
+      const auth = mockAuthContextFor("architect");
 
-      const row = await startInterrogationRound('proj-42', 7, auth);
+      const row = await startInterrogationRound("proj-42", 7, auth);
 
-      expect(row.projectId).toBe('proj-42');
+      expect(row.projectId).toBe("proj-42");
       expect(row.roundN).toBe(7);
-      expect(row.status).toBe('IN_PROGRESS');
+      expect(row.status).toBe("IN_PROGRESS");
       // Deterministic S3 URI derived only from bucket + projectId + roundN.
       expect(row.transcriptS3Uri).toBe(
-        's3://citadel-governance-transcripts-test/projects/proj-42/rounds/7.jsonl',
+        "s3://citadel-governance-transcripts-test/projects/proj-42/rounds/7.jsonl",
       );
-      expect(row.startedAt).toMatch(/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3}Z$/);
+      expect(row.startedAt).toMatch(
+        /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3}Z$/,
+      );
 
       const puts = ddbMock.commandCalls(PutCommand);
       expect(puts).toHaveLength(1);
       const put = puts[0].args[0].input;
-      expect(put.TableName).toBe('citadel-interrogation-rounds-test');
+      expect(put.TableName).toBe("citadel-interrogation-rounds-test");
       // Idempotency guard on the composite key — if a row for (projectId,
       // roundN) already exists, the Put must fail.
       expect(put.ConditionExpression).toMatch(
         /attribute_not_exists\(projectId\).*attribute_not_exists\(roundN\)/,
       );
-      expect((put.Item as Record<string, unknown>).status).toBe('IN_PROGRESS');
+      expect((put.Item as Record<string, unknown>).status).toBe("IN_PROGRESS");
       expect((put.Item as Record<string, unknown>).roundN).toBe(7);
 
       const ebCalls = ebMock.commandCalls(PutEventsCommand);
       expect(ebCalls).toHaveLength(1);
       const entry = ebCalls[0].args[0].input.Entries![0];
-      expect(entry.DetailType).toBe('governance.round.started');
+      expect(entry.DetailType).toBe("governance.round.started");
       const detail = JSON.parse(entry.Detail!);
-      expect(detail.projectId).toBe('proj-42');
+      expect(detail.projectId).toBe("proj-42");
       expect(detail.roundN).toBe(7);
     });
 
-    test('rejects caller without adr:create permission and issues no DDB write', async () => {
-      const auth = mockAuthContextFor('developer');
-      await expect(startInterrogationRound('proj-1', 1, auth)).rejects.toThrow(
+    test("rejects caller without adr:create permission and issues no DDB write", async () => {
+      const auth = mockAuthContextFor("developer");
+      await expect(startInterrogationRound("proj-1", 1, auth)).rejects.toThrow(
         /UnauthorizedError/,
       );
       expect(ddbMock.commandCalls(PutCommand)).toHaveLength(0);
       expect(ebMock.commandCalls(PutEventsCommand)).toHaveLength(0);
     });
 
-    test('rejects negative or non-integer roundN as ValidationError', async () => {
-      const auth = mockAuthContextFor('architect');
+    test("rejects negative or non-integer roundN as ValidationError", async () => {
+      const auth = mockAuthContextFor("architect");
+      await expect(startInterrogationRound("proj-1", 0, auth)).rejects.toThrow(
+        /ValidationError.*roundN/,
+      );
+      await expect(startInterrogationRound("proj-1", -3, auth)).rejects.toThrow(
+        /ValidationError.*roundN/,
+      );
       await expect(
-        startInterrogationRound('proj-1', 0, auth),
-      ).rejects.toThrow(/ValidationError.*roundN/);
-      await expect(
-        startInterrogationRound('proj-1', -3, auth),
-      ).rejects.toThrow(/ValidationError.*roundN/);
-      await expect(
-        startInterrogationRound('proj-1', 1.5, auth),
+        startInterrogationRound("proj-1", 1.5, auth),
       ).rejects.toThrow(/ValidationError.*roundN/);
       expect(ddbMock.commandCalls(PutCommand)).toHaveLength(0);
     });
@@ -153,43 +162,53 @@ describe('interrogation-round-resolver', () => {
 
   // ── stabiliseRound ─────────────────────────────────────────────────
 
-  describe('stabiliseRound', () => {
-    test('redacts email + phone BEFORE S3 write; transitions row to STABILISED; emits governance.round.completed', async () => {
-      const existing = baseRow({ status: 'IN_PROGRESS' });
+  describe("stabiliseRound", () => {
+    test("redacts email + phone BEFORE S3 write; transitions row to STABILISED; emits governance.round.completed", async () => {
+      const existing = baseRow({ status: "IN_PROGRESS" });
       ddbMock.on(GetCommand).resolves({ Item: existing });
       ddbMock
         .on(UpdateCommand)
-        .resolves({ Attributes: { ...existing, status: 'STABILISED', completedAt: '2026-04-30T00:00:01.000Z', transcriptSizeBytes: 42 } });
+        .resolves({
+          Attributes: {
+            ...existing,
+            status: "STABILISED",
+            completedAt: "2026-04-30T00:00:01.000Z",
+            transcriptSizeBytes: 42,
+          },
+        });
 
-      const auth = mockAuthContextFor('architect');
+      const auth = mockAuthContextFor("architect");
       const transcript = [
-        { role: 'user', content: 'reach me at bob@example.com or 555-1234' },
-        { role: 'assistant', content: 'Understood, I will not contact you.' },
+        { role: "user", content: "reach me at bob@example.com or 555-1234" },
+        { role: "assistant", content: "Understood, I will not contact you." },
       ];
 
       const result = await stabiliseRound(
-        'proj-1',
+        "proj-1",
         1,
         transcript,
-        'summary of the round',
+        "summary of the round",
         auth,
       );
 
-      expect(result.status).toBe('STABILISED');
+      expect(result.status).toBe("STABILISED");
 
       const s3Calls = s3Mock.commandCalls(PutObjectCommand);
       expect(s3Calls).toHaveLength(1);
       const s3Input = s3Calls[0].args[0].input;
-      expect(s3Input.Bucket).toBe('citadel-governance-transcripts-test');
-      expect(s3Input.Key).toBe('projects/proj-1/rounds/1.jsonl');
-      const body = typeof s3Input.Body === 'string' ? s3Input.Body: Buffer.from(s3Input.Body as Uint8Array).toString('utf8');
+      expect(s3Input.Bucket).toBe("citadel-governance-transcripts-test");
+      expect(s3Input.Key).toBe("projects/proj-1/rounds/1.jsonl");
+      const body =
+        typeof s3Input.Body === "string"
+          ? s3Input.Body
+          : Buffer.from(s3Input.Body as Uint8Array).toString("utf8");
       // PII must be redacted in the persisted object.
-      expect(body).toContain('[REDACTED:email]');
-      expect(body).toContain('[REDACTED:phone]');
-      expect(body).not.toContain('bob@example.com');
-      expect(body).not.toContain('555-1234');
+      expect(body).toContain("[REDACTED:email]");
+      expect(body).toContain("[REDACTED:phone]");
+      expect(body).not.toContain("bob@example.com");
+      expect(body).not.toContain("555-1234");
       // JSONL: each line is a valid JSON object.
-      const lines = body.trim().split('\n');
+      const lines = body.trim().split("\n");
       expect(lines.length).toBeGreaterThanOrEqual(2);
       for (const line of lines) {
         expect(() => JSON.parse(line)).not.toThrow();
@@ -198,29 +217,35 @@ describe('interrogation-round-resolver', () => {
       const updates = ddbMock.commandCalls(UpdateCommand);
       expect(updates).toHaveLength(1);
       const upd = updates[0].args[0].input;
-      expect(upd.ExpressionAttributeValues![':newStatus']).toBe('STABILISED');
+      expect(upd.ExpressionAttributeValues![":newStatus"]).toBe("STABILISED");
 
       const ebCalls = ebMock.commandCalls(PutEventsCommand);
       expect(ebCalls).toHaveLength(1);
       expect(ebCalls[0].args[0].input.Entries![0].DetailType).toBe(
-        'governance.round.completed',
+        "governance.round.completed",
       );
       const detail = JSON.parse(ebCalls[0].args[0].input.Entries![0].Detail!);
-      expect(detail.projectId).toBe('proj-1');
+      expect(detail.projectId).toBe("proj-1");
       expect(detail.roundN).toBe(1);
     });
 
-    test('already-STABILISED round: idempotent early-return, no S3 PutObject, no re-emit', async () => {
+    test("already-STABILISED round: idempotent early-return, no S3 PutObject, no re-emit", async () => {
       const alreadyStable = baseRow({
-        status: 'STABILISED',
-        completedAt: '2026-04-29T00:00:00.000Z',
+        status: "STABILISED",
+        completedAt: "2026-04-29T00:00:00.000Z",
         transcriptSizeBytes: 512,
       });
       ddbMock.on(GetCommand).resolves({ Item: alreadyStable });
 
-      const auth = mockAuthContextFor('architect');
-      const transcript = [{ role: 'user', content: 'anything' }];
-      const result = await stabiliseRound('proj-1', 1, transcript, 'summary', auth);
+      const auth = mockAuthContextFor("architect");
+      const transcript = [{ role: "user", content: "anything" }];
+      const result = await stabiliseRound(
+        "proj-1",
+        1,
+        transcript,
+        "summary",
+        auth,
+      );
 
       expect(result).toEqual(alreadyStable);
       expect(s3Mock.commandCalls(PutObjectCommand)).toHaveLength(0);
@@ -228,58 +253,78 @@ describe('interrogation-round-resolver', () => {
       expect(ebMock.commandCalls(PutEventsCommand)).toHaveLength(0);
     });
 
-    test('transcript >5MB: S3 write succeeds AND emits governance.round.transcript.overflow with sizeBytes', async () => {
-      const existing = baseRow({ status: 'IN_PROGRESS' });
+    test("transcript >5MB: S3 write succeeds AND emits governance.round.transcript.overflow with sizeBytes", async () => {
+      const existing = baseRow({ status: "IN_PROGRESS" });
       ddbMock.on(GetCommand).resolves({ Item: existing });
       ddbMock
         .on(UpdateCommand)
-        .resolves({ Attributes: { ...existing, status: 'STABILISED' } });
+        .resolves({ Attributes: { ...existing, status: "STABILISED" } });
 
       // Build a ~6MB payload — a single content string of 6 * 1024 * 1024 bytes.
       // After JSON-encoding + the role wrapper the JSONL body is comfortably >5MB.
       // Use space-separated tokens instead of a uniform 6MB 'x' run. A uniform
-            // long atext run triggers catastrophic backtracking in redactPII's
-            // EMAIL_RE (the greedy atext character class consumes the whole string
-            // before failing at @, then retries from every position — O(n^2) on a
-            // 6MB input = many minutes of CPU). Space-separated content caps each
-            // match attempt at one token.
-            const bigContent = ('hello world ').repeat(Math.ceil((6 * 1024 * 1024) / 12));
-      const transcript = [{ role: 'user', content: bigContent }];
+      // long atext run triggers catastrophic backtracking in redactPII's
+      // EMAIL_RE (the greedy atext character class consumes the whole string
+      // before failing at @, then retries from every position — O(n^2) on a
+      // 6MB input = many minutes of CPU). Space-separated content caps each
+      // match attempt at one token.
+      const bigContent = "hello world ".repeat(
+        Math.ceil((6 * 1024 * 1024) / 12),
+      );
+      const transcript = [{ role: "user", content: bigContent }];
 
-      const auth = mockAuthContextFor('architect');
-      await stabiliseRound('proj-1', 1, transcript, 'summary', auth);
+      const auth = mockAuthContextFor("architect");
+      await stabiliseRound("proj-1", 1, transcript, "summary", auth);
 
       expect(s3Mock.commandCalls(PutObjectCommand)).toHaveLength(1);
 
       const detailTypes = ebMock
         .commandCalls(PutEventsCommand)
         .map((c) => c.args[0].input.Entries![0].DetailType);
-      expect(detailTypes).toContain('governance.round.transcript.overflow');
-      expect(detailTypes).toContain('governance.round.completed');
+      expect(detailTypes).toContain("governance.round.transcript.overflow");
+      expect(detailTypes).toContain("governance.round.completed");
 
       const overflowCall = ebMock
         .commandCalls(PutEventsCommand)
-        .find((c) => c.args[0].input.Entries![0].DetailType === 'governance.round.transcript.overflow')!;
-      const overflowDetail = JSON.parse(overflowCall.args[0].input.Entries![0].Detail!);
-      expect(overflowDetail.projectId).toBe('proj-1');
+        .find(
+          (c) =>
+            c.args[0].input.Entries![0].DetailType ===
+            "governance.round.transcript.overflow",
+        )!;
+      const overflowDetail = JSON.parse(
+        overflowCall.args[0].input.Entries![0].Detail!,
+      );
+      expect(overflowDetail.projectId).toBe("proj-1");
       expect(overflowDetail.roundN).toBe(1);
       expect(overflowDetail.sizeBytes).toBeGreaterThan(5 * 1024 * 1024);
     });
 
-    test('rejects caller without adr:create permission', async () => {
-      const auth = mockAuthContextFor('developer');
+    test("rejects caller without adr:create permission", async () => {
+      const auth = mockAuthContextFor("developer");
       await expect(
-        stabiliseRound('proj-1', 1, [{ role: 'user', content: 'hi' }], 'summary', auth),
+        stabiliseRound(
+          "proj-1",
+          1,
+          [{ role: "user", content: "hi" }],
+          "summary",
+          auth,
+        ),
       ).rejects.toThrow(/UnauthorizedError/);
       expect(ddbMock.commandCalls(GetCommand)).toHaveLength(0);
       expect(s3Mock.commandCalls(PutObjectCommand)).toHaveLength(0);
     });
 
-    test('non-existent round throws before S3 write', async () => {
+    test("non-existent round throws before S3 write", async () => {
       ddbMock.on(GetCommand).resolves({});
-      const auth = mockAuthContextFor('architect');
+      const auth = mockAuthContextFor("architect");
       await expect(
-        stabiliseRound('proj-missing', 1, [{ role: 'user', content: 'hi' }], 'summary', auth),
+        stabiliseRound(
+          "proj-missing",
+          1,
+          [{ role: "user", content: "hi" }],
+          "summary",
+          auth,
+        ),
       ).rejects.toThrow(/not found/);
       expect(s3Mock.commandCalls(PutObjectCommand)).toHaveLength(0);
     });
@@ -287,105 +332,128 @@ describe('interrogation-round-resolver', () => {
 
   // ── injectConstraints ──────────────────────────────────────────────
 
-  describe('injectConstraints', () => {
-    test('IN_PROGRESS -> AWAITING_CONSTRAINTS and persists constraints', async () => {
-      const existing = baseRow({ status: 'IN_PROGRESS' });
+  describe("injectConstraints", () => {
+    test("IN_PROGRESS -> AWAITING_CONSTRAINTS and persists constraints", async () => {
+      const existing = baseRow({ status: "IN_PROGRESS" });
       ddbMock.on(GetCommand).resolves({ Item: existing });
       ddbMock.on(UpdateCommand).resolves({
         Attributes: {
           ...existing,
-          status: 'AWAITING_CONSTRAINTS',
-          humanConstraints: ['budget<$100k', 'timeline<=Q4'],
+          status: "AWAITING_CONSTRAINTS",
+          humanConstraints: ["budget<$100k", "timeline<=Q4"],
         },
       });
 
-      const auth = mockAuthContextFor('architect');
+      const auth = mockAuthContextFor("architect");
       const result = await injectConstraints(
-        'proj-1',
+        "proj-1",
         1,
-        ['budget<$100k', 'timeline<=Q4'],
+        ["budget<$100k", "timeline<=Q4"],
         auth,
       );
 
-      expect(result.status).toBe('AWAITING_CONSTRAINTS');
-      expect(result.humanConstraints).toEqual(['budget<$100k', 'timeline<=Q4']);
+      expect(result.status).toBe("AWAITING_CONSTRAINTS");
+      expect(result.humanConstraints).toEqual(["budget<$100k", "timeline<=Q4"]);
 
       const updates = ddbMock.commandCalls(UpdateCommand);
       expect(updates).toHaveLength(1);
       const upd = updates[0].args[0].input;
-      expect(upd.ExpressionAttributeValues![':newStatus']).toBe('AWAITING_CONSTRAINTS');
-      expect(upd.ExpressionAttributeValues![':constraints']).toEqual([
-        'budget<$100k',
-        'timeline<=Q4',
+      expect(upd.ExpressionAttributeValues![":newStatus"]).toBe(
+        "AWAITING_CONSTRAINTS",
+      );
+      expect(upd.ExpressionAttributeValues![":constraints"]).toEqual([
+        "budget<$100k",
+        "timeline<=Q4",
       ]);
     });
 
-    test('rejects injectConstraints on STABILISED round with Invalid status transition', async () => {
-      const terminal = baseRow({ status: 'STABILISED' });
+    test("rejects injectConstraints on STABILISED round with Invalid status transition", async () => {
+      const terminal = baseRow({ status: "STABILISED" });
       ddbMock.on(GetCommand).resolves({ Item: terminal });
 
-      const auth = mockAuthContextFor('architect');
-      await expect(
-        injectConstraints('proj-1', 1, ['x'], auth),
-      ).rejects.toThrow(/Invalid status transition/);
+      const auth = mockAuthContextFor("architect");
+      await expect(injectConstraints("proj-1", 1, ["x"], auth)).rejects.toThrow(
+        /Invalid status transition/,
+      );
       expect(ddbMock.commandCalls(UpdateCommand)).toHaveLength(0);
     });
 
-    test('rejects caller without adr:create permission', async () => {
-      const auth = mockAuthContextFor('developer');
-      await expect(
-        injectConstraints('proj-1', 1, ['x'], auth),
-      ).rejects.toThrow(/UnauthorizedError/);
+    test("rejects caller without adr:create permission", async () => {
+      const auth = mockAuthContextFor("developer");
+      await expect(injectConstraints("proj-1", 1, ["x"], auth)).rejects.toThrow(
+        /UnauthorizedError/,
+      );
     });
   });
 
   // ── getInterrogationRound / listInterrogationRounds ────────────────
 
-  describe('getInterrogationRound', () => {
-    test('returns null for missing (projectId, roundN)', async () => {
+  describe("getInterrogationRound", () => {
+    test("returns null for missing (projectId, roundN)", async () => {
       ddbMock.on(GetCommand).resolves({});
-      const row = await getInterrogationRound('proj-nope', 99);
+      const row = await getInterrogationRound("proj-nope", 99);
       expect(row).toBeNull();
     });
 
-    test('returns the row when present', async () => {
+    test("returns the row when present", async () => {
       const existing = baseRow();
       ddbMock.on(GetCommand).resolves({ Item: existing });
-      const row = await getInterrogationRound('proj-1', 1);
+      const row = await getInterrogationRound("proj-1", 1);
       expect(row).toEqual(existing);
     });
   });
 
-  describe('listInterrogationRounds', () => {
-    test('queries by projectId PK', async () => {
-      const items = [baseRow({ roundN: 1 }), baseRow({ roundN: 2, status: 'STABILISED' })];
+  describe("listInterrogationRounds", () => {
+    test("queries by projectId PK", async () => {
+      const items = [
+        baseRow({ roundN: 1 }),
+        baseRow({ roundN: 2, status: "STABILISED" }),
+      ];
       ddbMock.on(QueryCommand).resolves({ Items: items });
 
-      const rows = await listInterrogationRounds('proj-1');
+      const rows = await listInterrogationRounds("proj-1");
       expect(rows).toEqual(items);
 
       const calls = ddbMock.commandCalls(QueryCommand);
       expect(calls).toHaveLength(1);
       const input = calls[0].args[0].input;
-      expect(input.TableName).toBe('citadel-interrogation-rounds-test');
-      expect(input.KeyConditionExpression).toBe('projectId = :pid');
-      expect(input.ExpressionAttributeValues![':pid']).toBe('proj-1');
+      expect(input.TableName).toBe("citadel-interrogation-rounds-test");
+      expect(input.KeyConditionExpression).toBe("projectId = :pid");
+      expect(input.ExpressionAttributeValues![":pid"]).toBe("proj-1");
     });
 
-    test('returns [] when no rounds', async () => {
+    test("returns [] when no rounds", async () => {
       ddbMock.on(QueryCommand).resolves({ Items: [] });
-      const rows = await listInterrogationRounds('proj-empty');
+      const rows = await listInterrogationRounds("proj-empty");
       expect(rows).toEqual([]);
     });
   });
 
   // ── handler dispatch ────────────────────────────────────────────────
 
-  describe('handler dispatch', () => {
+  describe("handler dispatch", () => {
+    // finding 2c262386: handler dispatch now threads `event` into the
+    // project-org gate, so every dispatch test needs a project record
+    // whose organization matches the caller's `custom:organization` claim.
+    beforeEach(() => {
+      ddbMock
+        .on(GetCommand, {
+          TableName: "citadel-projects-test",
+          Key: { id: "proj-1" },
+        })
+        .resolves({
+          Item: {
+            id: "proj-1",
+            owner: "someone-else",
+            organization: "org-shared",
+          },
+        });
+    });
+
     function makeEvent(
       fieldName: string,
       args: Record<string, unknown>,
-      role: 'architect' | 'developer' = 'architect',
+      role: "architect" | "developer" = "architect",
     ) {
       return {
         info: { fieldName },
@@ -393,43 +461,60 @@ describe('interrogation-round-resolver', () => {
         identity: {
           sub: `user-${role}`,
           username: role,
-          'custom:role': role,
+          "custom:role": role,
+          "custom:organization": "org-shared",
         },
       };
     }
 
-    test('dispatches startInterrogationRound', async () => {
+    test("dispatches startInterrogationRound", async () => {
       ddbMock.on(PutCommand).resolves({});
       const result = (await handler(
-        makeEvent('startInterrogationRound', { projectId: 'proj-1', roundN: 1 }),
+        makeEvent("startInterrogationRound", {
+          projectId: "proj-1",
+          roundN: 1,
+        }),
       )) as { status: string };
-      expect(result.status).toBe('IN_PROGRESS');
+      expect(result.status).toBe("IN_PROGRESS");
     });
 
-    test('dispatches getInterrogationRound', async () => {
-      ddbMock.on(GetCommand).resolves({});
+    test("dispatches getInterrogationRound", async () => {
+      ddbMock
+        .on(GetCommand, {
+          TableName: "citadel-interrogation-rounds-test",
+          Key: { projectId: "proj-1", roundN: 1 },
+        })
+        .resolves({});
       const result = await handler(
-        makeEvent('getInterrogationRound', { projectId: 'proj-1', roundN: 1 }),
+        makeEvent("getInterrogationRound", { projectId: "proj-1", roundN: 1 }),
       );
       expect(result).toBeNull();
     });
 
-    test('dispatches listInterrogationRounds', async () => {
-      ddbMock.on(QueryCommand).resolves({ Items: [] });
+    test("dispatches listInterrogationRounds", async () => {
+      ddbMock
+        .on(QueryCommand, { TableName: "citadel-interrogation-rounds-test" })
+        .resolves({ Items: [] });
       const result = await handler(
-        makeEvent('listInterrogationRounds', { projectId: 'proj-1' }),
+        makeEvent("listInterrogationRounds", { projectId: "proj-1" }),
       );
       expect(result).toEqual([]);
     });
 
-    test('unknown field throws', async () => {
-      await expect(handler(makeEvent('notAField', {}))).rejects.toThrow(/Unsupported field/);
+    test("unknown field throws", async () => {
+      await expect(handler(makeEvent("notAField", {}))).rejects.toThrow(
+        /Unsupported field/,
+      );
     });
 
-    test('developer role cannot start a round', async () => {
+    test("developer role cannot start a round", async () => {
       await expect(
         handler(
-          makeEvent('startInterrogationRound', { projectId: 'proj-1', roundN: 1 }, 'developer'),
+          makeEvent(
+            "startInterrogationRound",
+            { projectId: "proj-1", roundN: 1 },
+            "developer",
+          ),
         ),
       ).rejects.toThrow(/UnauthorizedError/);
     });
@@ -437,29 +522,29 @@ describe('interrogation-round-resolver', () => {
 
   // ── Property tests ──────────────────────────────────────────────────
 
-  describe('property: redactPII idempotent through stabiliseRound', () => {
-    test('calling stabiliseRound twice with the same transcript is a no-op on the second call (200 iterations)', async () => {
+  describe("property: redactPII idempotent through stabiliseRound", () => {
+    test("calling stabiliseRound twice with the same transcript is a no-op on the second call (200 iterations)", async () => {
       // Generators for potentially-PII-bearing transcript content.
       const piiFragment = fc.oneof(
         fc.constantFrom(
-          'bob@example.com',
-          'alice@corp.io',
-          '555-1234',
-          '555-123-4567',
-          '+14155551234',
-          '123456789012',
-          'AKIAIOSFODNN7EXAMPLE',
-          'ASIAIOSFODNN7EXAMPLE',
-          '4111111111111111',
+          "bob@example.com",
+          "alice@corp.io",
+          "555-1234",
+          "555-123-4567",
+          "+14155551234",
+          "123456789012",
+          "AKIAIOSFODNN7EXAMPLE",
+          "ASIAIOSFODNN7EXAMPLE",
+          "4111111111111111",
         ),
         fc.string({ minLength: 1, maxLength: 20 }),
       );
       const messageContent = fc
         .array(piiFragment, { minLength: 1, maxLength: 4 })
-        .map((parts) => parts.join(' '));
+        .map((parts) => parts.join(" "));
       const transcriptArb = fc.array(
         fc.record({
-          role: fc.constantFrom('user', 'assistant', 'system'),
+          role: fc.constantFrom("user", "assistant", "system"),
           content: messageContent,
         }),
         { minLength: 1, maxLength: 3 },
@@ -472,26 +557,28 @@ describe('interrogation-round-resolver', () => {
           ebMock.reset();
           ebMock
             .on(PutEventsCommand)
-            .resolves({ FailedEntryCount: 0, Entries: [{ EventId: 'e' }] });
+            .resolves({ FailedEntryCount: 0, Entries: [{ EventId: "e" }] });
           __resetGovernanceNotifierForTest();
-                    s3Mock.on(PutObjectCommand).resolves({ ETag: '"a"' });
+          s3Mock.on(PutObjectCommand).resolves({ ETag: '"a"' });
 
           // First call: IN_PROGRESS -> STABILISED (S3 + DDB + event).
-          const inProgress = baseRow({ status: 'IN_PROGRESS' });
-          const stabilised = baseRow({ status: 'STABILISED' });
+          const inProgress = baseRow({ status: "IN_PROGRESS" });
+          const stabilised = baseRow({ status: "STABILISED" });
           // Simulate DDB state change: first GetCommand returns IN_PROGRESS,
           // the second returns STABILISED so the idempotent early-return
           // fires on the retry.
           let getCallCount = 0;
           ddbMock.on(GetCommand).callsFake(() => {
             getCallCount += 1;
-            return Promise.resolve({ Item: getCallCount === 1 ? inProgress: stabilised });
+            return Promise.resolve({
+              Item: getCallCount === 1 ? inProgress : stabilised,
+            });
           });
           ddbMock.on(UpdateCommand).resolves({ Attributes: stabilised });
 
-          const auth = mockAuthContextFor('architect');
-          await stabiliseRound('proj-1', 1, transcript, 'summary', auth);
-          await stabiliseRound('proj-1', 1, transcript, 'summary', auth);
+          const auth = mockAuthContextFor("architect");
+          await stabiliseRound("proj-1", 1, transcript, "summary", auth);
+          await stabiliseRound("proj-1", 1, transcript, "summary", auth);
 
           // First call writes S3 once. Second call (already-STABILISED) does not.
           expect(s3Mock.commandCalls(PutObjectCommand)).toHaveLength(1);
@@ -502,7 +589,8 @@ describe('interrogation-round-resolver', () => {
             .commandCalls(PutEventsCommand)
             .filter(
               (c) =>
-                c.args[0].input.Entries![0].DetailType === 'governance.round.completed',
+                c.args[0].input.Entries![0].DetailType ===
+                "governance.round.completed",
             );
           expect(completed).toHaveLength(1);
         }),

--- a/backend/src/lambda/__tests__/program-review-resolver-dispatch-gate-enumeration.test.ts
+++ b/backend/src/lambda/__tests__/program-review-resolver-dispatch-gate-enumeration.test.ts
@@ -1,0 +1,223 @@
+/**
+ * Enumeration-completeness guard for program-review-resolver.ts's dispatch
+ * switch (finding 2c262386 — module 4/4, guard 10 in the series).
+ *
+ * Root defect closed by finding 2c262386 (this module): runProgramReview
+ * reads another organization's accumulated governance evidence (ADRs,
+ * execution specs, interrogation rounds, agent design assessment) and
+ * writes an append-only ProgramReview row against a client-supplied
+ * projectId, gated only on hasPermission('adr:create') with no project-
+ * to-organization reconciliation. The fix threads an OPTIONAL `event`
+ * parameter through every exported function; the dispatch handler always
+ * supplies it. This guard also asserts runProgramReview's gate call
+ * precedes the evidence-fetch Promise.all AND the terminal PutCommand.
+ */
+import * as fs from "fs";
+import * as path from "path";
+
+const HANDLER_PATH = path.join(__dirname, "..", "program-review-resolver.ts");
+
+function extractDispatchCases(source: string): string[] {
+  const switchStart = source.indexOf("switch (fieldName)");
+  if (switchStart === -1) {
+    throw new Error(
+      "Could not locate `switch (fieldName)` in program-review-resolver.ts — " +
+        "dispatch structure changed; update this guard's parsing.",
+    );
+  }
+  const defaultIdx = source.indexOf("default:", switchStart);
+  if (defaultIdx === -1) {
+    throw new Error(
+      "Could not locate the dispatch switch's `default:` case — " +
+        "update this guard's parsing.",
+    );
+  }
+  const switchBody = source.slice(switchStart, defaultIdx);
+  const caseRe = /case\s+['"]([^'"]+)['"]\s*:/g;
+  const cases: string[] = [];
+  let m: RegExpExecArray | null;
+  while ((m = caseRe.exec(switchBody)) !== null) {
+    cases.push(m[1]);
+  }
+  return cases;
+}
+
+function extractCaseBody(source: string, fieldName: string): string {
+  const switchStart = source.indexOf("switch (fieldName)");
+  const defaultIdx = source.indexOf("default:", switchStart);
+  const switchBody = source.slice(switchStart, defaultIdx);
+
+  const caseIdx =
+    switchBody.indexOf(`case '${fieldName}'`) !== -1
+      ? switchBody.indexOf(`case '${fieldName}'`)
+      : switchBody.indexOf(`case "${fieldName}"`);
+  if (caseIdx === -1) {
+    throw new Error(`Could not locate case '${fieldName}' in dispatch switch`);
+  }
+  const nextCaseIdx = switchBody.indexOf("case ", caseIdx + 1);
+  return switchBody.slice(
+    caseIdx,
+    nextCaseIdx === -1 ? undefined : nextCaseIdx,
+  );
+}
+
+function extractCallSiteNames(caseBody: string): string[] {
+  const callRe = /await\s+([A-Za-z0-9_]+)\s*\(/g;
+  const names: string[] = [];
+  let m: RegExpExecArray | null;
+  while ((m = callRe.exec(caseBody)) !== null) {
+    names.push(m[1]);
+  }
+  return names;
+}
+
+function extractFunctionBody(source: string, fnName: string): string {
+  const declRe = new RegExp(
+    `(?:export\\s+)?async function ${fnName}\\b\\s*\\(`,
+  );
+  const declMatch = declRe.exec(source);
+  if (!declMatch) {
+    throw new Error(
+      `Could not locate function declaration for '${fnName}' in program-review-resolver.ts`,
+    );
+  }
+  const paramsOpenIdx = source.indexOf("(", declMatch.index);
+  let parenDepth = 0;
+  let j = paramsOpenIdx;
+  for (; j < source.length; j++) {
+    if (source[j] === "(") parenDepth++;
+    else if (source[j] === ")") {
+      parenDepth--;
+      if (parenDepth === 0) break;
+    }
+  }
+  const bodyStart = source.indexOf("{", j);
+  let depth = 0;
+  let i = bodyStart;
+  for (; i < source.length; i++) {
+    if (source[i] === "{") depth++;
+    else if (source[i] === "}") {
+      depth--;
+      if (depth === 0) break;
+    }
+  }
+  return source.slice(bodyStart, i + 1);
+}
+
+const GATE_CALL_RE = /assertProjectOrgAccess\s*\(/;
+const EVENT_PARAM_RE = /event\?\s*:\s*unknown/;
+
+const GATED_OPS: Record<string, { fn: string }> = {
+  runProgramReview: { fn: "runProgramReview" },
+  getProgramReview: { fn: "getProgramReview" },
+  listProgramReviewsForProject: { fn: "listProgramReviewsForProject" },
+};
+
+const EXEMPT_OPS: Record<string, string> = {};
+
+describe("program-review-resolver — dispatch enumeration completeness", () => {
+  const source = fs.readFileSync(HANDLER_PATH, "utf-8");
+  const cases = extractDispatchCases(source);
+
+  test("the dispatch switch actually has cases to check (sanity check on the parser itself)", () => {
+    expect(cases.length).toBeGreaterThanOrEqual(3);
+    expect(cases).toEqual(expect.arrayContaining(Object.keys(GATED_OPS)));
+  });
+
+  test("every dispatch case is accounted for in GATED_OPS or EXEMPT_OPS", () => {
+    const unaccounted = cases.filter(
+      (c) => !(c in GATED_OPS) && !(c in EXEMPT_OPS),
+    );
+    expect(unaccounted).toEqual([]);
+  });
+
+  test("GATED_OPS and EXEMPT_OPS do not both claim the same op", () => {
+    const overlap = Object.keys(GATED_OPS).filter((k) => k in EXEMPT_OPS);
+    expect(overlap).toEqual([]);
+  });
+
+  test("no GATED_OPS/EXEMPT_OPS entry references a case that no longer exists in the switch", () => {
+    const known = new Set(cases);
+    const staleGated = Object.keys(GATED_OPS).filter((k) => !known.has(k));
+    const staleExempt = Object.keys(EXEMPT_OPS).filter((k) => !known.has(k));
+    expect(staleGated).toEqual([]);
+    expect(staleExempt).toEqual([]);
+  });
+
+  describe.each(Object.entries(GATED_OPS))(
+    "GATED_OPS['%s'] dispatches to a function that threads `event` and calls assertProjectOrgAccess",
+    (fieldName, meta) => {
+      test(`${fieldName}'s case dispatches to ${meta.fn}`, () => {
+        const caseBody = extractCaseBody(source, fieldName);
+        const callSites = extractCallSiteNames(caseBody);
+        expect(callSites).toContain(meta.fn);
+      });
+
+      test(`${fieldName}'s case passes \`event\` as an argument to ${meta.fn}`, () => {
+        const caseBody = extractCaseBody(source, fieldName);
+        const callRe = new RegExp(
+          `${meta.fn}\\s*\\([^;]*?\\bevent\\b[^;]*?\\)`,
+        );
+        expect(callRe.test(caseBody)).toBe(true);
+      });
+
+      test(`${meta.fn}'s declaration accepts an optional \`event?: unknown\` parameter`, () => {
+        const declRe = new RegExp(
+          `(?:export\\s+)?async function ${meta.fn}\\b\\s*\\(([^)]*)\\)`,
+        );
+        const m = declRe.exec(source);
+        expect(m).not.toBeNull();
+        expect(EVENT_PARAM_RE.test((m as RegExpExecArray)[1])).toBe(true);
+      });
+
+      test(`${meta.fn}'s function body contains an assertProjectOrgAccess call`, () => {
+        const body = extractFunctionBody(source, meta.fn);
+        expect(GATE_CALL_RE.test(body)).toBe(true);
+      });
+    },
+  );
+
+  describe("runProgramReview gates before every evidence read and the terminal write", () => {
+    test("runProgramReview's gate call precedes the evidence-fetch Promise.all", () => {
+      const body = extractFunctionBody(source, "runProgramReview");
+      const gateIdx = body.search(GATE_CALL_RE);
+      const promiseAllIdx = body.indexOf("Promise.all([");
+      expect(gateIdx).toBeGreaterThan(-1);
+      expect(promiseAllIdx).toBeGreaterThan(-1);
+      expect(gateIdx).toBeLessThan(promiseAllIdx);
+    });
+
+    test("runProgramReview's gate call precedes the terminal PutCommand", () => {
+      const body = extractFunctionBody(source, "runProgramReview");
+      const gateIdx = body.search(GATE_CALL_RE);
+      const putIdx = body.indexOf("new PutCommand(");
+      expect(gateIdx).toBeGreaterThan(-1);
+      expect(putIdx).toBeGreaterThan(-1);
+      expect(gateIdx).toBeLessThan(putIdx);
+    });
+  });
+
+  describe("read-path ops return/query nothing before the gate resolves", () => {
+    test("getProgramReview's gate call precedes its `return review` statement", () => {
+      const body = extractFunctionBody(source, "getProgramReview");
+      const gateIdx = body.search(GATE_CALL_RE);
+      const returnIdx = body.lastIndexOf("return review;");
+      expect(gateIdx).toBeGreaterThan(-1);
+      expect(returnIdx).toBeGreaterThan(-1);
+      expect(gateIdx).toBeLessThan(returnIdx);
+    });
+
+    test("listProgramReviewsForProject's gate call precedes its QueryCommand (no foreign-data read at all)", () => {
+      const body = extractFunctionBody(source, "listProgramReviewsForProject");
+      const gateIdx = body.search(GATE_CALL_RE);
+      const queryIdx = body.indexOf("new QueryCommand(");
+      expect(gateIdx).toBeGreaterThan(-1);
+      expect(queryIdx).toBeGreaterThan(-1);
+      expect(gateIdx).toBeLessThan(queryIdx);
+    });
+  });
+
+  test("handler's hasPermission('adr:create') check is not removed by this fix (additive, not a replacement)", () => {
+    expect(source).toMatch(/hasPermission\(authContext, ['"]adr:create['"]\)/);
+  });
+});

--- a/backend/src/lambda/__tests__/program-review-resolver-org-scoping.test.ts
+++ b/backend/src/lambda/__tests__/program-review-resolver-org-scoping.test.ts
@@ -1,0 +1,348 @@
+/**
+ * Org-scoping tests for program-review-resolver (finding 2c262386, module
+ * 4/4).
+ *
+ * DEFECT: runProgramReview gated only on hasPermission('adr:create') and
+ * trusted the client-supplied projectId with NO project-to-organization
+ * reconciliation. It reads another organization's ACCUMULATED GOVERNANCE
+ * EVIDENCE (ADRs, execution specs, interrogation rounds, agent design
+ * assessment — fetched via the sibling resolvers' internal, event-less
+ * calls) and writes an append-only ProgramReview row against their
+ * projectId.
+ *
+ * FIX: assertProjectOrgAccess(projectId, event) — the SAME shared helper
+ * from PR 142 / finding 677c1a6c — is threaded through every exported
+ * function as an ADDITIONAL, optional `event` parameter. For
+ * runProgramReview, the gate runs BEFORE the parallel evidence-fetch
+ * Promise.all (so zero foreign evidence reads happen for a cross-org
+ * caller) and BEFORE the PutCommand that persists the review row.
+ *
+ * Acceptance:
+ *  - cross-org caller refused on runProgramReview/get/list; zero evidence
+ *    reads (adrs/specs/rounds/assessment), zero review writes
+ *  - same-org caller WITH adr:create succeeds
+ *  - same-org caller WITHOUT adr:create is still refused (additive)
+ */
+import {
+  DynamoDBDocumentClient,
+  GetCommand,
+  PutCommand,
+  QueryCommand,
+} from "@aws-sdk/lib-dynamodb";
+import { mockClient } from "aws-sdk-client-mock";
+import type { AuthContext } from "../../types";
+
+const ddbMock = mockClient(DynamoDBDocumentClient);
+
+process.env.PROGRAM_REVIEWS_TABLE = "citadel-program-reviews-test";
+process.env.ADRS_TABLE = "citadel-adrs-test";
+process.env.EXECUTION_SPECS_TABLE = "citadel-execution-specifications-test";
+process.env.INTERROGATION_ROUNDS_TABLE = "citadel-interrogation-rounds-test";
+process.env.AGENT_DESIGN_ASSESSMENTS_TABLE =
+  "citadel-agent-design-assessments-test";
+process.env.PROJECTS_TABLE = "citadel-projects-test";
+process.env.ENVIRONMENT = "test";
+
+import {
+  runProgramReview,
+  getProgramReview,
+  listProgramReviewsForProject,
+  handler,
+} from "../program-review-resolver";
+import { ProjectOrgAccessError } from "../../utils/project-org-access";
+
+function mockAuthContextFor(role: "architect" | "developer"): AuthContext {
+  return { userId: `user-${role}`, username: role, groups: [], roles: [role] };
+}
+
+function crossOrgEvent(
+  fieldName: string,
+  args: Record<string, unknown>,
+  role: "architect" | "developer" = "architect",
+) {
+  return {
+    info: { fieldName },
+    arguments: args,
+    identity: {
+      sub: `user-${role}-org-b`,
+      username: role,
+      "custom:role": role,
+      "custom:organization": "org-b",
+    },
+  };
+}
+
+function sameOrgEvent(
+  fieldName: string,
+  args: Record<string, unknown>,
+  role: "architect" | "developer" = "architect",
+) {
+  return {
+    info: { fieldName },
+    arguments: args,
+    identity: {
+      sub: `user-${role}-org-a`,
+      username: role,
+      "custom:role": role,
+      "custom:organization": "org-a",
+    },
+  };
+}
+
+const existingReview = {
+  reviewId: "review-1",
+  projectId: "proj-1",
+  results: [],
+  runAt: "2024-01-01T00:00:00.000Z",
+  runBy: "someone",
+  createdAt: "2024-01-01T00:00:00.000Z",
+};
+
+describe("program-review-resolver — project-org scoping (finding 2c262386)", () => {
+  beforeEach(() => {
+    ddbMock.reset();
+  });
+
+  function stubProject(organization = "org-a", owner = "someone-else") {
+    ddbMock
+      .on(GetCommand, {
+        TableName: "citadel-projects-test",
+        Key: { id: "proj-1" },
+      })
+      .resolves({ Item: { id: "proj-1", owner, organization } });
+  }
+
+  // ── runProgramReview (sharpest op: reads all evidence + writes review) ──
+
+  describe("runProgramReview", () => {
+    test("cross-org caller refused; ZERO evidence reads (adrs/specs/rounds/assessment) attempted", async () => {
+      stubProject("org-a");
+      const auth = mockAuthContextFor("architect");
+      const event = crossOrgEvent("runProgramReview", { projectId: "proj-1" });
+
+      await expect(
+        runProgramReview("proj-1", auth, event),
+      ).rejects.toBeInstanceOf(ProjectOrgAccessError);
+
+      const adrQueries = ddbMock
+        .commandCalls(QueryCommand)
+        .filter((c) => c.args[0].input.TableName === "citadel-adrs-test");
+      const specQueries = ddbMock
+        .commandCalls(QueryCommand)
+        .filter(
+          (c) =>
+            c.args[0].input.TableName ===
+            "citadel-execution-specifications-test",
+        );
+      const roundQueries = ddbMock
+        .commandCalls(QueryCommand)
+        .filter(
+          (c) =>
+            c.args[0].input.TableName === "citadel-interrogation-rounds-test",
+        );
+      const assessmentGets = ddbMock
+        .commandCalls(GetCommand)
+        .filter(
+          (c) =>
+            c.args[0].input.TableName ===
+            "citadel-agent-design-assessments-test",
+        );
+      expect(adrQueries).toHaveLength(0);
+      expect(specQueries).toHaveLength(0);
+      expect(roundQueries).toHaveLength(0);
+      expect(assessmentGets).toHaveLength(0);
+    });
+
+    test("cross-org caller refused; zero PutCommand to PROGRAM_REVIEWS_TABLE (no review persisted)", async () => {
+      stubProject("org-a");
+      const auth = mockAuthContextFor("architect");
+      const event = crossOrgEvent("runProgramReview", { projectId: "proj-1" });
+
+      await expect(
+        runProgramReview("proj-1", auth, event),
+      ).rejects.toBeInstanceOf(ProjectOrgAccessError);
+
+      const puts = ddbMock
+        .commandCalls(PutCommand)
+        .filter(
+          (c) => c.args[0].input.TableName === "citadel-program-reviews-test",
+        );
+      expect(puts).toHaveLength(0);
+    });
+
+    test("same-org caller with adr:create succeeds", async () => {
+      stubProject("org-a");
+      ddbMock.on(QueryCommand).resolves({ Items: [] });
+      ddbMock
+        .on(GetCommand, {
+          TableName: "citadel-agent-design-assessments-test",
+          Key: { projectId: "proj-1" },
+        })
+        .resolves({});
+      ddbMock.on(PutCommand).resolves({});
+      const auth = mockAuthContextFor("architect");
+      const event = sameOrgEvent("runProgramReview", { projectId: "proj-1" });
+
+      const review = await runProgramReview("proj-1", auth, event);
+      expect(review.projectId).toBe("proj-1");
+    });
+
+    test("same-org caller WITHOUT adr:create is still refused (additive, zero writes)", async () => {
+      stubProject("org-a");
+      const auth = mockAuthContextFor("developer");
+      const event = sameOrgEvent(
+        "runProgramReview",
+        { projectId: "proj-1" },
+        "developer",
+      );
+
+      await expect(runProgramReview("proj-1", auth, event)).rejects.toThrow(
+        /UnauthorizedError/,
+      );
+      const puts = ddbMock
+        .commandCalls(PutCommand)
+        .filter(
+          (c) => c.args[0].input.TableName === "citadel-program-reviews-test",
+        );
+      expect(puts).toHaveLength(0);
+    });
+
+    test("fetch-then-verify not needed here (projectId is a direct argument) — org check runs before any evidence fetch, not after", async () => {
+      stubProject("org-b"); // caller is org-a -> cross-org
+      const auth = mockAuthContextFor("architect");
+      const event = sameOrgEvent("runProgramReview", { projectId: "proj-1" });
+
+      await expect(
+        runProgramReview("proj-1", auth, event),
+      ).rejects.toBeInstanceOf(ProjectOrgAccessError);
+      expect(ddbMock.commandCalls(QueryCommand)).toHaveLength(0);
+      expect(
+        ddbMock
+          .commandCalls(GetCommand)
+          .filter((c) => c.args[0].input.TableName !== "citadel-projects-test"),
+      ).toHaveLength(0);
+    });
+  });
+
+  // ── getProgramReview (fetch-then-verify read) ────────────────────────
+
+  describe("getProgramReview", () => {
+    function stubReview() {
+      ddbMock
+        .on(GetCommand, {
+          TableName: "citadel-program-reviews-test",
+          Key: { reviewId: "review-1" },
+        })
+        .resolves({ Item: existingReview });
+    }
+
+    test("cross-org caller refused; review never returned", async () => {
+      stubReview();
+      stubProject("org-a");
+      const event = crossOrgEvent("getProgramReview", {
+        reviewId: "review-1",
+      });
+
+      await expect(getProgramReview("review-1", event)).rejects.toBeInstanceOf(
+        ProjectOrgAccessError,
+      );
+    });
+
+    test("same-org caller can read", async () => {
+      stubReview();
+      stubProject("org-a");
+      const event = sameOrgEvent("getProgramReview", {
+        reviewId: "review-1",
+      });
+
+      const review = await getProgramReview("review-1", event);
+      expect(review?.reviewId).toBe("review-1");
+    });
+
+    test("nonexistent review still returns null (fetch first, no crash)", async () => {
+      ddbMock.on(GetCommand).resolves({});
+      const event = sameOrgEvent("getProgramReview", { reviewId: "missing" });
+      const review = await getProgramReview("missing", event);
+      expect(review).toBeNull();
+    });
+  });
+
+  // ── listProgramReviewsForProject ─────────────────────────────────────
+
+  describe("listProgramReviewsForProject", () => {
+    test("cross-org caller refused; zero QueryCommand against PROGRAM_REVIEWS_TABLE", async () => {
+      stubProject("org-a");
+      const event = crossOrgEvent("listProgramReviewsForProject", {
+        projectId: "proj-1",
+      });
+
+      await expect(
+        listProgramReviewsForProject("proj-1", event),
+      ).rejects.toBeInstanceOf(ProjectOrgAccessError);
+      const queries = ddbMock
+        .commandCalls(QueryCommand)
+        .filter(
+          (c) => c.args[0].input.TableName === "citadel-program-reviews-test",
+        );
+      expect(queries).toHaveLength(0);
+    });
+
+    test("same-org caller can list", async () => {
+      stubProject("org-a");
+      ddbMock
+        .on(QueryCommand, { TableName: "citadel-program-reviews-test" })
+        .resolves({ Items: [] });
+      const event = sameOrgEvent("listProgramReviewsForProject", {
+        projectId: "proj-1",
+      });
+
+      const reviews = await listProgramReviewsForProject("proj-1", event);
+      expect(reviews).toEqual([]);
+    });
+  });
+
+  // ── handler dispatch always threads event ───────────────────────────
+
+  describe("handler dispatch threads event into the org gate", () => {
+    test("runProgramReview via handler: cross-org caller refused, zero evidence reads, zero writes", async () => {
+      stubProject("org-a");
+      await expect(
+        handler(crossOrgEvent("runProgramReview", { projectId: "proj-1" })),
+      ).rejects.toThrow(/Access denied/);
+      expect(ddbMock.commandCalls(QueryCommand)).toHaveLength(0);
+      expect(
+        ddbMock
+          .commandCalls(PutCommand)
+          .filter(
+            (c) => c.args[0].input.TableName === "citadel-program-reviews-test",
+          ),
+      ).toHaveLength(0);
+    });
+
+    test("runProgramReview via handler: same-org caller with permission succeeds", async () => {
+      stubProject("org-a");
+      ddbMock.on(QueryCommand).resolves({ Items: [] });
+      ddbMock
+        .on(GetCommand, { TableName: "citadel-agent-design-assessments-test" })
+        .resolves({});
+      ddbMock.on(PutCommand).resolves({});
+      const result = (await handler(
+        sameOrgEvent("runProgramReview", { projectId: "proj-1" }),
+      )) as { projectId: string };
+      expect(result.projectId).toBe("proj-1");
+    });
+
+    test("runProgramReview via handler: same-org caller without permission refused", async () => {
+      stubProject("org-a");
+      await expect(
+        handler(
+          sameOrgEvent(
+            "runProgramReview",
+            { projectId: "proj-1" },
+            "developer",
+          ),
+        ),
+      ).rejects.toThrow(/UnauthorizedError/);
+    });
+  });
+});

--- a/backend/src/lambda/__tests__/program-review-resolver.test.ts
+++ b/backend/src/lambda/__tests__/program-review-resolver.test.ts
@@ -32,22 +32,22 @@ import {
   GetCommand,
   PutCommand,
   QueryCommand,
-} from '@aws-sdk/lib-dynamodb';
-import { mockClient } from 'aws-sdk-client-mock';
-import * as fc from 'fast-check';
-import type { AuthContext } from '../../types';
+} from "@aws-sdk/lib-dynamodb";
+import { mockClient } from "aws-sdk-client-mock";
+import * as fc from "fast-check";
+import type { AuthContext } from "../../types";
 
 // ── Auth mock ─────────────────────────────────────────────────────────
 // `adr:create` is held by architect + project_manager (via the
 // governance story edits in auth.ts). Mock here to decouple
 // from Track B's pending auth.ts edits.
-jest.mock('../../utils/auth', () => ({
+jest.mock("../../utils/auth", () => ({
   hasPermission: (authContext: AuthContext, permission: string): boolean => {
-    if (authContext.roles?.includes('admin')) return true;
+    if (authContext.roles?.includes("admin")) return true;
     const grants: Record<string, string[]> = {
-      architect: ['adr:create', 'project:read'],
-      project_manager: ['adr:create', 'project:read'],
-      developer: ['project:read'],
+      architect: ["adr:create", "project:read"],
+      project_manager: ["adr:create", "project:read"],
+      developer: ["project:read"],
     };
     for (const role of authContext.roles || []) {
       if ((grants[role] || []).includes(permission)) return true;
@@ -59,28 +59,29 @@ jest.mock('../../utils/auth', () => ({
 const ddbMock = mockClient(DynamoDBDocumentClient);
 
 // Env vars must be set BEFORE importing the resolver (module-load capture).
-process.env.PROGRAM_REVIEWS_TABLE = 'citadel-program-reviews-test';
-process.env.ADRS_TABLE = 'citadel-adrs-test';
-process.env.EXECUTION_SPECS_TABLE = 'citadel-execution-specifications-test';
-process.env.INTERROGATION_ROUNDS_TABLE = 'citadel-interrogation-rounds-test';
-process.env.AGENT_DESIGN_ASSESSMENTS_TABLE = 'citadel-agent-design-assessments-test';
-process.env.PROJECTS_TABLE = 'citadel-projects-test';
+process.env.PROGRAM_REVIEWS_TABLE = "citadel-program-reviews-test";
+process.env.ADRS_TABLE = "citadel-adrs-test";
+process.env.EXECUTION_SPECS_TABLE = "citadel-execution-specifications-test";
+process.env.INTERROGATION_ROUNDS_TABLE = "citadel-interrogation-rounds-test";
+process.env.AGENT_DESIGN_ASSESSMENTS_TABLE =
+  "citadel-agent-design-assessments-test";
+process.env.PROJECTS_TABLE = "citadel-projects-test";
 
 import {
   runProgramReview,
   getProgramReview,
   listProgramReviewsForProject,
   handler,
-} from '../program-review-resolver';
-import * as adrResolver from '../adr-resolver';
-import * as execSpecResolver from '../execspec-resolver';
-import * as roundResolver from '../interrogation-round-resolver';
-import * as assessmentResolver from '../agent-design-assessment-resolver';
+} from "../program-review-resolver";
+import * as adrResolver from "../adr-resolver";
+import * as execSpecResolver from "../execspec-resolver";
+import * as roundResolver from "../interrogation-round-resolver";
+import * as assessmentResolver from "../agent-design-assessment-resolver";
 
-const REVIEWS_TABLE = 'citadel-program-reviews-test';
+const REVIEWS_TABLE = "citadel-program-reviews-test";
 
 function authContextFor(
-  role: 'architect' | 'developer' | 'project_manager' | 'admin',
+  role: "architect" | "developer" | "project_manager" | "admin",
 ): AuthContext {
   return {
     userId: `user-${role}`,
@@ -100,73 +101,79 @@ function fullyCompliantEvidence(projectId: string) {
   // Enough evidence to satisfy every automated question (Q001..Q012).
   const adrs = [
     {
-      adrId: 'adr-1',
+      adrId: "adr-1",
       projectId,
-      status: 'LOCKED',
-      lockedAt: '2026-04-01T00:00:00.000Z',
+      status: "LOCKED",
+      lockedAt: "2026-04-01T00:00:00.000Z",
     },
   ];
   const specs = [
     {
-      specId: 'spec-1',
+      specId: "spec-1",
       projectId,
-      status: 'APPROVED',
-      approvedBy: 'user-architect',
-      sourceAdrIds: ['adr-1'],
-      sourceDesignArtifactType: 'ADR',
-      executorKind: 'LAMBDA',
-      narrativeReviewStatus: 'REVIEWED',
+      status: "APPROVED",
+      approvedBy: "user-architect",
+      sourceAdrIds: ["adr-1"],
+      sourceDesignArtifactType: "ADR",
+      executorKind: "LAMBDA",
+      narrativeReviewStatus: "REVIEWED",
     },
   ];
   const rounds = [
     {
       projectId,
       roundN: 1,
-      status: 'STABILISED',
-      participantRoles: ['OPERATIONS', 'ARCHITECT'],
-      injectedConstraintIds: ['c1'],
+      status: "STABILISED",
+      participantRoles: ["OPERATIONS", "ARCHITECT"],
+      injectedConstraintIds: ["c1"],
     },
     {
       projectId,
       roundN: 2,
-      status: 'STABILISED',
-      participantRoles: ['OPERATIONS'],
-      injectedConstraintIds: ['c2'],
+      status: "STABILISED",
+      participantRoles: ["OPERATIONS"],
+      injectedConstraintIds: ["c2"],
     },
     {
       projectId,
       roundN: 3,
-      status: 'STABILISED',
-      participantRoles: ['OPERATIONS'],
-      injectedConstraintIds: ['c3'],
+      status: "STABILISED",
+      participantRoles: ["OPERATIONS"],
+      injectedConstraintIds: ["c3"],
     },
   ];
   const assessment = {
     projectId,
-    archetype: 'MONOLITHIC_DB',
-    archetypeStatus: 'CLASSIFIED',
-    completedAt: '2026-04-10T00:00:00.000Z',
+    archetype: "MONOLITHIC_DB",
+    archetypeStatus: "CLASSIFIED",
+    completedAt: "2026-04-10T00:00:00.000Z",
     dimensionRanking: [
-      { dimension: 'CODE', rank: 1, rationale: 'x' },
-      { dimension: 'DATA', rank: 2, rationale: 'x' },
+      { dimension: "CODE", rank: 1, rationale: "x" },
+      { dimension: "DATA", rank: 2, rationale: "x" },
       {
-        dimension: 'INTEGRATION_ARCHAEOLOGY',
+        dimension: "INTEGRATION_ARCHAEOLOGY",
         rank: 3,
-        rationale: 'x',
-        coverage: 'COMPLETE',
+        rationale: "x",
+        coverage: "COMPLETE",
       },
-      { dimension: 'INFRASTRUCTURE', rank: 4, rationale: 'x' },
+      { dimension: "INFRASTRUCTURE", rank: 4, rationale: "x" },
     ],
-    nonFunctionalConstraints: ['PERFORMANCE', 'SECURITY', 'COMPLIANCE'],
+    nonFunctionalConstraints: ["PERFORMANCE", "SECURITY", "COMPLIANCE"],
   };
   return { adrs, specs, rounds, assessment };
 }
 
 /** Resolver return types, used to cast loose test fixtures at the mock boundary. */
 type ADRList = Awaited<ReturnType<typeof adrResolver.listADRsForProject>>;
-type SpecList = Awaited<ReturnType<typeof execSpecResolver.listExecutionSpecifications>>;
-type RoundList = Awaited<ReturnType<typeof roundResolver.listInterrogationRounds>>;
-type AssessmentResult = Awaited<ReturnType<typeof assessmentResolver.getAgentDesignAssessment>>;
+type SpecList = Awaited<
+  ReturnType<typeof execSpecResolver.listExecutionSpecifications>
+>;
+type RoundList = Awaited<
+  ReturnType<typeof roundResolver.listInterrogationRounds>
+>;
+type AssessmentResult = Awaited<
+  ReturnType<typeof assessmentResolver.getAgentDesignAssessment>
+>;
 
 /** Loose evidence fixture shape accepted by installEvidence. */
 interface EvidenceFixture {
@@ -178,20 +185,20 @@ interface EvidenceFixture {
 
 function installEvidence(ev: EvidenceFixture): void {
   jest
-    .spyOn(adrResolver, 'listADRsForProject')
+    .spyOn(adrResolver, "listADRsForProject")
     .mockResolvedValue(ev.adrs as unknown as ADRList);
   jest
-    .spyOn(execSpecResolver, 'listExecutionSpecifications')
+    .spyOn(execSpecResolver, "listExecutionSpecifications")
     .mockResolvedValue(ev.specs as unknown as SpecList);
   jest
-    .spyOn(roundResolver, 'listInterrogationRounds')
+    .spyOn(roundResolver, "listInterrogationRounds")
     .mockResolvedValue(ev.rounds as unknown as RoundList);
   jest
-    .spyOn(assessmentResolver, 'getAgentDesignAssessment')
+    .spyOn(assessmentResolver, "getAgentDesignAssessment")
     .mockResolvedValue(ev.assessment as unknown as AssessmentResult);
 }
 
-describe('program-review-resolver', () => {
+describe("program-review-resolver", () => {
   beforeEach(() => {
     ddbMock.reset();
     jest.restoreAllMocks();
@@ -199,159 +206,209 @@ describe('program-review-resolver', () => {
 
   // ── AC 1: one result per question ────────────────────────────────────
 
-  describe('runProgramReview — structural invariants', () => {
-    test('1. AC1: returns exactly 20 results, one per checklist question', async () => {
+  describe("runProgramReview — structural invariants", () => {
+    test("1. AC1: returns exactly 20 results, one per checklist question", async () => {
       installEvidence(emptyEvidence());
       ddbMock.on(PutCommand).resolves({});
 
-      const review = await runProgramReview('proj-1', authContextFor('architect'));
+      const review = await runProgramReview(
+        "proj-1",
+        authContextFor("architect"),
+      );
 
       expect(review.results).toHaveLength(20);
       const ids = review.results.map((r) => r.questionId).sort();
-      const expected = Array.from({ length: 20 }, (_, i) =>
-        `Q${String(i + 1).padStart(3, '0')}`,
+      const expected = Array.from(
+        { length: 20 },
+        (_, i) => `Q${String(i + 1).padStart(3, "0")}`,
       ).sort();
       expect(ids).toEqual(expected);
     });
 
-    test('2. persists the review via PutCommand on PROGRAM_REVIEWS_TABLE', async () => {
+    test("2. persists the review via PutCommand on PROGRAM_REVIEWS_TABLE", async () => {
       installEvidence(emptyEvidence());
       ddbMock.on(PutCommand).resolves({});
 
-      const review = await runProgramReview('proj-1', authContextFor('architect'));
+      const review = await runProgramReview(
+        "proj-1",
+        authContextFor("architect"),
+      );
 
       const puts = ddbMock.commandCalls(PutCommand);
       expect(puts).toHaveLength(1);
       expect(puts[0].args[0].input.TableName).toBe(REVIEWS_TABLE);
       const item = puts[0].args[0].input.Item as Record<string, unknown>;
       expect(item.reviewId).toBe(review.reviewId);
-      expect(item.projectId).toBe('proj-1');
+      expect(item.projectId).toBe("proj-1");
       expect(Array.isArray(item.results)).toBe(true);
     });
 
-    test('3. stamps runAt, createdAt (ISO 8601) and runBy=authContext.userId', async () => {
+    test("3. stamps runAt, createdAt (ISO 8601) and runBy=authContext.userId", async () => {
       installEvidence(emptyEvidence());
       ddbMock.on(PutCommand).resolves({});
 
-      const review = await runProgramReview('proj-1', authContextFor('architect'));
+      const review = await runProgramReview(
+        "proj-1",
+        authContextFor("architect"),
+      );
 
-      expect(review.runBy).toBe('user-architect');
-      expect(review.runAt).toMatch(/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3}Z$/);
-      expect(review.createdAt).toMatch(/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3}Z$/);
+      expect(review.runBy).toBe("user-architect");
+      expect(review.runAt).toMatch(
+        /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3}Z$/,
+      );
+      expect(review.createdAt).toMatch(
+        /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3}Z$/,
+      );
       expect(review.reviewId).toMatch(/^[0-9a-f-]{36}$/);
     });
 
-    test('4. fetches the four evidence sources IN PARALLEL (all called once each)', async () => {
+    test("4. fetches the four evidence sources IN PARALLEL (all called once each)", async () => {
       installEvidence(emptyEvidence());
       ddbMock.on(PutCommand).resolves({});
 
-      await runProgramReview('proj-parallel', authContextFor('architect'));
+      await runProgramReview("proj-parallel", authContextFor("architect"));
 
       expect(adrResolver.listADRsForProject).toHaveBeenCalledTimes(1);
-      expect(adrResolver.listADRsForProject).toHaveBeenCalledWith('proj-parallel');
-      expect(execSpecResolver.listExecutionSpecifications).toHaveBeenCalledTimes(1);
+      expect(adrResolver.listADRsForProject).toHaveBeenCalledWith(
+        "proj-parallel",
+      );
+      expect(
+        execSpecResolver.listExecutionSpecifications,
+      ).toHaveBeenCalledTimes(1);
       expect(roundResolver.listInterrogationRounds).toHaveBeenCalledTimes(1);
-      expect(assessmentResolver.getAgentDesignAssessment).toHaveBeenCalledTimes(1);
+      expect(assessmentResolver.getAgentDesignAssessment).toHaveBeenCalledTimes(
+        1,
+      );
     });
   });
 
   // ── AC 2: completed assessment → Q001 PASS ──────────────────────────
 
-  describe('runProgramReview — evidence evaluation', () => {
-    test('5. AC2: completed assessment → Q001 PASS with assessment evidenceRef', async () => {
-      installEvidence(fullyCompliantEvidence('proj-1'));
+  describe("runProgramReview — evidence evaluation", () => {
+    test("5. AC2: completed assessment → Q001 PASS with assessment evidenceRef", async () => {
+      installEvidence(fullyCompliantEvidence("proj-1"));
       ddbMock.on(PutCommand).resolves({});
 
-      const review = await runProgramReview('proj-1', authContextFor('architect'));
-      const q001 = review.results.find((r) => r.questionId === 'Q001');
+      const review = await runProgramReview(
+        "proj-1",
+        authContextFor("architect"),
+      );
+      const q001 = review.results.find((r) => r.questionId === "Q001");
       expect(q001).toBeDefined();
-      expect(q001!.answer).toBe('PASS');
-      expect(q001!.evidenceRefs).toContain('AgentDesignAssessment:proj-1');
+      expect(q001!.answer).toBe("PASS");
+      expect(q001!.evidenceRefs).toContain("AgentDesignAssessment:proj-1");
     });
 
-    test('6. Q001 FAIL with empty evidenceRefs when assessment missing', async () => {
+    test("6. Q001 FAIL with empty evidenceRefs when assessment missing", async () => {
       installEvidence(emptyEvidence());
       ddbMock.on(PutCommand).resolves({});
 
-      const review = await runProgramReview('proj-1', authContextFor('architect'));
-      const q001 = review.results.find((r) => r.questionId === 'Q001');
-      expect(q001!.answer).toBe('FAIL');
+      const review = await runProgramReview(
+        "proj-1",
+        authContextFor("architect"),
+      );
+      const q001 = review.results.find((r) => r.questionId === "Q001");
+      expect(q001!.answer).toBe("FAIL");
       expect(q001!.evidenceRefs).toEqual([]);
     });
 
-    test('7. AC3: zero ADRs → Q006 FAIL with empty evidenceRefs', async () => {
+    test("7. AC3: zero ADRs → Q006 FAIL with empty evidenceRefs", async () => {
       installEvidence(emptyEvidence());
       ddbMock.on(PutCommand).resolves({});
 
-      const review = await runProgramReview('proj-1', authContextFor('architect'));
-      const q006 = review.results.find((r) => r.questionId === 'Q006');
+      const review = await runProgramReview(
+        "proj-1",
+        authContextFor("architect"),
+      );
+      const q006 = review.results.find((r) => r.questionId === "Q006");
       expect(q006).toBeDefined();
-      expect(q006!.answer).toBe('FAIL');
+      expect(q006!.answer).toBe("FAIL");
       expect(q006!.evidenceRefs).toEqual([]);
     });
 
-    test('8. LOCKED ADR → Q006 PASS with the adrId in evidenceRefs', async () => {
-      installEvidence(fullyCompliantEvidence('proj-1'));
+    test("8. LOCKED ADR → Q006 PASS with the adrId in evidenceRefs", async () => {
+      installEvidence(fullyCompliantEvidence("proj-1"));
       ddbMock.on(PutCommand).resolves({});
 
-      const review = await runProgramReview('proj-1', authContextFor('architect'));
-      const q006 = review.results.find((r) => r.questionId === 'Q006');
-      expect(q006!.answer).toBe('PASS');
+      const review = await runProgramReview(
+        "proj-1",
+        authContextFor("architect"),
+      );
+      const q006 = review.results.find((r) => r.questionId === "Q006");
+      expect(q006!.answer).toBe("PASS");
       expect(q006!.evidenceRefs.length).toBeGreaterThan(0);
-      expect(q006!.evidenceRefs.join(',')).toMatch(/adr-1/);
+      expect(q006!.evidenceRefs.join(",")).toMatch(/adr-1/);
     });
 
-    test('9. Q005: three stabilised rounds → PASS', async () => {
-      installEvidence(fullyCompliantEvidence('proj-1'));
+    test("9. Q005: three stabilised rounds → PASS", async () => {
+      installEvidence(fullyCompliantEvidence("proj-1"));
       ddbMock.on(PutCommand).resolves({});
 
-      const review = await runProgramReview('proj-1', authContextFor('architect'));
-      const q005 = review.results.find((r) => r.questionId === 'Q005');
-      expect(q005!.answer).toBe('PASS');
+      const review = await runProgramReview(
+        "proj-1",
+        authContextFor("architect"),
+      );
+      const q005 = review.results.find((r) => r.questionId === "Q005");
+      expect(q005!.answer).toBe("PASS");
     });
 
-    test('10. Q005: two stabilised rounds → FAIL', async () => {
-      const ev = fullyCompliantEvidence('proj-1');
+    test("10. Q005: two stabilised rounds → FAIL", async () => {
+      const ev = fullyCompliantEvidence("proj-1");
       ev.rounds = ev.rounds.slice(0, 2);
       installEvidence(ev);
       ddbMock.on(PutCommand).resolves({});
 
-      const review = await runProgramReview('proj-1', authContextFor('architect'));
-      const q005 = review.results.find((r) => r.questionId === 'Q005');
-      expect(q005!.answer).toBe('FAIL');
+      const review = await runProgramReview(
+        "proj-1",
+        authContextFor("architect"),
+      );
+      const q005 = review.results.find((r) => r.questionId === "Q005");
+      expect(q005!.answer).toBe("FAIL");
     });
 
-    test('11. Q010: APPROVED spec → PASS', async () => {
-      installEvidence(fullyCompliantEvidence('proj-1'));
+    test("11. Q010: APPROVED spec → PASS", async () => {
+      installEvidence(fullyCompliantEvidence("proj-1"));
       ddbMock.on(PutCommand).resolves({});
 
-      const review = await runProgramReview('proj-1', authContextFor('architect'));
-      const q010 = review.results.find((r) => r.questionId === 'Q010');
-      expect(q010!.answer).toBe('PASS');
+      const review = await runProgramReview(
+        "proj-1",
+        authContextFor("architect"),
+      );
+      const q010 = review.results.find((r) => r.questionId === "Q010");
+      expect(q010!.answer).toBe("PASS");
     });
 
-    test('12. investment / partner cluster questions default to PENDING_EVIDENCE with a note', async () => {
-      installEvidence(fullyCompliantEvidence('proj-1'));
+    test("12. investment / partner cluster questions default to PENDING_EVIDENCE with a note", async () => {
+      installEvidence(fullyCompliantEvidence("proj-1"));
       ddbMock.on(PutCommand).resolves({});
 
-      const review = await runProgramReview('proj-1', authContextFor('architect'));
-      const q013 = review.results.find((r) => r.questionId === 'Q013');
-      const q017 = review.results.find((r) => r.questionId === 'Q017');
-      expect(q013!.answer).toBe('PENDING_EVIDENCE');
+      const review = await runProgramReview(
+        "proj-1",
+        authContextFor("architect"),
+      );
+      const q013 = review.results.find((r) => r.questionId === "Q013");
+      const q017 = review.results.find((r) => r.questionId === "Q017");
+      expect(q013!.answer).toBe("PENDING_EVIDENCE");
       expect(q013!.notes).toMatch(/manual review|evaluator/i);
-      expect(q017!.answer).toBe('PENDING_EVIDENCE');
+      expect(q017!.answer).toBe("PENDING_EVIDENCE");
     });
   });
 
   // ── AC 4: historical-snapshot invariant ─────────────────────────────
 
-  describe('runProgramReview — historical snapshot', () => {
-    test('13. AC4: two runs → two distinct reviewIds, two PutCommands, first row not mutated', async () => {
+  describe("runProgramReview — historical snapshot", () => {
+    test("13. AC4: two runs → two distinct reviewIds, two PutCommands, first row not mutated", async () => {
       installEvidence(emptyEvidence());
       ddbMock.on(PutCommand).resolves({});
 
-      const first = await runProgramReview('proj-1', authContextFor('architect'));
-      const second = await runProgramReview('proj-1', authContextFor('architect'));
+      const first = await runProgramReview(
+        "proj-1",
+        authContextFor("architect"),
+      );
+      const second = await runProgramReview(
+        "proj-1",
+        authContextFor("architect"),
+      );
 
       expect(first.reviewId).not.toBe(second.reviewId);
 
@@ -371,32 +428,32 @@ describe('program-review-resolver', () => {
 
   // ── AC 5: determinism property (50 iters) ───────────────────────────
 
-  describe('runProgramReview — determinism', () => {
-    test('14. AC5: deterministic evidence → identical answers array across runs', async () => {
+  describe("runProgramReview — determinism", () => {
+    test("14. AC5: deterministic evidence → identical answers array across runs", async () => {
       ddbMock.on(PutCommand).resolves({});
 
       await fc.assert(
         fc.asyncProperty(
-          fc.constantFrom('proj-alpha', 'proj-beta', 'proj-gamma'),
+          fc.constantFrom("proj-alpha", "proj-beta", "proj-gamma"),
           fc.boolean(),
           fc.boolean(),
           async (projectId, hasAssessment, hasAdrs) => {
             // Build a deterministic evidence fixture per seed.
             const ev = {
               adrs: hasAdrs
-                ? [{ adrId: 'adr-x', projectId, status: 'LOCKED' }]
+                ? [{ adrId: "adr-x", projectId, status: "LOCKED" }]
                 : [],
               specs: hasAssessment
                 ? [
                     {
-                      specId: 'spec-x',
+                      specId: "spec-x",
                       projectId,
-                      status: 'APPROVED',
-                      approvedBy: 'user-architect',
-                      sourceDesignArtifactType: 'ADR',
-                      executorKind: 'LAMBDA',
-                      narrativeReviewStatus: 'REVIEWED',
-                      sourceAdrIds: ['adr-x'],
+                      status: "APPROVED",
+                      approvedBy: "user-architect",
+                      sourceDesignArtifactType: "ADR",
+                      executorKind: "LAMBDA",
+                      narrativeReviewStatus: "REVIEWED",
+                      sourceAdrIds: ["adr-x"],
                     },
                   ]
                 : [],
@@ -405,30 +462,36 @@ describe('program-review-resolver', () => {
                     {
                       projectId,
                       roundN: 1,
-                      status: 'STABILISED',
-                      participantRoles: ['OPERATIONS'],
-                      injectedConstraintIds: ['c1'],
+                      status: "STABILISED",
+                      participantRoles: ["OPERATIONS"],
+                      injectedConstraintIds: ["c1"],
                     },
                   ]
                 : [],
               assessment: hasAssessment
                 ? {
                     projectId,
-                    archetype: 'MONOLITHIC_DB',
-                    archetypeStatus: 'CLASSIFIED',
-                    completedAt: '2026-04-10T00:00:00.000Z',
+                    archetype: "MONOLITHIC_DB",
+                    archetypeStatus: "CLASSIFIED",
+                    completedAt: "2026-04-10T00:00:00.000Z",
                     dimensionRanking: [
-                      { dimension: 'CODE', rank: 1, rationale: 'x' },
+                      { dimension: "CODE", rank: 1, rationale: "x" },
                     ],
-                    nonFunctionalConstraints: ['PERFORMANCE'],
+                    nonFunctionalConstraints: ["PERFORMANCE"],
                   }
                 : null,
             };
 
             installEvidence(ev);
 
-            const a = await runProgramReview(projectId, authContextFor('architect'));
-            const b = await runProgramReview(projectId, authContextFor('architect'));
+            const a = await runProgramReview(
+              projectId,
+              authContextFor("architect"),
+            );
+            const b = await runProgramReview(
+              projectId,
+              authContextFor("architect"),
+            );
 
             // Answers array must be byte-identical under sort+stringify.
             const projA = a.results
@@ -458,24 +521,24 @@ describe('program-review-resolver', () => {
 
   // ── Permission gate ─────────────────────────────────────────────────
 
-  describe('runProgramReview — permission gate', () => {
-    test('15. developer denied BEFORE any evidence fetch or DDB write', async () => {
+  describe("runProgramReview — permission gate", () => {
+    test("15. developer denied BEFORE any evidence fetch or DDB write", async () => {
       const adrSpy = jest
-        .spyOn(adrResolver, 'listADRsForProject')
+        .spyOn(adrResolver, "listADRsForProject")
         .mockResolvedValue([]);
       const specSpy = jest
-        .spyOn(execSpecResolver, 'listExecutionSpecifications')
+        .spyOn(execSpecResolver, "listExecutionSpecifications")
         .mockResolvedValue([]);
       const roundSpy = jest
-        .spyOn(roundResolver, 'listInterrogationRounds')
+        .spyOn(roundResolver, "listInterrogationRounds")
         .mockResolvedValue([]);
       const assessSpy = jest
-        .spyOn(assessmentResolver, 'getAgentDesignAssessment')
+        .spyOn(assessmentResolver, "getAgentDesignAssessment")
         .mockResolvedValue(null);
       ddbMock.on(PutCommand).resolves({});
 
       await expect(
-        runProgramReview('proj-1', authContextFor('developer')),
+        runProgramReview("proj-1", authContextFor("developer")),
       ).rejects.toThrow(/UnauthorizedError/);
 
       expect(adrSpy).not.toHaveBeenCalled();
@@ -485,130 +548,169 @@ describe('program-review-resolver', () => {
       expect(ddbMock.commandCalls(PutCommand)).toHaveLength(0);
     });
 
-    test('16. architect allowed (adr:create granted)', async () => {
+    test("16. architect allowed (adr:create granted)", async () => {
       installEvidence(emptyEvidence());
       ddbMock.on(PutCommand).resolves({});
       await expect(
-        runProgramReview('proj-1', authContextFor('architect')),
+        runProgramReview("proj-1", authContextFor("architect")),
       ).resolves.toBeDefined();
     });
 
-    test('17. project_manager allowed (adr:create granted)', async () => {
+    test("17. project_manager allowed (adr:create granted)", async () => {
       installEvidence(emptyEvidence());
       ddbMock.on(PutCommand).resolves({});
       await expect(
-        runProgramReview('proj-1', authContextFor('project_manager')),
+        runProgramReview("proj-1", authContextFor("project_manager")),
       ).resolves.toBeDefined();
     });
   });
 
   // ── getProgramReview ────────────────────────────────────────────────
 
-  describe('getProgramReview', () => {
-    test('18. returns null when the reviewId is absent', async () => {
+  describe("getProgramReview", () => {
+    test("18. returns null when the reviewId is absent", async () => {
       ddbMock.on(GetCommand).resolves({ Item: undefined });
-      const result = await getProgramReview('missing-review');
+      const result = await getProgramReview("missing-review");
       expect(result).toBeNull();
     });
 
-    test('19. returns Item passthrough when present; Get against PROGRAM_REVIEWS_TABLE', async () => {
+    test("19. returns Item passthrough when present; Get against PROGRAM_REVIEWS_TABLE", async () => {
       const row = {
-        reviewId: 'rv-1',
-        projectId: 'proj-1',
+        reviewId: "rv-1",
+        projectId: "proj-1",
         results: [],
-        runAt: '2026-04-30T00:00:00.000Z',
-        runBy: 'user-architect',
-        createdAt: '2026-04-30T00:00:00.000Z',
+        runAt: "2026-04-30T00:00:00.000Z",
+        runBy: "user-architect",
+        createdAt: "2026-04-30T00:00:00.000Z",
       };
       ddbMock.on(GetCommand).resolves({ Item: row });
-      const result = await getProgramReview('rv-1');
+      const result = await getProgramReview("rv-1");
       expect(result).toEqual(row);
       const gets = ddbMock.commandCalls(GetCommand);
       expect(gets[0].args[0].input.TableName).toBe(REVIEWS_TABLE);
-      expect(gets[0].args[0].input.Key).toEqual({ reviewId: 'rv-1' });
+      expect(gets[0].args[0].input.Key).toEqual({ reviewId: "rv-1" });
     });
   });
 
   // ── listProgramReviewsForProject ────────────────────────────────────
 
-  describe('listProgramReviewsForProject', () => {
-    test('20. Query against project-index GSI on PROGRAM_REVIEWS_TABLE', async () => {
+  describe("listProgramReviewsForProject", () => {
+    test("20. Query against project-index GSI on PROGRAM_REVIEWS_TABLE", async () => {
       const rows = [
         {
-          reviewId: 'rv-1',
-          projectId: 'proj-1',
+          reviewId: "rv-1",
+          projectId: "proj-1",
           results: [],
-          runAt: '2026-04-01T00:00:00.000Z',
-          runBy: 'user-architect',
-          createdAt: '2026-04-01T00:00:00.000Z',
+          runAt: "2026-04-01T00:00:00.000Z",
+          runBy: "user-architect",
+          createdAt: "2026-04-01T00:00:00.000Z",
         },
       ];
       ddbMock.on(QueryCommand).resolves({ Items: rows });
 
-      const result = await listProgramReviewsForProject('proj-1');
+      const result = await listProgramReviewsForProject("proj-1");
       expect(result).toEqual(rows);
 
       const queries = ddbMock.commandCalls(QueryCommand);
       expect(queries).toHaveLength(1);
       expect(queries[0].args[0].input.TableName).toBe(REVIEWS_TABLE);
-      expect(queries[0].args[0].input.IndexName).toBe('project-index');
+      expect(queries[0].args[0].input.IndexName).toBe("project-index");
       expect(queries[0].args[0].input.KeyConditionExpression).toBe(
-        'projectId = :pid',
+        "projectId = :pid",
       );
     });
 
-    test('21. returns empty array when the project has no reviews', async () => {
+    test("21. returns empty array when the project has no reviews", async () => {
       ddbMock.on(QueryCommand).resolves({ Items: undefined });
-      const result = await listProgramReviewsForProject('proj-0');
+      const result = await listProgramReviewsForProject("proj-0");
       expect(result).toEqual([]);
     });
   });
 
   // ── handler dispatch ────────────────────────────────────────────────
 
-  describe('handler', () => {
-    test('22. dispatches runProgramReview', async () => {
+  describe("handler", () => {
+    // finding 2c262386: handler dispatch now threads `event` into the
+    // project-org gate, so every dispatch test needs a project record
+    // whose organization matches the caller's `custom:organization` claim.
+    function stubProjectFor(projectId: string, organization = "org-shared") {
+      ddbMock
+        .on(GetCommand, {
+          TableName: "citadel-projects-test",
+          Key: { id: projectId },
+        })
+        .resolves({
+          Item: { id: projectId, owner: "someone-else", organization },
+        });
+    }
+
+    test("22. dispatches runProgramReview", async () => {
       installEvidence(emptyEvidence());
+      stubProjectFor("proj-1");
       ddbMock.on(PutCommand).resolves({});
       const event = {
-        info: { fieldName: 'runProgramReview' },
-        arguments: { projectId: 'proj-1' },
-        identity: { sub: 'user-architect', 'custom:role': 'architect' },
+        info: { fieldName: "runProgramReview" },
+        arguments: { projectId: "proj-1" },
+        identity: {
+          sub: "user-architect",
+          "custom:role": "architect",
+          "custom:organization": "org-shared",
+        },
       };
-      const result = (await handler(event)) as { projectId: string; results: unknown[] };
-      expect(result.projectId).toBe('proj-1');
+      const result = (await handler(event)) as {
+        projectId: string;
+        results: unknown[];
+      };
+      expect(result.projectId).toBe("proj-1");
       expect(result.results).toHaveLength(20);
     });
 
-    test('23. dispatches getProgramReview', async () => {
-      ddbMock.on(GetCommand).resolves({
-        Item: { reviewId: 'rv-1', projectId: 'p1', results: [] },
-      });
+    test("23. dispatches getProgramReview", async () => {
+      stubProjectFor("p1");
+      ddbMock
+        .on(GetCommand, {
+          TableName: "citadel-program-reviews-test",
+          Key: { reviewId: "rv-1" },
+        })
+        .resolves({
+          Item: { reviewId: "rv-1", projectId: "p1", results: [] },
+        });
       const event = {
-        info: { fieldName: 'getProgramReview' },
-        arguments: { reviewId: 'rv-1' },
-        identity: { sub: 'user-architect', 'custom:role': 'architect' },
+        info: { fieldName: "getProgramReview" },
+        arguments: { reviewId: "rv-1" },
+        identity: {
+          sub: "user-architect",
+          "custom:role": "architect",
+          "custom:organization": "org-shared",
+        },
       };
       const result = (await handler(event)) as { reviewId: string };
-      expect(result.reviewId).toBe('rv-1');
+      expect(result.reviewId).toBe("rv-1");
     });
 
-    test('24. dispatches listProgramReviewsForProject', async () => {
-      ddbMock.on(QueryCommand).resolves({ Items: [] });
+    test("24. dispatches listProgramReviewsForProject", async () => {
+      stubProjectFor("proj-x");
+      ddbMock
+        .on(QueryCommand, { TableName: "citadel-program-reviews-test" })
+        .resolves({ Items: [] });
       const event = {
-        info: { fieldName: 'listProgramReviewsForProject' },
-        arguments: { projectId: 'proj-x' },
-        identity: { sub: 'user-architect', 'custom:role': 'architect' },
+        info: { fieldName: "listProgramReviewsForProject" },
+        arguments: { projectId: "proj-x" },
+        identity: {
+          sub: "user-architect",
+          "custom:role": "architect",
+          "custom:organization": "org-shared",
+        },
       };
       const result = await handler(event);
       expect(Array.isArray(result)).toBe(true);
     });
 
-    test('25. unknown fieldName throws', async () => {
+    test("25. unknown fieldName throws", async () => {
       const event = {
-        info: { fieldName: 'bogus' },
+        info: { fieldName: "bogus" },
         arguments: {},
-        identity: { sub: 'u', 'custom:role': 'architect' },
+        identity: { sub: "u", "custom:role": "architect" },
       };
       await expect(handler(event)).rejects.toThrow(/Unsupported field/);
     });

--- a/backend/src/lambda/agent-design-assessment-resolver.ts
+++ b/backend/src/lambda/agent-design-assessment-resolver.ts
@@ -34,16 +34,49 @@
  *   payload `{projectId, archetype, archetypeConfidence}` (the field name
  *   `archetypeConfidence` matches the typed DetailPayloadOf map in
  *   notifier-base.ts — the catalog entry is the source of truth).
+ *
+ * ## Per-operation disposition (finding 2c262386)
+ *
+ * DEFECT: startAgentDesignAssessment / submitAgentDesignAssessment gated
+ * only on hasPermission('assessment:submit') and trusted the client-
+ * supplied projectId with NO project-to-organization reconciliation.
+ * submitAgentDesignAssessment is the sharpest: its TransactWriteCommand
+ * mutates BOTH the assessments row AND another organization's
+ * citadel-projects row archetype/archetypeConfidence/archetypeStatus
+ * fields — a cross-org write reachable via a single client-supplied
+ * projectId. FIX: `assertProjectOrgAccess` (backend/src/utils/
+ * project-org-access.ts, the SAME shared helper landed for adr-resolver in
+ * finding 677c1a6c / PR 142, reused verbatim) is threaded through every
+ * exported function as an OPTIONAL trailing `event` parameter — additive
+ * to hasPermission, never a replacement. `handler` always supplies `event`.
+ *
+ *  - startAgentDesignAssessment — GATED. hasPermission('assessment:submit')
+ *                       unchanged; org check on projectId runs immediately
+ *                       after and BEFORE the PutCommand.
+ *  - submitAgentDesignAssessment — GATED (sharpest op). Permission check
+ *                       first, then eager input validation, then the org
+ *                       check on input.projectId runs immediately after
+ *                       validation and BEFORE the existing-row fetch AND
+ *                       BEFORE the TransactWriteCommand is even
+ *                       constructed — the gate precedes the WHOLE
+ *                       transaction (both the assessments-table leg and
+ *                       the PROJECTS-table leg), not one leg of it, so a
+ *                       cross-org caller triggers zero transaction
+ *                       commits.
+ *  - getAgentDesignAssessment — GATED. Fetch-then-verify: the row is read
+ *                       from DynamoDB but the org check runs BEFORE the
+ *                       row is returned to the caller.
  */
-import { DynamoDBClient } from '@aws-sdk/client-dynamodb';
+import { DynamoDBClient } from "@aws-sdk/client-dynamodb";
 import {
   DynamoDBDocumentClient,
   GetCommand,
   PutCommand,
   TransactWriteCommand,
-} from '@aws-sdk/lib-dynamodb';
-import { emitGovernanceEvent } from '../utils/notifier-base';
-import { hasPermission } from '../utils/auth';
+} from "@aws-sdk/lib-dynamodb";
+import { emitGovernanceEvent } from "../utils/notifier-base";
+import { hasPermission } from "../utils/auth";
+import { assertProjectOrgAccess } from "../utils/project-org-access";
 import type {
   AuthContext,
   AgentDesignAssessment,
@@ -52,8 +85,8 @@ import type {
   FourDimensionLiteral,
   GovernanceEventIdentity,
   GovernanceResolverEvent,
-} from '../types';
-import { ProjectArchetypeStatus } from '../types';
+} from "../types";
+import { ProjectArchetypeStatus } from "../types";
 
 const dynamoClient = new DynamoDBClient({});
 const docClient = DynamoDBDocumentClient.from(dynamoClient);
@@ -64,10 +97,10 @@ const PROJECTS_TABLE = process.env.PROJECTS_TABLE!;
 // escalate via archetypeStatus=PENDING_ESCALATION instead of introducing an
 // OTHER escape hatch.
 const FOUR_DIMENSIONS: readonly FourDimensionLiteral[] = [
-  'CODE',
-  'DATA',
-  'INTEGRATION',
-  'INFRASTRUCTURE',
+  "CODE",
+  "DATA",
+  "INTEGRATION",
+  "INFRASTRUCTURE",
 ];
 const EXPECTED_RANKS = [1, 2, 3, 4];
 
@@ -76,8 +109,7 @@ const EXPECTED_RANKS = [1, 2, 3, 4];
  * submitAgentDesignAssessment spreads its input at the top level of
  * `arguments`, hence the Partial<SubmitAgentDesignAssessmentInput> base.
  */
-interface AgentDesignAssessmentResolverArguments
-  extends Partial<SubmitAgentDesignAssessmentInput> {
+interface AgentDesignAssessmentResolverArguments extends Partial<SubmitAgentDesignAssessmentInput> {
   projectId: string;
 }
 
@@ -88,11 +120,11 @@ function authContextFromEvent(
   event: AgentDesignAssessmentResolverEvent,
 ): AuthContext {
   const identity: GovernanceEventIdentity = event?.identity || {};
-  const claimRole = identity['custom:role'] ?? identity.claims?.['custom:role'];
+  const claimRole = identity["custom:role"] ?? identity.claims?.["custom:role"];
   return {
-    userId: identity.sub || identity.username || 'anonymous',
+    userId: identity.sub || identity.username || "anonymous",
     username: identity.username,
-    groups: identity['cognito:groups'] || [],
+    groups: identity["cognito:groups"] || [],
     roles: claimRole ? [claimRole] : [],
   };
 }
@@ -103,10 +135,11 @@ function authContextFromEvent(
  * Mirrors the shape in adr-resolver.ts / execspec-resolver.ts.
  */
 function sanitizeForLog(input: unknown): unknown {
-  if (!input || typeof input !== 'object') return input;
+  if (!input || typeof input !== "object") return input;
   const out: Record<string, unknown> = {};
   for (const [k, v] of Object.entries(input as Record<string, unknown>)) {
-    out[k] = typeof v === 'string' && v.length > 200 ? v.slice(0, 200) + '…' : v;
+    out[k] =
+      typeof v === "string" && v.length > 200 ? v.slice(0, 200) + "…" : v;
   }
   return out;
 }
@@ -115,52 +148,44 @@ function requireAssessmentSubmitPermission(
   authContext: AuthContext,
   action: string,
 ): void {
-  if (!hasPermission(authContext, 'assessment:submit')) {
+  if (!hasPermission(authContext, "assessment:submit")) {
     throw new Error(
       `UnauthorizedError: assessment:submit permission required to ${action}`,
     );
   }
 }
 
-function validateDimensionRanking(
-  ranking: DimensionComplexityInput[],
-): void {
+function validateDimensionRanking(ranking: DimensionComplexityInput[]): void {
   if (!Array.isArray(ranking) || ranking.length !== 4) {
     throw new Error(
-      'ValidationError: dimensionRanking must have exactly 4 entries',
+      "ValidationError: dimensionRanking must have exactly 4 entries",
     );
   }
 
   // Ranks must form exactly {1,2,3,4} (sorted ascending).
   const ranks = ranking.map((r) => r.rank).sort((a, b) => a - b);
-  if (
-    ranks.length !== 4 ||
-    ranks.some((r, i) => r !== EXPECTED_RANKS[i])
-  ) {
+  if (ranks.length !== 4 || ranks.some((r, i) => r !== EXPECTED_RANKS[i])) {
     throw new Error(
-      'ValidationError: dimensionRanking ranks must form exactly the set {1,2,3,4}',
+      "ValidationError: dimensionRanking ranks must form exactly the set {1,2,3,4}",
     );
   }
 
   // Dimensions must be a permutation of the four canonical values.
   const dims = new Set(ranking.map((r) => r.dimension));
-  if (
-    dims.size !== 4 ||
-    !FOUR_DIMENSIONS.every((d) => dims.has(d))
-  ) {
+  if (dims.size !== 4 || !FOUR_DIMENSIONS.every((d) => dims.has(d))) {
     throw new Error(
-      'ValidationError: dimensionRanking dimensions must be exactly {CODE, DATA, INTEGRATION, INFRASTRUCTURE} with each appearing once',
+      "ValidationError: dimensionRanking dimensions must be exactly {CODE, DATA, INTEGRATION, INFRASTRUCTURE} with each appearing once",
     );
   }
 
   // Each rationale must be a non-empty trimmed string.
   for (const entry of ranking) {
     if (
-      typeof entry.rationale !== 'string' ||
+      typeof entry.rationale !== "string" ||
       entry.rationale.trim().length === 0
     ) {
       throw new Error(
-        'ValidationError: each dimensionRanking entry must have a non-empty rationale',
+        "ValidationError: each dimensionRanking entry must have a non-empty rationale",
       );
     }
   }
@@ -169,14 +194,19 @@ function validateDimensionRanking(
 export async function startAgentDesignAssessment(
   projectId: string,
   authContext: AuthContext,
+  event?: unknown,
 ): Promise<AgentDesignAssessment> {
   requireAssessmentSubmitPermission(
     authContext,
-    'start agent design assessments',
+    "start agent design assessments",
   );
 
-  if (typeof projectId !== 'string' || projectId.length === 0) {
-    throw new Error('ValidationError: projectId is required');
+  if (typeof projectId !== "string" || projectId.length === 0) {
+    throw new Error("ValidationError: projectId is required");
+  }
+
+  if (event !== undefined) {
+    await assertProjectOrgAccess(projectId, event);
   }
 
   const now = new Date().toISOString();
@@ -198,7 +228,7 @@ export async function startAgentDesignAssessment(
     new PutCommand({
       TableName: ASSESS_TABLE,
       Item: row,
-      ConditionExpression: 'attribute_not_exists(projectId)',
+      ConditionExpression: "attribute_not_exists(projectId)",
     }),
   );
   return row;
@@ -206,26 +236,32 @@ export async function startAgentDesignAssessment(
 
 export async function getAgentDesignAssessment(
   projectId: string,
+  event?: unknown,
 ): Promise<AgentDesignAssessment | null> {
   const res = await docClient.send(
     new GetCommand({ TableName: ASSESS_TABLE, Key: { projectId } }),
   );
-  return (res.Item as AgentDesignAssessment | undefined) ?? null;
+  const row = (res.Item as AgentDesignAssessment | undefined) ?? null;
+  if (row && event !== undefined) {
+    await assertProjectOrgAccess(projectId, event);
+  }
+  return row;
 }
 
 export async function submitAgentDesignAssessment(
   input: SubmitAgentDesignAssessmentInput,
   authContext: AuthContext,
+  event?: unknown,
 ): Promise<AgentDesignAssessment> {
   // Step 1: perm gate FIRST — no DDB, no event, before any state work.
   requireAssessmentSubmitPermission(
     authContext,
-    'submit agent design assessments',
+    "submit agent design assessments",
   );
 
   // Step 2: eager input validation.
-  if (typeof input?.projectId !== 'string' || input.projectId.length === 0) {
-    throw new Error('ValidationError: projectId is required');
+  if (typeof input?.projectId !== "string" || input.projectId.length === 0) {
+    throw new Error("ValidationError: projectId is required");
   }
   validateDimensionRanking(input.dimensionRanking);
   if (
@@ -233,7 +269,7 @@ export async function submitAgentDesignAssessment(
     input.accessibleDataSources.length === 0
   ) {
     throw new Error(
-      'ValidationError: accessibleDataSources must contain at least one entry',
+      "ValidationError: accessibleDataSources must contain at least one entry",
     );
   }
   if (
@@ -241,20 +277,30 @@ export async function submitAgentDesignAssessment(
     input.primaryRiskAreas.length === 0
   ) {
     throw new Error(
-      'ValidationError: primaryRiskAreas must contain at least one entry',
+      "ValidationError: primaryRiskAreas must contain at least one entry",
     );
+  }
+
+  // Step 2b: org-reconciliation gate (finding 2c262386). Runs BEFORE the
+  // existing-row fetch (step 3) and BEFORE the TransactWriteCommand is
+  // even constructed (step 4) — the gate precedes the WHOLE transaction,
+  // not one leg of it, so a cross-org caller triggers zero
+  // TransactWriteCommand calls at all, meaning neither the assessments-
+  // table leg NOR the PROJECTS-table leg is ever attempted.
+  if (event !== undefined) {
+    await assertProjectOrgAccess(input.projectId, event);
   }
 
   // Step 3: existing-row guards.
   const existing = await getAgentDesignAssessment(input.projectId);
   if (!existing) {
     throw new Error(
-      'AgentDesignAssessment not found — call startAgentDesignAssessment first',
+      "AgentDesignAssessment not found — call startAgentDesignAssessment first",
     );
   }
   if (existing.completedAt !== null && existing.completedAt !== undefined) {
     throw new Error(
-      'Assessment already completed — re-submission not permitted',
+      "Assessment already completed — re-submission not permitted",
     );
   }
 
@@ -270,27 +316,27 @@ export async function submitAgentDesignAssessment(
             TableName: ASSESS_TABLE,
             Key: { projectId: input.projectId },
             UpdateExpression:
-              'SET archetype = :archetype,' +
-              ' archetypeConfidence = :conf,' +
-              ' archetypeStatus = :classified,' +
-              ' dimensionRanking = :ranking,' +
-              ' accessibleDataSources = :sources,' +
-              ' primaryRiskAreas = :risks,' +
-              ' completedAt = :now,' +
-              ' completedBy = :userId,' +
-              ' updatedAt = :now',
+              "SET archetype = :archetype," +
+              " archetypeConfidence = :conf," +
+              " archetypeStatus = :classified," +
+              " dimensionRanking = :ranking," +
+              " accessibleDataSources = :sources," +
+              " primaryRiskAreas = :risks," +
+              " completedAt = :now," +
+              " completedBy = :userId," +
+              " updatedAt = :now",
             // DDB-side re-submission guard — catches concurrent double-submit
             // that raced past the client-side `completedAt !== null` check.
-            ConditionExpression: 'attribute_not_exists(completedAt)',
+            ConditionExpression: "attribute_not_exists(completedAt)",
             ExpressionAttributeValues: {
-              ':archetype': input.archetype,
-              ':conf': archetypeConfidence,
-              ':classified': ProjectArchetypeStatus.CLASSIFIED,
-              ':ranking': input.dimensionRanking,
-              ':sources': input.accessibleDataSources,
-              ':risks': input.primaryRiskAreas,
-              ':now': now,
-              ':userId': authContext.userId,
+              ":archetype": input.archetype,
+              ":conf": archetypeConfidence,
+              ":classified": ProjectArchetypeStatus.CLASSIFIED,
+              ":ranking": input.dimensionRanking,
+              ":sources": input.accessibleDataSources,
+              ":risks": input.primaryRiskAreas,
+              ":now": now,
+              ":userId": authContext.userId,
             },
           },
         },
@@ -299,15 +345,15 @@ export async function submitAgentDesignAssessment(
             TableName: PROJECTS_TABLE,
             Key: { id: input.projectId },
             UpdateExpression:
-              'SET archetype = :archetype,' +
-              ' archetypeConfidence = :conf,' +
-              ' archetypeStatus = :classified,' +
-              ' updatedAt = :now',
+              "SET archetype = :archetype," +
+              " archetypeConfidence = :conf," +
+              " archetypeStatus = :classified," +
+              " updatedAt = :now",
             ExpressionAttributeValues: {
-              ':archetype': input.archetype,
-              ':conf': archetypeConfidence,
-              ':classified': ProjectArchetypeStatus.CLASSIFIED,
-              ':now': now,
+              ":archetype": input.archetype,
+              ":conf": archetypeConfidence,
+              ":classified": ProjectArchetypeStatus.CLASSIFIED,
+              ":now": now,
             },
           },
         },
@@ -320,7 +366,7 @@ export async function submitAgentDesignAssessment(
   // as the payload field name for this detail-type ( catalog,
   // reconciled). The row/input schema field remains
   // `archetypeConfidence` — only the event payload is renamed.
-  await emitGovernanceEvent('governance.archetype.classified', {
+  await emitGovernanceEvent("governance.archetype.classified", {
     projectId: input.projectId,
     archetype: input.archetype,
     confidence: archetypeConfidence,
@@ -333,34 +379,38 @@ export async function submitAgentDesignAssessment(
     // Vanishingly unlikely (commit succeeded moments ago), but fail loud if
     // a downstream process has deleted the row between commit and read.
     throw new Error(
-      'AgentDesignAssessment vanished after commit — investigate TTL / concurrent delete',
+      "AgentDesignAssessment vanished after commit — investigate TTL / concurrent delete",
     );
   }
   return after;
 }
 
-export const handler = async (event: AgentDesignAssessmentResolverEvent): Promise<unknown> => {
+export const handler = async (
+  event: AgentDesignAssessmentResolverEvent,
+): Promise<unknown> => {
   const fieldName = event?.info?.fieldName;
   const authContext = authContextFromEvent(event);
   try {
     switch (fieldName) {
-      case 'startAgentDesignAssessment':
+      case "startAgentDesignAssessment":
         return await startAgentDesignAssessment(
           event.arguments.projectId,
           authContext,
+          event,
         );
-      case 'submitAgentDesignAssessment':
+      case "submitAgentDesignAssessment":
         return await submitAgentDesignAssessment(
           event.arguments as SubmitAgentDesignAssessmentInput,
           authContext,
+          event,
         );
-      case 'getAgentDesignAssessment':
-        return await getAgentDesignAssessment(event.arguments.projectId);
+      case "getAgentDesignAssessment":
+        return await getAgentDesignAssessment(event.arguments.projectId, event);
       default:
         throw new Error(`Unknown fieldName: ${fieldName}`);
     }
   } catch (err: unknown) {
-    console.error('agent-design-assessment-resolver error', {
+    console.error("agent-design-assessment-resolver error", {
       fieldName,
       message: err instanceof Error ? err.message : undefined,
       args: sanitizeForLog(event?.arguments),

--- a/backend/src/lambda/execspec-resolver.ts
+++ b/backend/src/lambda/execspec-resolver.ts
@@ -32,6 +32,53 @@
  * phase='audit-outcome' → ALLOWED | DENIED). Both auth-allowed and
  * auth-denied branches emit governance.specification.rejected so that
  * downstream alerting on denied attempts works identically to.
+ *
+ * ## Per-operation disposition (finding 2c262386)
+ *
+ * DEFECT: every op below gated only on hasPermission('spec:approve') and
+ * trusted the client-supplied/fetched projectId with NO project-to-
+ * organization reconciliation — an architect in org A could approve or
+ * rewrite org B's governance execution spec by specId. FIX:
+ * `assertProjectOrgAccess` (backend/src/utils/project-org-access.ts, the
+ * SAME shared helper landed for adr-resolver in finding 677c1a6c / PR 142,
+ * reused verbatim) is threaded through every exported function as an
+ * OPTIONAL trailing `event` parameter — additive to hasPermission, never a
+ * replacement. `handler` always supplies `event`.
+ *
+ *  - createExecutionSpecification — GATED. hasPermission('spec:approve')
+ *                       unchanged; org check on input.projectId runs
+ *                       immediately after and BEFORE the PutCommand.
+ *  - submitExecutionSpecification — GATED. Fetch-then-verify: specId is
+ *                       the only client-supplied key; the fetched spec's
+ *                       projectId is org-checked AFTER the fetch and
+ *                       BEFORE the transition-validating UpdateCommand.
+ *  - approveExecutionSpecification — GATED (sharpest op — approval changes
+ *                       a governance decision's state). Fetch-then-verify,
+ *                       same ordering as submit; org check runs BEFORE the
+ *                       UpdateCommand AND before the
+ *                       governance.specification.approved emission.
+ *  - rejectExecutionSpecification — GATED, but placed to PRESERVE the
+ *                       existing audit-before-auth ordering: the module's
+ *                       own pre-auth audit console.log line and the
+ *                       governance.specification.rejected emission (which
+ *                       must fire for every attempt, matching adr-
+ *                       resolver's reopenADR "audit row exists ∀
+ *                       invocation" intent) still run first. The org check
+ *                       is inserted AFTER the permission check (step 4)
+ *                       and AFTER the emit (step 6), but BEFORE the
+ *                       terminal UpdateCommand that flips the spec to
+ *                       REJECTED — so a cross-org caller is audited and
+ *                       denied loudly, but never gets the write.
+ *  - reviseExecutionSpecification — GATED. Fetch-then-verify; org check
+ *                       runs BEFORE the UpdateCommand that rewrites
+ *                       structuredPayload/narrativeS3Uri.
+ *  - getExecutionSpecification — GATED. Fetch-then-verify: the row is read
+ *                       from DynamoDB but the org check runs BEFORE the
+ *                       spec is returned to the caller.
+ *  - listExecutionSpecifications — GATED. org check on the client-supplied
+ *                       projectId runs BEFORE the QueryCommand, so a
+ *                       cross-org caller never triggers a read of another
+ *                       tenant's execution-spec rows at all.
  */
 import { DynamoDBClient } from '@aws-sdk/client-dynamodb';
 import {
@@ -45,6 +92,7 @@ import { v4 as uuidv4 } from 'uuid';
 import { LifecycleManager, EXECSPEC_TRANSITIONS } from '../adapters/lifecycle';
 import { emitGovernanceEvent } from '../utils/notifier-base';
 import { hasPermission } from '../utils/auth';
+import { assertProjectOrgAccess } from '../utils/project-org-access';
 import type {
   AuthContext,
   ExecutionSpecification,
@@ -139,11 +187,15 @@ function validateNarrativeUri(uri: unknown): void {
 export async function createExecutionSpecification(
   input: ExecutionSpecificationInput,
   authContext: AuthContext,
+  event?: unknown,
 ): Promise<ExecutionSpecification> {
   requireSpecApprovePermission(authContext, 'create execution specifications');
 
   if (!input.projectId) {
     throw new Error('ValidationError: projectId is required');
+  }
+  if (event !== undefined) {
+    await assertProjectOrgAccess(input.projectId, event);
   }
   if (!Array.isArray(input.sourceAdrIds) || input.sourceAdrIds.length === 0) {
     throw new Error('ValidationError: sourceAdrIds must be a non-empty array');
@@ -177,16 +229,25 @@ export async function createExecutionSpecification(
 
 export async function getExecutionSpecification(
   specId: string,
+  event?: unknown,
 ): Promise<ExecutionSpecification | null> {
   const res = await docClient.send(
     new GetCommand({ TableName: EXECUTION_SPECS_TABLE, Key: { specId } }),
   );
-  return (res.Item as ExecutionSpecification | undefined) ?? null;
+  const spec = (res.Item as ExecutionSpecification | undefined) ?? null;
+  if (spec && event !== undefined) {
+    await assertProjectOrgAccess(spec.projectId, event);
+  }
+  return spec;
 }
 
 export async function listExecutionSpecifications(
   projectId: string,
+  event?: unknown,
 ): Promise<ExecutionSpecification[]> {
+  if (event !== undefined) {
+    await assertProjectOrgAccess(projectId, event);
+  }
   const res = await docClient.send(
     new QueryCommand({
       TableName: EXECUTION_SPECS_TABLE,
@@ -244,10 +305,14 @@ async function updateStatus(
 export async function submitExecutionSpecification(
   specId: string,
   authContext: AuthContext,
+  event?: unknown,
 ): Promise<ExecutionSpecification> {
   requireSpecApprovePermission(authContext, 'submit execution specifications');
   const spec = await getExecutionSpecification(specId);
   if (!spec) throw new Error(`ExecutionSpecification not found: ${specId}`);
+  if (event !== undefined) {
+    await assertProjectOrgAccess(spec.projectId, event);
+  }
   execSpecLifecycle.validateTransition(spec.status, 'PENDING_REVIEW');
   return updateStatus(specId, spec.version, 'PENDING_REVIEW', {
     submittedAt: new Date().toISOString(),
@@ -257,11 +322,20 @@ export async function submitExecutionSpecification(
 export async function approveExecutionSpecification(
   specId: string,
   authContext: AuthContext,
+  event?: unknown,
 ): Promise<ExecutionSpecification> {
   // Permission check FIRST — no DDB access, no event, before any state work.
   requireSpecApprovePermission(authContext, 'approve execution specifications');
   const spec = await getExecutionSpecification(specId);
   if (!spec) throw new Error(`ExecutionSpecification not found: ${specId}`);
+  // Fetch-then-verify: specId is the only client-supplied key, so the org
+  // check runs on the FETCHED spec's projectId, after the fetch and BEFORE
+  // the UpdateCommand / governance event below — this is the sharpest op
+  // in the module (approval changes a governance decision's state), so
+  // nothing state-changing may happen before this gate passes.
+  if (event !== undefined) {
+    await assertProjectOrgAccess(spec.projectId, event);
+  }
   execSpecLifecycle.validateTransition(spec.status, 'APPROVED');
   const now = new Date().toISOString();
   const updated = await updateStatus(specId, spec.version, 'APPROVED', {
@@ -292,6 +366,12 @@ export async function approveExecutionSpecification(
  *      'ALLOWED' | 'DENIED' } AFTER the check.
  *   6. Emit governance.specification.rejected regardless of outcome so
  *      downstream monitoring on denied attempts works.
+ *   6b. Org-reconciliation gate (finding 2c262386): runs AFTER the audit
+ *      lines and emit above (preserving audit-before-auth — every attempt,
+ *      cross-org or not, is still audited and the event still emitted) but
+ *      BEFORE the terminal UpdateCommand in step 8 that flips the spec to
+ *      REJECTED. A cross-org caller is audited and denied, but the spec's
+ *      state is never mutated.
  *   7. If DENIED → throw UnauthorizedError (audit trail already durable).
  *   8. If ALLOWED → LifecycleManager.validateTransition then DDB update.
  *      A lifecycle-validation failure at this point leaves the audit lines
@@ -301,6 +381,7 @@ export async function rejectExecutionSpecification(
   specId: string,
   reason: string,
   authContext: AuthContext,
+  event?: unknown,
 ): Promise<ExecutionSpecification> {
   // Step 1: pre-audit input validation.
   if (typeof reason!== 'string' || !reason) {
@@ -358,6 +439,17 @@ export async function rejectExecutionSpecification(
   if (!spec) {
     throw new Error(`ExecutionSpecification not found: ${specId}`);
   }
+
+  // Step 8b: org-reconciliation gate (finding 2c262386). Placed AFTER the
+  // audit-before-auth sequence (steps 3-6) so the audit trail and the
+  // governance.specification.rejected emit still fire for every attempt,
+  // matching the existing invariant — but BEFORE the terminal
+  // UpdateCommand below, so a cross-org caller's REJECTED write never
+  // lands even if they somehow pass the spec:approve permission check.
+  if (event !== undefined) {
+    await assertProjectOrgAccess(spec.projectId, event);
+  }
+
   execSpecLifecycle.validateTransition(spec.status, 'REJECTED');
 
   return updateStatus(specId, spec.version, 'REJECTED', {
@@ -371,6 +463,7 @@ export async function reviseExecutionSpecification(
   specId: string,
   input: ReviseExecutionSpecificationInput,
   authContext: AuthContext,
+  event?: unknown,
 ): Promise<ExecutionSpecification> {
   requireSpecApprovePermission(authContext, 'revise execution specifications');
   if (typeof input.structuredPayload !== 'string' || !input.structuredPayload) {
@@ -380,6 +473,9 @@ export async function reviseExecutionSpecification(
 
   const spec = await getExecutionSpecification(specId);
   if (!spec) throw new Error(`ExecutionSpecification not found: ${specId}`);
+  if (event !== undefined) {
+    await assertProjectOrgAccess(spec.projectId, event);
+  }
   execSpecLifecycle.validateTransition(spec.status, 'DRAFT');
 
   return updateStatus(specId, spec.version, 'DRAFT', {
@@ -397,33 +493,41 @@ export const handler = async (event: ExecSpecResolverEvent): Promise<unknown> =>
         return await createExecutionSpecification(
           event.arguments.input as ExecutionSpecificationInput,
           authContext,
+          event,
         );
       case 'submitExecutionSpecification':
         return await submitExecutionSpecification(
           event.arguments.specId,
           authContext,
+          event,
         );
       case 'approveExecutionSpecification':
         return await approveExecutionSpecification(
           event.arguments.specId,
           authContext,
+          event,
         );
       case 'rejectExecutionSpecification':
         return await rejectExecutionSpecification(
           event.arguments.specId,
           event.arguments.reason,
           authContext,
+          event,
         );
       case 'reviseExecutionSpecification':
         return await reviseExecutionSpecification(
           event.arguments.specId,
           event.arguments.input as ReviseExecutionSpecificationInput,
           authContext,
+          event,
         );
       case 'getExecutionSpecification':
-        return await getExecutionSpecification(event.arguments.specId);
+        return await getExecutionSpecification(event.arguments.specId, event);
       case 'listExecutionSpecifications':
-        return await listExecutionSpecifications(event.arguments.projectId);
+        return await listExecutionSpecifications(
+          event.arguments.projectId,
+          event,
+        );
       default:
         throw new Error(`Unsupported field: ${fieldName}`);
     }

--- a/backend/src/lambda/interrogation-round-resolver.ts
+++ b/backend/src/lambda/interrogation-round-resolver.ts
@@ -32,25 +32,58 @@
  *   Mutations are gated on `adr:create` — per the spec, the existing
  *   architect/admin grant covers the advisory interrogation loop. Queries
  *   are gated on `project:read`.
+ *
+ * ## Per-operation disposition (finding 2c262386)
+ *
+ * DEFECT: startInterrogationRound / injectConstraints / stabiliseRound
+ * gated only on hasPermission('adr:create') and trusted the client-
+ * supplied projectId with NO project-to-organization reconciliation.
+ * stabiliseRound is the sharpest op: it writes a governance transcript to
+ * S3 (encrypted, carries PII) and sets TERMINAL state (STABILISED) on a
+ * foreign round. FIX: `assertProjectOrgAccess` (backend/src/utils/
+ * project-org-access.ts, the SAME shared helper landed for adr-resolver in
+ * finding 677c1a6c / PR 142, reused verbatim) is threaded through every
+ * exported function as an OPTIONAL trailing `event` parameter — additive
+ * to hasPermission, never a replacement. `handler` always supplies `event`.
+ *
+ *  - startInterrogationRound — GATED. hasPermission('adr:create')
+ *                       unchanged; org check on projectId runs
+ *                       immediately after and BEFORE the PutCommand.
+ *  - injectConstraints — GATED. Fetch-then-verify: the current round is
+ *                       fetched, then org-checked, BEFORE the UpdateCommand
+ *                       that transitions status to AWAITING_CONSTRAINTS.
+ *  - stabiliseRound   — GATED (sharpest op). Fetch-then-verify: the round
+ *                       is fetched, then org-checked, BEFORE the
+ *                       idempotent-STABILISED early-return (so a cross-org
+ *                       caller cannot even observe that shortcut for a
+ *                       foreign round), BEFORE the redactPII/S3
+ *                       PutObjectCommand transcript write, and BEFORE the
+ *                       terminal UpdateCommand + governance.round.completed
+ *                       emission.
+ *  - getInterrogationRound — GATED. Fetch-then-verify: the row is read but
+ *                       the org check runs BEFORE it is returned.
+ *  - listInterrogationRounds — GATED. org check on the client-supplied
+ *                       projectId runs BEFORE the QueryCommand.
  */
-import { DynamoDBClient } from '@aws-sdk/client-dynamodb';
+import { DynamoDBClient } from "@aws-sdk/client-dynamodb";
 import {
   DynamoDBDocumentClient,
   GetCommand,
   PutCommand,
   UpdateCommand,
   QueryCommand,
-} from '@aws-sdk/lib-dynamodb';
-import { S3Client, PutObjectCommand } from '@aws-sdk/client-s3';
-import { LifecycleManager, ROUND_TRANSITIONS } from '../adapters/lifecycle';
-import { emitGovernanceEvent } from '../utils/notifier-base';
-import { hasPermission } from '../utils/auth';
-import { redactPII } from '../utils/redact-pii';
+} from "@aws-sdk/lib-dynamodb";
+import { S3Client, PutObjectCommand } from "@aws-sdk/client-s3";
+import { LifecycleManager, ROUND_TRANSITIONS } from "../adapters/lifecycle";
+import { emitGovernanceEvent } from "../utils/notifier-base";
+import { hasPermission } from "../utils/auth";
+import { assertProjectOrgAccess } from "../utils/project-org-access";
+import { redactPII } from "../utils/redact-pii";
 import type {
   AuthContext,
   GovernanceEventIdentity,
   GovernanceResolverEvent,
-} from '../types';
+} from "../types";
 
 const dynamoClient = new DynamoDBClient({});
 const docClient = DynamoDBDocumentClient.from(dynamoClient);
@@ -63,10 +96,7 @@ const roundLifecycle = new LifecycleManager(ROUND_TRANSITIONS);
 const FIVE_MIB = 5 * 1024 * 1024;
 
 export type RoundStatusLiteral =
-  | 'IN_PROGRESS'
-  | 'AWAITING_CONSTRAINTS'
-  | 'REVISED'
-  | 'STABILISED';
+  "IN_PROGRESS" | "AWAITING_CONSTRAINTS" | "REVISED" | "STABILISED";
 
 export interface TranscriptMessage {
   role: string;
@@ -101,20 +131,21 @@ function authContextFromEvent(
   event: InterrogationRoundResolverEvent,
 ): AuthContext {
   const identity: GovernanceEventIdentity = event?.identity || {};
-  const claimRole = identity['custom:role'] ?? identity.claims?.['custom:role'];
+  const claimRole = identity["custom:role"] ?? identity.claims?.["custom:role"];
   return {
-    userId: identity.sub || identity.username || 'anonymous',
+    userId: identity.sub || identity.username || "anonymous",
     username: identity.username,
-    groups: identity['cognito:groups'] || [],
-    roles: claimRole? [claimRole] : [],
+    groups: identity["cognito:groups"] || [],
+    roles: claimRole ? [claimRole] : [],
   };
 }
 
 function sanitizeForLog(input: unknown): unknown {
-  if (!input || typeof input !== 'object') return input;
+  if (!input || typeof input !== "object") return input;
   const out: Record<string, unknown> = {};
   for (const [k, v] of Object.entries(input as Record<string, unknown>)) {
-    out[k] = typeof v === 'string' && v.length > 200 ? v.slice(0, 200) + '…' : v;
+    out[k] =
+      typeof v === "string" && v.length > 200 ? v.slice(0, 200) + "…" : v;
   }
   return out;
 }
@@ -135,12 +166,12 @@ function transcriptKeyFor(projectId: string, roundN: number): string {
 
 function validateRoundN(roundN: unknown): asserts roundN is number {
   if (
-    typeof roundN !== 'number' ||
+    typeof roundN !== "number" ||
     !Number.isFinite(roundN) ||
     !Number.isInteger(roundN) ||
     roundN <= 0
   ) {
-    throw new Error('ValidationError: roundN must be a positive integer');
+    throw new Error("ValidationError: roundN must be a positive integer");
   }
 }
 
@@ -148,20 +179,24 @@ export async function startInterrogationRound(
   projectId: string,
   roundN: number,
   authContext: AuthContext,
+  event?: unknown,
 ): Promise<InterrogationRound> {
-  if (!hasPermission(authContext, 'adr:create')) {
-    throw new Error('UnauthorizedError: adr:create permission required');
+  if (!hasPermission(authContext, "adr:create")) {
+    throw new Error("UnauthorizedError: adr:create permission required");
   }
   validateRoundN(roundN);
-  if (typeof projectId !== 'string' || projectId.length === 0) {
-    throw new Error('ValidationError: projectId is required');
+  if (typeof projectId !== "string" || projectId.length === 0) {
+    throw new Error("ValidationError: projectId is required");
+  }
+  if (event !== undefined) {
+    await assertProjectOrgAccess(projectId, event);
   }
 
   const row: InterrogationRound = {
     projectId,
     roundN,
     transcriptS3Uri: transcriptUriFor(projectId, roundN),
-    status: 'IN_PROGRESS',
+    status: "IN_PROGRESS",
     startedAt: new Date().toISOString(),
   };
 
@@ -173,11 +208,11 @@ export async function startInterrogationRound(
       TableName: ROUNDS_TABLE,
       Item: row,
       ConditionExpression:
-        'attribute_not_exists(projectId) AND attribute_not_exists(roundN)',
+        "attribute_not_exists(projectId) AND attribute_not_exists(roundN)",
     }),
   );
 
-  await emitGovernanceEvent('governance.round.started', {
+  await emitGovernanceEvent("governance.round.started", {
     projectId,
     roundN,
   });
@@ -188,21 +223,30 @@ export async function startInterrogationRound(
 export async function getInterrogationRound(
   projectId: string,
   roundN: number,
+  event?: unknown,
 ): Promise<InterrogationRound | null> {
   const res = await docClient.send(
     new GetCommand({ TableName: ROUNDS_TABLE, Key: { projectId, roundN } }),
   );
-  return (res.Item as InterrogationRound | undefined) ?? null;
+  const round = (res.Item as InterrogationRound | undefined) ?? null;
+  if (round && event !== undefined) {
+    await assertProjectOrgAccess(projectId, event);
+  }
+  return round;
 }
 
 export async function listInterrogationRounds(
   projectId: string,
+  event?: unknown,
 ): Promise<InterrogationRound[]> {
+  if (event !== undefined) {
+    await assertProjectOrgAccess(projectId, event);
+  }
   const res = await docClient.send(
     new QueryCommand({
       TableName: ROUNDS_TABLE,
-      KeyConditionExpression: 'projectId = :pid',
-      ExpressionAttributeValues: { ':pid': projectId },
+      KeyConditionExpression: "projectId = :pid",
+      ExpressionAttributeValues: { ":pid": projectId },
     }),
   );
   return (res.Items as InterrogationRound[] | undefined) ?? [];
@@ -213,13 +257,14 @@ export async function injectConstraints(
   roundN: number,
   constraints: string[],
   authContext: AuthContext,
+  event?: unknown,
 ): Promise<InterrogationRound> {
-  if (!hasPermission(authContext, 'adr:create')) {
-    throw new Error('UnauthorizedError: adr:create permission required');
+  if (!hasPermission(authContext, "adr:create")) {
+    throw new Error("UnauthorizedError: adr:create permission required");
   }
   validateRoundN(roundN);
   if (!Array.isArray(constraints)) {
-    throw new Error('ValidationError: constraints must be an array');
+    throw new Error("ValidationError: constraints must be an array");
   }
 
   const current = await getInterrogationRound(projectId, roundN);
@@ -227,22 +272,27 @@ export async function injectConstraints(
     throw new Error(`Interrogation round not found: ${projectId}/${roundN}`);
   }
 
+  if (event !== undefined) {
+    await assertProjectOrgAccess(projectId, event);
+  }
+
   // Only IN_PROGRESS and REVISED rounds accept new constraints (per the
   // action matrix in ROUND_TRANSITIONS). STABILISED is terminal and will
   // throw 'Invalid status transition'.
-  roundLifecycle.validateTransition(current.status, 'AWAITING_CONSTRAINTS');
+  roundLifecycle.validateTransition(current.status, "AWAITING_CONSTRAINTS");
 
   const res = await docClient.send(
     new UpdateCommand({
       TableName: ROUNDS_TABLE,
       Key: { projectId, roundN },
-      UpdateExpression: 'SET #status = :newStatus, humanConstraints = :constraints',
-      ExpressionAttributeNames: { '#status': 'status' },
+      UpdateExpression:
+        "SET #status = :newStatus, humanConstraints = :constraints",
+      ExpressionAttributeNames: { "#status": "status" },
       ExpressionAttributeValues: {
-        ':newStatus': 'AWAITING_CONSTRAINTS',
-        ':constraints': constraints,
+        ":newStatus": "AWAITING_CONSTRAINTS",
+        ":constraints": constraints,
       },
-      ReturnValues: 'ALL_NEW',
+      ReturnValues: "ALL_NEW",
     }),
   );
   return res.Attributes as InterrogationRound;
@@ -258,6 +308,12 @@ export async function injectConstraints(
  * Idempotent early-return: if the existing row is already STABILISED we
  * return it unchanged with no S3, DDB, or EventBridge side-effects. This
  * mirrors lockADR in and keeps retries free of duplicate objects.
+ *
+ * `event` is OPTIONAL (finding 2c262386). When supplied, the org check
+ * runs immediately after the round is fetched (so it has a projectId to
+ * reconcile) and BEFORE the idempotent-STABILISED early-return — a
+ * cross-org caller cannot even observe that shortcut for a foreign round
+ * — and BEFORE the S3 transcript write / terminal UpdateCommand below.
  */
 export async function stabiliseRound(
   projectId: string,
@@ -265,16 +321,17 @@ export async function stabiliseRound(
   transcript: TranscriptMessage[],
   stabilisedSummary: string,
   authContext: AuthContext,
+  event?: unknown,
 ): Promise<InterrogationRound> {
-  if (!hasPermission(authContext, 'adr:create')) {
-    throw new Error('UnauthorizedError: adr:create permission required');
+  if (!hasPermission(authContext, "adr:create")) {
+    throw new Error("UnauthorizedError: adr:create permission required");
   }
   validateRoundN(roundN);
   if (!Array.isArray(transcript)) {
-    throw new Error('ValidationError: transcript must be an array');
+    throw new Error("ValidationError: transcript must be an array");
   }
-  if (typeof stabilisedSummary !== 'string') {
-    throw new Error('ValidationError: stabilisedSummary must be a string');
+  if (typeof stabilisedSummary !== "string") {
+    throw new Error("ValidationError: stabilisedSummary must be a string");
   }
 
   const current = await getInterrogationRound(projectId, roundN);
@@ -282,14 +339,18 @@ export async function stabiliseRound(
     throw new Error(`Interrogation round not found: ${projectId}/${roundN}`);
   }
 
+  if (event !== undefined) {
+    await assertProjectOrgAccess(projectId, event);
+  }
+
   // Idempotent early-return mirrors lockADR. A retry of
   // stabiliseRound on an already-STABILISED row must not re-write S3 or
   // re-emit governance.round.completed.
-  if (current.status === 'STABILISED') {
+  if (current.status === "STABILISED") {
     return current;
   }
 
-  roundLifecycle.validateTransition(current.status, 'STABILISED');
+  roundLifecycle.validateTransition(current.status, "STABILISED");
 
   // Sanitise transcript content BEFORE serialisation. redactPII is
   // idempotent (contract) so repeated application is safe.
@@ -297,8 +358,8 @@ export async function stabiliseRound(
     role: msg.role,
     content: redactPII(msg.content),
   }));
-  const jsonl = sanitised.map((m) => JSON.stringify(m)).join('\n');
-  const body = Buffer.from(jsonl, 'utf8');
+  const jsonl = sanitised.map((m) => JSON.stringify(m)).join("\n");
+  const body = Buffer.from(jsonl, "utf8");
   const sizeBytes = body.byteLength;
 
   await s3Client.send(
@@ -306,8 +367,8 @@ export async function stabiliseRound(
       Bucket: TRANSCRIPTS_BUCKET,
       Key: transcriptKeyFor(projectId, roundN),
       Body: body,
-      ContentType: 'application/x-ndjson',
-      ServerSideEncryption: 'aws:kms',
+      ContentType: "application/x-ndjson",
+      ServerSideEncryption: "aws:kms",
     }),
   );
 
@@ -317,19 +378,19 @@ export async function stabiliseRound(
       TableName: ROUNDS_TABLE,
       Key: { projectId, roundN },
       UpdateExpression:
-        'SET #status = :newStatus, completedAt = :completedAt, transcriptSizeBytes = :sizeBytes, revisedRecommendation = :summary',
-      ExpressionAttributeNames: { '#status': 'status' },
+        "SET #status = :newStatus, completedAt = :completedAt, transcriptSizeBytes = :sizeBytes, revisedRecommendation = :summary",
+      ExpressionAttributeNames: { "#status": "status" },
       ExpressionAttributeValues: {
-        ':newStatus': 'STABILISED',
-        ':completedAt': completedAt,
-        ':sizeBytes': sizeBytes,
-        ':summary': stabilisedSummary,
+        ":newStatus": "STABILISED",
+        ":completedAt": completedAt,
+        ":sizeBytes": sizeBytes,
+        ":summary": stabilisedSummary,
       },
-      ReturnValues: 'ALL_NEW',
+      ReturnValues: "ALL_NEW",
     }),
   );
 
-  await emitGovernanceEvent('governance.round.completed', {
+  await emitGovernanceEvent("governance.round.completed", {
     projectId,
     roundN,
   });
@@ -337,7 +398,7 @@ export async function stabiliseRound(
   // Emit overflow AFTER the successful write so observers always see the
   // completed event first. Do NOT block the write on size.
   if (sizeBytes > FIVE_MIB) {
-    await emitGovernanceEvent('governance.round.transcript.overflow', {
+    await emitGovernanceEvent("governance.round.transcript.overflow", {
       projectId,
       roundN,
       sizeBytes,
@@ -347,44 +408,50 @@ export async function stabiliseRound(
   return res.Attributes as InterrogationRound;
 }
 
-export const handler = async (event: InterrogationRoundResolverEvent): Promise<unknown> => {
+export const handler = async (
+  event: InterrogationRoundResolverEvent,
+): Promise<unknown> => {
   const fieldName = event?.info?.fieldName;
   const authContext = authContextFromEvent(event);
   try {
     switch (fieldName) {
-      case 'startInterrogationRound':
+      case "startInterrogationRound":
         return await startInterrogationRound(
           event.arguments.projectId,
           event.arguments.roundN,
           authContext,
+          event,
         );
-      case 'injectConstraints':
+      case "injectConstraints":
         return await injectConstraints(
           event.arguments.projectId,
           event.arguments.roundN,
           event.arguments.constraints,
           authContext,
+          event,
         );
-      case 'stabiliseRound':
+      case "stabiliseRound":
         return await stabiliseRound(
           event.arguments.projectId,
           event.arguments.roundN,
           event.arguments.transcript,
           event.arguments.stabilisedSummary,
           authContext,
+          event,
         );
-      case 'getInterrogationRound':
+      case "getInterrogationRound":
         return await getInterrogationRound(
           event.arguments.projectId,
           event.arguments.roundN,
+          event,
         );
-      case 'listInterrogationRounds':
-        return await listInterrogationRounds(event.arguments.projectId);
+      case "listInterrogationRounds":
+        return await listInterrogationRounds(event.arguments.projectId, event);
       default:
         throw new Error(`Unsupported field: ${fieldName}`);
     }
   } catch (err: unknown) {
-    console.error('interrogation-round-resolver error', {
+    console.error("interrogation-round-resolver error", {
       fieldName,
       message: err instanceof Error ? err.message : undefined,
       args: sanitizeForLog(event?.arguments),

--- a/backend/src/lambda/program-review-resolver.ts
+++ b/backend/src/lambda/program-review-resolver.ts
@@ -29,31 +29,63 @@
  *   known Q001..Q020 evaluators are pinned explicitly so any future
  *   checklist-author adding Qnnn entries triggers a deliberate code
  *   change here rather than a silent PENDING_EVIDENCE.
+ *
+ * ## Per-operation disposition (finding 2c262386)
+ *
+ * DEFECT: runProgramReview gated only on hasPermission('adr:create') and
+ * trusted the client-supplied projectId with NO project-to-organization
+ * reconciliation — an architect in one org could read another org's
+ * accumulated governance evidence (ADRs, execution specs, interrogation
+ * rounds, agent design assessment) and write a ProgramReview row against
+ * their projectId. FIX: `assertProjectOrgAccess` (backend/src/utils/
+ * project-org-access.ts, the SAME shared helper landed for adr-resolver in
+ * finding 677c1a6c / PR 142, reused verbatim) is threaded through every
+ * exported function as an OPTIONAL trailing `event` parameter — additive
+ * to hasPermission, never a replacement. `handler` always supplies `event`.
+ *
+ *  - runProgramReview — GATED. hasPermission('adr:create') unchanged; org
+ *                       check on projectId runs immediately after and
+ *                       BEFORE the parallel evidence-fetch Promise.all
+ *                       (listADRsForProject / listExecutionSpecifications /
+ *                       listInterrogationRounds / getAgentDesignAssessment)
+ *                       — zero foreign evidence reads happen for a cross-
+ *                       org caller — and BEFORE the PutCommand that
+ *                       persists the review row.
+ *  - getProgramReview  — GATED. Fetch-then-verify: the row is read but the
+ *                       org check runs BEFORE it is returned.
+ *  - listProgramReviewsForProject — GATED. org check on the client-
+ *                       supplied projectId runs BEFORE the QueryCommand.
+ *
+ * Note: the sibling evidence-source functions this module calls
+ * (listADRsForProject, listExecutionSpecifications,
+ * listInterrogationRounds, getAgentDesignAssessment) are invoked with NO
+ * `event` — they are internal, system-level calls whose right to read
+ * `projectId`'s evidence has already been established by THIS module's
+ * own gate above, matching the adr-resolver docblock's convention for
+ * internal/system callers.
  */
-import { DynamoDBClient } from '@aws-sdk/client-dynamodb';
+import { DynamoDBClient } from "@aws-sdk/client-dynamodb";
 import {
   DynamoDBDocumentClient,
   GetCommand,
   PutCommand,
   QueryCommand,
-} from '@aws-sdk/lib-dynamodb';
-import { v4 as uuidv4 } from 'uuid';
-import * as fs from 'fs';
-import * as path from 'path';
-import {
-  parseChecklist,
-  type ChecklistQuestion,
-} from './checklist-parser';
-import { listADRsForProject } from './adr-resolver';
-import { listExecutionSpecifications } from './execspec-resolver';
-import { listInterrogationRounds } from './interrogation-round-resolver';
-import { getAgentDesignAssessment } from './agent-design-assessment-resolver';
-import { hasPermission } from '../utils/auth';
+} from "@aws-sdk/lib-dynamodb";
+import { v4 as uuidv4 } from "uuid";
+import * as fs from "fs";
+import * as path from "path";
+import { parseChecklist, type ChecklistQuestion } from "./checklist-parser";
+import { listADRsForProject } from "./adr-resolver";
+import { listExecutionSpecifications } from "./execspec-resolver";
+import { listInterrogationRounds } from "./interrogation-round-resolver";
+import { getAgentDesignAssessment } from "./agent-design-assessment-resolver";
+import { hasPermission } from "../utils/auth";
+import { assertProjectOrgAccess } from "../utils/project-org-access";
 import type {
   AuthContext,
   GovernanceEventIdentity,
   GovernanceResolverEvent,
-} from '../types';
+} from "../types";
 
 const dynamoClient = new DynamoDBClient({});
 const docClient = DynamoDBDocumentClient.from(dynamoClient);
@@ -66,10 +98,7 @@ const PROGRAM_REVIEWS_TABLE = process.env.PROGRAM_REVIEWS_TABLE!;
 // and interface shapes exactly match the Track B contract.
 
 export type ChecklistAnswerLiteral =
-  | 'PASS'
-  | 'FAIL'
-  | 'NOT_APPLICABLE'
-  | 'PENDING_EVIDENCE';
+  "PASS" | "FAIL" | "NOT_APPLICABLE" | "PENDING_EVIDENCE";
 
 export interface ChecklistResult {
   questionId: string;
@@ -103,22 +132,25 @@ export interface ProgramReview {
  * and the operator sees the error in CloudWatch.
  */
 function resolveChecklistPath(): string {
-  return path.join(__dirname, 'governance-checklist.md');
+  return path.join(__dirname, "governance-checklist.md");
 }
 
 const CHECKLIST_PATH = resolveChecklistPath();
 let CHECKLIST: ChecklistQuestion[] = [];
 try {
-  CHECKLIST = parseChecklist(fs.readFileSync(CHECKLIST_PATH, 'utf-8'));
+  CHECKLIST = parseChecklist(fs.readFileSync(CHECKLIST_PATH, "utf-8"));
 } catch (err) {
   // Cold-start failure: the checklist file is missing or malformed. Log
   // and continue with an empty list — runProgramReview will still emit a
   // valid (but empty) review row. This keeps the Lambda serviceable for
   // the /get/list paths even if the checklist is temporarily misbundled.
-  console.error('program-review-resolver: failed to load checklist at cold start', {
-    path: CHECKLIST_PATH,
-    error: (err as Error)?.message,
-  });
+  console.error(
+    "program-review-resolver: failed to load checklist at cold start",
+    {
+      path: CHECKLIST_PATH,
+      error: (err as Error)?.message,
+    },
+  );
 }
 
 // ── Evidence + Evaluator types ──────────────────────────────────────
@@ -185,16 +217,16 @@ type Evaluator = (evidence: Evidence) => EvaluatorOutput;
  * can surface the question as open rather than silently passing it.
  */
 const defaultEvaluator: Evaluator = () => ({
-  answer: 'PENDING_EVIDENCE',
+  answer: "PENDING_EVIDENCE",
   evidenceRefs: [],
   notes:
-    'No automated evaluator registered for this question; manual review required.',
+    "No automated evaluator registered for this question; manual review required.",
 });
 
 // ── Concrete evaluators Q001..Q012 ──────────────────────────────────
 // Q013..Q020 fall through to defaultEvaluator because their evidence
 // sources (investment breakdown, partner capability) are not yet modelled
-// by a backend entity. The spec explicitly permits PENDING_EVIDENCE for 
+// by a backend entity. The spec explicitly permits PENDING_EVIDENCE for
 // those clusters.
 
 const EVALUATORS: Record<string, Evaluator> = {
@@ -206,22 +238,23 @@ const EVALUATORS: Record<string, Evaluator> = {
     const completed =
       a != null &&
       a.completedAt != null &&
-      a.completedAt !== '' &&
-      a.archetypeStatus === 'CLASSIFIED' &&
+      a.completedAt !== "" &&
+      a.archetypeStatus === "CLASSIFIED" &&
       Array.isArray(a.dimensionRanking) &&
       a.dimensionRanking.length === 4;
     return completed
       ? {
-          answer: 'PASS',
+          answer: "PASS",
           evidenceRefs: [`AgentDesignAssessment:${ev.projectId}`],
           notes: null,
         }
       : {
-          answer: 'FAIL',
+          answer: "FAIL",
           evidenceRefs: [],
-          notes: a == null
-            ? 'No AgentDesignAssessment row for project.'
-            : 'Assessment incomplete or not CLASSIFIED.',
+          notes:
+            a == null
+              ? "No AgentDesignAssessment row for project."
+              : "Assessment incomplete or not CLASSIFIED.",
         };
   },
 
@@ -232,21 +265,21 @@ const EVALUATORS: Record<string, Evaluator> = {
     const hits = ev.rounds.filter(
       (r) =>
         Array.isArray(r.participantRoles) &&
-        r.participantRoles.includes('OPERATIONS') &&
-        (r.status === 'STABILISED' || r.status === 'COMPLETE'),
+        r.participantRoles.includes("OPERATIONS") &&
+        (r.status === "STABILISED" || r.status === "COMPLETE"),
     );
     return hits.length > 0
       ? {
-          answer: 'PASS',
+          answer: "PASS",
           evidenceRefs: hits
             .map((r) => `InterrogationRound:${ev.projectId}:${r.roundN}`)
             .sort(),
           notes: null,
         }
       : {
-          answer: 'FAIL',
+          answer: "FAIL",
           evidenceRefs: [],
-          notes: 'No operations-role interrogation rounds recorded.',
+          notes: "No operations-role interrogation rounds recorded.",
         };
   },
 
@@ -257,26 +290,26 @@ const EVALUATORS: Record<string, Evaluator> = {
     const a = ev.assessment;
     if (a == null || !Array.isArray(a.dimensionRanking)) {
       return {
-        answer: 'FAIL',
+        answer: "FAIL",
         evidenceRefs: [],
-        notes: 'Assessment missing.',
+        notes: "Assessment missing.",
       };
     }
     const hit = a.dimensionRanking.find(
       (d) =>
-        d.dimension === 'INTEGRATION_ARCHAEOLOGY' && d.coverage === 'COMPLETE',
+        d.dimension === "INTEGRATION_ARCHAEOLOGY" && d.coverage === "COMPLETE",
     );
     return hit
       ? {
-          answer: 'PASS',
+          answer: "PASS",
           evidenceRefs: [`AgentDesignAssessment:${ev.projectId}`],
           notes: null,
         }
       : {
-          answer: 'FAIL',
+          answer: "FAIL",
           evidenceRefs: [],
           notes:
-            'Integration archaeology dimension missing or not marked COMPLETE.',
+            "Integration archaeology dimension missing or not marked COMPLETE.",
         };
   },
 
@@ -286,40 +319,40 @@ const EVALUATORS: Record<string, Evaluator> = {
     const a = ev.assessment;
     if (a == null || !Array.isArray(a.nonFunctionalConstraints)) {
       return {
-        answer: 'FAIL',
+        answer: "FAIL",
         evidenceRefs: [],
-        notes: 'Assessment missing or nonFunctionalConstraints unset.',
+        notes: "Assessment missing or nonFunctionalConstraints unset.",
       };
     }
-    const needed = ['PERFORMANCE', 'SECURITY', 'COMPLIANCE'];
+    const needed = ["PERFORMANCE", "SECURITY", "COMPLIANCE"];
     const have = new Set(a.nonFunctionalConstraints);
     const missing = needed.filter((n) => !have.has(n));
     return missing.length === 0
       ? {
-          answer: 'PASS',
+          answer: "PASS",
           evidenceRefs: [`AgentDesignAssessment:${ev.projectId}`],
           notes: null,
         }
       : {
-          answer: 'FAIL',
+          answer: "FAIL",
           evidenceRefs: [],
-          notes: `Missing NFR classes: ${missing.join(', ')}.`,
+          notes: `Missing NFR classes: ${missing.join(", ")}.`,
         };
   },
 
   // Q005: Advisory multi-round loop (≥ 3 stabilised rounds).
   Q005: (ev) => {
-    const stabilised = ev.rounds.filter((r) => r.status === 'STABILISED');
+    const stabilised = ev.rounds.filter((r) => r.status === "STABILISED");
     return stabilised.length >= 3
       ? {
-          answer: 'PASS',
+          answer: "PASS",
           evidenceRefs: stabilised
             .map((r) => `InterrogationRound:${ev.projectId}:${r.roundN}`)
             .sort(),
           notes: null,
         }
       : {
-          answer: 'FAIL',
+          answer: "FAIL",
           evidenceRefs: [],
           notes: `Only ${stabilised.length} stabilised round(s); need ≥3.`,
         };
@@ -327,17 +360,17 @@ const EVALUATORS: Record<string, Evaluator> = {
 
   // Q006: Decisions captured as locked ADRs.
   Q006: (ev) => {
-    const locked = ev.adrs.filter((a) => a.status === 'LOCKED');
+    const locked = ev.adrs.filter((a) => a.status === "LOCKED");
     return locked.length >= 1
       ? {
-          answer: 'PASS',
+          answer: "PASS",
           evidenceRefs: locked.map((a) => `ADR:${a.adrId}`).sort(),
           notes: null,
         }
       : {
-          answer: 'FAIL',
+          answer: "FAIL",
           evidenceRefs: [],
-          notes: 'No LOCKED ADR recorded for project.',
+          notes: "No LOCKED ADR recorded for project.",
         };
   },
 
@@ -346,22 +379,22 @@ const EVALUATORS: Record<string, Evaluator> = {
   Q007: (ev) => {
     const hits = ev.rounds.filter(
       (r) =>
-        r.status === 'STABILISED' &&
+        r.status === "STABILISED" &&
         Array.isArray(r.injectedConstraintIds) &&
         r.injectedConstraintIds.length > 0,
     );
     return hits.length > 0
       ? {
-          answer: 'PASS',
+          answer: "PASS",
           evidenceRefs: hits
             .map((r) => `InterrogationRound:${ev.projectId}:${r.roundN}`)
             .sort(),
           notes: null,
         }
       : {
-          answer: 'FAIL',
+          answer: "FAIL",
           evidenceRefs: [],
-          notes: 'No stabilised round with injected constraints.',
+          notes: "No stabilised round with injected constraints.",
         };
   },
 
@@ -371,23 +404,25 @@ const EVALUATORS: Record<string, Evaluator> = {
     const total = ev.rounds.length;
     if (total === 0) {
       return {
-        answer: 'NOT_APPLICABLE',
+        answer: "NOT_APPLICABLE",
         evidenceRefs: [],
-        notes: 'No interrogation rounds recorded.',
+        notes: "No interrogation rounds recorded.",
       };
     }
     const stabilised = ev.rounds.filter(
-      (r) => r.status === 'STABILISED',
+      (r) => r.status === "STABILISED",
     ).length;
     const ratio = stabilised / total;
     return ratio >= 0.75
       ? {
-          answer: 'PASS',
-          evidenceRefs: [`InterrogationRound:${ev.projectId}:ratio=${ratio.toFixed(2)}`],
+          answer: "PASS",
+          evidenceRefs: [
+            `InterrogationRound:${ev.projectId}:ratio=${ratio.toFixed(2)}`,
+          ],
           notes: null,
         }
       : {
-          answer: 'FAIL',
+          answer: "FAIL",
           evidenceRefs: [],
           notes: `Stabilised/total = ${stabilised}/${total} = ${ratio.toFixed(2)} < 0.75.`,
         };
@@ -399,20 +434,23 @@ const EVALUATORS: Record<string, Evaluator> = {
   Q009: (ev) => {
     const hits = ev.specs.filter(
       (s) =>
-        (s.sourceDesignArtifactType === 'ADR' ||
-          s.sourceDesignArtifactType === 'AgentDesignAssessment') &&
-        s.executorKind !== 'DESIGN_AGENT',
+        (s.sourceDesignArtifactType === "ADR" ||
+          s.sourceDesignArtifactType === "AgentDesignAssessment") &&
+        s.executorKind !== "DESIGN_AGENT",
     );
     return hits.length > 0
       ? {
-          answer: 'PASS',
-          evidenceRefs: hits.map((s) => `ExecutionSpecification:${s.specId}`).sort(),
+          answer: "PASS",
+          evidenceRefs: hits
+            .map((s) => `ExecutionSpecification:${s.specId}`)
+            .sort(),
           notes: null,
         }
       : {
-          answer: 'FAIL',
+          answer: "FAIL",
           evidenceRefs: [],
-          notes: 'No execution specification with clean design↔exec separation.',
+          notes:
+            "No execution specification with clean design↔exec separation.",
         };
   },
 
@@ -421,20 +459,22 @@ const EVALUATORS: Record<string, Evaluator> = {
   Q010: (ev) => {
     const hits = ev.specs.filter(
       (s) =>
-        s.status === 'APPROVED' &&
-        typeof s.approvedBy === 'string' &&
+        s.status === "APPROVED" &&
+        typeof s.approvedBy === "string" &&
         s.approvedBy.length > 0,
     );
     return hits.length > 0
       ? {
-          answer: 'PASS',
-          evidenceRefs: hits.map((s) => `ExecutionSpecification:${s.specId}`).sort(),
+          answer: "PASS",
+          evidenceRefs: hits
+            .map((s) => `ExecutionSpecification:${s.specId}`)
+            .sort(),
           notes: null,
         }
       : {
-          answer: 'FAIL',
+          answer: "FAIL",
           evidenceRefs: [],
-          notes: 'No human-approved execution specification on record.',
+          notes: "No human-approved execution specification on record.",
         };
   },
 
@@ -443,7 +483,7 @@ const EVALUATORS: Record<string, Evaluator> = {
   // those IDs maps to an ADR whose status='LOCKED'.
   Q011: (ev) => {
     const lockedIds = new Set(
-      ev.adrs.filter((a) => a.status === 'LOCKED').map((a) => a.adrId),
+      ev.adrs.filter((a) => a.status === "LOCKED").map((a) => a.adrId),
     );
     const hits = ev.specs.filter(
       (s) =>
@@ -452,14 +492,16 @@ const EVALUATORS: Record<string, Evaluator> = {
     );
     return hits.length > 0
       ? {
-          answer: 'PASS',
-          evidenceRefs: hits.map((s) => `ExecutionSpecification:${s.specId}`).sort(),
+          answer: "PASS",
+          evidenceRefs: hits
+            .map((s) => `ExecutionSpecification:${s.specId}`)
+            .sort(),
           notes: null,
         }
       : {
-          answer: 'FAIL',
+          answer: "FAIL",
           evidenceRefs: [],
-          notes: 'No execution specification cites a LOCKED ADR.',
+          notes: "No execution specification cites a LOCKED ADR.",
         };
   },
 
@@ -467,19 +509,20 @@ const EVALUATORS: Record<string, Evaluator> = {
   // PASS when ≥1 spec with narrativeReviewStatus='REVIEWED' and status='APPROVED'.
   Q012: (ev) => {
     const hits = ev.specs.filter(
-      (s) =>
-        s.narrativeReviewStatus === 'REVIEWED' && s.status === 'APPROVED',
+      (s) => s.narrativeReviewStatus === "REVIEWED" && s.status === "APPROVED",
     );
     return hits.length > 0
       ? {
-          answer: 'PASS',
-          evidenceRefs: hits.map((s) => `ExecutionSpecification:${s.specId}`).sort(),
+          answer: "PASS",
+          evidenceRefs: hits
+            .map((s) => `ExecutionSpecification:${s.specId}`)
+            .sort(),
           notes: null,
         }
       : {
-          answer: 'FAIL',
+          answer: "FAIL",
           evidenceRefs: [],
-          notes: 'No approved spec with REVIEWED narrative.',
+          notes: "No approved spec with REVIEWED narrative.",
         };
   },
 
@@ -494,7 +537,7 @@ function evaluate(
   question: ChecklistQuestion,
   evidence: Evidence,
 ): ChecklistResult {
-  const evaluator = EVALUATORS[question.questionId]?? defaultEvaluator;
+  const evaluator = EVALUATORS[question.questionId] ?? defaultEvaluator;
   const out = evaluator(evidence);
   return {
     questionId: question.questionId,
@@ -513,17 +556,17 @@ interface ProgramReviewArguments {
   reviewId: string;
 }
 
-type ProgramReviewResolverEvent = GovernanceResolverEvent<ProgramReviewArguments>;
+type ProgramReviewResolverEvent =
+  GovernanceResolverEvent<ProgramReviewArguments>;
 
 function authContextFromEvent(event: ProgramReviewResolverEvent): AuthContext {
   const identity: GovernanceEventIdentity = event?.identity || {};
-  const claimRole =
-    identity['custom:role'] ?? identity.claims?.['custom:role'];
+  const claimRole = identity["custom:role"] ?? identity.claims?.["custom:role"];
   return {
-    userId: identity.sub || identity.username || 'anonymous',
+    userId: identity.sub || identity.username || "anonymous",
     username: identity.username,
-    groups: identity['cognito:groups'] || [],
-    roles: claimRole ? [claimRole]: [],
+    groups: identity["cognito:groups"] || [],
+    roles: claimRole ? [claimRole] : [],
   };
 }
 
@@ -532,10 +575,11 @@ function authContextFromEvent(event: ProgramReviewResolverEvent): AuthContext {
  * be weaponised to exfiltrate long payloads. Non-string values pass through.
  */
 function sanitizeForLog(input: unknown): unknown {
-  if (!input || typeof input !== 'object') return input;
+  if (!input || typeof input !== "object") return input;
   const out: Record<string, unknown> = {};
   for (const [k, v] of Object.entries(input as Record<string, unknown>)) {
-    out[k] = typeof v === 'string' && v.length > 200 ? v.slice(0, 200) + '…' : v;
+    out[k] =
+      typeof v === "string" && v.length > 200 ? v.slice(0, 200) + "…" : v;
   }
   return out;
 }
@@ -557,14 +601,24 @@ function sanitizeForLog(input: unknown): unknown {
 export async function runProgramReview(
   projectId: string,
   authContext: AuthContext,
+  event?: unknown,
 ): Promise<ProgramReview> {
-  if (!hasPermission(authContext, 'adr:create')) {
+  if (!hasPermission(authContext, "adr:create")) {
     throw new Error(
-      'UnauthorizedError: adr:create permission required to run program review',
+      "UnauthorizedError: adr:create permission required to run program review",
     );
   }
-  if (typeof projectId !== 'string' || projectId.length === 0) {
-    throw new Error('ValidationError: projectId is required');
+  if (typeof projectId !== "string" || projectId.length === 0) {
+    throw new Error("ValidationError: projectId is required");
+  }
+
+  // Org-reconciliation gate (finding 2c262386). Runs BEFORE the parallel
+  // evidence-fetch Promise.all below — a cross-org caller triggers ZERO
+  // reads of another organization's ADRs, execution specs, interrogation
+  // rounds, or agent design assessment — and BEFORE the PutCommand that
+  // persists the review row.
+  if (event !== undefined) {
+    await assertProjectOrgAccess(projectId, event);
   }
 
   // Fetch the four evidence sources in parallel. listInterrogationRounds
@@ -585,7 +639,9 @@ export async function runProgramReview(
     assessment: assessmentP ?? null,
   };
 
-  const results: ChecklistResult[] = CHECKLIST.map((q) => evaluate(q, evidence));
+  const results: ChecklistResult[] = CHECKLIST.map((q) =>
+    evaluate(q, evidence),
+  );
 
   const now = new Date().toISOString();
   const review: ProgramReview = {
@@ -601,7 +657,7 @@ export async function runProgramReview(
     new PutCommand({
       TableName: PROGRAM_REVIEWS_TABLE,
       Item: review,
-      ConditionExpression: 'attribute_not_exists(reviewId)',
+      ConditionExpression: "attribute_not_exists(reviewId)",
     }),
   );
   return review;
@@ -618,7 +674,7 @@ async function safeCall<T>(fn: () => Promise<T>): Promise<T | null> {
   try {
     return await fn();
   } catch (err) {
-    console.warn('program-review-resolver: evidence source failed', {
+    console.warn("program-review-resolver: evidence source failed", {
       error: (err as Error)?.message,
     });
     return null;
@@ -627,43 +683,61 @@ async function safeCall<T>(fn: () => Promise<T>): Promise<T | null> {
 
 export async function getProgramReview(
   reviewId: string,
+  event?: unknown,
 ): Promise<ProgramReview | null> {
   const res = await docClient.send(
     new GetCommand({ TableName: PROGRAM_REVIEWS_TABLE, Key: { reviewId } }),
   );
-  return (res.Item as ProgramReview | undefined) ?? null;
+  const review = (res.Item as ProgramReview | undefined) ?? null;
+  if (review && event !== undefined) {
+    await assertProjectOrgAccess(review.projectId, event);
+  }
+  return review;
 }
 
 export async function listProgramReviewsForProject(
   projectId: string,
+  event?: unknown,
 ): Promise<ProgramReview[]> {
+  if (event !== undefined) {
+    await assertProjectOrgAccess(projectId, event);
+  }
   const res = await docClient.send(
     new QueryCommand({
       TableName: PROGRAM_REVIEWS_TABLE,
-      IndexName: 'project-index',
-      KeyConditionExpression: 'projectId = :pid',
-      ExpressionAttributeValues: { ':pid': projectId },
+      IndexName: "project-index",
+      KeyConditionExpression: "projectId = :pid",
+      ExpressionAttributeValues: { ":pid": projectId },
     }),
   );
   return (res.Items as ProgramReview[] | undefined) ?? [];
 }
 
-export const handler = async (event: ProgramReviewResolverEvent): Promise<unknown> => {
+export const handler = async (
+  event: ProgramReviewResolverEvent,
+): Promise<unknown> => {
   const fieldName = event?.info?.fieldName;
   const authContext = authContextFromEvent(event);
   try {
     switch (fieldName) {
-      case 'runProgramReview':
-        return await runProgramReview(event.arguments.projectId, authContext);
-      case 'getProgramReview':
-        return await getProgramReview(event.arguments.reviewId);
-      case 'listProgramReviewsForProject':
-        return await listProgramReviewsForProject(event.arguments.projectId);
+      case "runProgramReview":
+        return await runProgramReview(
+          event.arguments.projectId,
+          authContext,
+          event,
+        );
+      case "getProgramReview":
+        return await getProgramReview(event.arguments.reviewId, event);
+      case "listProgramReviewsForProject":
+        return await listProgramReviewsForProject(
+          event.arguments.projectId,
+          event,
+        );
       default:
         throw new Error(`Unsupported field: ${fieldName}`);
     }
   } catch (err: unknown) {
-    console.error('program-review-resolver error', {
+    console.error("program-review-resolver error", {
       fieldName,
       message: err instanceof Error ? err.message : undefined,
       args: sanitizeForLog(event?.arguments),


### PR DESCRIPTION
## Summary

Four governance modules gated on a permission and then trusted a client-supplied `projectId` or record id with no project-to-organization reconciliation. A permitted user of one organization could act on another organization's governance records - the audit trail the platform presents as authoritative. All four now use the shared `assertProjectOrgAccess` introduced with the ADR fix, with existing permission checks kept **additional** rather than replaced. One commit per module so a bisect can isolate them.

- **execspec-resolver** - `approveExecutionSpecification` and `reviseExecutionSpecification` allowed an architect to approve or rewrite another organization's execution spec. Approve is fetch-then-verify before its update and event emission; reject's gate sits after its deliberate audit-before-auth emission but before the terminal write
- **agent-design-assessment-resolver** - `submitAgentDesignAssessment` performed a cross-org `TransactWrite` mutating another organization's `PROJECTS` row. The gate precedes the **whole transaction**, not one leg: a per-leg gate would have refused one write while committing the others, and refusal is verified by asserting the transact mock recorded nothing 
- **interrogation-round-resolver** - `stabiliseRound` wrote a PII-bearing encrypted transcript and set terminal state on a foreign round. Gated before the idempotent already-stabilised early return, before the S3 write and before the update, so the fast path cannot be used to slip through
- **program-review-resolver** - `runProgramReview` read another organization's evidence and wrote a review against their project. Gated before the four-way evidence fetch and the write

## Three of the four Lambdas could not perform the join

`execspec`, `interrogation-round` and `program-review` had **no projects-table grant or environment variable**, so the gates would have been dead code - refusing everyone or erroring. Read-only access plus the env var were added for each and confirmed in the synthesized governance template; agent-design-assessment' already had access for its own mirror write.

This is the fourth module family in this series where the authorization fix was blocked on missing infrastructure, which argues for treating "can this function read what it must authorize against?" as a first question rather than a discovery.

## Testing

- Per module, a cross-org caller is refused with zero writes, zero transaction commits, zero transcript writes and zero foreign evidence reads
- Permission additivity confirmed per module: a same-org caller without the relevant permission is still refused
- Fail-closed proven by mutation across all four modules, with byte-identical restore
- Executed bite proofs on the two sharpest cases - execspec approve and assessment submit - with the verbatim failing assertions capturing the cross-org effect
- Four more dispatch-derived gate-enumeration guards (ten in the series), each proven to bite
- tsc, lint exit 0; 286 targeted tests; guards 215; full backend jest 7565; CI-equivalent synth with cdk-nag enabled clean after a dist rebuild; `split:gates` unaffected

## Remaining from this sweep

Each needs a different fix rather than this helper, so they are deliberately not bundled: `workflow-resolver` create/import trusting `input.orgId`, `ListExecutions` missing an org filter, and the fabricator-queue's unfiltered scan (which needs `orgId` stamped on rows and a real query). Two modules await a product answer: whether admin is platform-global for `promotion-policy-resolver`, and role gating for `governance-ui-resolver`'s IAM-posture reads.