### PR TITLE
fix(security): derive or filter organization on three resolver paths

### DIFF
--- a/backend/src/lambda/__tests__/datastore-resolver-item-org-scoping.test.ts
+++ b/backend/src/lambda/__tests__/datastore-resolver-item-org-scoping.test.ts
@@ -15,8 +15,20 @@
  * (backend/src/utils/auth-event.ts) — load the row, reconcile its orgId
  * against the caller's server-derived org (extractOrgFromEvent), and refuse
  * BEFORE any mutation, secret deletion, IAM change, or adapter/provider
- * call. Admins bypass, mirroring the read-path admin bypass already used by
- * listDataStores/getDataStoreStats/listAvailableDataSources.
+ * call. Admins bypass for EXISTING-ROW ops (getDataStore/updateDataStore/
+ * deleteDataStore/connectDataStore/disconnectDataStore/
+ * testDataStoreConnection), mirroring the read-path admin bypass already
+ * used by listDataStores/getDataStoreStats/listAvailableDataSources.
+ *
+ * createDataStore is the ONE exception (decision b5d463f2, owner-ratified):
+ * it does NOT honour the admin bypass. Previously a non-admin's mismatched
+ * input.orgId was rejected but an admin's was not, so an admin could write
+ * an arbitrary orgId into the record AND the Secrets Manager path
+ * (/citadel/datastores/{orgId}/...). The mismatch is now rejected for
+ * EVERYONE, admins included, before any DynamoDB write, Secrets Manager
+ * call, or IAM change. If platform operators genuinely need to provision on
+ * a tenant's behalf, that requires an EXPLICIT separate operator path —
+ * intentionally not built here; this fix only removes the implicit bypass.
  */
 
 // ---- Mock setup ----
@@ -298,7 +310,7 @@ describe("legitimate same-org callers still succeed", () => {
     expect(mockPolicyManager.deleteRole).toHaveBeenCalledTimes(1);
   });
 
-  test("admin caller may act cross-org (bypass preserved)", async () => {
+  test("admin caller may act cross-org for existing-row ops (bypass preserved)", async () => {
     const result = (await handler(
       makeEvent("getDataStore", { dataStoreId: "ds-victim" }, ADMIN_IDENTITY),
     )) as { dataStoreId: string };
@@ -379,40 +391,39 @@ describe("createDataStore rejects a foreign/mismatched orgId", () => {
     expect(result.dataStoreId).toBe("test-uuid");
   });
 
-  test("admin may create with an explicit orgId (bypass preserved)", async () => {
-    mockDynamoSend.mockImplementation((cmd: { _type?: string }) => {
-      if (cmd._type === "Query") return Promise.resolve({ Items: [] });
-      if (cmd._type === "Put") return Promise.resolve({});
-      if (cmd._type === "Update") {
-        return Promise.resolve({
-          Attributes: {
-            dataStoreId: "test-uuid",
-            status: "CONNECTED",
-            version: 1,
-          },
-        });
-      }
-      return Promise.resolve({});
-    });
+  test("admin caller is REJECTED for a mismatched orgId — no implicit admin bypass on createDataStore (decision b5d463f2)", async () => {
+    const putBefore = mockDynamoSend.mock.calls.length;
 
-    const result = (await handler(
-      makeEvent(
-        "createDataStore",
-        {
-          input: {
-            name: "admin-created",
-            type: "S3",
-            category: "S3_STORAGE",
-            provisionMode: "CONNECT_EXISTING",
-            orgId: "org-any",
-            config: JSON.stringify({ bucketName: "b" }),
-            clientRequestToken: "tok-admin-1",
+    await expect(
+      handler(
+        makeEvent(
+          "createDataStore",
+          {
+            input: {
+              name: "admin-attempted-foreign-write",
+              type: "S3",
+              category: "S3_STORAGE",
+              provisionMode: "CONNECT_EXISTING",
+              orgId: "org-any",
+              config: JSON.stringify({ bucketName: "b" }),
+              clientRequestToken: "tok-admin-1",
+            },
           },
-        },
-        ADMIN_IDENTITY,
+          ADMIN_IDENTITY,
+        ),
       ),
-    )) as { dataStoreId: string };
+    ).rejects.toThrow(/access denied|org/i);
 
-    expect(result.dataStoreId).toBe("test-uuid");
+    // Prove fail-closed by mutation, not by asserting an empty result:
+    // zero DynamoDB calls of ANY kind (no Put, no Query, no Update), zero
+    // Secrets Manager calls, zero IAM/policy-manager calls — the rejection
+    // must happen before any of createDataStore's side effects, including
+    // the idempotency-check Query that normally runs first.
+    expect(mockDynamoSend.mock.calls.length).toBe(putBefore);
+    expect(mockSecretsSend).not.toHaveBeenCalled();
+    expect(mockPolicyManager.ensureRole).not.toHaveBeenCalled();
+    expect(mockPolicyManager.assumeScopedRole).not.toHaveBeenCalled();
+    expect(mockAdapter.provision).not.toHaveBeenCalled();
+    expect(mockAdapter.connect).not.toHaveBeenCalled();
   });
 });

--- a/backend/src/lambda/__tests__/execution-resolver-dispatch-gate-enumeration.test.ts
+++ b/backend/src/lambda/__tests__/execution-resolver-dispatch-gate-enumeration.test.ts
@@ -1,0 +1,250 @@
+/**
+ * Enumeration-completeness guard for execution-resolver.ts's dispatch
+ * switch (finding 2c262386 — execution-resolver addition to the
+ * dispatch-gate-enumeration series continued from
+ * workflow-resolver-dispatch-gate-enumeration.test.ts and siblings).
+ *
+ * Root defect closed by finding 2c262386: listExecutions ran its
+ * WorkflowIndex query directly with NO org check of any kind — any
+ * client-supplied workflowId exposed that workflow's executions (including
+ * input/output) across tenants, while every sibling op on this dispatch
+ * surface (get/start/cancel/resume) already reconciled org via
+ * `extractOrgFromEvent` + an "Access denied" throw before any read/write.
+ * The fix loads the parent WORKFLOWS_TABLE row for the requested
+ * workflowId (the org source of truth — EXECUTIONS_TABLE carries no orgId
+ * GSI, only WorkflowIndex on workflowId+startedAt) and reconciles it
+ * against the caller's derived org BEFORE running the executions query —
+ * refuse, not filter-and-return.
+ */
+import * as fs from "fs";
+import * as path from "path";
+
+const HANDLER_PATH = path.join(__dirname, "..", "execution-resolver.ts");
+
+function extractDispatchCases(source: string): string[] {
+  const switchStart = source.indexOf("switch (fieldName)");
+  if (switchStart === -1) {
+    throw new Error(
+      "Could not locate `switch (fieldName)` in execution-resolver.ts — " +
+        "dispatch structure changed; update this guard's parsing.",
+    );
+  }
+  const defaultIdx = source.indexOf("default:", switchStart);
+  if (defaultIdx === -1) {
+    throw new Error(
+      "Could not locate the dispatch switch's `default:` case — " +
+        "update this guard's parsing.",
+    );
+  }
+  const switchBody = source.slice(switchStart, defaultIdx);
+  const caseRe = /case\s+['"]([^'"]+)['"]\s*:/g;
+  const cases: string[] = [];
+  let m: RegExpExecArray | null;
+  while ((m = caseRe.exec(switchBody)) !== null) {
+    cases.push(m[1]);
+  }
+  return cases;
+}
+
+function extractCaseBody(source: string, fieldName: string): string {
+  const switchStart = source.indexOf("switch (fieldName)");
+  const defaultIdx = source.indexOf("default:", switchStart);
+  const switchBody = source.slice(switchStart, defaultIdx);
+
+  const caseIdx =
+    switchBody.indexOf(`case "${fieldName}"`) !== -1
+      ? switchBody.indexOf(`case "${fieldName}"`)
+      : switchBody.indexOf(`case '${fieldName}'`);
+  if (caseIdx === -1) {
+    throw new Error(`Could not locate case '${fieldName}' in dispatch switch`);
+  }
+  const nextCaseIdx = switchBody.indexOf("case ", caseIdx + 1);
+  return switchBody.slice(
+    caseIdx,
+    nextCaseIdx === -1 ? undefined : nextCaseIdx,
+  );
+}
+
+function extractCallSiteNames(caseBody: string): string[] {
+  const callRe = /await\s+([A-Za-z0-9_]+)\s*\(/g;
+  const names: string[] = [];
+  let m: RegExpExecArray | null;
+  while ((m = callRe.exec(caseBody)) !== null) {
+    names.push(m[1]);
+  }
+  return names;
+}
+
+function extractFunctionBody(source: string, fnName: string): string {
+  const declRe = new RegExp(
+    `(?:export\\s+)?async function ${fnName}\\b\\s*\\(`,
+  );
+  const declMatch = declRe.exec(source);
+  if (!declMatch) {
+    throw new Error(
+      `Could not locate function declaration for '${fnName}' in execution-resolver.ts`,
+    );
+  }
+  const paramsOpenIdx = source.indexOf("(", declMatch.index);
+  let parenDepth = 0;
+  let j = paramsOpenIdx;
+  for (; j < source.length; j++) {
+    if (source[j] === "(") parenDepth++;
+    else if (source[j] === ")") {
+      parenDepth--;
+      if (parenDepth === 0) break;
+    }
+  }
+  // From the params-closing paren, the return-type annotation (which may
+  // itself contain object-literal braces, e.g. `Promise<{ items: ... }>`)
+  // comes before the real body brace. Walk forward tracking `<`/`>` and
+  // `{`/`}` nesting so a brace inside the type annotation's angle brackets
+  // is not mistaken for the body's opening brace — the true body start is
+  // the first top-level `{` encountered while angle-bracket depth is 0.
+  let angleDepth = 0;
+  let bodyStart = -1;
+  for (let k = j + 1; k < source.length; k++) {
+    const ch = source[k];
+    if (ch === "<") angleDepth++;
+    else if (ch === ">") angleDepth = Math.max(0, angleDepth - 1);
+    else if (ch === "{" && angleDepth === 0) {
+      bodyStart = k;
+      break;
+    }
+  }
+  if (bodyStart === -1) {
+    throw new Error(
+      `Could not locate body opening brace for '${fnName}' in execution-resolver.ts`,
+    );
+  }
+  let depth = 0;
+  let i = bodyStart;
+  for (; i < source.length; i++) {
+    if (source[i] === "{") depth++;
+    else if (source[i] === "}") {
+      depth--;
+      if (depth === 0) break;
+    }
+  }
+  return source.slice(bodyStart, i + 1);
+}
+
+const GATE_CALL_RE = /extractOrgFromEvent\s*\(/;
+const DENY_RE = /Access denied/;
+
+/**
+ * Every op on this dispatch surface that touches tenant-scoped execution
+ * or workflow data must, somewhere in its call chain, call
+ * extractOrgFromEvent and be able to throw "Access denied" on
+ * mismatch/unresolvable org before any read/write of that data. `fn` is
+ * the function the dispatch case calls directly; `gateOwner` is the
+ * function whose body actually performs the check (some ops delegate to
+ * `getExecution` for the gate rather than checking inline).
+ */
+const GATED_OPS: Record<string, { fn: string; gateOwner: string }> = {
+  getExecution: { fn: "getExecution", gateOwner: "getExecution" },
+  listExecutions: { fn: "listExecutions", gateOwner: "listExecutions" },
+  startExecution: { fn: "startExecution", gateOwner: "startExecution" },
+  cancelExecution: { fn: "cancelExecution", gateOwner: "getExecution" },
+  resumeExecution: { fn: "resumeExecution", gateOwner: "getExecution" },
+};
+
+/**
+ * publishWorkflowProgress is an IAM-signed fan-out mutation that only
+ * echoes its input back to AppSync subscribers — it touches no
+ * tenant-scoped DynamoDB row at all, so there is nothing to reconcile.
+ */
+const EXEMPT_OPS: Record<string, string> = {
+  publishWorkflowProgress: "IAM-signed echo, no tenant data read/written",
+};
+
+describe("execution-resolver — dispatch enumeration completeness (org reconciliation)", () => {
+  const source = fs.readFileSync(HANDLER_PATH, "utf-8");
+  const cases = extractDispatchCases(source);
+
+  test("the dispatch switch actually has cases to check (sanity check on the parser itself)", () => {
+    expect(cases.length).toBeGreaterThanOrEqual(6);
+    expect(cases).toEqual(expect.arrayContaining(Object.keys(GATED_OPS)));
+  });
+
+  test("every dispatch case is accounted for in GATED_OPS or EXEMPT_OPS", () => {
+    const unaccounted = cases.filter(
+      (c) => !(c in GATED_OPS) && !(c in EXEMPT_OPS),
+    );
+    expect(unaccounted).toEqual([]);
+  });
+
+  test("GATED_OPS and EXEMPT_OPS do not both claim the same op", () => {
+    const overlap = Object.keys(GATED_OPS).filter((k) => k in EXEMPT_OPS);
+    expect(overlap).toEqual([]);
+  });
+
+  test("no GATED_OPS/EXEMPT_OPS entry references a case that no longer exists in the switch", () => {
+    const known = new Set(cases);
+    const staleGated = Object.keys(GATED_OPS).filter((k) => !known.has(k));
+    const staleExempt = Object.keys(EXEMPT_OPS).filter((k) => !known.has(k));
+    expect(staleGated).toEqual([]);
+    expect(staleExempt).toEqual([]);
+  });
+
+  describe.each(Object.entries(GATED_OPS))(
+    "GATED_OPS['%s'] dispatches to a function that threads `event`, and its gate owner calls extractOrgFromEvent and can throw Access denied",
+    (fieldName, meta) => {
+      test(`${fieldName}'s case dispatches to ${meta.fn}`, () => {
+        const caseBody = extractCaseBody(source, fieldName);
+        const callSites = extractCallSiteNames(caseBody);
+        expect(callSites).toContain(meta.fn);
+      });
+
+      test(`${fieldName}'s case passes \`event\` as an argument to ${meta.fn}`, () => {
+        const caseBody = extractCaseBody(source, fieldName);
+        const callRe = new RegExp(
+          `${meta.fn}\\s*\\([^;]*?\\bevent\\b[^;]*?\\)`,
+        );
+        expect(callRe.test(caseBody)).toBe(true);
+      });
+
+      test(`${meta.fn} threads event to its gate owner ${meta.gateOwner} (directly or via delegation)`, () => {
+        if (meta.fn === meta.gateOwner) {
+          // The dispatched function IS the gate owner — already proven by
+          // the next two tests on gateOwner's own body.
+          expect(true).toBe(true);
+          return;
+        }
+        const body = extractFunctionBody(source, meta.fn);
+        const callRe = new RegExp(
+          `${meta.gateOwner}\\s*\\([^;]*?\\bevent\\b[^;]*?\\)`,
+        );
+        expect(callRe.test(body)).toBe(true);
+      });
+
+      test(`${meta.gateOwner}'s function body contains an extractOrgFromEvent call`, () => {
+        const body = extractFunctionBody(source, meta.gateOwner);
+        expect(GATE_CALL_RE.test(body)).toBe(true);
+      });
+
+      test(`${meta.gateOwner}'s function body can throw "Access denied"`, () => {
+        const body = extractFunctionBody(source, meta.gateOwner);
+        expect(DENY_RE.test(body)).toBe(true);
+      });
+    },
+  );
+
+  test("listExecutions's extractOrgFromEvent call precedes its executions QueryCommand", () => {
+    const body = extractFunctionBody(source, "listExecutions");
+    const gateIdx = body.search(GATE_CALL_RE);
+    const queryIdx = body.indexOf("new QueryCommand(");
+    expect(gateIdx).toBeGreaterThan(-1);
+    expect(queryIdx).toBeGreaterThan(-1);
+    expect(gateIdx).toBeLessThan(queryIdx);
+  });
+
+  test("listExecutions loads the parent workflow row (org source of truth) before its gate check", () => {
+    const body = extractFunctionBody(source, "listExecutions");
+    const getIdx = body.indexOf("new GetCommand(");
+    const gateIdx = body.search(GATE_CALL_RE);
+    expect(getIdx).toBeGreaterThan(-1);
+    expect(gateIdx).toBeGreaterThan(-1);
+    expect(getIdx).toBeLessThan(gateIdx);
+  });
+});

--- a/backend/src/lambda/__tests__/execution-resolver.test.ts
+++ b/backend/src/lambda/__tests__/execution-resolver.test.ts
@@ -301,6 +301,9 @@ describe("execution-resolver", () => {
 
   describe("listExecutions", () => {
     test("queries WorkflowIndex GSI by workflowId", async () => {
+      ddbMock.on(GetCommand).resolves({
+        Item: { workflowId: "wf-1", orgId: "org-1", status: "PUBLISHED" },
+      });
       const items = [
         {
           executionId: "exec-1",
@@ -328,6 +331,77 @@ describe("execution-resolver", () => {
       expect(queryCall.args[0].input.KeyConditionExpression).toContain(
         "workflowId",
       );
+    });
+
+    // Org filter (finding 2c262386, execution-resolver): listExecutions had
+    // NO org check at all — any client-supplied workflowId returned that
+    // workflow's executions (incl. input/output) regardless of tenant.
+    // EXECUTIONS_TABLE carries no orgId GSI (only WorkflowIndex on
+    // workflowId+startedAt exists — confirmed against backend-stack.ts), so
+    // there is no direct org-filtered index to query. The least-bad correct
+    // option: load the parent WORKFLOWS_TABLE row (already the org source
+    // of truth for this workflowId, same lookup startExecution performs)
+    // and reconcile it against the caller's derived org BEFORE running the
+    // WorkflowIndex query — refuse rather than return filtered/foreign data,
+    // matching get/start/cancel/resume's existing "Access denied" semantics
+    // exactly rather than inventing a new silent-empty-list behavior.
+    test("throws Access denied and issues zero QueryCommands when the workflow belongs to a different org", async () => {
+      ddbMock.on(GetCommand).resolves({
+        Item: {
+          workflowId: "wf-victim",
+          orgId: "org-other",
+          status: "PUBLISHED",
+        },
+      });
+
+      await expect(
+        invoke(makeEvent("listExecutions", { workflowId: "wf-victim" })),
+      ).rejects.toThrow("Access denied");
+
+      expect(ddbMock.commandCalls(QueryCommand)).toHaveLength(0);
+    });
+
+    test("returns executions when the workflow belongs to the caller's org", async () => {
+      ddbMock.on(GetCommand).resolves({
+        Item: { workflowId: "wf-1", orgId: "org-1", status: "PUBLISHED" },
+      });
+      const items = [
+        {
+          executionId: "exec-1",
+          workflowId: "wf-1",
+          orgId: "org-1",
+          status: "completed",
+          startedAt: "2024-01-01T00:00:00Z",
+        },
+      ];
+      ddbMock.on(QueryCommand).resolves({ Items: items });
+
+      const result = await invoke(
+        makeEvent("listExecutions", { workflowId: "wf-1" }),
+      );
+
+      expect(result).toEqual({ items, nextToken: undefined });
+    });
+
+    test("fails closed (throws) when the workflow does not exist", async () => {
+      ddbMock.on(GetCommand).resolves({ Item: undefined });
+
+      await expect(
+        invoke(makeEvent("listExecutions", { workflowId: "wf-missing" })),
+      ).rejects.toThrow(/not found/i);
+      expect(ddbMock.commandCalls(QueryCommand)).toHaveLength(0);
+    });
+
+    test("fails closed when the caller org is unresolvable, even though the workflow exists and matches by coincidence", async () => {
+      cognitoMock.on(AdminGetUserCommand).rejects(new Error("user not found"));
+      ddbMock.on(GetCommand).resolves({
+        Item: { workflowId: "wf-1", orgId: "org-1", status: "PUBLISHED" },
+      });
+
+      await expect(
+        invoke(makeEvent("listExecutions", { workflowId: "wf-1" })),
+      ).rejects.toThrow("Access denied");
+      expect(ddbMock.commandCalls(QueryCommand)).toHaveLength(0);
     });
   });
 
@@ -570,6 +644,16 @@ describe("execution-resolver", () => {
   // ─── Cold-start metric ──────────────────────────────────────────
 
   describe("cold-start metric", () => {
+    beforeEach(() => {
+      // listExecutions is used here purely as a cheap probe call for the
+      // cold-start-metric behavior; seed the workflow-org lookup it now
+      // performs (finding 2c262386 org filter) so these tests aren't
+      // testing org semantics incidentally.
+      ddbMock.on(GetCommand).resolves({
+        Item: { workflowId: "wf-1", orgId: "org-1", status: "PUBLISHED" },
+      });
+    });
+
     test("first invocation in a fresh container emits NodeColdStart", async () => {
       ddbMock.on(QueryCommand).resolves({ Items: [] });
 

--- a/backend/src/lambda/__tests__/workflow-resolver-dispatch-gate-enumeration.test.ts
+++ b/backend/src/lambda/__tests__/workflow-resolver-dispatch-gate-enumeration.test.ts
@@ -1,0 +1,253 @@
+/**
+ * Enumeration-completeness guard for workflow-resolver.ts's dispatch switch
+ * (finding 2c262386 lower set — workflow/execution addition to the
+ * dispatch-gate-enumeration series continued from
+ * execspec-resolver-dispatch-gate-enumeration.test.ts and siblings).
+ *
+ * Root defect closed by finding 2c262386: createWorkflow and importWorkflow
+ * trusted a client-supplied input.orgId outright and stamped it verbatim
+ * onto the new workflow row — a caller could plant a DRAFT workflow into
+ * ANOTHER tenant's workspace by setting orgId=victim. The fix threads the
+ * AppSync `event` into createWorkflow/importWorkflow (both already accept
+ * an optional `event` for reuse by the IAM-only intake-orchestration
+ * caller, which derives orgId itself and passes no event) and each callee
+ * derives the caller's org via `extractOrgFromEvent` and REJECTS a
+ * mismatched or unresolvable org BEFORE any DynamoDB PutCommand — reject,
+ * not coerce (decision b5d463f2 mutation convention).
+ *
+ * Existing-row mutation/read ops (getWorkflow, updateWorkflow,
+ * deleteWorkflow, publishWorkflow, updateWorkflowConfiguration,
+ * exportWorkflow, getWorkflowVersion, importBlueprint, listAppWorkflows)
+ * already gate via `getWorkflow`'s or their own inline
+ * `extractOrgFromEvent` + `Access denied` check against the LOADED row's
+ * orgId (not a client-supplied create input) — those are accounted for as
+ * EXEMPT here (their own field-level tests cover them) since this guard is
+ * scoped to the create/import client-orgId-trust defect specifically.
+ * listWorkflows/listBlueprints are read-only collection queries scoped by
+ * the caller's derived org already (listWorkflows) or global blueprint
+ * data (listBlueprints) — also EXEMPT.
+ */
+import * as fs from "fs";
+import * as path from "path";
+
+const HANDLER_PATH = path.join(__dirname, "..", "workflow-resolver.ts");
+
+function extractDispatchCases(source: string): string[] {
+  const switchStart = source.indexOf("switch (fieldName)");
+  if (switchStart === -1) {
+    throw new Error(
+      "Could not locate `switch (fieldName)` in workflow-resolver.ts — " +
+        "dispatch structure changed; update this guard's parsing.",
+    );
+  }
+  const defaultIdx = source.indexOf("default:", switchStart);
+  if (defaultIdx === -1) {
+    throw new Error(
+      "Could not locate the dispatch switch's `default:` case — " +
+        "update this guard's parsing.",
+    );
+  }
+  const switchBody = source.slice(switchStart, defaultIdx);
+  const caseRe = /case\s+['"]([^'"]+)['"]\s*:/g;
+  const cases: string[] = [];
+  let m: RegExpExecArray | null;
+  while ((m = caseRe.exec(switchBody)) !== null) {
+    cases.push(m[1]);
+  }
+  return cases;
+}
+
+function extractCaseBody(source: string, fieldName: string): string {
+  const switchStart = source.indexOf("switch (fieldName)");
+  const defaultIdx = source.indexOf("default:", switchStart);
+  const switchBody = source.slice(switchStart, defaultIdx);
+
+  const caseIdx =
+    switchBody.indexOf(`case '${fieldName}'`) !== -1
+      ? switchBody.indexOf(`case '${fieldName}'`)
+      : switchBody.indexOf(`case "${fieldName}"`);
+  if (caseIdx === -1) {
+    throw new Error(`Could not locate case '${fieldName}' in dispatch switch`);
+  }
+  const nextCaseIdx = switchBody.indexOf("case ", caseIdx + 1);
+  return switchBody.slice(
+    caseIdx,
+    nextCaseIdx === -1 ? undefined : nextCaseIdx,
+  );
+}
+
+function extractCallSiteNames(caseBody: string): string[] {
+  const callRe = /await\s+([A-Za-z0-9_]+)\s*\(/g;
+  const names: string[] = [];
+  let m: RegExpExecArray | null;
+  while ((m = callRe.exec(caseBody)) !== null) {
+    names.push(m[1]);
+  }
+  return names;
+}
+
+/**
+ * Extracts a top-level `[export] async function <name>(...) { ... }` body
+ * by brace-counting from the function keyword, matching the parameter
+ * list's closing paren first.
+ */
+function extractFunctionBody(source: string, fnName: string): string {
+  const declRe = new RegExp(
+    `(?:export\\s+)?async function ${fnName}\\b\\s*\\(`,
+  );
+  const declMatch = declRe.exec(source);
+  if (!declMatch) {
+    throw new Error(
+      `Could not locate function declaration for '${fnName}' in workflow-resolver.ts`,
+    );
+  }
+  const paramsOpenIdx = source.indexOf("(", declMatch.index);
+  let parenDepth = 0;
+  let j = paramsOpenIdx;
+  for (; j < source.length; j++) {
+    if (source[j] === "(") parenDepth++;
+    else if (source[j] === ")") {
+      parenDepth--;
+      if (parenDepth === 0) break;
+    }
+  }
+  const bodyStart = source.indexOf("{", j);
+  let depth = 0;
+  let i = bodyStart;
+  for (; i < source.length; i++) {
+    if (source[i] === "{") depth++;
+    else if (source[i] === "}") {
+      depth--;
+      if (depth === 0) break;
+    }
+  }
+  return source.slice(bodyStart, i + 1);
+}
+
+const GATE_CALL_RE = /extractOrgFromEvent\s*\(/;
+const EVENT_PARAM_RE = /event\?\s*:\s*unknown/;
+
+/**
+ * Ops whose callee must derive-and-reject the caller's org against a
+ * client-supplied create/import input before any write.
+ */
+const GATED_OPS: Record<string, { fn: string }> = {
+  createWorkflow: { fn: "createWorkflow" },
+  importWorkflow: { fn: "importWorkflowFn" },
+};
+
+/**
+ * Every other dispatch case is exempt from THIS guard because it already
+ * gates by loading an existing row and reconciling ITS orgId
+ * (getWorkflow/updateWorkflow/deleteWorkflow/publishWorkflow/
+ * updateWorkflowConfiguration/exportWorkflow/getWorkflowVersion/
+ * listAppWorkflows/importBlueprint — all covered by field-level tests in
+ * workflow-resolver.test.ts), or is a collection read with no create-shaped
+ * client-orgId-trust surface (listWorkflows/listBlueprints).
+ */
+const EXEMPT_OPS: Record<string, string> = {
+  getWorkflow: "existing-row org check via extractOrgFromEvent+Access denied",
+  listWorkflows: "caller-derived org query, no client orgId trusted for writes",
+  listBlueprints: "global blueprint read, no org dimension",
+  updateWorkflow: "existing-row org check via getWorkflow",
+  deleteWorkflow: "existing-row org check via getWorkflow",
+  publishWorkflow: "existing-row org check via getWorkflow",
+  updateWorkflowConfiguration: "existing-row org check via getWorkflow",
+  importBlueprint: "derives orgId from the target App row, not client input",
+  exportWorkflow: "existing-row org check via getWorkflow",
+  getWorkflowVersion: "existing-row org check via getWorkflow",
+  listAppWorkflows: "existing-row org check via the App row",
+};
+
+describe("workflow-resolver — dispatch enumeration completeness (create/import org-trust)", () => {
+  const source = fs.readFileSync(HANDLER_PATH, "utf-8");
+  const cases = extractDispatchCases(source);
+
+  test("the dispatch switch actually has cases to check (sanity check on the parser itself)", () => {
+    expect(cases.length).toBeGreaterThanOrEqual(11);
+    expect(cases).toEqual(expect.arrayContaining(Object.keys(GATED_OPS)));
+  });
+
+  test("every dispatch case is accounted for in GATED_OPS or EXEMPT_OPS", () => {
+    const unaccounted = cases.filter(
+      (c) => !(c in GATED_OPS) && !(c in EXEMPT_OPS),
+    );
+    expect(unaccounted).toEqual([]);
+  });
+
+  test("GATED_OPS and EXEMPT_OPS do not both claim the same op", () => {
+    const overlap = Object.keys(GATED_OPS).filter((k) => k in EXEMPT_OPS);
+    expect(overlap).toEqual([]);
+  });
+
+  test("no GATED_OPS/EXEMPT_OPS entry references a case that no longer exists in the switch", () => {
+    const known = new Set(cases);
+    const staleGated = Object.keys(GATED_OPS).filter((k) => !known.has(k));
+    const staleExempt = Object.keys(EXEMPT_OPS).filter((k) => !known.has(k));
+    expect(staleGated).toEqual([]);
+    expect(staleExempt).toEqual([]);
+  });
+
+  describe.each(Object.entries(GATED_OPS))(
+    "GATED_OPS['%s'] dispatches to a function that threads `event`, accepts it optionally, and calls extractOrgFromEvent",
+    (fieldName, meta) => {
+      test(`${fieldName}'s case dispatches to ${meta.fn}`, () => {
+        const caseBody = extractCaseBody(source, fieldName);
+        const callSites = extractCallSiteNames(caseBody);
+        expect(callSites).toContain(meta.fn);
+      });
+
+      test(`${fieldName}'s case passes \`event\` as an argument to ${meta.fn}`, () => {
+        const caseBody = extractCaseBody(source, fieldName);
+        const callRe = new RegExp(
+          `${meta.fn}\\s*\\([^;]*?\\bevent\\b[^;]*?\\)`,
+        );
+        expect(callRe.test(caseBody)).toBe(true);
+      });
+
+      test(`${meta.fn}'s declaration accepts an optional \`event?: unknown\` parameter`, () => {
+        const declRe = new RegExp(
+          `(?:export\\s+)?async function ${meta.fn}\\b\\s*\\(([^)]*)\\)`,
+        );
+        const m = declRe.exec(source);
+        expect(m).not.toBeNull();
+        expect(EVENT_PARAM_RE.test((m as RegExpExecArray)[1])).toBe(true);
+      });
+
+      test(`${meta.fn}'s function body contains an extractOrgFromEvent call`, () => {
+        const body = extractFunctionBody(source, meta.fn);
+        expect(GATE_CALL_RE.test(body)).toBe(true);
+      });
+    },
+  );
+
+  describe("gated create/import ops derive-and-reject org BEFORE their DynamoDB write side effect", () => {
+    test("createWorkflow's extractOrgFromEvent call precedes its PutCommand", () => {
+      const body = extractFunctionBody(source, "createWorkflow");
+      const gateIdx = body.search(GATE_CALL_RE);
+      const putIdx = body.indexOf("new PutCommand(");
+      expect(gateIdx).toBeGreaterThan(-1);
+      expect(putIdx).toBeGreaterThan(-1);
+      expect(gateIdx).toBeLessThan(putIdx);
+    });
+
+    test("importWorkflowFn's extractOrgFromEvent call precedes its PutCommand", () => {
+      const body = extractFunctionBody(source, "importWorkflowFn");
+      const gateIdx = body.search(GATE_CALL_RE);
+      const putIdx = body.indexOf("new PutCommand(");
+      expect(gateIdx).toBeGreaterThan(-1);
+      expect(putIdx).toBeGreaterThan(-1);
+      expect(gateIdx).toBeLessThan(putIdx);
+    });
+  });
+
+  test("createWorkflow rejects a mismatched orgId rather than silently coercing (reject-not-coerce wording present)", () => {
+    const body = extractFunctionBody(source, "createWorkflow");
+    expect(body).toMatch(/Access denied.*orgId does not match/s);
+  });
+
+  test("importWorkflowFn rejects a mismatched orgId rather than silently coercing (reject-not-coerce wording present)", () => {
+    const body = extractFunctionBody(source, "importWorkflowFn");
+    expect(body).toMatch(/Access denied.*orgId does not match/s);
+  });
+});

--- a/backend/src/lambda/__tests__/workflow-resolver.test.ts
+++ b/backend/src/lambda/__tests__/workflow-resolver.test.ts
@@ -2,24 +2,42 @@
  * Unit tests for workflow-resolver Lambda — CRUD operations
  * Uses aws-sdk-client-mock for DynamoDB, EventBridge, Cognito
  */
-import { DynamoDBDocumentClient, GetCommand, PutCommand, UpdateCommand, QueryCommand, DeleteCommand, BatchGetCommand } from '@aws-sdk/lib-dynamodb';
-import { EventBridgeClient, PutEventsCommand } from '@aws-sdk/client-eventbridge';
-import { CognitoIdentityProviderClient, AdminGetUserCommand } from '@aws-sdk/client-cognito-identity-provider';
-import { mockClient } from 'aws-sdk-client-mock';
+import {
+  DynamoDBDocumentClient,
+  GetCommand,
+  PutCommand,
+  UpdateCommand,
+  QueryCommand,
+  DeleteCommand,
+  BatchGetCommand,
+} from "@aws-sdk/lib-dynamodb";
+import {
+  EventBridgeClient,
+  PutEventsCommand,
+} from "@aws-sdk/client-eventbridge";
+import {
+  CognitoIdentityProviderClient,
+  AdminGetUserCommand,
+} from "@aws-sdk/client-cognito-identity-provider";
+import { mockClient } from "aws-sdk-client-mock";
 
 const ddbMock = mockClient(DynamoDBDocumentClient);
 const ebMock = mockClient(EventBridgeClient);
 const cognitoMock = mockClient(CognitoIdentityProviderClient);
 
-jest.mock('../../utils/appsync', () => ({
-  getUserId: jest.fn().mockReturnValue('user-123'),
+jest.mock("../../utils/appsync", () => ({
+  getUserId: jest.fn().mockReturnValue("user-123"),
 }));
 
-import { handler } from '../workflow-resolver';
+import { handler } from "../workflow-resolver";
 
 type HandlerEvent = Parameters<typeof handler>[0];
 
-function makeEvent(fieldName: string, args: Record<string, unknown>, sub = 'user-123'): HandlerEvent {
+function makeEvent(
+  fieldName: string,
+  args: Record<string, unknown>,
+  sub = "user-123",
+): HandlerEvent {
   return {
     info: { fieldName },
     arguments: args,
@@ -34,7 +52,9 @@ function makeEvent(fieldName: string, args: Record<string, unknown>, sub = 'user
 const invokeHandler = handler as (event: HandlerEvent) => Promise<unknown>;
 
 /** Invokes the handler and casts the result. */
-async function invoke<T = Record<string, unknown>>(event: HandlerEvent): Promise<T> {
+async function invoke<T = Record<string, unknown>>(
+  event: HandlerEvent,
+): Promise<T> {
   return (await invokeHandler(event)) as T;
 }
 
@@ -42,26 +62,26 @@ async function invoke<T = Record<string, unknown>>(event: HandlerEvent): Promise
 function mockCognitoOrg(orgId: string) {
   cognitoMock.on(AdminGetUserCommand).resolves({
     UserAttributes: [
-      { Name: 'sub', Value: 'user-123' },
-      { Name: 'custom:organization', Value: orgId },
+      { Name: "sub", Value: "user-123" },
+      { Name: "custom:organization", Value: orgId },
     ],
   });
 }
 
-describe('workflow-resolver', () => {
+describe("workflow-resolver", () => {
   beforeAll(() => {
-    process.env.WORKFLOWS_TABLE = 'citadel-workflows-test';
-    process.env.APPS_TABLE = 'citadel-apps-test';
-    process.env.AGENT_CONFIG_TABLE = 'citadel-agents-test';
-    process.env.EVENT_BUS_NAME = 'citadel-agents-test';
-    process.env.USER_POOL_ID = 'us-east-1_test';
+    process.env.WORKFLOWS_TABLE = "citadel-workflows-test";
+    process.env.APPS_TABLE = "citadel-apps-test";
+    process.env.AGENT_CONFIG_TABLE = "citadel-agents-test";
+    process.env.EVENT_BUS_NAME = "citadel-agents-test";
+    process.env.USER_POOL_ID = "us-east-1_test";
   });
 
   beforeEach(() => {
     ddbMock.reset();
     ebMock.reset();
     cognitoMock.reset();
-    mockCognitoOrg('org-1');
+    mockCognitoOrg("org-1");
     ebMock.on(PutEventsCommand).resolves({});
   });
 
@@ -75,49 +95,53 @@ describe('workflow-resolver', () => {
 
   // ─── getWorkflow ───────────────────────────────────────────────
 
-  describe('getWorkflow', () => {
-    test('returns item when caller orgId matches workflow orgId', async () => {
+  describe("getWorkflow", () => {
+    test("returns item when caller orgId matches workflow orgId", async () => {
       const workflow = {
-        workflowId: 'wf-1',
-        orgId: 'org-1',
-        name: 'Test Workflow',
-        status: 'DRAFT',
+        workflowId: "wf-1",
+        orgId: "org-1",
+        name: "Test Workflow",
+        status: "DRAFT",
         version: 1,
       };
       ddbMock.on(GetCommand).resolves({ Item: workflow });
 
       const result = await invoke(
-        makeEvent('getWorkflow', { workflowId: 'wf-1' }),
+        makeEvent("getWorkflow", { workflowId: "wf-1" }),
       );
 
       expect(result).toEqual(workflow);
     });
 
-    test('throws Access denied when caller orgId does not match workflow orgId', async () => {
+    test("throws Access denied when caller orgId does not match workflow orgId", async () => {
       ddbMock.on(GetCommand).resolves({
-        Item: { workflowId: 'wf-1', orgId: 'org-other', name: 'Other Org Workflow' },
+        Item: {
+          workflowId: "wf-1",
+          orgId: "org-other",
+          name: "Other Org Workflow",
+        },
       });
 
       await expect(
-        invoke(makeEvent('getWorkflow', { workflowId: 'wf-1' }),),
-      ).rejects.toThrow('Access denied');
+        invoke(makeEvent("getWorkflow", { workflowId: "wf-1" })),
+      ).rejects.toThrow("Access denied");
     });
 
-    test('claim-first path: reads custom:organization from identity and skips Cognito', async () => {
+    test("claim-first path: reads custom:organization from identity and skips Cognito", async () => {
       const workflow = {
-        workflowId: 'wf-claim',
-        orgId: 'org-claim',
-        name: 'Claim Workflow',
-        status: 'DRAFT',
+        workflowId: "wf-claim",
+        orgId: "org-claim",
+        name: "Claim Workflow",
+        status: "DRAFT",
         version: 1,
       };
       ddbMock.on(GetCommand).resolves({ Item: workflow });
 
       // identity carries the claim directly — Cognito must not be called
       const claimEvent = {
-        info: { fieldName: 'getWorkflow' },
-        arguments: { workflowId: 'wf-claim' },
-        identity: { sub: 'user-123', 'custom:organization': 'org-claim' },
+        info: { fieldName: "getWorkflow" },
+        arguments: { workflowId: "wf-claim" },
+        identity: { sub: "user-123", "custom:organization": "org-claim" },
       } as unknown as HandlerEvent;
 
       const result = await invoke(claimEvent);
@@ -129,122 +153,196 @@ describe('workflow-resolver', () => {
 
   // ─── listWorkflows ─────────────────────────────────────────────
 
-  describe('listWorkflows', () => {
-    test('queries OrgStatusIndex and filters isBlueprint=false', async () => {
+  describe("listWorkflows", () => {
+    test("queries OrgStatusIndex and filters isBlueprint=false", async () => {
       const items = [
-        { workflowId: 'wf-1', orgId: 'org-1', isBlueprint: 'false', status: 'DRAFT' },
-        { workflowId: 'wf-2', orgId: 'org-1', isBlueprint: 'false', status: 'PUBLISHED' },
+        {
+          workflowId: "wf-1",
+          orgId: "org-1",
+          isBlueprint: "false",
+          status: "DRAFT",
+        },
+        {
+          workflowId: "wf-2",
+          orgId: "org-1",
+          isBlueprint: "false",
+          status: "PUBLISHED",
+        },
       ];
       ddbMock.on(QueryCommand).resolves({ Items: items });
 
       const result = await invoke(
-        makeEvent('listWorkflows', { orgId: 'org-1' }),
+        makeEvent("listWorkflows", { orgId: "org-1" }),
       );
 
       expect(result).toEqual({ items, nextToken: undefined });
 
       const queryCall = ddbMock.commandCalls(QueryCommand)[0];
-      expect(queryCall.args[0].input.IndexName).toBe('OrgStatusIndex');
+      expect(queryCall.args[0].input.IndexName).toBe("OrgStatusIndex");
     });
   });
 
   // ─── listBlueprints ────────────────────────────────────────────
 
-  describe('listBlueprints', () => {
-    test('queries BlueprintIndex for isBlueprint=true and filters by category', async () => {
+  describe("listBlueprints", () => {
+    test("queries BlueprintIndex for isBlueprint=true and filters by category", async () => {
       const blueprints = [
         {
-          workflowId: 'bp-1',
-          isBlueprint: 'true',
-          metadata: JSON.stringify({ category: 'data-processing' }),
+          workflowId: "bp-1",
+          isBlueprint: "true",
+          metadata: JSON.stringify({ category: "data-processing" }),
         },
       ];
       ddbMock.on(QueryCommand).resolves({ Items: blueprints });
 
       const result = await invoke(
-        makeEvent('listBlueprints', { category: 'data-processing' }),
+        makeEvent("listBlueprints", { category: "data-processing" }),
       );
 
       expect(result).toEqual({ items: blueprints, nextToken: undefined });
 
       const queryCall = ddbMock.commandCalls(QueryCommand)[0];
-      expect(queryCall.args[0].input.IndexName).toBe('BlueprintIndex');
+      expect(queryCall.args[0].input.IndexName).toBe("BlueprintIndex");
     });
   });
 
   // ─── createWorkflow ────────────────────────────────────────────
 
-  describe('createWorkflow', () => {
+  describe("createWorkflow", () => {
     test('sets version=1, status=DRAFT, generates UUID, isBlueprint defaults to "false"', async () => {
       ddbMock.on(PutCommand).resolves({});
 
       const result = await invoke(
-        makeEvent('createWorkflow', {
+        makeEvent("createWorkflow", {
           input: {
-            name: 'New Workflow',
-            description: 'A test workflow',
-            orgId: 'org-1',
+            name: "New Workflow",
+            description: "A test workflow",
+            orgId: "org-1",
             definition: JSON.stringify({ nodes: [], edges: [] }),
           },
         }),
       );
 
       expect(result).toMatchObject({
-        name: 'New Workflow',
-        orgId: 'org-1',
-        status: 'DRAFT',
+        name: "New Workflow",
+        orgId: "org-1",
+        status: "DRAFT",
         version: 1,
-        isBlueprint: 'false',
+        isBlueprint: "false",
       });
       expect(result.workflowId).toBeDefined();
       expect(result.createdAt).toBeDefined();
       expect(result.updatedAt).toBeDefined();
-      expect(result.createdBy).toBe('user-123');
+      expect(result.createdBy).toBe("user-123");
 
       expect(ddbMock.commandCalls(PutCommand)).toHaveLength(1);
+    });
+
+    // Org derivation (finding 2c262386 lower set): createWorkflow must
+    // derive orgId from the authenticated identity and REJECT a mismatched
+    // client-supplied input.orgId rather than stamping it verbatim — same
+    // convention as decision b5d463f2 (createDataStore mutation path).
+    test("rejects a mismatched input.orgId and does not persist (plant-into-foreign-org attempt)", async () => {
+      // Caller's identity resolves to org-1 (mockCognitoOrg('org-1') in
+      // beforeEach); attempt to plant a workflow into org-victim.
+      await expect(
+        invoke(
+          makeEvent("createWorkflow", {
+            input: {
+              name: "Malicious Plant",
+              orgId: "org-victim",
+              definition: JSON.stringify({ nodes: [], edges: [] }),
+            },
+          }),
+        ),
+      ).rejects.toThrow(/Access denied|orgId/i);
+      expect(ddbMock.commandCalls(PutCommand)).toHaveLength(0);
+    });
+
+    test("derives orgId from identity when input.orgId is absent", async () => {
+      ddbMock.on(PutCommand).resolves({});
+
+      const result = await invoke(
+        makeEvent("createWorkflow", {
+          input: {
+            name: "No OrgId Supplied",
+            definition: JSON.stringify({ nodes: [], edges: [] }),
+          },
+        }),
+      );
+
+      expect(result.orgId).toBe("org-1");
+      expect(ddbMock.commandCalls(PutCommand)).toHaveLength(1);
+    });
+
+    test("fails closed when caller org is unresolvable (no claim, Cognito lookup fails)", async () => {
+      cognitoMock.on(AdminGetUserCommand).rejects(new Error("user not found"));
+
+      await expect(
+        invoke(
+          makeEvent("createWorkflow", {
+            input: {
+              name: "Unresolvable Org",
+              orgId: "org-1",
+              definition: JSON.stringify({ nodes: [], edges: [] }),
+            },
+          }),
+        ),
+      ).rejects.toThrow(/Access denied|orgId|organization/i);
+      expect(ddbMock.commandCalls(PutCommand)).toHaveLength(0);
     });
   });
 
   // ─── updateWorkflow ────────────────────────────────────────────
 
-  describe('updateWorkflow', () => {
-    test('succeeds with correct version (optimistic lock)', async () => {
+  describe("updateWorkflow", () => {
+    test("succeeds with correct version (optimistic lock)", async () => {
       ddbMock.on(UpdateCommand).resolves({
         Attributes: {
-          workflowId: 'wf-1',
-          orgId: 'org-1',
-          name: 'Updated Name',
+          workflowId: "wf-1",
+          orgId: "org-1",
+          name: "Updated Name",
           version: 2,
-          status: 'DRAFT',
+          status: "DRAFT",
         },
       });
       // Mock getWorkflow for org check
       ddbMock.on(GetCommand).resolves({
-        Item: { workflowId: 'wf-1', orgId: 'org-1', version: 1, status: 'DRAFT' },
+        Item: {
+          workflowId: "wf-1",
+          orgId: "org-1",
+          version: 1,
+          status: "DRAFT",
+        },
       });
 
       const result = await invoke(
-        makeEvent('updateWorkflow', {
-          input: { workflowId: 'wf-1', name: 'Updated Name', version: 1 },
+        makeEvent("updateWorkflow", {
+          input: { workflowId: "wf-1", name: "Updated Name", version: 1 },
         }),
       );
 
-      expect(result.name).toBe('Updated Name');
+      expect(result.name).toBe("Updated Name");
       expect(result.version).toBe(2);
     });
 
-    test('throws conflict error when version is stale', async () => {
+    test("throws conflict error when version is stale", async () => {
       ddbMock.on(GetCommand).resolves({
-        Item: { workflowId: 'wf-1', orgId: 'org-1', version: 3, status: 'DRAFT' },
+        Item: {
+          workflowId: "wf-1",
+          orgId: "org-1",
+          version: 3,
+          status: "DRAFT",
+        },
       });
-      const condErr = new Error('ConditionalCheckFailedException');
-      condErr.name = 'ConditionalCheckFailedException';
+      const condErr = new Error("ConditionalCheckFailedException");
+      condErr.name = "ConditionalCheckFailedException";
       ddbMock.on(UpdateCommand).rejects(condErr);
 
       await expect(
         invoke(
-          makeEvent('updateWorkflow', {
-            input: { workflowId: 'wf-1', name: 'Stale', version: 1 },
+          makeEvent("updateWorkflow", {
+            input: { workflowId: "wf-1", name: "Stale", version: 1 },
           }),
         ),
       ).rejects.toThrow(/Conflict/);
@@ -259,91 +357,97 @@ describe('workflow-resolver', () => {
   // through validateDefinitionStructure, which now rejects '#' in any
   // nodes[].id before the definition reaches DynamoDB.
 
-  describe('node id ledger-key delimiter rejection', () => {
+  describe("node id ledger-key delimiter rejection", () => {
     test('createWorkflow rejects a node id containing "#", naming the field/character, and does not persist', async () => {
       await expect(
         invoke(
-          makeEvent('createWorkflow', {
+          makeEvent("createWorkflow", {
             input: {
-              name: 'Bad Node Id',
-              orgId: 'org-1',
+              name: "Bad Node Id",
+              orgId: "org-1",
               definition: JSON.stringify({
-                nodes: [{ id: 'n1#comp', agentId: 'agent-1', type: 'agent' }],
+                nodes: [{ id: "n1#comp", agentId: "agent-1", type: "agent" }],
                 edges: [],
               }),
             },
           }),
         ),
-      ).rejects.toThrow(/Invalid workflow definition.*n1#comp.*reserved delimiter.*'#'/s);
+      ).rejects.toThrow(
+        /Invalid workflow definition.*n1#comp.*reserved delimiter.*'#'/s,
+      );
       expect(ddbMock.commandCalls(PutCommand)).toHaveLength(0);
     });
 
     test('updateWorkflow rejects a node id containing "#" on the changed definition and does not persist', async () => {
       ddbMock.on(GetCommand).resolves({
         Item: {
-          workflowId: 'wf-1',
-          orgId: 'org-1',
+          workflowId: "wf-1",
+          orgId: "org-1",
           version: 1,
-          status: 'DRAFT',
+          status: "DRAFT",
           definition: '{"nodes":[],"edges":[]}',
-          updatedAt: '2024-01-01T00:00:00Z',
-          createdBy: 'user-123',
+          updatedAt: "2024-01-01T00:00:00Z",
+          createdBy: "user-123",
         },
       });
 
       await expect(
         invoke(
-          makeEvent('updateWorkflow', {
+          makeEvent("updateWorkflow", {
             input: {
-              workflowId: 'wf-1',
+              workflowId: "wf-1",
               version: 1,
               definition: JSON.stringify({
-                nodes: [{ id: 'n1#comp', agentId: 'agent-1', type: 'agent' }],
+                nodes: [{ id: "n1#comp", agentId: "agent-1", type: "agent" }],
                 edges: [],
               }),
             },
           }),
         ),
-      ).rejects.toThrow(/Invalid workflow definition.*n1#comp.*reserved delimiter.*'#'/s);
+      ).rejects.toThrow(
+        /Invalid workflow definition.*n1#comp.*reserved delimiter.*'#'/s,
+      );
       expect(ddbMock.commandCalls(UpdateCommand)).toHaveLength(0);
     });
 
     test('importWorkflow rejects a node id containing "#" and does not persist', async () => {
       const workflowJson = JSON.stringify({
-        name: 'Bad Import',
+        name: "Bad Import",
         definition: JSON.stringify({
-          nodes: [{ id: 'n1#comp', agentId: 'a1', type: 'agent' }],
+          nodes: [{ id: "n1#comp", agentId: "a1", type: "agent" }],
           edges: [],
         }),
       });
 
       await expect(
         invoke(
-          makeEvent('importWorkflow', {
-            input: { orgId: 'org-1', workflowJson },
+          makeEvent("importWorkflow", {
+            input: { orgId: "org-1", workflowJson },
           }),
         ),
-      ).rejects.toThrow(/Invalid workflow definition.*n1#comp.*reserved delimiter.*'#'/s);
+      ).rejects.toThrow(
+        /Invalid workflow definition.*n1#comp.*reserved delimiter.*'#'/s,
+      );
       expect(ddbMock.commandCalls(PutCommand)).toHaveLength(0);
     });
 
-    test('createWorkflow still accepts a node id with other punctuation (hyphen, underscore, dot)', async () => {
+    test("createWorkflow still accepts a node id with other punctuation (hyphen, underscore, dot)", async () => {
       ddbMock.on(PutCommand).resolves({});
 
       const result = await invoke(
-        makeEvent('createWorkflow', {
+        makeEvent("createWorkflow", {
           input: {
-            name: 'Legit Punctuation',
-            orgId: 'org-1',
+            name: "Legit Punctuation",
+            orgId: "org-1",
             definition: JSON.stringify({
-              nodes: [{ id: 'n1-a_b.c', agentId: 'agent-1', type: 'agent' }],
+              nodes: [{ id: "n1-a_b.c", agentId: "agent-1", type: "agent" }],
               edges: [],
             }),
           },
         }),
       );
 
-      expect(result.status).toBe('DRAFT');
+      expect(result.status).toBe("DRAFT");
       expect(ddbMock.commandCalls(PutCommand)).toHaveLength(1);
     });
 
@@ -354,22 +458,22 @@ describe('workflow-resolver', () => {
       // never call validateDefinitionStructure, so a pre-existing legacy
       // definition is not bricked.
       const legacyDefinition = JSON.stringify({
-        nodes: [{ id: 'legacy#node', agentId: 'agent-1', type: 'agent' }],
+        nodes: [{ id: "legacy#node", agentId: "agent-1", type: "agent" }],
         edges: [],
       });
       ddbMock.on(GetCommand).resolves({
         Item: {
-          workflowId: 'wf-legacy',
-          orgId: 'org-1',
-          name: 'Legacy Workflow',
+          workflowId: "wf-legacy",
+          orgId: "org-1",
+          name: "Legacy Workflow",
           definition: legacyDefinition,
-          status: 'DRAFT',
+          status: "DRAFT",
           version: 1,
         },
       });
 
       const result = await invoke(
-        makeEvent('getWorkflow', { workflowId: 'wf-legacy' }),
+        makeEvent("getWorkflow", { workflowId: "wf-legacy" }),
       );
 
       expect(result.definition).toBe(legacyDefinition);
@@ -382,29 +486,35 @@ describe('workflow-resolver', () => {
       // is present in the update.
       ddbMock.on(GetCommand).resolves({
         Item: {
-          workflowId: 'wf-legacy',
-          orgId: 'org-1',
+          workflowId: "wf-legacy",
+          orgId: "org-1",
           version: 1,
-          status: 'DRAFT',
+          status: "DRAFT",
           definition: JSON.stringify({
-            nodes: [{ id: 'legacy#node', agentId: 'agent-1', type: 'agent' }],
+            nodes: [{ id: "legacy#node", agentId: "agent-1", type: "agent" }],
             edges: [],
           }),
-          updatedAt: '2024-01-01T00:00:00Z',
-          createdBy: 'user-123',
+          updatedAt: "2024-01-01T00:00:00Z",
+          createdBy: "user-123",
         },
       });
       ddbMock.on(UpdateCommand).resolves({
-        Attributes: { workflowId: 'wf-legacy', orgId: 'org-1', name: 'Renamed', version: 2, status: 'DRAFT' },
+        Attributes: {
+          workflowId: "wf-legacy",
+          orgId: "org-1",
+          name: "Renamed",
+          version: 2,
+          status: "DRAFT",
+        },
       });
 
       const result = await invoke(
-        makeEvent('updateWorkflow', {
-          input: { workflowId: 'wf-legacy', name: 'Renamed', version: 1 },
+        makeEvent("updateWorkflow", {
+          input: { workflowId: "wf-legacy", name: "Renamed", version: 1 },
         }),
       );
 
-      expect(result.name).toBe('Renamed');
+      expect(result.name).toBe("Renamed");
       expect(ddbMock.commandCalls(UpdateCommand)).toHaveLength(1);
     });
   });
@@ -413,43 +523,47 @@ describe('workflow-resolver', () => {
   // AppSync delivers AWSJSON arguments as parsed OBJECTS, not strings.
   // The resolver must accept both and always persist JSON STRINGS.
 
-  describe('AWSJSON object normalization (AppSync delivers parsed objects)', () => {
+  describe("AWSJSON object normalization (AppSync delivers parsed objects)", () => {
     const defObject = {
-      version: '1.0.0',
-      nodes: [{ id: 'n1', agentId: 'agent-1', type: 'agent' }],
+      version: "1.0.0",
+      nodes: [{ id: "n1", agentId: "agent-1", type: "agent" }],
       edges: [],
     };
 
-    describe('createWorkflow with object arguments', () => {
-      test('accepts definition as OBJECT (live-bug regression) and persists a JSON string', async () => {
+    describe("createWorkflow with object arguments", () => {
+      test("accepts definition as OBJECT (live-bug regression) and persists a JSON string", async () => {
         ddbMock.on(PutCommand).resolves({});
 
         const result = await invoke(
-          makeEvent('createWorkflow', {
+          makeEvent("createWorkflow", {
             input: {
-              name: 'Object Definition Workflow',
-              orgId: 'org-1',
+              name: "Object Definition Workflow",
+              orgId: "org-1",
               definition: defObject, // object, exactly as AppSync delivers AWSJSON
               isBlueprint: true,
             },
           }),
         );
 
-        expect(result.status).toBe('DRAFT');
-        expect(result.isBlueprint).toBe('true'); // isBlueprint flag honored
+        expect(result.status).toBe("DRAFT");
+        expect(result.isBlueprint).toBe("true"); // isBlueprint flag honored
 
         const putItem = ddbMock.commandCalls(PutCommand)[0].args[0].input.Item!;
-        expect(typeof putItem.definition).toBe('string');
+        expect(typeof putItem.definition).toBe("string");
         expect(JSON.parse(putItem.definition)).toEqual(defObject); // round-trips
       });
 
-      test('accepts definition as STRING and persists the identical string (no double-encoding)', async () => {
+      test("accepts definition as STRING and persists the identical string (no double-encoding)", async () => {
         ddbMock.on(PutCommand).resolves({});
         const defString = JSON.stringify(defObject);
 
         await invoke(
-          makeEvent('createWorkflow', {
-            input: { name: 'String Definition Workflow', orgId: 'org-1', definition: defString },
+          makeEvent("createWorkflow", {
+            input: {
+              name: "String Definition Workflow",
+              orgId: "org-1",
+              definition: defString,
+            },
           }),
         );
 
@@ -457,38 +571,44 @@ describe('workflow-resolver', () => {
         expect(putItem.definition).toBe(defString); // not wrapped in extra quotes
       });
 
-      test('still rejects a non-JSON definition string', async () => {
+      test("still rejects a non-JSON definition string", async () => {
         await expect(
           invoke(
-            makeEvent('createWorkflow', {
-              input: { name: 'Bad', orgId: 'org-1', definition: 'not-json' },
+            makeEvent("createWorkflow", {
+              input: { name: "Bad", orgId: "org-1", definition: "not-json" },
             }),
           ),
         ).rejects.toThrow(/Invalid workflow definition/);
         expect(ddbMock.commandCalls(PutCommand)).toHaveLength(0);
       });
 
-      test('rejects an OBJECT definition missing nodes/edges arrays', async () => {
+      test("rejects an OBJECT definition missing nodes/edges arrays", async () => {
         await expect(
           invoke(
-            makeEvent('createWorkflow', {
-              input: { name: 'Bad', orgId: 'org-1', definition: { version: '1.0.0' } },
+            makeEvent("createWorkflow", {
+              input: {
+                name: "Bad",
+                orgId: "org-1",
+                definition: { version: "1.0.0" },
+              },
             }),
           ),
         ).rejects.toThrow(/Invalid workflow definition/);
         expect(ddbMock.commandCalls(PutCommand)).toHaveLength(0);
       });
 
-      test('persists configuration and metadata OBJECTS as JSON strings', async () => {
+      test("persists configuration and metadata OBJECTS as JSON strings", async () => {
         ddbMock.on(PutCommand).resolves({});
-        const configuration = { integrations: { int1: { endpoint: 'https://example.com' } } };
-        const metadata = { category: 'data-processing' };
+        const configuration = {
+          integrations: { int1: { endpoint: "https://example.com" } },
+        };
+        const metadata = { category: "data-processing" };
 
         await invoke(
-          makeEvent('createWorkflow', {
+          makeEvent("createWorkflow", {
             input: {
-              name: 'Config Meta Workflow',
-              orgId: 'org-1',
+              name: "Config Meta Workflow",
+              orgId: "org-1",
               definition: defObject,
               configuration,
               metadata,
@@ -497,332 +617,376 @@ describe('workflow-resolver', () => {
         );
 
         const putItem = ddbMock.commandCalls(PutCommand)[0].args[0].input.Item!;
-        expect(typeof putItem.configuration).toBe('string');
+        expect(typeof putItem.configuration).toBe("string");
         expect(JSON.parse(putItem.configuration)).toEqual(configuration);
-        expect(typeof putItem.metadata).toBe('string');
+        expect(typeof putItem.metadata).toBe("string");
         expect(JSON.parse(putItem.metadata)).toEqual(metadata);
       });
     });
 
-    describe('updateWorkflow with object arguments', () => {
+    describe("updateWorkflow with object arguments", () => {
       beforeEach(() => {
         ddbMock.on(GetCommand).resolves({
           Item: {
-            workflowId: 'wf-1',
-            orgId: 'org-1',
+            workflowId: "wf-1",
+            orgId: "org-1",
             version: 1,
-            status: 'DRAFT',
+            status: "DRAFT",
             definition: '{"nodes":[],"edges":[]}',
-            updatedAt: '2024-01-01T00:00:00Z',
-            createdBy: 'user-123',
+            updatedAt: "2024-01-01T00:00:00Z",
+            createdBy: "user-123",
           },
         });
         ddbMock.on(UpdateCommand).resolves({
-          Attributes: { workflowId: 'wf-1', orgId: 'org-1', version: 2, status: 'DRAFT' },
+          Attributes: {
+            workflowId: "wf-1",
+            orgId: "org-1",
+            version: 2,
+            status: "DRAFT",
+          },
         });
       });
 
-      test('accepts definition as OBJECT (live-bug regression) and persists a JSON string', async () => {
+      test("accepts definition as OBJECT (live-bug regression) and persists a JSON string", async () => {
         await invoke(
-          makeEvent('updateWorkflow', {
-            input: { workflowId: 'wf-1', definition: defObject, version: 1 },
+          makeEvent("updateWorkflow", {
+            input: { workflowId: "wf-1", definition: defObject, version: 1 },
           }),
         );
 
         const exprValues =
-          ddbMock.commandCalls(UpdateCommand)[0].args[0].input.ExpressionAttributeValues!;
-        expect(typeof exprValues[':definition']).toBe('string');
-        expect(JSON.parse(exprValues[':definition'])).toEqual(defObject);
+          ddbMock.commandCalls(UpdateCommand)[0].args[0].input
+            .ExpressionAttributeValues!;
+        expect(typeof exprValues[":definition"]).toBe("string");
+        expect(JSON.parse(exprValues[":definition"])).toEqual(defObject);
       });
 
-      test('accepts definition as STRING and persists the identical string (no double-encoding)', async () => {
+      test("accepts definition as STRING and persists the identical string (no double-encoding)", async () => {
         const defString = JSON.stringify(defObject);
 
         await invoke(
-          makeEvent('updateWorkflow', {
-            input: { workflowId: 'wf-1', definition: defString, version: 1 },
+          makeEvent("updateWorkflow", {
+            input: { workflowId: "wf-1", definition: defString, version: 1 },
           }),
         );
 
         const exprValues =
-          ddbMock.commandCalls(UpdateCommand)[0].args[0].input.ExpressionAttributeValues!;
-        expect(exprValues[':definition']).toBe(defString);
+          ddbMock.commandCalls(UpdateCommand)[0].args[0].input
+            .ExpressionAttributeValues!;
+        expect(exprValues[":definition"]).toBe(defString);
       });
 
-      test('still rejects an OBJECT definition missing nodes/edges arrays', async () => {
+      test("still rejects an OBJECT definition missing nodes/edges arrays", async () => {
         await expect(
           invoke(
-            makeEvent('updateWorkflow', {
-              input: { workflowId: 'wf-1', definition: { foo: 'bar' }, version: 1 },
+            makeEvent("updateWorkflow", {
+              input: {
+                workflowId: "wf-1",
+                definition: { foo: "bar" },
+                version: 1,
+              },
             }),
           ),
         ).rejects.toThrow(/Invalid workflow definition/);
         expect(ddbMock.commandCalls(UpdateCommand)).toHaveLength(0);
       });
 
-      test('persists configuration and metadata OBJECTS as JSON strings', async () => {
-        const configuration = { parameters: { key1: 'value1' } };
-        const metadata = { category: 'ops' };
+      test("persists configuration and metadata OBJECTS as JSON strings", async () => {
+        const configuration = { parameters: { key1: "value1" } };
+        const metadata = { category: "ops" };
 
         await invoke(
-          makeEvent('updateWorkflow', {
-            input: { workflowId: 'wf-1', configuration, metadata, version: 1 },
+          makeEvent("updateWorkflow", {
+            input: { workflowId: "wf-1", configuration, metadata, version: 1 },
           }),
         );
 
         const exprValues =
-          ddbMock.commandCalls(UpdateCommand)[0].args[0].input.ExpressionAttributeValues!;
-        expect(typeof exprValues[':configuration']).toBe('string');
-        expect(JSON.parse(exprValues[':configuration'])).toEqual(configuration);
-        expect(typeof exprValues[':metadata']).toBe('string');
-        expect(JSON.parse(exprValues[':metadata'])).toEqual(metadata);
+          ddbMock.commandCalls(UpdateCommand)[0].args[0].input
+            .ExpressionAttributeValues!;
+        expect(typeof exprValues[":configuration"]).toBe("string");
+        expect(JSON.parse(exprValues[":configuration"])).toEqual(configuration);
+        expect(typeof exprValues[":metadata"]).toBe("string");
+        expect(JSON.parse(exprValues[":metadata"])).toEqual(metadata);
       });
     });
   });
 
   // ─── deleteWorkflow ────────────────────────────────────────────
 
-  describe('deleteWorkflow', () => {
-    test('succeeds when workflow is DRAFT', async () => {
+  describe("deleteWorkflow", () => {
+    test("succeeds when workflow is DRAFT", async () => {
       ddbMock.on(GetCommand).resolves({
-        Item: { workflowId: 'wf-1', orgId: 'org-1', status: 'DRAFT' },
+        Item: { workflowId: "wf-1", orgId: "org-1", status: "DRAFT" },
       });
       ddbMock.on(DeleteCommand).resolves({});
 
       const result = await invoke(
-        makeEvent('deleteWorkflow', { workflowId: 'wf-1' }),
+        makeEvent("deleteWorkflow", { workflowId: "wf-1" }),
       );
 
       expect(result).toEqual({ success: true, message: expect.any(String) });
       expect(ddbMock.commandCalls(DeleteCommand)).toHaveLength(1);
     });
 
-    test('throws error when workflow is PUBLISHED', async () => {
+    test("throws error when workflow is PUBLISHED", async () => {
       ddbMock.on(GetCommand).resolves({
-        Item: { workflowId: 'wf-1', orgId: 'org-1', status: 'PUBLISHED' },
+        Item: { workflowId: "wf-1", orgId: "org-1", status: "PUBLISHED" },
       });
 
       await expect(
-        invoke(makeEvent('deleteWorkflow', { workflowId: 'wf-1' }),),
+        invoke(makeEvent("deleteWorkflow", { workflowId: "wf-1" })),
       ).rejects.toThrow(/published/i);
     });
   });
 
   // ─── publishWorkflow ───────────────────────────────────────────
 
-  describe('publishWorkflow', () => {
+  describe("publishWorkflow", () => {
     const validDefinition = JSON.stringify({
       nodes: [
-        { id: 'n1', agentId: 'agent-1', type: 'agent' },
-        { id: 'n2', agentId: 'agent-2', type: 'agent' },
+        { id: "n1", agentId: "agent-1", type: "agent" },
+        { id: "n2", agentId: "agent-2", type: "agent" },
       ],
-      edges: [{ id: 'e1', source: 'n1', target: 'n2' }],
+      edges: [{ id: "e1", source: "n1", target: "n2" }],
     });
 
-    test('validates definition and updates status to PUBLISHED', async () => {
+    test("validates definition and updates status to PUBLISHED", async () => {
       ddbMock.on(GetCommand).resolves({
         Item: {
-          workflowId: 'wf-1',
-          orgId: 'org-1',
-          status: 'DRAFT',
+          workflowId: "wf-1",
+          orgId: "org-1",
+          status: "DRAFT",
           definition: validDefinition,
           version: 1,
         },
       });
       ddbMock.on(BatchGetCommand).resolves({
-        Responses: { 'citadel-agents-test': [{ agentId: 'agent-1' }, { agentId: 'agent-2' }] },
+        Responses: {
+          "citadel-agents-test": [
+            { agentId: "agent-1" },
+            { agentId: "agent-2" },
+          ],
+        },
       });
       ddbMock.on(UpdateCommand).resolves({
         Attributes: {
-          workflowId: 'wf-1',
-          orgId: 'org-1',
-          status: 'PUBLISHED',
+          workflowId: "wf-1",
+          orgId: "org-1",
+          status: "PUBLISHED",
           definition: validDefinition,
           version: 2,
         },
       });
 
       const result = await invoke(
-        makeEvent('publishWorkflow', { workflowId: 'wf-1' }),
+        makeEvent("publishWorkflow", { workflowId: "wf-1" }),
       );
 
-      expect(result.status).toBe('PUBLISHED');
+      expect(result.status).toBe("PUBLISHED");
     });
 
-    test('returns validation errors for invalid definition (node missing agentId)', async () => {
+    test("returns validation errors for invalid definition (node missing agentId)", async () => {
       const invalidDef = JSON.stringify({
         nodes: [
-          { id: 'n1', type: 'agent' }, // missing agentId
+          { id: "n1", type: "agent" }, // missing agentId
         ],
         edges: [],
       });
       ddbMock.on(GetCommand).resolves({
         Item: {
-          workflowId: 'wf-1',
-          orgId: 'org-1',
-          status: 'DRAFT',
+          workflowId: "wf-1",
+          orgId: "org-1",
+          status: "DRAFT",
           definition: invalidDef,
           version: 1,
         },
       });
 
       await expect(
-        invoke(makeEvent('publishWorkflow', { workflowId: 'wf-1' }),),
+        invoke(makeEvent("publishWorkflow", { workflowId: "wf-1" })),
       ).rejects.toThrow(/validation/i);
     });
 
-    test('rejects when any node has a placeholder- agentId', async () => {
+    test("rejects when any node has a placeholder- agentId", async () => {
       const placeholderDef = JSON.stringify({
-        nodes: [
-          { id: 'n1', agentId: 'placeholder-foo', type: 'agent' },
-        ],
+        nodes: [{ id: "n1", agentId: "placeholder-foo", type: "agent" }],
         edges: [],
       });
       ddbMock.on(GetCommand).resolves({
         Item: {
-          workflowId: 'wf-1',
-          orgId: 'org-1',
-          status: 'DRAFT',
+          workflowId: "wf-1",
+          orgId: "org-1",
+          status: "DRAFT",
           definition: placeholderDef,
           version: 1,
         },
       });
 
       await expect(
-        invoke(makeEvent('publishWorkflow', { workflowId: 'wf-1' }),),
+        invoke(makeEvent("publishWorkflow", { workflowId: "wf-1" })),
       ).rejects.toThrow(/placeholder.*n1/i);
     });
 
-    test('accepts when all nodes have real (12-char alphanumeric) agentIds', async () => {
+    test("accepts when all nodes have real (12-char alphanumeric) agentIds", async () => {
       const realDef = JSON.stringify({
         nodes: [
-          { id: 'n1', agentId: 'a1b2c3d4e5f6', type: 'agent' },
-          { id: 'n2', agentId: 'z9y8x7w6v5u4', type: 'agent' },
+          { id: "n1", agentId: "a1b2c3d4e5f6", type: "agent" },
+          { id: "n2", agentId: "z9y8x7w6v5u4", type: "agent" },
         ],
-        edges: [{ id: 'e1', source: 'n1', target: 'n2' }],
+        edges: [{ id: "e1", source: "n1", target: "n2" }],
       });
       ddbMock.on(GetCommand).resolves({
         Item: {
-          workflowId: 'wf-1',
-          orgId: 'org-1',
-          status: 'DRAFT',
+          workflowId: "wf-1",
+          orgId: "org-1",
+          status: "DRAFT",
           definition: realDef,
           version: 1,
         },
       });
       ddbMock.on(BatchGetCommand).resolves({
-        Responses: { 'citadel-agents-test': [{ agentId: 'a1b2c3d4e5f6' }, { agentId: 'z9y8x7w6v5u4' }] },
+        Responses: {
+          "citadel-agents-test": [
+            { agentId: "a1b2c3d4e5f6" },
+            { agentId: "z9y8x7w6v5u4" },
+          ],
+        },
       });
       ddbMock.on(UpdateCommand).resolves({
         Attributes: {
-          workflowId: 'wf-1',
-          orgId: 'org-1',
-          status: 'PUBLISHED',
+          workflowId: "wf-1",
+          orgId: "org-1",
+          status: "PUBLISHED",
           definition: realDef,
           version: 2,
         },
       });
 
       const result = await invoke(
-        makeEvent('publishWorkflow', { workflowId: 'wf-1' }),
+        makeEvent("publishWorkflow", { workflowId: "wf-1" }),
       );
 
-      expect(result.status).toBe('PUBLISHED');
+      expect(result.status).toBe("PUBLISHED");
     });
 
-    test('rejects when one node has placeholder- among many real ones (full validation, not first-match)', async () => {
+    test("rejects when one node has placeholder- among many real ones (full validation, not first-match)", async () => {
       const mixedDef = JSON.stringify({
         nodes: [
-          { id: 'n1', agentId: 'a1b2c3d4e5f6', type: 'agent' },
-          { id: 'n2', agentId: 'z9y8x7w6v5u4', type: 'agent' },
-          { id: 'n3', agentId: 'placeholder-bad', type: 'agent' },
+          { id: "n1", agentId: "a1b2c3d4e5f6", type: "agent" },
+          { id: "n2", agentId: "z9y8x7w6v5u4", type: "agent" },
+          { id: "n3", agentId: "placeholder-bad", type: "agent" },
         ],
         edges: [
-          { id: 'e1', source: 'n1', target: 'n2' },
-          { id: 'e2', source: 'n2', target: 'n3' },
+          { id: "e1", source: "n1", target: "n2" },
+          { id: "e2", source: "n2", target: "n3" },
         ],
       });
       ddbMock.on(GetCommand).resolves({
         Item: {
-          workflowId: 'wf-1',
-          orgId: 'org-1',
-          status: 'DRAFT',
+          workflowId: "wf-1",
+          orgId: "org-1",
+          status: "DRAFT",
           definition: mixedDef,
           version: 1,
         },
       });
 
       await expect(
-        invoke(makeEvent('publishWorkflow', { workflowId: 'wf-1' }),),
+        invoke(makeEvent("publishWorkflow", { workflowId: "wf-1" })),
       ).rejects.toThrow(/placeholder.*n3/i);
     });
 
-    test('rejects publish when a node agentId does not exist in the agents table (stays DRAFT)', async () => {
+    test("rejects publish when a node agentId does not exist in the agents table (stays DRAFT)", async () => {
       const def = JSON.stringify({
         nodes: [
-          { id: 'n1', agentId: 'real-agent-1', type: 'agent' },
-          { id: 'n2', agentId: 'ghost-agent', type: 'agent' },
+          { id: "n1", agentId: "real-agent-1", type: "agent" },
+          { id: "n2", agentId: "ghost-agent", type: "agent" },
         ],
-        edges: [{ id: 'e1', source: 'n1', target: 'n2' }],
+        edges: [{ id: "e1", source: "n1", target: "n2" }],
       });
       ddbMock.on(GetCommand).resolves({
-        Item: { workflowId: 'wf-1', orgId: 'org-1', status: 'DRAFT', definition: def, version: 1 },
+        Item: {
+          workflowId: "wf-1",
+          orgId: "org-1",
+          status: "DRAFT",
+          definition: def,
+          version: 1,
+        },
       });
       // Only real-agent-1 exists; ghost-agent is absent from the agents table
       ddbMock.on(BatchGetCommand).resolves({
-        Responses: { 'citadel-agents-test': [{ agentId: 'real-agent-1' }] },
+        Responses: { "citadel-agents-test": [{ agentId: "real-agent-1" }] },
       });
 
       await expect(
-        invoke(makeEvent('publishWorkflow', { workflowId: 'wf-1' }),),
+        invoke(makeEvent("publishWorkflow", { workflowId: "wf-1" })),
       ).rejects.toThrow(/ghost-agent/i);
 
       // Must remain DRAFT — no status transition
       expect(ddbMock.commandCalls(UpdateCommand)).toHaveLength(0);
     });
 
-    test('publishes when every node agentId resolves to an existing agent (queries agents table)', async () => {
+    test("publishes when every node agentId resolves to an existing agent (queries agents table)", async () => {
       const def = JSON.stringify({
         nodes: [
-          { id: 'n1', agentId: 'real-agent-1', type: 'agent' },
-          { id: 'n2', agentId: 'real-agent-2', type: 'agent' },
+          { id: "n1", agentId: "real-agent-1", type: "agent" },
+          { id: "n2", agentId: "real-agent-2", type: "agent" },
         ],
-        edges: [{ id: 'e1', source: 'n1', target: 'n2' }],
+        edges: [{ id: "e1", source: "n1", target: "n2" }],
       });
       ddbMock.on(GetCommand).resolves({
-        Item: { workflowId: 'wf-1', orgId: 'org-1', status: 'DRAFT', definition: def, version: 1 },
+        Item: {
+          workflowId: "wf-1",
+          orgId: "org-1",
+          status: "DRAFT",
+          definition: def,
+          version: 1,
+        },
       });
       ddbMock.on(BatchGetCommand).resolves({
-        Responses: { 'citadel-agents-test': [{ agentId: 'real-agent-1' }, { agentId: 'real-agent-2' }] },
+        Responses: {
+          "citadel-agents-test": [
+            { agentId: "real-agent-1" },
+            { agentId: "real-agent-2" },
+          ],
+        },
       });
       ddbMock.on(UpdateCommand).resolves({
-        Attributes: { workflowId: 'wf-1', orgId: 'org-1', status: 'PUBLISHED', version: 2 },
+        Attributes: {
+          workflowId: "wf-1",
+          orgId: "org-1",
+          status: "PUBLISHED",
+          version: 2,
+        },
       });
 
       const result = await invoke(
-        makeEvent('publishWorkflow', { workflowId: 'wf-1' }),
+        makeEvent("publishWorkflow", { workflowId: "wf-1" }),
       );
 
-      expect(result.status).toBe('PUBLISHED');
+      expect(result.status).toBe("PUBLISHED");
 
       // Existence check must have queried the agents table
       const batchCalls = ddbMock.commandCalls(BatchGetCommand);
       expect(batchCalls.length).toBeGreaterThanOrEqual(1);
-      expect(batchCalls[0].args[0].input.RequestItems!['citadel-agents-test']).toBeDefined();
+      expect(
+        batchCalls[0].args[0].input.RequestItems!["citadel-agents-test"],
+      ).toBeDefined();
     });
   });
 
   // ─── EventBridge events ────────────────────────────────────────
 
-  describe('EventBridge events', () => {
-    test('emits workflow.created event on createWorkflow', async () => {
+  describe("EventBridge events", () => {
+    test("emits workflow.created event on createWorkflow", async () => {
       ddbMock.on(PutCommand).resolves({});
 
       await invoke(
-        makeEvent('createWorkflow', {
+        makeEvent("createWorkflow", {
           input: {
-            name: 'EB Test',
-            orgId: 'org-1',
+            name: "EB Test",
+            orgId: "org-1",
             definition: JSON.stringify({ nodes: [], edges: [] }),
           },
         }),
@@ -831,118 +995,137 @@ describe('workflow-resolver', () => {
       const ebCalls = ebMock.commandCalls(PutEventsCommand);
       expect(ebCalls).toHaveLength(1);
       const entry = ebCalls[0].args[0].input.Entries![0];
-      expect(entry.Source).toBe('citadel.workflows');
-      expect(entry.DetailType).toBe('workflow.created');
+      expect(entry.Source).toBe("citadel.workflows");
+      expect(entry.DetailType).toBe("workflow.created");
     });
 
-    test('emits workflow.updated event on updateWorkflow', async () => {
+    test("emits workflow.updated event on updateWorkflow", async () => {
       ddbMock.on(GetCommand).resolves({
-        Item: { workflowId: 'wf-1', orgId: 'org-1', version: 1, status: 'DRAFT' },
+        Item: {
+          workflowId: "wf-1",
+          orgId: "org-1",
+          version: 1,
+          status: "DRAFT",
+        },
       });
       ddbMock.on(UpdateCommand).resolves({
-        Attributes: { workflowId: 'wf-1', orgId: 'org-1', name: 'Updated', version: 2 },
+        Attributes: {
+          workflowId: "wf-1",
+          orgId: "org-1",
+          name: "Updated",
+          version: 2,
+        },
       });
 
       await invoke(
-        makeEvent('updateWorkflow', {
-          input: { workflowId: 'wf-1', name: 'Updated', version: 1 },
+        makeEvent("updateWorkflow", {
+          input: { workflowId: "wf-1", name: "Updated", version: 1 },
         }),
       );
 
       const ebCalls = ebMock.commandCalls(PutEventsCommand);
       expect(ebCalls).toHaveLength(1);
       const entry = ebCalls[0].args[0].input.Entries![0];
-      expect(entry.Source).toBe('citadel.workflows');
-      expect(entry.DetailType).toBe('workflow.updated');
+      expect(entry.Source).toBe("citadel.workflows");
+      expect(entry.DetailType).toBe("workflow.updated");
     });
 
-    test('emits workflow.deleted event on deleteWorkflow', async () => {
+    test("emits workflow.deleted event on deleteWorkflow", async () => {
       ddbMock.on(GetCommand).resolves({
-        Item: { workflowId: 'wf-1', orgId: 'org-1', status: 'DRAFT' },
+        Item: { workflowId: "wf-1", orgId: "org-1", status: "DRAFT" },
       });
       ddbMock.on(DeleteCommand).resolves({});
 
-      await invoke(
-        makeEvent('deleteWorkflow', { workflowId: 'wf-1' }),
-      );
+      await invoke(makeEvent("deleteWorkflow", { workflowId: "wf-1" }));
 
       const ebCalls = ebMock.commandCalls(PutEventsCommand);
       expect(ebCalls).toHaveLength(1);
       const entry = ebCalls[0].args[0].input.Entries![0];
-      expect(entry.Source).toBe('citadel.workflows');
-      expect(entry.DetailType).toBe('workflow.deleted');
+      expect(entry.Source).toBe("citadel.workflows");
+      expect(entry.DetailType).toBe("workflow.deleted");
     });
 
-    test('emits workflow.published event on publishWorkflow', async () => {
+    test("emits workflow.published event on publishWorkflow", async () => {
       const validDef = JSON.stringify({
         nodes: [
-          { id: 'n1', agentId: 'a1', type: 'agent' },
-          { id: 'n2', agentId: 'a2', type: 'agent' },
+          { id: "n1", agentId: "a1", type: "agent" },
+          { id: "n2", agentId: "a2", type: "agent" },
         ],
-        edges: [{ id: 'e1', source: 'n1', target: 'n2' }],
+        edges: [{ id: "e1", source: "n1", target: "n2" }],
       });
       ddbMock.on(GetCommand).resolves({
-        Item: { workflowId: 'wf-1', orgId: 'org-1', status: 'DRAFT', definition: validDef, version: 1 },
+        Item: {
+          workflowId: "wf-1",
+          orgId: "org-1",
+          status: "DRAFT",
+          definition: validDef,
+          version: 1,
+        },
       });
       ddbMock.on(BatchGetCommand).resolves({
-        Responses: { 'citadel-agents-test': [{ agentId: 'a1' }, { agentId: 'a2' }] },
+        Responses: {
+          "citadel-agents-test": [{ agentId: "a1" }, { agentId: "a2" }],
+        },
       });
       ddbMock.on(UpdateCommand).resolves({
-        Attributes: { workflowId: 'wf-1', orgId: 'org-1', status: 'PUBLISHED', version: 2 },
+        Attributes: {
+          workflowId: "wf-1",
+          orgId: "org-1",
+          status: "PUBLISHED",
+          version: 2,
+        },
       });
 
-      await invoke(
-        makeEvent('publishWorkflow', { workflowId: 'wf-1' }),
-      );
+      await invoke(makeEvent("publishWorkflow", { workflowId: "wf-1" }));
 
       const ebCalls = ebMock.commandCalls(PutEventsCommand);
       expect(ebCalls).toHaveLength(1);
       const entry = ebCalls[0].args[0].input.Entries![0];
-      expect(entry.Source).toBe('citadel.workflows');
-      expect(entry.DetailType).toBe('workflow.published');
+      expect(entry.Source).toBe("citadel.workflows");
+      expect(entry.DetailType).toBe("workflow.published");
     });
   });
 
   // ─── updateWorkflowConfiguration ──────────────────────────────
 
-  describe('updateWorkflowConfiguration', () => {
-    test('shallow merges config at top-level keys and uses optimistic lock via version', async () => {
+  describe("updateWorkflowConfiguration", () => {
+    test("shallow merges config at top-level keys and uses optimistic lock via version", async () => {
       const existingConfig = JSON.stringify({
-        integrations: { int1: { endpoint: 'https://old.com' } },
-        credentials: { cred1: 'secret-ref-1' },
+        integrations: { int1: { endpoint: "https://old.com" } },
+        credentials: { cred1: "secret-ref-1" },
       });
       const newConfig = JSON.stringify({
-        integrations: { int2: { endpoint: 'https://new.com' } },
-        parameters: { key1: 'value1' },
+        integrations: { int2: { endpoint: "https://new.com" } },
+        parameters: { key1: "value1" },
       });
       // GetCommand returns existing workflow with config
       ddbMock.on(GetCommand).resolves({
         Item: {
-          workflowId: 'wf-1',
-          orgId: 'org-1',
+          workflowId: "wf-1",
+          orgId: "org-1",
           version: 3,
-          status: 'DRAFT',
+          status: "DRAFT",
           configuration: existingConfig,
         },
       });
       // UpdateCommand returns merged result
       ddbMock.on(UpdateCommand).resolves({
         Attributes: {
-          workflowId: 'wf-1',
-          orgId: 'org-1',
+          workflowId: "wf-1",
+          orgId: "org-1",
           version: 4,
-          status: 'DRAFT',
+          status: "DRAFT",
           configuration: JSON.stringify({
-            integrations: { int2: { endpoint: 'https://new.com' } },
-            credentials: { cred1: 'secret-ref-1' },
-            parameters: { key1: 'value1' },
+            integrations: { int2: { endpoint: "https://new.com" } },
+            credentials: { cred1: "secret-ref-1" },
+            parameters: { key1: "value1" },
           }),
         },
       });
 
       const result = await invoke(
-        makeEvent('updateWorkflowConfiguration', {
-          workflowId: 'wf-1',
+        makeEvent("updateWorkflowConfiguration", {
+          workflowId: "wf-1",
           configuration: newConfig,
           version: 3,
         }),
@@ -953,43 +1136,44 @@ describe('workflow-resolver', () => {
       const updateCalls = ddbMock.commandCalls(UpdateCommand);
       expect(updateCalls).toHaveLength(1);
       const updateInput = updateCalls[0].args[0].input;
-      expect(updateInput.ConditionExpression).toContain('version');
+      expect(updateInput.ConditionExpression).toContain("version");
     });
   });
 
   // ─── importBlueprint ──────────────────────────────────────────
 
-  describe('importBlueprint', () => {
+  describe("importBlueprint", () => {
     const blueprintDef = JSON.stringify({
       nodes: [
-        { id: 'n1', agentId: 'agent-1', type: 'agent' },
-        { id: 'n2', agentId: 'agent-2', type: 'agent' },
+        { id: "n1", agentId: "agent-1", type: "agent" },
+        { id: "n2", agentId: "agent-2", type: "agent" },
       ],
-      edges: [{ id: 'e1', source: 'n1', target: 'n2' }],
+      edges: [{ id: "e1", source: "n1", target: "n2" }],
     });
 
-    test('deep-copies definition from PUBLISHED blueprint, sets DRAFT, isBlueprint=false, appends workflowId to app workflowIds, emits workflow.imported', async () => {
+    test("deep-copies definition from PUBLISHED blueprint, sets DRAFT, isBlueprint=false, appends workflowId to app workflowIds, emits workflow.imported", async () => {
       // First GetCommand: blueprint lookup
-      ddbMock.on(GetCommand)
+      ddbMock
+        .on(GetCommand)
         .resolvesOnce({
           Item: {
-            workflowId: 'bp-1',
-            orgId: 'org-1',
-            name: 'My Blueprint',
-            status: 'PUBLISHED',
-            isBlueprint: 'true',
+            workflowId: "bp-1",
+            orgId: "org-1",
+            name: "My Blueprint",
+            status: "PUBLISHED",
+            isBlueprint: "true",
             definition: blueprintDef,
-            metadata: JSON.stringify({ category: 'data-processing' }),
+            metadata: JSON.stringify({ category: "data-processing" }),
             version: 2,
           },
         })
         // Second GetCommand: app lookup
         .resolvesOnce({
           Item: {
-            appId: 'app-1',
-            orgId: 'org-1',
-            name: 'My App',
-            workflowIds: ['wf-existing'],
+            appId: "app-1",
+            orgId: "org-1",
+            name: "My App",
+            workflowIds: ["wf-existing"],
             version: 1,
           },
         });
@@ -997,16 +1181,16 @@ describe('workflow-resolver', () => {
       ddbMock.on(UpdateCommand).resolves({});
 
       const result = await invoke(
-        makeEvent('importBlueprint', { blueprintId: 'bp-1', appId: 'app-1' }),
+        makeEvent("importBlueprint", { blueprintId: "bp-1", appId: "app-1" }),
       );
 
       // New workflow created as DRAFT, not a blueprint
-      expect(result.status).toBe('DRAFT');
-      expect(result.isBlueprint).toBe('false');
+      expect(result.status).toBe("DRAFT");
+      expect(result.isBlueprint).toBe("false");
       expect(result.workflowId).toBeDefined();
-      expect(result.workflowId).not.toBe('bp-1'); // new UUID
-      expect(result.name).toBe('My Blueprint (Copy)'); // default name
-      expect(result.appId).toBe('app-1');
+      expect(result.workflowId).not.toBe("bp-1"); // new UUID
+      expect(result.name).toBe("My Blueprint (Copy)"); // default name
+      expect(result.appId).toBe("app-1");
 
       // Definition is deep-copied
       expect(result.definition).toBe(blueprintDef);
@@ -1019,17 +1203,17 @@ describe('workflow-resolver', () => {
       const ebCalls = ebMock.commandCalls(PutEventsCommand);
       expect(ebCalls).toHaveLength(1);
       const entry = ebCalls[0].args[0].input.Entries![0];
-      expect(entry.DetailType).toBe('workflow.imported');
+      expect(entry.DetailType).toBe("workflow.imported");
     });
 
-    test('rejects draft blueprints', async () => {
+    test("rejects draft blueprints", async () => {
       ddbMock.on(GetCommand).resolvesOnce({
         Item: {
-          workflowId: 'bp-draft',
-          orgId: 'org-1',
-          name: 'Draft Blueprint',
-          status: 'DRAFT',
-          isBlueprint: 'true',
+          workflowId: "bp-draft",
+          orgId: "org-1",
+          name: "Draft Blueprint",
+          status: "DRAFT",
+          isBlueprint: "true",
           definition: blueprintDef,
           version: 1,
         },
@@ -1037,29 +1221,33 @@ describe('workflow-resolver', () => {
 
       await expect(
         invoke(
-          makeEvent('importBlueprint', { blueprintId: 'bp-draft', appId: 'app-1' }),
+          makeEvent("importBlueprint", {
+            blueprintId: "bp-draft",
+            appId: "app-1",
+          }),
         ),
       ).rejects.toThrow(/published/i);
     });
 
-    test('rejects wrong orgId (throws Access denied)', async () => {
-      ddbMock.on(GetCommand)
+    test("rejects wrong orgId (throws Access denied)", async () => {
+      ddbMock
+        .on(GetCommand)
         .resolvesOnce({
           Item: {
-            workflowId: 'bp-1',
-            orgId: 'org-1',
-            name: 'Blueprint',
-            status: 'PUBLISHED',
-            isBlueprint: 'true',
+            workflowId: "bp-1",
+            orgId: "org-1",
+            name: "Blueprint",
+            status: "PUBLISHED",
+            isBlueprint: "true",
             definition: blueprintDef,
             version: 2,
           },
         })
         .resolvesOnce({
           Item: {
-            appId: 'app-1',
-            orgId: 'org-other', // different org
-            name: 'Other App',
+            appId: "app-1",
+            orgId: "org-other", // different org
+            name: "Other App",
             workflowIds: [],
             version: 1,
           },
@@ -1067,95 +1255,123 @@ describe('workflow-resolver', () => {
 
       await expect(
         invoke(
-          makeEvent('importBlueprint', { blueprintId: 'bp-1', appId: 'app-1' }),
+          makeEvent("importBlueprint", { blueprintId: "bp-1", appId: "app-1" }),
         ),
       ).rejects.toThrow(/Access denied/i);
     });
 
-    test('applies agentMapping to rewrite placeholder node agentIds to real agentIds', async () => {
+    test("applies agentMapping to rewrite placeholder node agentIds to real agentIds", async () => {
       const placeholderDef = JSON.stringify({
         nodes: [
-          { id: 'n1', agentId: 'placeholder-writer', type: 'agent' },
-          { id: 'n2', agentId: 'placeholder-reviewer', type: 'agent' },
+          { id: "n1", agentId: "placeholder-writer", type: "agent" },
+          { id: "n2", agentId: "placeholder-reviewer", type: "agent" },
         ],
-        edges: [{ id: 'e1', source: 'n1', target: 'n2' }],
+        edges: [{ id: "e1", source: "n1", target: "n2" }],
       });
-      ddbMock.on(GetCommand)
+      ddbMock
+        .on(GetCommand)
         .resolvesOnce({
           Item: {
-            workflowId: 'bp-1', orgId: 'org-1', name: 'BP', status: 'PUBLISHED',
-            isBlueprint: 'true', definition: placeholderDef, version: 2,
+            workflowId: "bp-1",
+            orgId: "org-1",
+            name: "BP",
+            status: "PUBLISHED",
+            isBlueprint: "true",
+            definition: placeholderDef,
+            version: 2,
           },
         })
         .resolvesOnce({
-          Item: { appId: 'app-1', orgId: 'org-1', name: 'App', workflowIds: [], version: 1 },
+          Item: {
+            appId: "app-1",
+            orgId: "org-1",
+            name: "App",
+            workflowIds: [],
+            version: 1,
+          },
         });
       ddbMock.on(PutCommand).resolves({});
       ddbMock.on(UpdateCommand).resolves({});
 
       const result = await invoke(
-        makeEvent('importBlueprint', {
-          blueprintId: 'bp-1',
-          appId: 'app-1',
+        makeEvent("importBlueprint", {
+          blueprintId: "bp-1",
+          appId: "app-1",
           agentMapping: JSON.stringify({
-            'placeholder-writer': 'real-agent-1',
-            'placeholder-reviewer': 'real-agent-2',
+            "placeholder-writer": "real-agent-1",
+            "placeholder-reviewer": "real-agent-2",
           }),
         }),
       );
 
       const parsed = JSON.parse(result.definition as string);
-      expect(parsed.nodes[0].agentId).toBe('real-agent-1');
-      expect(parsed.nodes[1].agentId).toBe('real-agent-2');
+      expect(parsed.nodes[0].agentId).toBe("real-agent-1");
+      expect(parsed.nodes[1].agentId).toBe("real-agent-2");
       // Persisted definition must also be remapped
       const putItem = ddbMock.commandCalls(PutCommand)[0].args[0].input.Item;
-      expect(JSON.parse(putItem!.definition).nodes[0].agentId).toBe('real-agent-1');
+      expect(JSON.parse(putItem!.definition).nodes[0].agentId).toBe(
+        "real-agent-1",
+      );
     });
 
-    test('leaves unmapped node agentIds unchanged when applying agentMapping', async () => {
+    test("leaves unmapped node agentIds unchanged when applying agentMapping", async () => {
       const mixedDef = JSON.stringify({
         nodes: [
-          { id: 'n1', agentId: 'placeholder-writer', type: 'agent' },
-          { id: 'n2', agentId: 'already-real', type: 'agent' },
+          { id: "n1", agentId: "placeholder-writer", type: "agent" },
+          { id: "n2", agentId: "already-real", type: "agent" },
         ],
-        edges: [{ id: 'e1', source: 'n1', target: 'n2' }],
+        edges: [{ id: "e1", source: "n1", target: "n2" }],
       });
-      ddbMock.on(GetCommand)
+      ddbMock
+        .on(GetCommand)
         .resolvesOnce({
           Item: {
-            workflowId: 'bp-1', orgId: 'org-1', name: 'BP', status: 'PUBLISHED',
-            isBlueprint: 'true', definition: mixedDef, version: 2,
+            workflowId: "bp-1",
+            orgId: "org-1",
+            name: "BP",
+            status: "PUBLISHED",
+            isBlueprint: "true",
+            definition: mixedDef,
+            version: 2,
           },
         })
         .resolvesOnce({
-          Item: { appId: 'app-1', orgId: 'org-1', name: 'App', workflowIds: [], version: 1 },
+          Item: {
+            appId: "app-1",
+            orgId: "org-1",
+            name: "App",
+            workflowIds: [],
+            version: 1,
+          },
         });
       ddbMock.on(PutCommand).resolves({});
       ddbMock.on(UpdateCommand).resolves({});
 
       const result = await invoke(
-        makeEvent('importBlueprint', {
-          blueprintId: 'bp-1',
-          appId: 'app-1',
-          agentMapping: JSON.stringify({ 'placeholder-writer': 'real-agent-1' }),
+        makeEvent("importBlueprint", {
+          blueprintId: "bp-1",
+          appId: "app-1",
+          agentMapping: JSON.stringify({
+            "placeholder-writer": "real-agent-1",
+          }),
         }),
       );
 
       const parsed = JSON.parse(result.definition as string);
-      expect(parsed.nodes[0].agentId).toBe('real-agent-1');
-      expect(parsed.nodes[1].agentId).toBe('already-real');
+      expect(parsed.nodes[0].agentId).toBe("real-agent-1");
+      expect(parsed.nodes[1].agentId).toBe("already-real");
     });
   });
 
   // ─── importWorkflow ────────────────────────────────────────────
 
-  describe('importWorkflow', () => {
-    test('validates JSON structure, generates new UUID, sets version=1, status=DRAFT', async () => {
+  describe("importWorkflow", () => {
+    test("validates JSON structure, generates new UUID, sets version=1, status=DRAFT", async () => {
       const workflowJson = JSON.stringify({
-        name: 'Imported Workflow',
-        description: 'From export',
+        name: "Imported Workflow",
+        description: "From export",
         definition: JSON.stringify({
-          nodes: [{ id: 'n1', agentId: 'a1', type: 'agent' }],
+          nodes: [{ id: "n1", agentId: "a1", type: "agent" }],
           edges: [],
         }),
         configuration: null,
@@ -1164,117 +1380,208 @@ describe('workflow-resolver', () => {
       ddbMock.on(PutCommand).resolves({});
 
       const result = await invoke(
-        makeEvent('importWorkflow', {
-          input: { orgId: 'org-1', workflowJson, name: 'Custom Name' },
+        makeEvent("importWorkflow", {
+          input: { orgId: "org-1", workflowJson, name: "Custom Name" },
         }),
       );
 
       expect(result.workflowId).toBeDefined();
       expect(result.version).toBe(1);
-      expect(result.status).toBe('DRAFT');
-      expect(result.name).toBe('Custom Name');
-      expect(result.orgId).toBe('org-1');
+      expect(result.status).toBe("DRAFT");
+      expect(result.name).toBe("Custom Name");
+      expect(result.orgId).toBe("org-1");
       expect(ddbMock.commandCalls(PutCommand)).toHaveLength(1);
+    });
+
+    // Org derivation (finding 2c262386 lower set, primary case): importWorkflow
+    // let a caller plant a DRAFT workflow into ANOTHER tenant's workspace by
+    // setting input.orgId=victim. Must derive orgId from identity and REJECT
+    // a mismatched client value — zero writes.
+    test("rejects a mismatched input.orgId and does not persist (plant-into-foreign-org attempt)", async () => {
+      const workflowJson = JSON.stringify({
+        name: "Planted Workflow",
+        definition: JSON.stringify({
+          nodes: [{ id: "n1", agentId: "a1", type: "agent" }],
+          edges: [],
+        }),
+      });
+
+      await expect(
+        invoke(
+          makeEvent("importWorkflow", {
+            input: { orgId: "org-victim", workflowJson },
+          }),
+        ),
+      ).rejects.toThrow(/Access denied|orgId/i);
+      expect(ddbMock.commandCalls(PutCommand)).toHaveLength(0);
+    });
+
+    test("derives orgId from identity when input.orgId is absent", async () => {
+      const workflowJson = JSON.stringify({
+        name: "No OrgId Import",
+        definition: JSON.stringify({
+          nodes: [{ id: "n1", agentId: "a1", type: "agent" }],
+          edges: [],
+        }),
+      });
+      ddbMock.on(PutCommand).resolves({});
+
+      const result = await invoke(
+        makeEvent("importWorkflow", { input: { workflowJson } }),
+      );
+
+      expect(result.orgId).toBe("org-1");
+      expect(ddbMock.commandCalls(PutCommand)).toHaveLength(1);
+    });
+
+    test("fails closed when caller org is unresolvable", async () => {
+      cognitoMock.on(AdminGetUserCommand).rejects(new Error("user not found"));
+      const workflowJson = JSON.stringify({
+        name: "Unresolvable",
+        definition: JSON.stringify({ nodes: [], edges: [] }),
+      });
+
+      await expect(
+        invoke(
+          makeEvent("importWorkflow", {
+            input: { orgId: "org-1", workflowJson },
+          }),
+        ),
+      ).rejects.toThrow(/Access denied|orgId|organization/i);
+      expect(ddbMock.commandCalls(PutCommand)).toHaveLength(0);
     });
   });
 
   // ─── exportWorkflow ────────────────────────────────────────────
 
-  describe('exportWorkflow', () => {
-    test('returns workflow as JSON and verifies org access', async () => {
+  describe("exportWorkflow", () => {
+    test("returns workflow as JSON and verifies org access", async () => {
       const definition = JSON.stringify({ nodes: [], edges: [] });
       ddbMock.on(GetCommand).resolves({
         Item: {
-          workflowId: 'wf-1',
-          orgId: 'org-1',
-          name: 'Export Me',
+          workflowId: "wf-1",
+          orgId: "org-1",
+          name: "Export Me",
           definition,
           configuration: null,
           metadata: null,
-          status: 'DRAFT',
+          status: "DRAFT",
           version: 1,
         },
       });
 
       const result = await invoke(
-        makeEvent('exportWorkflow', { workflowId: 'wf-1' }),
+        makeEvent("exportWorkflow", { workflowId: "wf-1" }),
       );
 
       // Should return the workflow data as JSON
       expect(result).toBeDefined();
-      const parsed = typeof result === 'string' ? JSON.parse(result) : result;
-      expect(parsed.name).toBe('Export Me');
+      const parsed = typeof result === "string" ? JSON.parse(result) : result;
+      expect(parsed.name).toBe("Export Me");
       expect(parsed.definition).toBe(definition);
     });
   });
 
   // ─── getWorkflowVersion ────────────────────────────────────────
 
-  describe('getWorkflowVersion', () => {
-    test('extracts correct version from versionHistory array', async () => {
-      const v1Def = JSON.stringify({ nodes: [{ id: 'n1', agentId: 'a1', type: 'agent' }], edges: [] });
-      const v2Def = JSON.stringify({ nodes: [{ id: 'n1', agentId: 'a1', type: 'agent' }, { id: 'n2', agentId: 'a2', type: 'agent' }], edges: [] });
+  describe("getWorkflowVersion", () => {
+    test("extracts correct version from versionHistory array", async () => {
+      const v1Def = JSON.stringify({
+        nodes: [{ id: "n1", agentId: "a1", type: "agent" }],
+        edges: [],
+      });
+      const v2Def = JSON.stringify({
+        nodes: [
+          { id: "n1", agentId: "a1", type: "agent" },
+          { id: "n2", agentId: "a2", type: "agent" },
+        ],
+        edges: [],
+      });
       const currentDef = JSON.stringify({ nodes: [], edges: [] });
 
       ddbMock.on(GetCommand).resolves({
         Item: {
-          workflowId: 'wf-1',
-          orgId: 'org-1',
-          name: 'Versioned Workflow',
+          workflowId: "wf-1",
+          orgId: "org-1",
+          name: "Versioned Workflow",
           definition: currentDef,
           version: 3,
           versionHistory: [
-            { version: 1, definition: v1Def, updatedAt: '2024-01-01T00:00:00Z', updatedBy: 'user-1' },
-            { version: 2, definition: v2Def, updatedAt: '2024-01-02T00:00:00Z', updatedBy: 'user-1' },
+            {
+              version: 1,
+              definition: v1Def,
+              updatedAt: "2024-01-01T00:00:00Z",
+              updatedBy: "user-1",
+            },
+            {
+              version: 2,
+              definition: v2Def,
+              updatedAt: "2024-01-02T00:00:00Z",
+              updatedBy: "user-1",
+            },
           ],
         },
       });
 
       const result = await invoke(
-        makeEvent('getWorkflowVersion', { workflowId: 'wf-1', version: 1 }),
+        makeEvent("getWorkflowVersion", { workflowId: "wf-1", version: 1 }),
       );
 
       expect(result.definition).toBe(v1Def);
-      expect(result.workflowId).toBe('wf-1');
+      expect(result.workflowId).toBe("wf-1");
     });
   });
 
   // ─── versioning ─────────────────────────────────────────────────
 
-  describe('versioning', () => {
-    const oldDef = JSON.stringify({ nodes: [{ id: 'n1', agentId: 'a1', type: 'agent' }], edges: [] });
-    const newDef = JSON.stringify({ nodes: [{ id: 'n1', agentId: 'a1', type: 'agent' }, { id: 'n2', agentId: 'a2', type: 'agent' }], edges: [] });
+  describe("versioning", () => {
+    const oldDef = JSON.stringify({
+      nodes: [{ id: "n1", agentId: "a1", type: "agent" }],
+      edges: [],
+    });
+    const newDef = JSON.stringify({
+      nodes: [
+        { id: "n1", agentId: "a1", type: "agent" },
+        { id: "n2", agentId: "a2", type: "agent" },
+      ],
+      edges: [],
+    });
 
-    test('updateWorkflow appends previous state to versionHistory before updating', async () => {
+    test("updateWorkflow appends previous state to versionHistory before updating", async () => {
       // Existing workflow at version 2 with one history entry
       ddbMock.on(GetCommand).resolves({
         Item: {
-          workflowId: 'wf-1',
-          orgId: 'org-1',
+          workflowId: "wf-1",
+          orgId: "org-1",
           version: 2,
-          status: 'DRAFT',
+          status: "DRAFT",
           definition: oldDef,
-          updatedAt: '2024-01-02T00:00:00Z',
-          createdBy: 'user-123',
+          updatedAt: "2024-01-02T00:00:00Z",
+          createdBy: "user-123",
           versionHistory: [
-            { version: 1, definition: '{"nodes":[],"edges":[]}', updatedAt: '2024-01-01T00:00:00Z', updatedBy: 'user-123' },
+            {
+              version: 1,
+              definition: '{"nodes":[],"edges":[]}',
+              updatedAt: "2024-01-01T00:00:00Z",
+              updatedBy: "user-123",
+            },
           ],
         },
       });
       ddbMock.on(UpdateCommand).resolves({
         Attributes: {
-          workflowId: 'wf-1',
-          orgId: 'org-1',
-          name: 'Updated',
+          workflowId: "wf-1",
+          orgId: "org-1",
+          name: "Updated",
           version: 3,
-          status: 'DRAFT',
+          status: "DRAFT",
           definition: newDef,
         },
       });
 
       await invoke(
-        makeEvent('updateWorkflow', {
-          input: { workflowId: 'wf-1', definition: newDef, version: 2 },
+        makeEvent("updateWorkflow", {
+          input: { workflowId: "wf-1", definition: newDef, version: 2 },
         }),
       );
 
@@ -1283,107 +1590,128 @@ describe('workflow-resolver', () => {
       expect(updateCalls).toHaveLength(1);
       const updateInput = updateCalls[0].args[0].input;
       const updateExpr = updateInput.UpdateExpression as string;
-      expect(updateExpr).toContain('versionHistory');
+      expect(updateExpr).toContain("versionHistory");
     });
 
-    test('versionHistory entry contains correct version, definition, updatedAt, updatedBy fields', async () => {
+    test("versionHistory entry contains correct version, definition, updatedAt, updatedBy fields", async () => {
       ddbMock.on(GetCommand).resolves({
         Item: {
-          workflowId: 'wf-1',
-          orgId: 'org-1',
+          workflowId: "wf-1",
+          orgId: "org-1",
           version: 2,
-          status: 'DRAFT',
+          status: "DRAFT",
           definition: oldDef,
-          updatedAt: '2024-06-15T10:30:00Z',
-          createdBy: 'user-123',
+          updatedAt: "2024-06-15T10:30:00Z",
+          createdBy: "user-123",
           versionHistory: [],
         },
       });
       ddbMock.on(UpdateCommand).resolves({
         Attributes: {
-          workflowId: 'wf-1',
-          orgId: 'org-1',
+          workflowId: "wf-1",
+          orgId: "org-1",
           version: 3,
           definition: newDef,
         },
       });
 
       await invoke(
-        makeEvent('updateWorkflow', {
-          input: { workflowId: 'wf-1', definition: newDef, version: 2 },
+        makeEvent("updateWorkflow", {
+          input: { workflowId: "wf-1", definition: newDef, version: 2 },
         }),
       );
 
       const updateCalls = ddbMock.commandCalls(UpdateCommand);
-      const exprValues = updateCalls[0].args[0].input.ExpressionAttributeValues!;
-      const historyEntry = exprValues[':historyEntry'];
+      const exprValues =
+        updateCalls[0].args[0].input.ExpressionAttributeValues!;
+      const historyEntry = exprValues[":historyEntry"];
       expect(historyEntry).toBeDefined();
       expect(historyEntry).toEqual([
         {
           version: 2,
           definition: oldDef,
-          updatedAt: '2024-06-15T10:30:00Z',
-          updatedBy: 'user-123',
+          updatedAt: "2024-06-15T10:30:00Z",
+          updatedBy: "user-123",
         },
       ]);
     });
 
-    test('getWorkflowVersion returns correct historical definition from versionHistory', async () => {
+    test("getWorkflowVersion returns correct historical definition from versionHistory", async () => {
       const v1Def = JSON.stringify({ nodes: [], edges: [] });
       ddbMock.on(GetCommand).resolves({
         Item: {
-          workflowId: 'wf-1',
-          orgId: 'org-1',
+          workflowId: "wf-1",
+          orgId: "org-1",
           version: 3,
           definition: newDef,
           versionHistory: [
-            { version: 1, definition: v1Def, updatedAt: '2024-01-01T00:00:00Z', updatedBy: 'user-1' },
-            { version: 2, definition: oldDef, updatedAt: '2024-01-02T00:00:00Z', updatedBy: 'user-1' },
+            {
+              version: 1,
+              definition: v1Def,
+              updatedAt: "2024-01-01T00:00:00Z",
+              updatedBy: "user-1",
+            },
+            {
+              version: 2,
+              definition: oldDef,
+              updatedAt: "2024-01-02T00:00:00Z",
+              updatedBy: "user-1",
+            },
           ],
         },
       });
 
       const result = await invoke(
-        makeEvent('getWorkflowVersion', { workflowId: 'wf-1', version: 2 }),
+        makeEvent("getWorkflowVersion", { workflowId: "wf-1", version: 2 }),
       );
 
       expect(result.version).toBe(2);
       expect(result.definition).toBe(oldDef);
-      expect(result.workflowId).toBe('wf-1');
+      expect(result.workflowId).toBe("wf-1");
     });
   });
 
   // ─── listAppWorkflows ──────────────────────────────────────────
 
-  describe('listAppWorkflows', () => {
-    test('fetches app by appId, then BatchGetItem for workflows by workflowIds', async () => {
+  describe("listAppWorkflows", () => {
+    test("fetches app by appId, then BatchGetItem for workflows by workflowIds", async () => {
       // GetCommand returns the app
       ddbMock.on(GetCommand).resolves({
         Item: {
-          appId: 'app-1',
-          orgId: 'org-1',
-          name: 'My App',
-          workflowIds: ['wf-1', 'wf-2'],
+          appId: "app-1",
+          orgId: "org-1",
+          name: "My App",
+          workflowIds: ["wf-1", "wf-2"],
           version: 1,
         },
       });
       // BatchGetCommand returns the workflows
       ddbMock.on(BatchGetCommand).resolves({
         Responses: {
-          'citadel-workflows-test': [
-            { workflowId: 'wf-1', orgId: 'org-1', name: 'Workflow 1', status: 'DRAFT' },
-            { workflowId: 'wf-2', orgId: 'org-1', name: 'Workflow 2', status: 'PUBLISHED' },
+          "citadel-workflows-test": [
+            {
+              workflowId: "wf-1",
+              orgId: "org-1",
+              name: "Workflow 1",
+              status: "DRAFT",
+            },
+            {
+              workflowId: "wf-2",
+              orgId: "org-1",
+              name: "Workflow 2",
+              status: "PUBLISHED",
+            },
           ],
         },
       });
 
       const result = await invoke<Record<string, unknown>[]>(
-        makeEvent('listAppWorkflows', { appId: 'app-1' }),
+        makeEvent("listAppWorkflows", { appId: "app-1" }),
       );
 
       expect(result).toHaveLength(2);
-      expect(result[0].workflowId).toBe('wf-1');
-      expect(result[1].workflowId).toBe('wf-2');
+      expect(result[0].workflowId).toBe("wf-1");
+      expect(result[1].workflowId).toBe("wf-2");
 
       // Verify BatchGetCommand was called
       expect(ddbMock.commandCalls(BatchGetCommand)).toHaveLength(1);

--- a/backend/src/lambda/datastore-resolver.ts
+++ b/backend/src/lambda/datastore-resolver.ts
@@ -426,16 +426,21 @@ async function createDataStore(
   // trusted a client-supplied input.orgId outright. Mutation convention is
   // reject-not-coerce (unlike the read-path collection queries above): derive
   // the caller's org server-side and refuse a mismatched client value BEFORE
-  // any DynamoDB write, Secrets Manager call, or IAM change. Admins may still
-  // create on behalf of any org (same bypass every other operation honours).
-  const admin = isAdminFromEvent(event);
-  if (!admin) {
-    const callerOrgId = await extractOrgFromEvent(event);
-    if (!callerOrgId || callerOrgId !== input.orgId) {
-      throw new PermissionError(
-        "Access denied: orgId does not match caller's organization",
-      );
-    }
+  // any DynamoDB write, Secrets Manager call, or IAM change.
+  //
+  // Decision b5d463f2 (owner-ratified): this check does NOT honour the admin
+  // bypass that every other op in this file uses. An admin previously skipped
+  // the check entirely and could write an arbitrary orgId into the record AND
+  // the Secrets Manager path (/citadel/datastores/{orgId}/...) — the mismatch
+  // is now rejected for EVERYONE, admins included. If platform operators
+  // genuinely need to provision on a tenant's behalf, that requires an
+  // EXPLICIT separate operator path — intentionally not built speculatively
+  // here; this fix only removes the implicit bypass.
+  const callerOrgId = await extractOrgFromEvent(event);
+  if (!callerOrgId || callerOrgId !== input.orgId) {
+    throw new PermissionError(
+      "Access denied: orgId does not match caller's organization",
+    );
   }
 
   const dataStoreId = uuidv4();

--- a/backend/src/lambda/execution-resolver.ts
+++ b/backend/src/lambda/execution-resolver.ts
@@ -254,7 +254,7 @@ export const handler: AppSyncResolverHandler<
       case "getExecution":
         return await getExecution(args.executionId, userId, event);
       case "listExecutions":
-        return await listExecutions(args.workflowId);
+        return await listExecutions(args.workflowId, event);
       case "startExecution":
         return await startExecution(args.workflowId, args.input, userId, event);
       case "cancelExecution":
@@ -305,7 +305,36 @@ async function getExecution(
 
 async function listExecutions(
   workflowId: string,
+  event: ExecutionResolverEvent,
 ): Promise<{ items: unknown[]; nextToken?: string }> {
+  // Org filter (finding 2c262386): listExecutions previously ran the
+  // WorkflowIndex query directly with no org check at all — any
+  // client-supplied workflowId exposed that workflow's executions
+  // (including input/output) across tenants. EXECUTIONS_TABLE carries no
+  // orgId GSI (only WorkflowIndex on workflowId+startedAt), so there is no
+  // direct org-filtered index available. Least-bad correct option: load
+  // the parent WORKFLOWS_TABLE row (the org source of truth for this
+  // workflowId — the same lookup startExecution already performs) and
+  // reconcile it against the caller's derived org BEFORE running the
+  // query. Refuse rather than return filtered/foreign data, matching
+  // get/start/cancel/resume's existing "Access denied" semantics exactly.
+  const workflowResult = await docClient.send(
+    new GetCommand({
+      TableName: WORKFLOWS_TABLE,
+      Key: { workflowId },
+    }),
+  );
+
+  const workflow = workflowResult.Item;
+  if (!workflow) {
+    throw new Error("Workflow not found");
+  }
+
+  const userOrg = await extractOrgFromEvent(event);
+  if (!userOrg || workflow.orgId !== userOrg) {
+    throw new Error("Access denied");
+  }
+
   const result = await docClient.send(
     new QueryCommand({
       TableName: EXECUTIONS_TABLE,

--- a/backend/src/lambda/workflow-resolver.ts
+++ b/backend/src/lambda/workflow-resolver.ts
@@ -1,10 +1,23 @@
-import { AppSyncResolverHandler, AppSyncResolverEvent } from 'aws-lambda';
-import { DynamoDBClient } from '@aws-sdk/client-dynamodb';
-import { DynamoDBDocumentClient, GetCommand, PutCommand, UpdateCommand, QueryCommand, DeleteCommand, BatchGetCommand, QueryCommandInput, UpdateCommandInput } from '@aws-sdk/lib-dynamodb';
-import { EventBridgeClient, PutEventsCommand } from '@aws-sdk/client-eventbridge';
-import { v4 as uuidv4 } from 'uuid';
-import { getUserId } from '../utils/appsync';
-import { extractOrgFromEvent } from '../utils/auth-event';
+import { AppSyncResolverHandler, AppSyncResolverEvent } from "aws-lambda";
+import { DynamoDBClient } from "@aws-sdk/client-dynamodb";
+import {
+  DynamoDBDocumentClient,
+  GetCommand,
+  PutCommand,
+  UpdateCommand,
+  QueryCommand,
+  DeleteCommand,
+  BatchGetCommand,
+  QueryCommandInput,
+  UpdateCommandInput,
+} from "@aws-sdk/lib-dynamodb";
+import {
+  EventBridgeClient,
+  PutEventsCommand,
+} from "@aws-sdk/client-eventbridge";
+import { v4 as uuidv4 } from "uuid";
+import { getUserId } from "../utils/appsync";
+import { extractOrgFromEvent } from "../utils/auth-event";
 
 const dynamoClient = new DynamoDBClient({});
 const docClient = DynamoDBDocumentClient.from(dynamoClient);
@@ -101,8 +114,11 @@ interface ParsedWorkflowDefinition {
   edges?: WorkflowDefinitionEdge[];
 }
 
-export const handler: AppSyncResolverHandler<WorkflowResolverArguments, unknown> = async (event) => {
-  console.log('Workflow resolver event:', JSON.stringify(event, null, 2));
+export const handler: AppSyncResolverHandler<
+  WorkflowResolverArguments,
+  unknown
+> = async (event) => {
+  console.log("Workflow resolver event:", JSON.stringify(event, null, 2));
 
   const { info, arguments: args, identity } = event;
   const fieldName = info.fieldName;
@@ -110,46 +126,70 @@ export const handler: AppSyncResolverHandler<WorkflowResolverArguments, unknown>
 
   try {
     switch (fieldName) {
-      case 'getWorkflow':
+      case "getWorkflow":
         return await getWorkflow(args.workflowId, userId, event);
-      case 'listWorkflows':
+      case "listWorkflows":
         return await listWorkflows(args.orgId, args.status, userId, event);
-      case 'listBlueprints':
+      case "listBlueprints":
         return await listBlueprints(args.category);
-      case 'createWorkflow':
-        return await createWorkflow(args.input, userId);
-      case 'updateWorkflow':
+      case "createWorkflow":
+        return await createWorkflow(args.input, userId, event);
+      case "updateWorkflow":
         return await updateWorkflow(args.input, userId, event);
-      case 'deleteWorkflow':
+      case "deleteWorkflow":
         return await deleteWorkflow(args.workflowId, userId, event);
-      case 'publishWorkflow':
+      case "publishWorkflow":
         return await publishWorkflow(args.workflowId, userId, event);
-      case 'updateWorkflowConfiguration':
-        return await updateWorkflowConfiguration(args.workflowId, args.configuration, args.version, userId, event);
-      case 'importBlueprint':
-        return await importBlueprint(args.blueprintId, args.appId, args.name, args.agentMapping, userId, event);
-      case 'importWorkflow':
-        return await importWorkflowFn(args.input, userId);
-      case 'exportWorkflow':
+      case "updateWorkflowConfiguration":
+        return await updateWorkflowConfiguration(
+          args.workflowId,
+          args.configuration,
+          args.version,
+          userId,
+          event,
+        );
+      case "importBlueprint":
+        return await importBlueprint(
+          args.blueprintId,
+          args.appId,
+          args.name,
+          args.agentMapping,
+          userId,
+          event,
+        );
+      case "importWorkflow":
+        return await importWorkflowFn(args.input, userId, event);
+      case "exportWorkflow":
         return await exportWorkflow(args.workflowId, userId, event);
-      case 'getWorkflowVersion':
-        return await getWorkflowVersion(args.workflowId, args.version, userId, event);
-      case 'listAppWorkflows':
+      case "getWorkflowVersion":
+        return await getWorkflowVersion(
+          args.workflowId,
+          args.version,
+          userId,
+          event,
+        );
+      case "listAppWorkflows":
         return await listAppWorkflows(args.appId, userId, event);
       default:
         throw new Error(`Unknown field: ${fieldName}`);
     }
   } catch (error) {
-    console.error('Workflow resolver error:', error);
+    console.error("Workflow resolver error:", error);
     throw error;
   }
 };
 
-async function getWorkflow(workflowId: string, userId: string, event: unknown): Promise<WorkflowRecord | null> {
-  const result = await docClient.send(new GetCommand({
-    TableName: WORKFLOWS_TABLE,
-    Key: { workflowId },
-  }));
+async function getWorkflow(
+  workflowId: string,
+  userId: string,
+  event: unknown,
+): Promise<WorkflowRecord | null> {
+  const result = await docClient.send(
+    new GetCommand({
+      TableName: WORKFLOWS_TABLE,
+      Key: { workflowId },
+    }),
+  );
 
   if (!result.Item) {
     return null;
@@ -157,7 +197,7 @@ async function getWorkflow(workflowId: string, userId: string, event: unknown): 
 
   const userOrg = await extractOrgFromEvent(event);
   if (userOrg && result.Item.orgId !== userOrg) {
-    throw new Error('Access denied');
+    throw new Error("Access denied");
   }
 
   return result.Item as WorkflowRecord;
@@ -174,23 +214,25 @@ async function listWorkflows(
 
   const params: QueryCommandInput = {
     TableName: WORKFLOWS_TABLE,
-    IndexName: 'OrgStatusIndex',
+    IndexName: "OrgStatusIndex",
     KeyConditionExpression: status
-      ? 'orgId = :orgId AND #status = :status'
-      : 'orgId = :orgId',
+      ? "orgId = :orgId AND #status = :status"
+      : "orgId = :orgId",
     ExpressionAttributeValues: {
-      ':orgId': queryOrgId,
-      ':isBlueprintFalse': 'false',
-      ...(status ? { ':status': status } : {}),
+      ":orgId": queryOrgId,
+      ":isBlueprintFalse": "false",
+      ...(status ? { ":status": status } : {}),
     },
-    FilterExpression: 'isBlueprint = :isBlueprintFalse',
-    ...(status ? { ExpressionAttributeNames: { '#status': 'status' } } : {}),
+    FilterExpression: "isBlueprint = :isBlueprintFalse",
+    ...(status ? { ExpressionAttributeNames: { "#status": "status" } } : {}),
   };
 
   const result = await docClient.send(new QueryCommand(params));
   return {
     items: result.Items || [],
-    nextToken: result.LastEvaluatedKey ? JSON.stringify(result.LastEvaluatedKey) : undefined,
+    nextToken: result.LastEvaluatedKey
+      ? JSON.stringify(result.LastEvaluatedKey)
+      : undefined,
   };
 }
 
@@ -199,10 +241,10 @@ async function listBlueprints(
 ): Promise<{ items: unknown[]; nextToken?: string }> {
   const params: QueryCommandInput = {
     TableName: WORKFLOWS_TABLE,
-    IndexName: 'BlueprintIndex',
-    KeyConditionExpression: 'isBlueprint = :isBlueprint',
+    IndexName: "BlueprintIndex",
+    KeyConditionExpression: "isBlueprint = :isBlueprint",
     ExpressionAttributeValues: {
-      ':isBlueprint': 'true',
+      ":isBlueprint": "true",
     },
     ScanIndexForward: false,
   };
@@ -213,7 +255,10 @@ async function listBlueprints(
   if (category) {
     items = items.filter((item) => {
       try {
-        const meta = typeof item.metadata === 'string' ? JSON.parse(item.metadata) : item.metadata;
+        const meta =
+          typeof item.metadata === "string"
+            ? JSON.parse(item.metadata)
+            : item.metadata;
         return meta?.category === category;
       } catch {
         return false;
@@ -223,14 +268,43 @@ async function listBlueprints(
 
   return {
     items,
-    nextToken: result.LastEvaluatedKey ? JSON.stringify(result.LastEvaluatedKey) : undefined,
+    nextToken: result.LastEvaluatedKey
+      ? JSON.stringify(result.LastEvaluatedKey)
+      : undefined,
   };
 }
 
 // Exported for reuse by intake-orchestration-resolver (the IAM-only intake
 // blueprint mutation delegates here so definition-structure validation and
-// the workflow.created event stay in exactly one place).
-export async function createWorkflow(input: CreateWorkflowInput, userId: string): Promise<unknown> {
+// the workflow.created event stay in exactly one place). That caller has no
+// AppSync identity to extract an org from — it derives orgId itself via its
+// own session-based mechanism (resolveOrgId) and is IAM-signed, not a
+// client-facing mutation path — so `event` is optional: when omitted, the
+// caller-supplied orgId is trusted as-is (server-derived upstream); when an
+// `event` IS supplied (the AppSync dispatch path), the caller's identity org
+// is derived and a mismatched or unresolvable org is REJECTED (decision
+// b5d463f2 mutation convention: reject, don't coerce).
+export async function createWorkflow(
+  input: CreateWorkflowInput,
+  userId: string,
+  event?: unknown,
+): Promise<unknown> {
+  let orgId = input.orgId;
+  if (event !== undefined) {
+    // Org derivation (finding 2c262386 lower set): createWorkflow previously
+    // trusted input.orgId outright on the client-facing dispatch path.
+    const callerOrgId = await extractOrgFromEvent(event);
+    if (!callerOrgId) {
+      throw new Error("Access denied: unable to resolve caller organization");
+    }
+    if (input.orgId && input.orgId !== callerOrgId) {
+      throw new Error(
+        "Access denied: orgId does not match caller's organization",
+      );
+    }
+    orgId = callerOrgId;
+  }
+
   const now = new Date().toISOString();
   const workflowId = uuidv4();
 
@@ -243,17 +317,19 @@ export async function createWorkflow(input: CreateWorkflowInput, userId: string)
   if (definition) {
     const validation = validateDefinitionStructure(definition);
     if (!validation.valid) {
-      throw new Error(`Invalid workflow definition: ${validation.errors.join('; ')}`);
+      throw new Error(
+        `Invalid workflow definition: ${validation.errors.join("; ")}`,
+      );
     }
   }
 
   const workflow = {
     workflowId,
-    orgId: input.orgId,
+    orgId,
     name: input.name,
-    description: input.description || '',
-    status: 'DRAFT',
-    isBlueprint: input.isBlueprint ? 'true' : 'false',
+    description: input.description || "",
+    status: "DRAFT",
+    isBlueprint: input.isBlueprint ? "true" : "false",
     definition,
     configuration,
     version: 1,
@@ -265,31 +341,39 @@ export async function createWorkflow(input: CreateWorkflowInput, userId: string)
     metadata,
   };
 
-  await docClient.send(new PutCommand({
-    TableName: WORKFLOWS_TABLE,
-    Item: workflow,
-  }));
+  await docClient.send(
+    new PutCommand({
+      TableName: WORKFLOWS_TABLE,
+      Item: workflow,
+    }),
+  );
 
-  await emitEvent('workflow.created', {
+  await emitEvent("workflow.created", {
     workflowId,
-    orgId: input.orgId,
+    orgId,
     userId,
   });
 
   return workflow;
 }
 
-async function updateWorkflow(input: UpdateWorkflowInput, userId: string, event: WorkflowResolverEvent): Promise<unknown> {
+async function updateWorkflow(
+  input: UpdateWorkflowInput,
+  userId: string,
+  event: WorkflowResolverEvent,
+): Promise<unknown> {
   // Verify org access first
   const existing = await getWorkflow(input.workflowId, userId, event);
   if (!existing) {
-    throw new Error('Workflow not found');
+    throw new Error("Workflow not found");
   }
 
   const now = new Date().toISOString();
   const updateExpression: string[] = [];
   const expressionAttributeNames: Record<string, string> = {};
-  const expressionAttributeValues: NonNullable<UpdateCommandInput['ExpressionAttributeValues']> = {};
+  const expressionAttributeValues: NonNullable<
+    UpdateCommandInput["ExpressionAttributeValues"]
+  > = {};
 
   // Push current state to versionHistory before updating
   const historyEntry = {
@@ -298,20 +382,22 @@ async function updateWorkflow(input: UpdateWorkflowInput, userId: string, event:
     updatedAt: existing.updatedAt,
     updatedBy: existing.createdBy || userId,
   };
-  updateExpression.push('#versionHistory = list_append(if_not_exists(#versionHistory, :emptyList), :historyEntry)');
-  expressionAttributeNames['#versionHistory'] = 'versionHistory';
-  expressionAttributeValues[':historyEntry'] = [historyEntry];
-  expressionAttributeValues[':emptyList'] = [];
+  updateExpression.push(
+    "#versionHistory = list_append(if_not_exists(#versionHistory, :emptyList), :historyEntry)",
+  );
+  expressionAttributeNames["#versionHistory"] = "versionHistory";
+  expressionAttributeValues[":historyEntry"] = [historyEntry];
+  expressionAttributeValues[":emptyList"] = [];
 
   if (input.name !== undefined) {
-    updateExpression.push('#name = :name');
-    expressionAttributeNames['#name'] = 'name';
-    expressionAttributeValues[':name'] = input.name;
+    updateExpression.push("#name = :name");
+    expressionAttributeNames["#name"] = "name";
+    expressionAttributeValues[":name"] = input.name;
   }
   if (input.description !== undefined) {
-    updateExpression.push('#description = :description');
-    expressionAttributeNames['#description'] = 'description';
-    expressionAttributeValues[':description'] = input.description;
+    updateExpression.push("#description = :description");
+    expressionAttributeNames["#description"] = "description";
+    expressionAttributeValues[":description"] = input.description;
   }
   if (input.definition !== undefined) {
     // AppSync delivers AWSJSON as parsed objects — normalize to a JSON string first.
@@ -319,44 +405,50 @@ async function updateWorkflow(input: UpdateWorkflowInput, userId: string, event:
     // Validate definition structure before persistence (WF-01 AC 12)
     const validation = validateDefinitionStructure(definition);
     if (!validation.valid) {
-      throw new Error(`Invalid workflow definition: ${validation.errors.join('; ')}`);
+      throw new Error(
+        `Invalid workflow definition: ${validation.errors.join("; ")}`,
+      );
     }
-    updateExpression.push('#definition = :definition');
-    expressionAttributeNames['#definition'] = 'definition';
-    expressionAttributeValues[':definition'] = definition;
+    updateExpression.push("#definition = :definition");
+    expressionAttributeNames["#definition"] = "definition";
+    expressionAttributeValues[":definition"] = definition;
   }
   if (input.configuration !== undefined) {
-    updateExpression.push('#configuration = :configuration');
-    expressionAttributeNames['#configuration'] = 'configuration';
-    expressionAttributeValues[':configuration'] = toJsonString(input.configuration);
+    updateExpression.push("#configuration = :configuration");
+    expressionAttributeNames["#configuration"] = "configuration";
+    expressionAttributeValues[":configuration"] = toJsonString(
+      input.configuration,
+    );
   }
   if (input.metadata !== undefined) {
-    updateExpression.push('#metadata = :metadata');
-    expressionAttributeNames['#metadata'] = 'metadata';
-    expressionAttributeValues[':metadata'] = toJsonString(input.metadata);
+    updateExpression.push("#metadata = :metadata");
+    expressionAttributeNames["#metadata"] = "metadata";
+    expressionAttributeValues[":metadata"] = toJsonString(input.metadata);
   }
 
-  updateExpression.push('#updatedAt = :updatedAt');
-  expressionAttributeNames['#updatedAt'] = 'updatedAt';
-  expressionAttributeValues[':updatedAt'] = now;
+  updateExpression.push("#updatedAt = :updatedAt");
+  expressionAttributeNames["#updatedAt"] = "updatedAt";
+  expressionAttributeValues[":updatedAt"] = now;
 
-  updateExpression.push('#version = :nextVersion');
-  expressionAttributeNames['#version'] = 'version';
-  expressionAttributeValues[':nextVersion'] = input.version + 1;
-  expressionAttributeValues[':currentVersion'] = input.version;
+  updateExpression.push("#version = :nextVersion");
+  expressionAttributeNames["#version"] = "version";
+  expressionAttributeValues[":nextVersion"] = input.version + 1;
+  expressionAttributeValues[":currentVersion"] = input.version;
 
   try {
-    const result = await docClient.send(new UpdateCommand({
-      TableName: WORKFLOWS_TABLE,
-      Key: { workflowId: input.workflowId },
-      UpdateExpression: `SET ${updateExpression.join(', ')}`,
-      ConditionExpression: 'version = :currentVersion',
-      ExpressionAttributeNames: expressionAttributeNames,
-      ExpressionAttributeValues: expressionAttributeValues,
-      ReturnValues: 'ALL_NEW',
-    }));
+    const result = await docClient.send(
+      new UpdateCommand({
+        TableName: WORKFLOWS_TABLE,
+        Key: { workflowId: input.workflowId },
+        UpdateExpression: `SET ${updateExpression.join(", ")}`,
+        ConditionExpression: "version = :currentVersion",
+        ExpressionAttributeNames: expressionAttributeNames,
+        ExpressionAttributeValues: expressionAttributeValues,
+        ReturnValues: "ALL_NEW",
+      }),
+    );
 
-    await emitEvent('workflow.updated', {
+    await emitEvent("workflow.updated", {
       workflowId: input.workflowId,
       userId,
       changes: input,
@@ -364,29 +456,40 @@ async function updateWorkflow(input: UpdateWorkflowInput, userId: string, event:
 
     return result.Attributes;
   } catch (error: unknown) {
-    if (error instanceof Error && error.name === 'ConditionalCheckFailedException') {
-      throw new Error('Conflict: workflow was modified concurrently. Please retry.');
+    if (
+      error instanceof Error &&
+      error.name === "ConditionalCheckFailedException"
+    ) {
+      throw new Error(
+        "Conflict: workflow was modified concurrently. Please retry.",
+      );
     }
     throw error;
   }
 }
 
-async function deleteWorkflow(workflowId: string, userId: string, event: WorkflowResolverEvent): Promise<unknown> {
+async function deleteWorkflow(
+  workflowId: string,
+  userId: string,
+  event: WorkflowResolverEvent,
+): Promise<unknown> {
   const workflow = await getWorkflow(workflowId, userId, event);
   if (!workflow) {
-    throw new Error('Workflow not found');
+    throw new Error("Workflow not found");
   }
 
-  if (workflow.status === 'PUBLISHED') {
-    throw new Error('Cannot delete a published workflow. Unpublish it first.');
+  if (workflow.status === "PUBLISHED") {
+    throw new Error("Cannot delete a published workflow. Unpublish it first.");
   }
 
-  await docClient.send(new DeleteCommand({
-    TableName: WORKFLOWS_TABLE,
-    Key: { workflowId },
-  }));
+  await docClient.send(
+    new DeleteCommand({
+      TableName: WORKFLOWS_TABLE,
+      Key: { workflowId },
+    }),
+  );
 
-  await emitEvent('workflow.deleted', {
+  await emitEvent("workflow.deleted", {
     workflowId,
     orgId: workflow.orgId,
     userId,
@@ -405,7 +508,7 @@ function toJsonString(value: unknown): string | null {
   if (value === null || value === undefined) {
     return null;
   }
-  if (typeof value === 'string') {
+  if (typeof value === "string") {
     return value;
   }
   return JSON.stringify(value);
@@ -428,7 +531,7 @@ function toJsonString(value: unknown): string | null {
 // the ledger key's nodeId segment. `agentId` and edge ids are not ledger
 // key segments (agentId is validated for existence elsewhere via
 // verifyAgentsExist; edge ids are not used to build ledger keys at all).
-const LEDGER_KEY_DELIMITER = '#';
+const LEDGER_KEY_DELIMITER = "#";
 
 /**
  * Validates workflow definition structure before persistence (WF-01 AC 12).
@@ -438,28 +541,34 @@ const LEDGER_KEY_DELIMITER = '#';
  * Accepts either a JSON string or an already-parsed object (AppSync AWSJSON).
  * Exported for the intake Python-client contract test (envelope round-trip).
  */
-export function validateDefinitionStructure(definitionValue: unknown): { valid: boolean; errors: string[] } {
+export function validateDefinitionStructure(definitionValue: unknown): {
+  valid: boolean;
+  errors: string[];
+} {
   const errors: string[] = [];
   let definition: unknown;
-  if (typeof definitionValue === 'string') {
+  if (typeof definitionValue === "string") {
     try {
       definition = JSON.parse(definitionValue);
     } catch {
-      return { valid: false, errors: ['Invalid JSON in workflow definition'] };
+      return { valid: false, errors: ["Invalid JSON in workflow definition"] };
     }
   } else {
     definition = definitionValue;
   }
-  if (typeof definition !== 'object' || definition === null) {
-    errors.push('Workflow definition must be a JSON object');
+  if (typeof definition !== "object" || definition === null) {
+    errors.push("Workflow definition must be a JSON object");
   } else {
     const candidate = definition as { nodes?: unknown; edges?: unknown };
     if (!Array.isArray(candidate.nodes)) {
-      errors.push('Workflow definition must contain a nodes array');
+      errors.push("Workflow definition must contain a nodes array");
     } else {
       for (const node of candidate.nodes) {
         const nodeId = (node as { id?: unknown } | null)?.id;
-        if (typeof nodeId === 'string' && nodeId.includes(LEDGER_KEY_DELIMITER)) {
+        if (
+          typeof nodeId === "string" &&
+          nodeId.includes(LEDGER_KEY_DELIMITER)
+        ) {
           errors.push(
             `Node id '${nodeId}' must not contain the reserved delimiter '${LEDGER_KEY_DELIMITER}'`,
           );
@@ -467,7 +576,7 @@ export function validateDefinitionStructure(definitionValue: unknown): { valid: 
       }
     }
     if (!Array.isArray(candidate.edges)) {
-      errors.push('Workflow definition must contain an edges array');
+      errors.push("Workflow definition must contain an edges array");
     }
   }
   return { valid: errors.length === 0, errors };
@@ -477,14 +586,17 @@ export function validateDefinitionStructure(definitionValue: unknown): { valid: 
  * Validates a workflow definition for publishing.
  * Returns { valid: boolean, errors: string[] }
  */
-function validateDefinition(definitionJson: string): { valid: boolean; errors: string[] } {
+function validateDefinition(definitionJson: string): {
+  valid: boolean;
+  errors: string[];
+} {
   const errors: string[] = [];
 
   let definition: ParsedWorkflowDefinition;
   try {
     definition = JSON.parse(definitionJson);
   } catch {
-    return { valid: false, errors: ['Invalid JSON in workflow definition'] };
+    return { valid: false, errors: ["Invalid JSON in workflow definition"] };
   }
 
   const nodes: WorkflowDefinitionNode[] = definition.nodes || [];
@@ -494,11 +606,14 @@ function validateDefinition(definitionJson: string): { valid: boolean; errors: s
   for (const node of nodes) {
     if (!node.agentId) {
       errors.push(`Node "${node.id}" is missing agentId`);
-    } else if (typeof node.agentId === 'string' && node.agentId.startsWith('placeholder-')) {
+    } else if (
+      typeof node.agentId === "string" &&
+      node.agentId.startsWith("placeholder-")
+    ) {
       errors.push(
         `Workflow contains placeholder agentId '${node.agentId}' in node '${node.id}'. ` +
-        `Replace with real agent IDs before publishing. ` +
-        `(Blueprint templates contain placeholder agentIds for illustration; clone and re-map.)`
+          `Replace with real agent IDs before publishing. ` +
+          `(Blueprint templates contain placeholder agentIds for illustration; clone and re-map.)`,
       );
     }
   }
@@ -547,7 +662,7 @@ function validateDefinition(definitionJson: string): { valid: boolean; errors: s
     for (const node of nodes) {
       if (!visited.has(node.id)) {
         if (hasCycle(node.id)) {
-          errors.push('Workflow definition contains circular dependencies');
+          errors.push("Workflow definition contains circular dependencies");
           break;
         }
       }
@@ -582,7 +697,7 @@ async function verifyAgentsExist(
     new Set(
       nodes
         .map((n) => n.agentId)
-        .filter((a): a is string => typeof a === 'string' && a.length > 0),
+        .filter((a): a is string => typeof a === "string" && a.length > 0),
     ),
   );
 
@@ -606,7 +721,7 @@ async function verifyAgentsExist(
       }),
     );
     for (const item of result.Responses?.[agentConfigTable] || []) {
-      if (item && typeof item.agentId === 'string') {
+      if (item && typeof item.agentId === "string") {
         existing.add(item.agentId);
       }
     }
@@ -614,7 +729,11 @@ async function verifyAgentsExist(
 
   const missing: { nodeId: string; agentId: string }[] = [];
   for (const node of nodes) {
-    if (typeof node.agentId === 'string' && node.agentId.length > 0 && !existing.has(node.agentId)) {
+    if (
+      typeof node.agentId === "string" &&
+      node.agentId.length > 0 &&
+      !existing.has(node.agentId)
+    ) {
       missing.push({ nodeId: node.id, agentId: node.agentId });
     }
   }
@@ -626,15 +745,19 @@ async function verifyAgentsExist(
 // blueprint mutation delegates here so the definition validator and the
 // agent-existence gate stay in exactly one place). The event parameter only
 // feeds extractOrgFromEvent(unknown), hence the wide type.
-export async function publishWorkflow(workflowId: string, userId: string, event: unknown): Promise<unknown> {
+export async function publishWorkflow(
+  workflowId: string,
+  userId: string,
+  event: unknown,
+): Promise<unknown> {
   const workflow = await getWorkflow(workflowId, userId, event);
   if (!workflow) {
-    throw new Error('Workflow not found');
+    throw new Error("Workflow not found");
   }
 
   const validation = validateDefinition(workflow.definition);
   if (!validation.valid) {
-    throw new Error(`Validation failed: ${validation.errors.join('; ')}`);
+    throw new Error(`Validation failed: ${validation.errors.join("; ")}`);
   }
 
   // A workflow cannot reach PUBLISHED until every node's agentId resolves to an
@@ -643,32 +766,35 @@ export async function publishWorkflow(workflowId: string, userId: string, event:
   if (!existence.ok) {
     const details = existence.missing
       .map((m) => `node '${m.nodeId}' -> agentId '${m.agentId}'`)
-      .join('; ');
+      .join("; ");
     throw new Error(
       `Validation failed: workflow references agents that do not exist: ${details}. ` +
-      `Map each node to an existing agent before publishing; the workflow remains DRAFT.`,
+        `Map each node to an existing agent before publishing; the workflow remains DRAFT.`,
     );
   }
 
   const now = new Date().toISOString();
-  const result = await docClient.send(new UpdateCommand({
-    TableName: WORKFLOWS_TABLE,
-    Key: { workflowId },
-    UpdateExpression: 'SET #status = :status, #updatedAt = :updatedAt, #version = :nextVersion',
-    ExpressionAttributeNames: {
-      '#status': 'status',
-      '#updatedAt': 'updatedAt',
-      '#version': 'version',
-    },
-    ExpressionAttributeValues: {
-      ':status': 'PUBLISHED',
-      ':updatedAt': now,
-      ':nextVersion': workflow.version + 1,
-    },
-    ReturnValues: 'ALL_NEW',
-  }));
+  const result = await docClient.send(
+    new UpdateCommand({
+      TableName: WORKFLOWS_TABLE,
+      Key: { workflowId },
+      UpdateExpression:
+        "SET #status = :status, #updatedAt = :updatedAt, #version = :nextVersion",
+      ExpressionAttributeNames: {
+        "#status": "status",
+        "#updatedAt": "updatedAt",
+        "#version": "version",
+      },
+      ExpressionAttributeValues: {
+        ":status": "PUBLISHED",
+        ":updatedAt": now,
+        ":nextVersion": workflow.version + 1,
+      },
+      ReturnValues: "ALL_NEW",
+    }),
+  );
 
-  await emitEvent('workflow.published', {
+  await emitEvent("workflow.published", {
     workflowId,
     orgId: workflow.orgId,
     userId,
@@ -686,11 +812,13 @@ async function updateWorkflowConfiguration(
 ): Promise<unknown> {
   const existing = await getWorkflow(workflowId, userId, event);
   if (!existing) {
-    throw new Error('Workflow not found');
+    throw new Error("Workflow not found");
   }
 
   const existingConfig = existing.configuration
-    ? (typeof existing.configuration === 'string' ? JSON.parse(existing.configuration) : existing.configuration)
+    ? typeof existing.configuration === "string"
+      ? JSON.parse(existing.configuration)
+      : existing.configuration
     : {};
   const newConfig = JSON.parse(configurationJson);
 
@@ -700,26 +828,29 @@ async function updateWorkflowConfiguration(
   const now = new Date().toISOString();
 
   try {
-    const result = await docClient.send(new UpdateCommand({
-      TableName: WORKFLOWS_TABLE,
-      Key: { workflowId },
-      UpdateExpression: 'SET #configuration = :configuration, #updatedAt = :updatedAt, #version = :nextVersion',
-      ConditionExpression: 'version = :currentVersion',
-      ExpressionAttributeNames: {
-        '#configuration': 'configuration',
-        '#updatedAt': 'updatedAt',
-        '#version': 'version',
-      },
-      ExpressionAttributeValues: {
-        ':configuration': JSON.stringify(merged),
-        ':updatedAt': now,
-        ':nextVersion': version + 1,
-        ':currentVersion': version,
-      },
-      ReturnValues: 'ALL_NEW',
-    }));
+    const result = await docClient.send(
+      new UpdateCommand({
+        TableName: WORKFLOWS_TABLE,
+        Key: { workflowId },
+        UpdateExpression:
+          "SET #configuration = :configuration, #updatedAt = :updatedAt, #version = :nextVersion",
+        ConditionExpression: "version = :currentVersion",
+        ExpressionAttributeNames: {
+          "#configuration": "configuration",
+          "#updatedAt": "updatedAt",
+          "#version": "version",
+        },
+        ExpressionAttributeValues: {
+          ":configuration": JSON.stringify(merged),
+          ":updatedAt": now,
+          ":nextVersion": version + 1,
+          ":currentVersion": version,
+        },
+        ReturnValues: "ALL_NEW",
+      }),
+    );
 
-    await emitEvent('workflow.updated', {
+    await emitEvent("workflow.updated", {
       workflowId,
       userId,
       changes: { configuration: merged },
@@ -727,8 +858,13 @@ async function updateWorkflowConfiguration(
 
     return result.Attributes;
   } catch (error: unknown) {
-    if (error instanceof Error && error.name === 'ConditionalCheckFailedException') {
-      throw new Error('Conflict: workflow was modified concurrently. Please retry.');
+    if (
+      error instanceof Error &&
+      error.name === "ConditionalCheckFailedException"
+    ) {
+      throw new Error(
+        "Conflict: workflow was modified concurrently. Please retry.",
+      );
     }
     throw error;
   }
@@ -748,35 +884,39 @@ export async function importBlueprint(
   event: unknown,
 ): Promise<unknown> {
   // Get the blueprint
-  const blueprintResult = await docClient.send(new GetCommand({
-    TableName: WORKFLOWS_TABLE,
-    Key: { workflowId: blueprintId },
-  }));
+  const blueprintResult = await docClient.send(
+    new GetCommand({
+      TableName: WORKFLOWS_TABLE,
+      Key: { workflowId: blueprintId },
+    }),
+  );
 
   const blueprint = blueprintResult.Item;
   if (!blueprint) {
-    throw new Error('Blueprint not found');
+    throw new Error("Blueprint not found");
   }
 
-  if (blueprint.status !== 'PUBLISHED') {
-    throw new Error('Only published blueprints can be imported');
+  if (blueprint.status !== "PUBLISHED") {
+    throw new Error("Only published blueprints can be imported");
   }
 
   // Get the target app
-  const appResult = await docClient.send(new GetCommand({
-    TableName: APPS_TABLE,
-    Key: { appId },
-  }));
+  const appResult = await docClient.send(
+    new GetCommand({
+      TableName: APPS_TABLE,
+      Key: { appId },
+    }),
+  );
 
   const app = appResult.Item;
   if (!app) {
-    throw new Error('App not found');
+    throw new Error("App not found");
   }
 
   // Verify org access
   const userOrg = await extractOrgFromEvent(event);
   if (userOrg && app.orgId !== userOrg) {
-    throw new Error('Access denied');
+    throw new Error("Access denied");
   }
 
   const now = new Date().toISOString();
@@ -786,21 +926,28 @@ export async function importBlueprint(
   // optional agentMapping to rewrite each node's placeholder/slot agentId to the
   // caller-chosen real agentId. Nodes whose agentId is not present in the mapping
   // are left unchanged. Contract: agentMapping = { [placeholderAgentId]: realAgentId }.
-  const definitionStr = typeof blueprint.definition === 'string'
-    ? blueprint.definition
-    : JSON.stringify(blueprint.definition);
+  const definitionStr =
+    typeof blueprint.definition === "string"
+      ? blueprint.definition
+      : JSON.stringify(blueprint.definition);
   const parsedDefinition = JSON.parse(definitionStr);
 
   const mapping: Record<string, string> =
-    typeof agentMapping === 'string'
-      ? (agentMapping.trim() ? JSON.parse(agentMapping) : {})
-      : (agentMapping || {});
+    typeof agentMapping === "string"
+      ? agentMapping.trim()
+        ? JSON.parse(agentMapping)
+        : {}
+      : agentMapping || {};
 
-  if (parsedDefinition && Array.isArray(parsedDefinition.nodes) && Object.keys(mapping).length > 0) {
+  if (
+    parsedDefinition &&
+    Array.isArray(parsedDefinition.nodes) &&
+    Object.keys(mapping).length > 0
+  ) {
     for (const node of parsedDefinition.nodes) {
       if (
         node &&
-        typeof node.agentId === 'string' &&
+        typeof node.agentId === "string" &&
         Object.prototype.hasOwnProperty.call(mapping, node.agentId)
       ) {
         node.agentId = mapping[node.agentId];
@@ -814,9 +961,9 @@ export async function importBlueprint(
     workflowId,
     orgId: app.orgId,
     name: name || `${blueprint.name} (Copy)`,
-    description: blueprint.description || '',
-    status: 'DRAFT',
-    isBlueprint: 'false',
+    description: blueprint.description || "",
+    status: "DRAFT",
+    isBlueprint: "false",
     definition,
     configuration: blueprint.configuration || null,
     version: 1,
@@ -829,26 +976,31 @@ export async function importBlueprint(
   };
 
   // Put the new workflow
-  await docClient.send(new PutCommand({
-    TableName: WORKFLOWS_TABLE,
-    Item: workflow,
-  }));
+  await docClient.send(
+    new PutCommand({
+      TableName: WORKFLOWS_TABLE,
+      Item: workflow,
+    }),
+  );
 
   // Append workflowId to app's workflowIds
-  await docClient.send(new UpdateCommand({
-    TableName: APPS_TABLE,
-    Key: { appId },
-    UpdateExpression: 'SET #workflowIds = list_append(if_not_exists(#workflowIds, :emptyList), :newWorkflowId)',
-    ExpressionAttributeNames: {
-      '#workflowIds': 'workflowIds',
-    },
-    ExpressionAttributeValues: {
-      ':newWorkflowId': [workflowId],
-      ':emptyList': [],
-    },
-  }));
+  await docClient.send(
+    new UpdateCommand({
+      TableName: APPS_TABLE,
+      Key: { appId },
+      UpdateExpression:
+        "SET #workflowIds = list_append(if_not_exists(#workflowIds, :emptyList), :newWorkflowId)",
+      ExpressionAttributeNames: {
+        "#workflowIds": "workflowIds",
+      },
+      ExpressionAttributeValues: {
+        ":newWorkflowId": [workflowId],
+        ":emptyList": [],
+      },
+    }),
+  );
 
-  await emitEvent('workflow.imported', {
+  await emitEvent("workflow.imported", {
     blueprintId,
     workflowId,
     appId,
@@ -858,8 +1010,29 @@ export async function importBlueprint(
   return workflow;
 }
 
-async function importWorkflowFn(input: ImportWorkflowInput, userId: string): Promise<unknown> {
-  const { orgId, workflowJson, name } = input;
+async function importWorkflowFn(
+  input: ImportWorkflowInput,
+  userId: string,
+  event?: unknown,
+): Promise<unknown> {
+  const { orgId: inputOrgId, workflowJson, name } = input;
+
+  // Org derivation (finding 2c262386 — primary case): importWorkflow let a
+  // caller plant a DRAFT workflow into ANOTHER tenant's workspace by setting
+  // orgId=victim. Same reject-not-coerce convention as createWorkflow/
+  // decision b5d463f2: derive the caller's org server-side and refuse a
+  // mismatched client value BEFORE any DynamoDB write. Fail closed when the
+  // caller's org cannot be resolved at all.
+  const callerOrgId = await extractOrgFromEvent(event);
+  if (!callerOrgId) {
+    throw new Error("Access denied: unable to resolve caller organization");
+  }
+  if (inputOrgId && inputOrgId !== callerOrgId) {
+    throw new Error(
+      "Access denied: orgId does not match caller's organization",
+    );
+  }
+  const orgId = callerOrgId;
 
   let parsed: {
     name?: string;
@@ -871,12 +1044,12 @@ async function importWorkflowFn(input: ImportWorkflowInput, userId: string): Pro
   try {
     parsed = JSON.parse(workflowJson);
   } catch {
-    throw new Error('Invalid JSON in workflow import');
+    throw new Error("Invalid JSON in workflow import");
   }
 
   // Validate the definition exists
   if (!parsed.definition) {
-    throw new Error('Imported workflow must contain a definition');
+    throw new Error("Imported workflow must contain a definition");
   }
 
   // Validate definition structure, incl. no reserved ledger-key delimiter
@@ -884,7 +1057,9 @@ async function importWorkflowFn(input: ImportWorkflowInput, userId: string): Pro
   // previously bypassed validateDefinitionStructure entirely).
   const importValidation = validateDefinitionStructure(parsed.definition);
   if (!importValidation.valid) {
-    throw new Error(`Invalid workflow definition: ${importValidation.errors.join('; ')}`);
+    throw new Error(
+      `Invalid workflow definition: ${importValidation.errors.join("; ")}`,
+    );
   }
 
   const now = new Date().toISOString();
@@ -893,10 +1068,10 @@ async function importWorkflowFn(input: ImportWorkflowInput, userId: string): Pro
   const workflow = {
     workflowId,
     orgId,
-    name: name || parsed.name || 'Imported Workflow',
-    description: parsed.description || '',
-    status: 'DRAFT',
-    isBlueprint: 'false',
+    name: name || parsed.name || "Imported Workflow",
+    description: parsed.description || "",
+    status: "DRAFT",
+    isBlueprint: "false",
     definition: parsed.definition,
     configuration: parsed.configuration || null,
     version: 1,
@@ -908,18 +1083,24 @@ async function importWorkflowFn(input: ImportWorkflowInput, userId: string): Pro
     metadata: parsed.metadata || null,
   };
 
-  await docClient.send(new PutCommand({
-    TableName: WORKFLOWS_TABLE,
-    Item: workflow,
-  }));
+  await docClient.send(
+    new PutCommand({
+      TableName: WORKFLOWS_TABLE,
+      Item: workflow,
+    }),
+  );
 
   return workflow;
 }
 
-async function exportWorkflow(workflowId: string, userId: string, event: WorkflowResolverEvent): Promise<unknown> {
+async function exportWorkflow(
+  workflowId: string,
+  userId: string,
+  event: WorkflowResolverEvent,
+): Promise<unknown> {
   const workflow = await getWorkflow(workflowId, userId, event);
   if (!workflow) {
-    throw new Error('Workflow not found');
+    throw new Error("Workflow not found");
   }
 
   return JSON.stringify({
@@ -941,7 +1122,7 @@ async function getWorkflowVersion(
 ): Promise<unknown> {
   const workflow = await getWorkflow(workflowId, userId, event);
   if (!workflow) {
-    throw new Error('Workflow not found');
+    throw new Error("Workflow not found");
   }
 
   // If requesting current version, return as-is
@@ -963,22 +1144,28 @@ async function getWorkflowVersion(
   };
 }
 
-async function listAppWorkflows(appId: string, userId: string, event: WorkflowResolverEvent): Promise<unknown[]> {
+async function listAppWorkflows(
+  appId: string,
+  userId: string,
+  event: WorkflowResolverEvent,
+): Promise<unknown[]> {
   // Get the app first
-  const appResult = await docClient.send(new GetCommand({
-    TableName: APPS_TABLE,
-    Key: { appId },
-  }));
+  const appResult = await docClient.send(
+    new GetCommand({
+      TableName: APPS_TABLE,
+      Key: { appId },
+    }),
+  );
 
   const app = appResult.Item;
   if (!app) {
-    throw new Error('App not found');
+    throw new Error("App not found");
   }
 
   // Verify org access
   const userOrg = await extractOrgFromEvent(event);
   if (userOrg && app.orgId !== userOrg) {
-    throw new Error('Access denied');
+    throw new Error("Access denied");
   }
 
   const workflowIds: string[] = app.workflowIds || [];
@@ -989,26 +1176,30 @@ async function listAppWorkflows(appId: string, userId: string, event: WorkflowRe
   // BatchGetItem for workflows
   const keys = workflowIds.map((id) => ({ workflowId: id }));
   const tableName = process.env.WORKFLOWS_TABLE!;
-  const result = await docClient.send(new BatchGetCommand({
-    RequestItems: {
-      [tableName]: {
-        Keys: keys,
+  const result = await docClient.send(
+    new BatchGetCommand({
+      RequestItems: {
+        [tableName]: {
+          Keys: keys,
+        },
       },
-    },
-  }));
+    }),
+  );
 
   return result.Responses?.[tableName] || [];
 }
 
 async function emitEvent(eventType: string, detail: unknown): Promise<void> {
-  await eventBridgeClient.send(new PutEventsCommand({
-    Entries: [
-      {
-        Source: 'citadel.workflows',
-        DetailType: eventType,
-        Detail: JSON.stringify(detail),
-        EventBusName: EVENT_BUS_NAME,
-      },
-    ],
-  }));
+  await eventBridgeClient.send(
+    new PutEventsCommand({
+      Entries: [
+        {
+          Source: "citadel.workflows",
+          DetailType: eventType,
+          Detail: JSON.stringify(detail),
+          EventBusName: EVENT_BUS_NAME,
+        },
+      ],
+    }),
+  );
 }


### PR DESCRIPTION
## Summary

Three remaining paths from the resolver authorization sweep, each trusting a client-supplied organization or applying none at all. One commit per fix.

**Workflow planting** - `createWorkflow` and `importworkflow` trusted `input.orgId`, so a caller could plant a workflow into another tenant. Both now derive the organization from the authenticated identity and **reject** a mismatched client value before any write, per the established mutations-reject convention. An optional `event` parameter preserves the IAM-only intake-orchestration caller, which has no AppSync identity and derives its own organization. `importBlueprint` and every other operation in that resolver were checked and already derive organization from a loaded row, so no sibling was left inconsistent.

**Execution disclosure** - `ListExecutions` had no organization check, exposing another tenant's executions including inputs and outputs. The executions table has only a workflow index and no organization GSI, so rather than invent a silent filtered list, it loads the parent workflow row (the organization source of truth, the same lookup `startExecution` uses) and **refuses**, matching `get` / `start` / `cancel` / `resume` semantics. Refusing also avoids leaking existence through a result count or pagination cursor.
**Datastore admin bypass** - `createDataStore` rejected a mismatched `input.orgId` for non-admins but skipped the check for admins, so an administrator could write an arbitrary organization into both the record and the Secrets Manager path. Per the ratified decision, the mismatch is now rejected for **everyone**. No platform-operator path was built speculatively; the commit records that an explicit separate route is the sanctioned option if operators genuinely need it.

## Testing

- Executed attacks: `importworkflow` and `createworkflow` with a foreign `orgId` rejected with zero writes; `listExecutions` returns no foreign executions with two organizations seeded; `createDataStore` as an **admin** with a foreign organization rejected with zero DynamoDB writes, zero secret creation and zero IAM role creation
- Executed bite proofs on both write paths, quoting the verbatim assertion showing the foreign organization persisted when the check is removed; restored byte-identically
- Fail-closed proven by mutation rather than by asserting an empty result
- Two new dispatch-derived gate-enumeration guards (workflow, execution), taking the series to twelve, each proven to bite
- tsc, lint exit o; 217 targeted tests; guards 47; full backend jest 7622; CI-equivalent synth with cdk-nag enabled clean after a dist rebuild. No IAM or CDK files touched, so no rail-6 entry applies

## Notes

- A pre-existing test asserted that the `createDataStore` admin bypass **was** preserved. It was inverted into a rejection test proving zero side effects, rather than deleted - the sixth module in this series where a fixture encoded the gap
- Remaining from the sweep: the fabricator-queue's unfiltered scan, which needs `orgId` stamped rows plus a real query and therefore a backfill decision for existing rows. Two modules still await a product answer: whether admin is platform-global for `promotion-policy-resolver` and how `governance-ui-resolver`'s IAM-posture reads should be gated