### PR TITLE
fix(security): org-scope the fabricator queue and remove the raw scan

### DIFF
--- a/arbiter/fabricator/__tests__/test_fabrication_status_org_scoping.py
+++ b/arbiter/fabricator/__tests__/test_fabrication_status_org_scoping.py
@@ -1,0 +1,167 @@
+"""
+Cross-tenant exposure fix (design evidence bf4a13f2, fabricator-queue
+section) — org_id stamping tests for the arbiter's fabrication-status
+writer.
+
+process_event must thread the SQS event's org_id through to every
+_write_fabrication_status call (PROCESSING, COMPLETED, and every FAILED
+path), and _write_fabrication_status itself must stamp orgId onto the row
+with if_not_exists semantics so it never clobbers a producer-set orgId
+(e.g. the direct-UI PENDING write).
+"""
+
+import sys
+import os
+from unittest.mock import patch, MagicMock
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+
+os.environ.setdefault("TOOL_CONFIG_TABLE", "fake-tool-table")
+os.environ.setdefault("AGENT_CONFIG_TABLE", "fake-agent-table")
+os.environ.setdefault("AGENT_BUCKET_NAME", "fake-bucket")
+os.environ.setdefault("COMPLETION_BUS_NAME", "fake-bus")
+os.environ.setdefault("WORKER_QUEUE_URL", "https://sqs.fake/queue")
+
+import index
+
+
+def _base_event(org_id=None):
+    event = {
+        "orchestration_id": "sess-1",
+        "agent_use_id": "MyAgent",
+        "node": "fabricator",
+        "agent_input": {"taskDetails": "Create an agent that does things"},
+        "agent_index": 0,
+        "total_agents": 1,
+    }
+    if org_id is not None:
+        event["org_id"] = org_id
+    return event
+
+
+class TestOrgIdThreadedThroughProcessEvent:
+    def setup_method(self):
+        os.environ["FABRICATION_JOBS_TABLE"] = "citadel-fabrication-jobs-test"
+
+    def teardown_method(self):
+        os.environ.pop("FABRICATION_JOBS_TABLE", None)
+
+    def test_org_id_from_event_reaches_every_status_write_on_success(self):
+        calls = []
+
+        def record(orchestration_id, agent_use_id, status, **kwargs):
+            calls.append((status, kwargs))
+
+        with patch.object(index, "_write_fabrication_status", side_effect=record), \
+                patch.object(index, "check_design_assessment"), \
+                patch.object(index, "create_agent_fabricator") as mk, \
+                patch.object(index, "publish_intake_progress"):
+            mk.return_value = MagicMock()
+            index.process_event(_base_event(org_id="org-caller"), {}, request_type="agent-creation")
+
+        assert len(calls) >= 2
+        for status, kwargs in calls:
+            assert kwargs.get("org_id") == "org-caller", (
+                f"status={status} write did not receive org_id"
+            )
+
+    def test_org_id_from_event_reaches_the_failed_write_on_exception(self):
+        calls = []
+
+        def record(orchestration_id, agent_use_id, status, **kwargs):
+            calls.append((status, kwargs))
+
+        boom = RuntimeError("fabrication blew up")
+        with patch.object(index, "_write_fabrication_status", side_effect=record), \
+                patch.object(index, "check_design_assessment"), \
+                patch.object(index, "create_agent_fabricator") as mk, \
+                patch.object(index, "publish_intake_progress"), \
+                patch.object(index, "publish_fabrication_event"):
+            agent = MagicMock(side_effect=boom)
+            mk.return_value = agent
+            try:
+                index.process_event(_base_event(org_id="org-caller"), {}, request_type="agent-creation")
+            except RuntimeError:
+                pass
+
+        failed_calls = [kw for s, kw in calls if s == "FAILED"]
+        assert failed_calls, "expected at least one FAILED status write"
+        for kwargs in failed_calls:
+            assert kwargs.get("org_id") == "org-caller"
+
+    def test_missing_org_id_on_event_defaults_to_empty_and_is_not_stamped(self):
+        # Mirrors the existing '' fallback convention (Phase 2b) — absent
+        # org_id must not block fabrication, and must not write a blank
+        # orgId attribute onto the row (verified at the lower level below).
+        calls = []
+
+        def record(orchestration_id, agent_use_id, status, **kwargs):
+            calls.append((status, kwargs))
+
+        with patch.object(index, "_write_fabrication_status", side_effect=record), \
+                patch.object(index, "check_design_assessment"), \
+                patch.object(index, "create_agent_fabricator") as mk, \
+                patch.object(index, "publish_intake_progress"):
+            mk.return_value = MagicMock()
+            index.process_event(_base_event(), {}, request_type="agent-creation")
+
+        for status, kwargs in calls:
+            assert kwargs.get("org_id") == ""
+
+
+class TestWriteFabricationStatusStampsOrgIdWithIfNotExists:
+    """Lower-level: _write_fabrication_status's actual UpdateExpression."""
+
+    def setup_method(self):
+        os.environ["FABRICATION_JOBS_TABLE"] = "citadel-fabrication-jobs-test"
+
+    def teardown_method(self):
+        os.environ.pop("FABRICATION_JOBS_TABLE", None)
+
+    def test_org_id_written_with_if_not_exists_semantics(self):
+        captured = {}
+
+        class FakeDynamoClient:
+            def update_item(self, **kwargs):
+                captured.update(kwargs)
+                return {}
+
+        with patch.object(index.boto3, "client", return_value=FakeDynamoClient()):
+            index._write_fabrication_status(
+                "sess-1", "AgentX", "PROCESSING", agent_name="AgentX", org_id="org-a",
+            )
+
+        assert "orgId = if_not_exists(orgId, :orgId)" in captured["UpdateExpression"]
+        assert captured["ExpressionAttributeValues"][":orgId"] == {"S": "org-a"}
+
+    def test_no_org_id_attribute_written_when_org_id_is_empty(self):
+        captured = {}
+
+        class FakeDynamoClient:
+            def update_item(self, **kwargs):
+                captured.update(kwargs)
+                return {}
+
+        with patch.object(index.boto3, "client", return_value=FakeDynamoClient()):
+            index._write_fabrication_status(
+                "sess-1", "AgentX", "PROCESSING", agent_name="AgentX", org_id="",
+            )
+
+        assert "orgId" not in captured["UpdateExpression"]
+        assert ":orgId" not in captured["ExpressionAttributeValues"]
+
+    def test_no_org_id_attribute_written_when_org_id_omitted(self):
+        captured = {}
+
+        class FakeDynamoClient:
+            def update_item(self, **kwargs):
+                captured.update(kwargs)
+                return {}
+
+        with patch.object(index.boto3, "client", return_value=FakeDynamoClient()):
+            index._write_fabrication_status(
+                "sess-1", "AgentX", "PROCESSING", agent_name="AgentX",
+            )
+
+        assert "orgId" not in captured["UpdateExpression"]
+        assert ":orgId" not in captured["ExpressionAttributeValues"]

--- a/arbiter/fabricator/index.py
+++ b/arbiter/fabricator/index.py
@@ -298,6 +298,7 @@ def _write_fabrication_status(
     error_message: str | None = None,
     agent_name: str | None = None,
     registration_errors: list | None = None,
+    org_id: str | None = None,
 ) -> bool:
     """Upsert a per-agent fabrication status row in the durable jobs table.
 
@@ -305,6 +306,15 @@ def _write_fabrication_status(
     (``citadel-fabrication-jobs-${env}``) is keyed by orchestrationId (PK) /
     agentUseId (SK). process_event calls this at the START (PROCESSING), on
     SUCCESS (COMPLETED + agentId) and on EXCEPTION (FAILED + errorMessage).
+
+    ``org_id`` (Phase 2b / cross-tenant exposure fix, design evidence
+    bf4a13f2): the caller's organization, stamped onto the row so the
+    org-scoped getFabricatorQueue GSI query can find it. Written with
+    ``if_not_exists`` semantics — same rationale as ``agentName`` below — so
+    this arbiter write never clobbers an orgId a producer (direct-UI PENDING
+    write) already stamped on the row. Omitted entirely when empty/None
+    rather than writing a blank string, so an unresolvable org reads as
+    absent, not as a false empty-string match against a caller with no org.
 
     ``registration_errors`` is an ADDITIVE attribute (no new status enum
     value — the 4-value {PENDING, PROCESSING, COMPLETED, FAILED} contract is
@@ -365,6 +375,11 @@ def _write_fabrication_status(
         set_parts.append("#agentId = :agentId")
         names["#agentId"] = "agentId"
         values[":agentId"] = {"S": agent_id}
+    if org_id:
+        # if_not_exists: never clobber a producer-set orgId (e.g. the
+        # direct-UI PENDING write) — see docstring.
+        set_parts.append("orgId = if_not_exists(orgId, :orgId)")
+        values[":orgId"] = {"S": org_id}
     if error_message is not None:
         set_parts.append("#errorMessage = :errorMessage")
         names["#errorMessage"] = "errorMessage"
@@ -2194,7 +2209,8 @@ def process_event(event, context, request_type=None):
         # Durable status: mark this agent PROCESSING at the start. Best-effort
         # — a status-write failure never changes fabrication behavior.
         _write_fabrication_status(
-            orchestration_id, agent_use_id, "PROCESSING", agent_name=agent_use_id
+            orchestration_id, agent_use_id, "PROCESSING", agent_name=agent_use_id,
+            org_id=org_id,
         )
 
         # since this needs variable injection, keep within handler method scope.
@@ -2402,6 +2418,7 @@ def process_event(event, context, request_type=None):
                 error_message=all_failed_message[:1000],
                 agent_name=agent_use_id,
                 registration_errors=registration_errors,
+                org_id=org_id,
             )
             return
 
@@ -2409,6 +2426,7 @@ def process_event(event, context, request_type=None):
             orchestration_id, agent_use_id, "COMPLETED",
             agent_id=agent_use_id, agent_name=agent_use_id,
             registration_errors=registration_errors,
+            org_id=org_id,
         )
 
     except FabricationDeadlineExceeded as deadline_exc:
@@ -2427,7 +2445,8 @@ def process_event(event, context, request_type=None):
         _write_fabrication_status(
             orchestration_id, agent_use_id, "FAILED",
             error_message=timeout_message,
-            agent_name=agent_use_id
+            agent_name=agent_use_id,
+            org_id=org_id,
         )
         # Best-effort failure signals: the CLEAN RETURN is the loop-breaker,
         # so a failing EventBridge publish must never turn this path back
@@ -2460,7 +2479,8 @@ def process_event(event, context, request_type=None):
         _write_fabrication_status(
             orchestration_id, agent_use_id, "FAILED",
             error_message=user_actionable_failure_message(e),
-            agent_name=agent_use_id
+            agent_name=agent_use_id,
+            org_id=org_id,
         )
         # Publish intake progress failure
         publish_intake_progress(orchestration_id, agent_index, total_agents, agent_use_id, failed=True)

--- a/backend/lib/backend-stack.ts
+++ b/backend/lib/backend-stack.ts
@@ -983,17 +983,40 @@ export class BackendStack extends cdk.Stack {
     // PK orchestrationId (intake session id, or '0' for direct UI requests) /
     // SK agentUseId (agent name / requestId). On-demand + PITR per conventions;
     // a `ttl` attribute (epoch seconds, ~7 days) keeps the table self-pruning.
-    new dynamodb.Table(this, "FabricationJobsTable", {
-      tableName: `citadel-fabrication-jobs-${props.environment}`,
-      partitionKey: {
-        name: "orchestrationId",
-        type: dynamodb.AttributeType.STRING,
+    const fabricationJobsTable = new dynamodb.Table(
+      this,
+      "FabricationJobsTable",
+      {
+        tableName: `citadel-fabrication-jobs-${props.environment}`,
+        partitionKey: {
+          name: "orchestrationId",
+          type: dynamodb.AttributeType.STRING,
+        },
+        sortKey: { name: "agentUseId", type: dynamodb.AttributeType.STRING },
+        billingMode: dynamodb.BillingMode.PAY_PER_REQUEST,
+        pointInTimeRecoverySpecification: { pointInTimeRecoveryEnabled: true },
+        timeToLiveAttribute: "ttl",
+        removalPolicy: cdk.RemovalPolicy.DESTROY,
       },
-      sortKey: { name: "agentUseId", type: dynamodb.AttributeType.STRING },
-      billingMode: dynamodb.BillingMode.PAY_PER_REQUEST,
-      pointInTimeRecoverySpecification: { pointInTimeRecoveryEnabled: true },
-      timeToLiveAttribute: "ttl",
-      removalPolicy: cdk.RemovalPolicy.DESTROY,
+    );
+
+    // Org-scoped GSI (cross-tenant exposure fix, design evidence bf4a13f2):
+    // the fabricator-queue-resolver previously had no way to scope its read
+    // to the caller's own tenant — it either bound a client-supplied
+    // projectId directly to the base-table PK with no org check, or ran an
+    // unfiltered Scan across every tenant's rows. All three writers now
+    // stamp a server-derived `orgId` onto the row; this index lets the
+    // resolver ALWAYS query by the caller's own org (never a Scan, never an
+    // unreconciled client-supplied key). submittedAt as sort key preserves
+    // the resolver's existing "most recent first" ordering without a
+    // separate client-side sort pass. Legacy rows written before this
+    // change carry no orgId and simply fall out of this index's query —
+    // no backfill; they age out via the table's existing 7-day TTL.
+    fabricationJobsTable.addGlobalSecondaryIndex({
+      indexName: "OrgIndex",
+      partitionKey: { name: "orgId", type: dynamodb.AttributeType.STRING },
+      sortKey: { name: "submittedAt", type: dynamodb.AttributeType.STRING },
+      projectionType: dynamodb.ProjectionType.ALL,
     });
 
     // NOTE: fabricatorRequestResolverFunction/fabricatorQueueResolverFunction

--- a/backend/lib/registry-stack.ts
+++ b/backend/lib/registry-stack.ts
@@ -780,13 +780,17 @@ export class RegistryStack extends cdk.Stack {
         ],
       }),
     );
-    // Least privilege: the queue resolver only reads (Query for a given
-    // project, Scan otherwise) — matches the baseline exactly.
+    // Least privilege (cross-tenant exposure fix, design evidence bf4a13f2):
+    // the resolver now ALWAYS queries the org-scoped OrgIndex GSI by the
+    // caller's own server-derived org — the raw table Scan is removed
+    // entirely (it was the widest leak: an unfiltered harvest across every
+    // tenant). dynamodb:Query is scoped to the GSI ARN only; the resolver no
+    // longer reads the base table's primary index directly.
     fabricatorQueueResolverFunction.addToRolePolicy(
       new iam.PolicyStatement({
         effect: iam.Effect.ALLOW,
-        actions: ["dynamodb:Query", "dynamodb:Scan"],
-        resources: [fabricationJobsTableArn],
+        actions: ["dynamodb:Query"],
+        resources: [`${fabricationJobsTableArn}/index/OrgIndex`],
       }),
     );
 

--- a/backend/split-baseline/citadel-backend-dev.json
+++ b/backend/split-baseline/citadel-backend-dev.json
@@ -1501,9 +1501,35 @@
           {
             "AttributeName": "agentUseId",
             "AttributeType": "S"
+          },
+          {
+            "AttributeName": "orgId",
+            "AttributeType": "S"
+          },
+          {
+            "AttributeName": "submittedAt",
+            "AttributeType": "S"
           }
         ],
         "BillingMode": "PAY_PER_REQUEST",
+        "GlobalSecondaryIndexes": [
+          {
+            "IndexName": "OrgIndex",
+            "KeySchema": [
+              {
+                "AttributeName": "orgId",
+                "KeyType": "HASH"
+              },
+              {
+                "AttributeName": "submittedAt",
+                "KeyType": "RANGE"
+              }
+            ],
+            "Projection": {
+              "ProjectionType": "ALL"
+            }
+          }
+        ],
         "KeySchema": [
           {
             "AttributeName": "orchestrationId",
@@ -5747,11 +5773,10 @@
       {
         "effect": "Allow",
         "actions": [
-          "dynamodb:Query",
-          "dynamodb:Scan"
+          "dynamodb:Query"
         ],
         "resources": [
-          "arn:aws:dynamodb:us-west-2:257192363080:table/citadel-fabrication-jobs-dev"
+          "arn:aws:dynamodb:us-west-2:257192363080:table/citadel-fabrication-jobs-dev/index/OrgIndex"
         ],
         "conditionKeys": []
       },

--- a/backend/split-baseline/citadel-backend-test.json
+++ b/backend/split-baseline/citadel-backend-test.json
@@ -1336,6 +1336,14 @@
           {
             "AttributeName": "agentUseId",
             "AttributeType": "S"
+          },
+          {
+            "AttributeName": "orgId",
+            "AttributeType": "S"
+          },
+          {
+            "AttributeName": "submittedAt",
+            "AttributeType": "S"
           }
         ],
         "BillingMode": "PAY_PER_REQUEST",
@@ -1378,7 +1386,25 @@
         "TimeToLiveSpecification": {
           "AttributeName": "ttl",
           "Enabled": true
-        }
+        },
+        "GlobalSecondaryIndexes": [
+          {
+            "IndexName": "OrgIndex",
+            "KeySchema": [
+              {
+                "AttributeName": "orgId",
+                "KeyType": "HASH"
+              },
+              {
+                "AttributeName": "submittedAt",
+                "KeyType": "RANGE"
+              }
+            ],
+            "Projection": {
+              "ProjectionType": "ALL"
+            }
+          }
+        ]
       }
     },
     "TaskRunnerResolverFunctionLogsDF000813": {

--- a/backend/src/lambda/__tests__/fabricator-queue-resolver-org-scoping.test.ts
+++ b/backend/src/lambda/__tests__/fabricator-queue-resolver-org-scoping.test.ts
@@ -1,0 +1,194 @@
+/**
+ * Cross-tenant exposure fix for fabricator-queue-resolver.ts (design
+ * evidence bf4a13f2, fabricator-queue section; option (c)).
+ *
+ * Before this fix: getFabricatorQueue leaked two ways.
+ *  - With a projectId: Query bound directly to the client-supplied
+ *    projectId as PK=orchestrationId, with NO org reconciliation — any
+ *    caller who knew/guessed another tenant's projectId read that
+ *    tenant's jobs.
+ *  - Without a projectId: an unfiltered ScanCommand(Limit 100) harvested
+ *    up to 100 rows across ALL tenants, returning tenant-identifying
+ *    agentName/taskDescription/orchestrationId.
+ *
+ * Fix: rows are now stamped with a server-derived `orgId` at write time
+ * (all three writers), a new GSI (orgId PK, submittedAt SK) supports an
+ * org-scoped query, and the resolver:
+ *  - ALWAYS queries the GSI by the caller's server-derived org
+ *    (extractOrgFromEvent) — the Scan is gone entirely.
+ *  - When a projectId is supplied, additionally filters results to rows
+ *    whose orchestrationId matches that projectId (still scoped to the
+ *    caller's own org rows — never a cross-org read).
+ *  - Fails closed (returns []) when the caller's org cannot be resolved.
+ */
+import {
+  DynamoDBDocumentClient,
+  QueryCommand,
+  ScanCommand,
+} from "@aws-sdk/lib-dynamodb";
+import { mockClient } from "aws-sdk-client-mock";
+
+const ddbMock = mockClient(DynamoDBDocumentClient);
+
+jest.mock("../../utils/auth-event", () => ({
+  extractOrgFromEvent: jest.fn(),
+}));
+
+import { extractOrgFromEvent } from "../../utils/auth-event";
+import { handler } from "../fabricator-queue-resolver";
+
+type HandlerEvent = Parameters<typeof handler>[0];
+
+const mockExtractOrg = extractOrgFromEvent as jest.MockedFunction<
+  typeof extractOrgFromEvent
+>;
+
+const makeEvent = (
+  args: { projectId?: string } = {},
+  identity: Record<string, unknown> = { sub: "caller-1" },
+): HandlerEvent =>
+  ({
+    info: { fieldName: "getFabricatorQueue" },
+    arguments: args,
+    identity,
+  }) as unknown as HandlerEvent;
+
+const row = (over: Record<string, unknown>) => ({
+  orchestrationId: "0",
+  agentUseId: "req-1",
+  orgId: "org-victim",
+  status: "PENDING",
+  agentName: "AgentOne",
+  taskDescription: "do a thing",
+  submittedAt: "2026-06-01T00:00:00.000Z",
+  ...over,
+});
+
+describe("fabricator-queue-resolver — org scoping (cross-tenant fix)", () => {
+  beforeEach(() => {
+    ddbMock.reset();
+    jest.clearAllMocks();
+    process.env.FABRICATION_JOBS_TABLE = "citadel-fabrication-jobs-test";
+  });
+
+  test("the raw Scan is gone entirely — no ScanCommand is ever issued", async () => {
+    mockExtractOrg.mockResolvedValue("org-caller");
+    ddbMock.on(QueryCommand).resolves({ Items: [] });
+
+    await handler(makeEvent());
+
+    expect(ddbMock.commandCalls(ScanCommand)).toHaveLength(0);
+  });
+
+  test("no-projectId path queries the org GSI by the caller's server-derived org, never a table Scan", async () => {
+    mockExtractOrg.mockResolvedValue("org-caller");
+    ddbMock.on(QueryCommand).resolves({
+      Items: [row({ orgId: "org-caller", agentUseId: "req-mine" })],
+    });
+
+    const result = await handler(makeEvent());
+
+    expect(ddbMock.commandCalls(ScanCommand)).toHaveLength(0);
+    const calls = ddbMock.commandCalls(QueryCommand);
+    expect(calls).toHaveLength(1);
+    const input = calls[0].args[0].input;
+    expect(input.IndexName).toBeDefined();
+    expect(JSON.stringify(input.ExpressionAttributeValues)).toContain(
+      "org-caller",
+    );
+    expect(result.map((r) => r.requestId)).toEqual(["req-mine"]);
+  });
+
+  test("cross-org caller cannot read another tenant's jobs by supplying that tenant's projectId", async () => {
+    // Caller belongs to org-attacker but supplies a projectId belonging to
+    // org-victim. The GSI query is scoped to org-attacker, so the
+    // org-victim row (even if it happened to share orchestrationId) never
+    // enters the result set — and the resolver additionally filters by
+    // projectId within that org-scoped set.
+    mockExtractOrg.mockResolvedValue("org-attacker");
+    ddbMock.on(QueryCommand).resolves({ Items: [] });
+
+    const result = await handler(
+      makeEvent(
+        { projectId: "victim-project" },
+        { sub: "attacker-1", "custom:organization": "org-attacker" },
+      ),
+    );
+
+    expect(result).toEqual([]);
+    const calls = ddbMock.commandCalls(QueryCommand);
+    expect(calls).toHaveLength(1);
+    const input = calls[0].args[0].input;
+    // Must query the caller's own org — never the victim's org and never
+    // the raw orchestrationId=victim-project PK pattern from the old code.
+    expect(JSON.stringify(input.ExpressionAttributeValues)).toContain(
+      "org-attacker",
+    );
+    expect(JSON.stringify(input.ExpressionAttributeValues)).not.toContain(
+      "victim-project",
+    );
+  });
+
+  test("no-projectId path returns ONLY the caller's org rows when two orgs' rows exist", async () => {
+    // Seed two orgs' worth of rows in the mocked GSI response — the
+    // resolver's query itself is what scopes to one org (DynamoDB would
+    // never actually return the other org's rows for a Query keyed on
+    // orgId=:org), so this also proves the query key, not just client-side
+    // filtering, is what's carrying the guarantee.
+    mockExtractOrg.mockResolvedValue("org-a");
+    ddbMock.on(QueryCommand).callsFake((input) => {
+      const orgKey = JSON.stringify(input.ExpressionAttributeValues);
+      if (orgKey.includes("org-a")) {
+        return Promise.resolve({
+          Items: [row({ orgId: "org-a", agentUseId: "req-a1" })],
+        });
+      }
+      return Promise.resolve({ Items: [] });
+    });
+
+    const result = await handler(makeEvent());
+
+    expect(result.map((r) => r.requestId)).toEqual(["req-a1"]);
+  });
+
+  test("projectId path filters within the caller's own org rows to the requested project", async () => {
+    mockExtractOrg.mockResolvedValue("org-caller");
+    ddbMock.on(QueryCommand).resolves({
+      Items: [
+        row({
+          orgId: "org-caller",
+          orchestrationId: "proj-mine",
+          agentUseId: "req-proj",
+        }),
+        row({
+          orgId: "org-caller",
+          orchestrationId: "some-other-project",
+          agentUseId: "req-other",
+        }),
+      ],
+    });
+
+    const result = await handler(makeEvent({ projectId: "proj-mine" }));
+
+    expect(result.map((r) => r.requestId)).toEqual(["req-proj"]);
+  });
+
+  test("fails closed (returns []) when the caller's org cannot be resolved, and issues no Query", async () => {
+    mockExtractOrg.mockResolvedValue(null);
+
+    const result = await handler(makeEvent());
+
+    expect(result).toEqual([]);
+    expect(ddbMock.commandCalls(QueryCommand)).toHaveLength(0);
+    expect(ddbMock.commandCalls(ScanCommand)).toHaveLength(0);
+  });
+
+  test("fails closed when the caller identity is anonymous/unresolvable", async () => {
+    mockExtractOrg.mockResolvedValue(null);
+
+    const result = await handler(makeEvent({}, {}));
+
+    expect(result).toEqual([]);
+    expect(ddbMock.commandCalls(QueryCommand)).toHaveLength(0);
+  });
+});

--- a/backend/src/lambda/__tests__/fabricator-queue-resolver-path-gate-enumeration.test.ts
+++ b/backend/src/lambda/__tests__/fabricator-queue-resolver-path-gate-enumeration.test.ts
@@ -1,0 +1,102 @@
+/**
+ * Path-enumeration guard for fabricator-queue-resolver.ts (cross-tenant
+ * exposure fix, design evidence bf4a13f2). This resolver has no
+ * `switch (fieldName)` dispatch — it's a single-field handler with exactly
+ * two access PATHS gated on whether the caller supplied a `projectId`. This
+ * guard is the shape-appropriate sibling of the dispatch-gate-enumeration
+ * guards used on multi-field resolvers (tool-config-resolver,
+ * registry-agent-record-resolver, etc.): instead of enumerating switch
+ * cases and checking each is either gated or exempted, it enumerates the
+ * two known access paths and asserts BOTH are routed through the org-scope
+ * gate, and that the previously-exploited unfiltered-Scan path is entirely
+ * absent from the source — not just unreachable at runtime, but literally
+ * not present as code a future edit could accidentally re-enable.
+ *
+ * Root defect this closes (see fabricator-queue-resolver-org-scoping.test.ts
+ * for the behavioral tests): getFabricatorQueue leaked cross-tenant data via
+ * (a) a projectId-bound Query with no org reconciliation, and (b) an
+ * unfiltered ScanCommand harvesting up to 100 rows across every tenant.
+ */
+import * as fs from "fs";
+import * as path from "path";
+
+const HANDLER_PATH = path.join(__dirname, "..", "fabricator-queue-resolver.ts");
+
+describe("fabricator-queue-resolver — path enumeration completeness (no dispatch switch; two projectId-gated paths)", () => {
+  const source = fs.readFileSync(HANDLER_PATH, "utf-8");
+
+  test("sanity check: the handler function actually exists at the expected export", () => {
+    expect(/export const handler = async/.test(source)).toBe(true);
+  });
+
+  test("the previously-exploited unfiltered ScanCommand is entirely absent from the source (not merely unreached)", () => {
+    // Not just "never called" — the import and the class reference must
+    // both be gone, so a future edit can't silently reintroduce the Scan
+    // path by importing it back in and wiring it up.
+    expect(/\bScanCommand\b/.test(source)).toBe(false);
+    expect(source).not.toMatch(
+      /from ["']@aws-sdk\/lib-dynamodb["'][^;]*ScanCommand/,
+    );
+  });
+
+  test("the handler resolves the caller's org via extractOrgFromEvent before either path runs a query", () => {
+    const handlerBody = source.slice(source.indexOf("export const handler"));
+    const orgCallIdx = handlerBody.search(/extractOrgFromEvent\s*\(/);
+    const queryIdx = handlerBody.search(/new QueryCommand\s*\(/);
+    expect(orgCallIdx).toBeGreaterThan(-1);
+    expect(queryIdx).toBeGreaterThan(-1);
+    expect(orgCallIdx).toBeLessThan(queryIdx);
+  });
+
+  test("the handler fails closed (returns before any DynamoDB call) when the caller org is unresolved", () => {
+    const handlerBody = source.slice(source.indexOf("export const handler"));
+    const orgCheckMatch = handlerBody.match(
+      /if\s*\(\s*!callerOrg\s*\)\s*\{[^}]*return\s*\[\]\s*;/s,
+    );
+    expect(orgCheckMatch).not.toBeNull();
+    const queryIdx = handlerBody.search(/new QueryCommand\s*\(/);
+    const failClosedIdx = orgCheckMatch
+      ? handlerBody.indexOf(orgCheckMatch[0])
+      : -1;
+    expect(failClosedIdx).toBeGreaterThan(-1);
+    expect(failClosedIdx).toBeLessThan(queryIdx);
+  });
+
+  describe.each([
+    { pathName: "no-projectId path", hasProjectId: false },
+    { pathName: "projectId-supplied path", hasProjectId: true },
+  ])("$pathName", ({ hasProjectId }) => {
+    test("both paths share the SAME single QueryCommand call against the org-scoped index (no separate unscoped branch)", () => {
+      const queryMatches = source.match(/new QueryCommand\s*\(/g) ?? [];
+      // Exactly one QueryCommand call site in the whole module: both the
+      // projectId and no-projectId cases must flow through it — a second
+      // call site would mean a path bypassing the org-scope gate.
+      expect(queryMatches).toHaveLength(1);
+
+      const queryCallSite = source.slice(
+        source.indexOf("new QueryCommand("),
+        source.indexOf("new QueryCommand(") + 500,
+      );
+      expect(queryCallSite).toMatch(/IndexName:\s*ORG_INDEX_NAME/);
+      expect(queryCallSite).toMatch(/orgId\s*=\s*:orgId/);
+      expect(queryCallSite).toMatch(/":orgId":\s*callerOrg/);
+
+      if (hasProjectId) {
+        // The projectId path must filter WITHIN the already org-scoped
+        // result set, never via a second/alternate query bound to a raw
+        // client-supplied key.
+        expect(source).toMatch(/item\.orchestrationId\s*===\s*projectId/);
+      }
+    });
+  });
+
+  test("ORG_INDEX_NAME is a fixed literal, never derived from event/arguments input", () => {
+    const constMatch = source.match(
+      /const ORG_INDEX_NAME\s*=\s*(["'][^"']+["']);/,
+    );
+    expect(constMatch).not.toBeNull();
+    // Must not reference event.arguments / event.identity anywhere on the
+    // same declaration line — the index name is not client-influenceable.
+    expect(source).not.toMatch(/ORG_INDEX_NAME\s*=\s*event\./);
+  });
+});

--- a/backend/src/lambda/__tests__/fabricator-queue-resolver.test.ts
+++ b/backend/src/lambda/__tests__/fabricator-queue-resolver.test.ts
@@ -1,11 +1,15 @@
 /**
- * Tests for fabricator-queue-resolver Lambda.
+ * Tests for fabricator-queue-resolver Lambda (mapRow/normalization
+ * behavior). Org-scoping / cross-tenant security behavior is covered
+ * separately in fabricator-queue-resolver-org-scoping.test.ts.
  *
  * The resolver reads the durable fabrication-jobs table (source of truth for
- * per-agent fabrication status) instead of peeking SQS. When a projectId is
- * supplied it Queries by PK=orchestrationId; otherwise it Scans with a bounded
- * Limit. Rows map to FabricationQueueItem, sorted by submittedAt descending.
- * On any error it returns [] to preserve the existing contract.
+ * per-agent fabrication status) via the org-scoped `OrgIndex` GSI
+ * (orgId PK / submittedAt SK) — always scoped to the caller's own
+ * server-derived org. When a projectId is supplied, results are further
+ * filtered (client-side, within the org-scoped set) to that project's
+ * orchestrationId. Rows map to FabricationQueueItem, sorted by submittedAt
+ * descending. On any error it returns [] to preserve the existing contract.
  */
 import {
   DynamoDBDocumentClient,
@@ -16,22 +20,34 @@ import { mockClient } from "aws-sdk-client-mock";
 
 const ddbMock = mockClient(DynamoDBDocumentClient);
 
+jest.mock("../../utils/auth-event", () => ({
+  extractOrgFromEvent: jest.fn(),
+}));
+
+import { extractOrgFromEvent } from "../../utils/auth-event";
+
 process.env.FABRICATION_JOBS_TABLE = "citadel-fabrication-jobs-test";
 
 import { handler } from "../fabricator-queue-resolver";
 
 type HandlerEvent = Parameters<typeof handler>[0];
 
-/** Build the minimal AppSync event the resolver reads (info.fieldName + arguments). */
+const mockExtractOrg = extractOrgFromEvent as jest.MockedFunction<
+  typeof extractOrgFromEvent
+>;
+
+/** Build the minimal AppSync event the resolver reads (info.fieldName + arguments + identity). */
 const makeEvent = (args: { projectId?: string } = {}): HandlerEvent =>
   ({
     info: { fieldName: "getFabricatorQueue" },
     arguments: args,
+    identity: { sub: "caller-1", "custom:organization": "org-caller" },
   }) as unknown as HandlerEvent;
 
 const row = (over: Record<string, unknown>) => ({
   orchestrationId: "0",
   agentUseId: "req-1",
+  orgId: "org-caller",
   status: "PENDING",
   agentName: "AgentOne",
   taskDescription: "do a thing",
@@ -42,11 +58,13 @@ const row = (over: Record<string, unknown>) => ({
 describe("fabricator-queue-resolver", () => {
   beforeEach(() => {
     ddbMock.reset();
+    jest.clearAllMocks();
     process.env.FABRICATION_JOBS_TABLE = "citadel-fabrication-jobs-test";
+    mockExtractOrg.mockResolvedValue("org-caller");
   });
 
-  test("Scans (bounded) and maps rows when no projectId is given", async () => {
-    ddbMock.on(ScanCommand).resolves({
+  test("Queries the org GSI (never a Scan) and maps rows when no projectId is given", async () => {
+    ddbMock.on(QueryCommand).resolves({
       Items: [
         row({ agentUseId: "req-1", submittedAt: "2026-06-01T00:00:00.000Z" }),
         row({
@@ -61,11 +79,10 @@ describe("fabricator-queue-resolver", () => {
 
     const result = await handler(makeEvent());
 
-    expect(ddbMock.commandCalls(ScanCommand)).toHaveLength(1);
-    expect(ddbMock.commandCalls(QueryCommand)).toHaveLength(0);
-    expect(
-      ddbMock.commandCalls(ScanCommand)[0].args[0].input.Limit,
-    ).toBeDefined();
+    expect(ddbMock.commandCalls(ScanCommand)).toHaveLength(0);
+    expect(ddbMock.commandCalls(QueryCommand)).toHaveLength(1);
+    const input = ddbMock.commandCalls(QueryCommand)[0].args[0].input;
+    expect(input.IndexName).toBeDefined();
     // Sorted by submittedAt descending → req-2 first.
     expect(result.map((r) => r.requestId)).toEqual(["req-2", "req-1"]);
     expect(result[0]).toMatchObject({
@@ -78,10 +95,16 @@ describe("fabricator-queue-resolver", () => {
     });
   });
 
-  test("Queries by PK=orchestrationId when projectId is provided", async () => {
+  test("filters to the requested project (within the caller's own org rows) when projectId is provided", async () => {
     ddbMock.on(QueryCommand).resolves({
       Items: [
-        row({ agentUseId: "req-9", status: "FAILED", errorMessage: "boom" }),
+        row({
+          agentUseId: "req-9",
+          orchestrationId: "proj-42",
+          status: "FAILED",
+          errorMessage: "boom",
+        }),
+        row({ agentUseId: "req-other", orchestrationId: "some-other-proj" }),
       ],
     });
 
@@ -89,10 +112,6 @@ describe("fabricator-queue-resolver", () => {
 
     expect(ddbMock.commandCalls(QueryCommand)).toHaveLength(1);
     expect(ddbMock.commandCalls(ScanCommand)).toHaveLength(0);
-    const qInput = ddbMock.commandCalls(QueryCommand)[0].args[0].input;
-    expect(qInput.ExpressionAttributeValues).toMatchObject({
-      ":pk": "proj-42",
-    });
     expect(result).toHaveLength(1);
     expect(result[0]).toMatchObject({
       requestId: "req-9",
@@ -102,11 +121,12 @@ describe("fabricator-queue-resolver", () => {
   });
 
   test("falls back agentName to agentId when agentName is absent", async () => {
-    ddbMock.on(ScanCommand).resolves({
+    ddbMock.on(QueryCommand).resolves({
       Items: [
         {
           orchestrationId: "0",
           agentUseId: "req-1",
+          orgId: "org-caller",
           status: "PROCESSING",
           agentId: "FabricatedAgentX",
           updatedAt: "2026-06-10T00:00:00.000Z",
@@ -120,11 +140,12 @@ describe("fabricator-queue-resolver", () => {
   });
 
   test("falls back agentName to agentUseId when only agentUseId is present", async () => {
-    ddbMock.on(ScanCommand).resolves({
+    ddbMock.on(QueryCommand).resolves({
       Items: [
         {
           orchestrationId: "0",
           agentUseId: "agent-use-77",
+          orgId: "org-caller",
           status: "PROCESSING",
           updatedAt: "2026-06-10T00:00:00.000Z",
         },
@@ -137,11 +158,12 @@ describe("fabricator-queue-resolver", () => {
   });
 
   test("falls back submittedAt to updatedAt when submittedAt is absent", async () => {
-    ddbMock.on(ScanCommand).resolves({
+    ddbMock.on(QueryCommand).resolves({
       Items: [
         {
           orchestrationId: "0",
           agentUseId: "req-1",
+          orgId: "org-caller",
           status: "PROCESSING",
           agentId: "FabricatedAgentX",
           updatedAt: "2026-06-10T12:34:56.000Z",
@@ -155,7 +177,7 @@ describe("fabricator-queue-resolver", () => {
   });
 
   test("uses agentName and submittedAt as-is when both are present", async () => {
-    ddbMock.on(ScanCommand).resolves({
+    ddbMock.on(QueryCommand).resolves({
       Items: [
         row({
           agentName: "RealName",
@@ -173,7 +195,7 @@ describe("fabricator-queue-resolver", () => {
   });
 
   test("returns [] on a DynamoDB error", async () => {
-    ddbMock.on(ScanCommand).rejects(new Error("ddb down"));
+    ddbMock.on(QueryCommand).rejects(new Error("ddb down"));
     const result = await handler(makeEvent());
     expect(result).toEqual([]);
   });
@@ -182,7 +204,7 @@ describe("fabricator-queue-resolver", () => {
     delete process.env.FABRICATION_JOBS_TABLE;
     const result = await handler(makeEvent());
     expect(result).toEqual([]);
-    expect(ddbMock.commandCalls(ScanCommand)).toHaveLength(0);
+    expect(ddbMock.commandCalls(QueryCommand)).toHaveLength(0);
   });
 
   describe("status normalization (badge-stuck incident hardening)", () => {
@@ -192,11 +214,12 @@ describe("fabricator-queue-resolver", () => {
     // must also never pass through verbatim (invalid GraphQL enum member).
 
     test("a row with a missing status is not surfaced as active work (normalized to FAILED, not PENDING)", async () => {
-      ddbMock.on(ScanCommand).resolves({
+      ddbMock.on(QueryCommand).resolves({
         Items: [
           {
             orchestrationId: "0",
             agentUseId: "req-no-status",
+            orgId: "org-caller",
             agentName: "AgentNoStatus",
             submittedAt: "2026-06-01T00:00:00.000Z",
           },
@@ -209,7 +232,7 @@ describe("fabricator-queue-resolver", () => {
     });
 
     test("a row with an unrecognized status is normalized to a valid enum member instead of passing through verbatim", async () => {
-      ddbMock.on(ScanCommand).resolves({
+      ddbMock.on(QueryCommand).resolves({
         Items: [row({ agentUseId: "req-bad-status", status: "DONE" })],
       });
 
@@ -221,7 +244,7 @@ describe("fabricator-queue-resolver", () => {
     test.each(["PENDING", "PROCESSING", "COMPLETED", "FAILED"] as const)(
       "a valid %s status passes through unchanged",
       async (status) => {
-        ddbMock.on(ScanCommand).resolves({
+        ddbMock.on(QueryCommand).resolves({
           Items: [row({ agentUseId: `req-${status}`, status })],
         });
 

--- a/backend/src/lambda/fabricator-queue-resolver.ts
+++ b/backend/src/lambda/fabricator-queue-resolver.ts
@@ -1,10 +1,7 @@
 import { DynamoDBClient } from "@aws-sdk/client-dynamodb";
-import {
-  DynamoDBDocumentClient,
-  QueryCommand,
-  ScanCommand,
-} from "@aws-sdk/lib-dynamodb";
+import { DynamoDBDocumentClient, QueryCommand } from "@aws-sdk/lib-dynamodb";
 import { AppSyncResolverEvent } from "aws-lambda";
+import { extractOrgFromEvent } from "../utils/auth-event";
 
 const docClient = DynamoDBDocumentClient.from(new DynamoDBClient({}));
 
@@ -14,9 +11,15 @@ function getFabricationJobsTable(): string | undefined {
   return process.env.FABRICATION_JOBS_TABLE;
 }
 
-// Upper bound on rows returned by the unfiltered (Scan) path so the queue
-// view stays cheap regardless of table size.
-const SCAN_LIMIT = 100;
+// Name of the org-scoped GSI (orgId PK / submittedAt SK) added to close the
+// cross-tenant exposure this resolver previously had via an unfiltered Scan
+// and a projectId Query with no org reconciliation. Must match the GSI name
+// registered on FabricationJobsTable in backend-stack.ts.
+const ORG_INDEX_NAME = "OrgIndex";
+
+// Upper bound on rows returned per query so the queue view stays cheap
+// regardless of table size.
+const QUERY_LIMIT = 100;
 
 type FabricationStatus = "PENDING" | "PROCESSING" | "COMPLETED" | "FAILED";
 
@@ -63,6 +66,7 @@ interface FabricationJobRow {
   updatedAt?: string;
   errorMessage?: string;
   orchestrationId?: string;
+  orgId?: string;
   [key: string]: unknown;
 }
 
@@ -93,10 +97,23 @@ function mapRow(item: FabricationJobRow): FabricationQueueItem {
  * fabrication status. Replaces the previous SQS ReceiveMessage approach, which
  * was unreliable and competed with the fabricator consumer for messages.
  *
- * - With projectId: Query PK=orchestrationId (the intake session/project id).
- * - Without projectId: Scan with a bounded Limit.
- * Rows are sorted by submittedAt descending. On any error (or when the table
- * env var is unset) returns [] to preserve the resolver's existing contract.
+ * SECURITY (cross-tenant exposure fix, design evidence bf4a13f2): rows are
+ * stamped with a server-derived `orgId` at write time (all three writers —
+ * arbiter, intake, direct-UI). This resolver ALWAYS queries the new
+ * `OrgIndex` GSI (orgId PK / submittedAt SK) by the caller's own
+ * server-derived org (`extractOrgFromEvent`) — never a client-suppliable
+ * value, and never an unfiltered table Scan. When a projectId is supplied,
+ * results are additionally filtered to that project's orchestrationId, but
+ * ALWAYS from within the caller's own org-scoped result set — a caller can
+ * never read another tenant's rows by guessing their projectId.
+ *
+ * Fails closed: if the caller's organization cannot be resolved, returns []
+ * without issuing any query. Rows written before this fix carry no orgId
+ * and so fall out of the org-scoped query; they age out via the table's
+ * 7-day TTL (no backfill — see design evidence).
+ *
+ * On any error (or when the table env var is unset) returns [] to preserve
+ * the resolver's existing contract.
  */
 export const handler = async (
   event: AppSyncResolverEvent<{ projectId?: string }>,
@@ -109,27 +126,34 @@ export const handler = async (
     return [];
   }
 
+  const callerOrg = await extractOrgFromEvent(event);
+  if (!callerOrg) {
+    console.warn(
+      "getFabricatorQueue: caller organization could not be resolved; failing closed",
+    );
+    return [];
+  }
+
   const projectId = event.arguments?.projectId;
 
   try {
-    let items: FabricationJobRow[] = [];
+    const response = await docClient.send(
+      new QueryCommand({
+        TableName: table,
+        IndexName: ORG_INDEX_NAME,
+        KeyConditionExpression: "orgId = :orgId",
+        ExpressionAttributeValues: { ":orgId": callerOrg },
+        Limit: QUERY_LIMIT,
+        ScanIndexForward: false,
+      }),
+    );
+    let items = (response.Items || []) as FabricationJobRow[];
+
     if (projectId) {
-      const response = await docClient.send(
-        new QueryCommand({
-          TableName: table,
-          KeyConditionExpression: "orchestrationId = :pk",
-          ExpressionAttributeValues: { ":pk": projectId },
-        }),
-      );
-      items = (response.Items || []) as FabricationJobRow[];
-    } else {
-      const response = await docClient.send(
-        new ScanCommand({
-          TableName: table,
-          Limit: SCAN_LIMIT,
-        }),
-      );
-      items = (response.Items || []) as FabricationJobRow[];
+      // Constrain to the requested project WITHIN the caller's own
+      // org-scoped result set — never a raw orchestrationId lookup across
+      // tenants (that was the original defect).
+      items = items.filter((item) => item.orchestrationId === projectId);
     }
 
     const queueItems = items.map(mapRow);

--- a/backend/src/lambda/fabricator-request-resolver.ts
+++ b/backend/src/lambda/fabricator-request-resolver.ts
@@ -1,9 +1,13 @@
-import { SQSClient, SendMessageCommand } from '@aws-sdk/client-sqs';
-import { DynamoDBClient } from '@aws-sdk/client-dynamodb';
-import { DynamoDBDocumentClient, GetCommand, PutCommand } from '@aws-sdk/lib-dynamodb';
-import { randomUUID } from 'crypto';
-import type { RegistryRecord } from '../services/registry-service';
-import { extractOrgFromEvent } from '../utils/auth-event';
+import { SQSClient, SendMessageCommand } from "@aws-sdk/client-sqs";
+import { DynamoDBClient } from "@aws-sdk/client-dynamodb";
+import {
+  DynamoDBDocumentClient,
+  GetCommand,
+  PutCommand,
+} from "@aws-sdk/lib-dynamodb";
+import { randomUUID } from "crypto";
+import type { RegistryRecord } from "../services/registry-service";
+import { extractOrgFromEvent } from "../utils/auth-event";
 
 const sqsClient = new SQSClient({});
 const dynamoClient = new DynamoDBClient({});
@@ -44,8 +48,8 @@ function deriveAgentName(taskDetails: string): string {
   if (match && match[1].trim()) {
     return match[1].trim();
   }
-  const firstLine = taskDetails.split('\n').find((l) => l.trim().length > 0);
-  return firstLine ? firstLine.trim() : 'Unknown Agent';
+  const firstLine = taskDetails.split("\n").find((l) => l.trim().length > 0);
+  return firstLine ? firstLine.trim() : "Unknown Agent";
 }
 
 /**
@@ -59,12 +63,15 @@ function deriveAgentName(taskDetails: string): string {
 async function writePendingFabricationStatus(
   requestId: string,
   taskDetails: string,
-  requestType: 'agent-creation' | 'tool-creation',
+  requestType: "agent-creation" | "tool-creation",
   requestedBy: string,
+  orgId: string | null,
 ): Promise<void> {
   const table = getFabricationJobsTable();
   if (!table) {
-    console.log('FABRICATION_JOBS_TABLE unset; skipping fabrication status write');
+    console.log(
+      "FABRICATION_JOBS_TABLE unset; skipping fabrication status write",
+    );
     return;
   }
   const now = new Date().toISOString();
@@ -73,13 +80,19 @@ async function writePendingFabricationStatus(
       new PutCommand({
         TableName: table,
         Item: {
-          orchestrationId: '0',
+          orchestrationId: "0",
           agentUseId: requestId,
-          status: 'PENDING',
+          // Server-derived caller org (Phase 2b already resolves this via
+          // extractOrgFromEvent for the SQS org_id field) — stamped onto the
+          // row so the org-scoped getFabricatorQueue GSI query can find it.
+          // Omitted (never a blank string) when unresolvable so a missing
+          // orgId reads as absent, not as a false empty-string match.
+          ...(orgId ? { orgId } : {}),
+          status: "PENDING",
           agentName: deriveAgentName(taskDetails),
           taskDescription: taskDetails.slice(0, TASK_DESCRIPTION_MAX),
           requestType,
-          requestedBy: requestedBy || 'unknown',
+          requestedBy: requestedBy || "unknown",
           submittedAt: now,
           updatedAt: now,
           ttl: Math.floor(Date.now() / 1000) + FABRICATION_JOBS_TTL_SECONDS,
@@ -88,7 +101,10 @@ async function writePendingFabricationStatus(
     );
   } catch (error) {
     // Eventually-consistent: never block the enqueue on a status-write error.
-    console.error('Failed to write PENDING fabrication status (continuing):', error);
+    console.error(
+      "Failed to write PENDING fabrication status (continuing):",
+      error,
+    );
   }
 }
 
@@ -113,9 +129,9 @@ function _projectIdFromRegistryRecord(
     const parsed = JSON.parse(record.customDescriptorContent);
     if (
       parsed &&
-      typeof parsed === 'object' &&
+      typeof parsed === "object" &&
       !Array.isArray(parsed) &&
-      typeof parsed.sourceProjectId === 'string'
+      typeof parsed.sourceProjectId === "string"
     ) {
       return parsed.sourceProjectId;
     }
@@ -157,11 +173,11 @@ interface CreateToolRequest {
  * `createdBy` on the Registry record.
  */
 function extractRequestedBy(event: FabricatorRequestResolverEvent): string {
-  return (
-    ((event.identity && ('sub' in event.identity ? event.identity.sub : undefined)) ||
-      (event.identity && ('username' in event.identity ? event.identity.username : undefined)) ||
-      'unknown') as string
-  );
+  return ((event.identity &&
+    ("sub" in event.identity ? event.identity.sub : undefined)) ||
+    (event.identity &&
+      ("username" in event.identity ? event.identity.username : undefined)) ||
+    "unknown") as string;
 }
 
 /** AppSync event slice this resolver reads. */
@@ -172,7 +188,7 @@ interface FabricatorRequestResolverEvent {
 }
 
 export const handler = async (event: FabricatorRequestResolverEvent) => {
-  console.log('Event:', JSON.stringify(event, null, 2));
+  console.log("Event:", JSON.stringify(event, null, 2));
 
   const fieldName = event.info.fieldName;
   const requestedBy = extractRequestedBy(event);
@@ -182,17 +198,25 @@ export const handler = async (event: FabricatorRequestResolverEvent) => {
   const orgId = await extractOrgFromEvent(event);
 
   try {
-    if (fieldName === 'requestAgentCreation') {
-      return await requestAgentCreation(event.arguments.input as CreateAgentRequest, requestedBy, orgId);
+    if (fieldName === "requestAgentCreation") {
+      return await requestAgentCreation(
+        event.arguments.input as CreateAgentRequest,
+        requestedBy,
+        orgId,
+      );
     }
 
-    if (fieldName === 'requestToolCreation') {
-      return await requestToolCreation(event.arguments.input as CreateToolRequest, requestedBy, orgId);
+    if (fieldName === "requestToolCreation") {
+      return await requestToolCreation(
+        event.arguments.input as CreateToolRequest,
+        requestedBy,
+        orgId,
+      );
     }
 
     throw new Error(`Unknown field: ${fieldName}`);
   } catch (error) {
-    console.error('Error:', error);
+    console.error("Error:", error);
     throw error;
   }
 };
@@ -200,7 +224,7 @@ export const handler = async (event: FabricatorRequestResolverEvent) => {
 async function sendToFabricatorQueue(
   requestId: string,
   taskDetails: string,
-  requestType: 'agent-creation' | 'tool-creation',
+  requestType: "agent-creation" | "tool-creation",
   requestedBy: string,
   orgId: string | null,
   sourceProjectId?: string,
@@ -213,9 +237,9 @@ async function sendToFabricatorQueue(
   }
 
   const fabricatorMessage = {
-    orchestration_id: '0', // Direct request, not part of orchestration
+    orchestration_id: "0", // Direct request, not part of orchestration
     agent_use_id: requestId,
-    node: 'fabricator',
+    node: "fabricator",
     agent_input,
     requested_by: requestedBy,
     // Phase 2b: carry caller org through the SQS boundary. Python fabricator
@@ -223,7 +247,7 @@ async function sendToFabricatorQueue(
     org_id: orgId || null,
   };
 
-  console.log('Sending message to Fabricator queue:', fabricatorMessage);
+  console.log("Sending message to Fabricator queue:", fabricatorMessage);
 
   try {
     await sqsClient.send(
@@ -232,27 +256,33 @@ async function sendToFabricatorQueue(
         MessageBody: JSON.stringify(fabricatorMessage),
         MessageAttributes: {
           requestType: {
-            DataType: 'String',
+            DataType: "String",
             StringValue: requestType,
           },
           requestId: {
-            DataType: 'String',
+            DataType: "String",
             StringValue: requestId,
           },
         },
-      })
+      }),
     );
 
-    console.log('Message sent successfully to Fabricator queue');
+    console.log("Message sent successfully to Fabricator queue");
   } catch (error) {
-    console.error('Error sending message to Fabricator queue:', error);
+    console.error("Error sending message to Fabricator queue:", error);
     throw new Error(`Failed to send request to Fabricator: ${error}`);
   }
 
   // Durable PENDING status row so the queue UI reflects this request even
   // after the consumer pulls the SQS message. Best-effort — never fails the
   // enqueue.
-  await writePendingFabricationStatus(requestId, taskDetails, requestType, requestedBy);
+  await writePendingFabricationStatus(
+    requestId,
+    taskDetails,
+    requestType,
+    requestedBy,
+    orgId,
+  );
 }
 
 /**
@@ -261,31 +291,46 @@ async function sendToFabricatorQueue(
  * A missing projectId means the fabricator design-assessment gate is a no-op,
  * which is the forward-compatible default.
  */
-async function resolveSourceProjectId(appId?: string): Promise<string | undefined> {
+async function resolveSourceProjectId(
+  appId?: string,
+): Promise<string | undefined> {
   if (!appId) return undefined;
   const appsTable = getAppsTable();
   if (!appsTable) {
-    console.warn('APPS_TABLE env var unset; skipping sourceProjectId lookup for app', appId);
+    console.warn(
+      "APPS_TABLE env var unset; skipping sourceProjectId lookup for app",
+      appId,
+    );
     return undefined;
   }
   try {
-    const result = await docClient.send(new GetCommand({
-      TableName: appsTable,
-      Key: { appId },
-    }));
+    const result = await docClient.send(
+      new GetCommand({
+        TableName: appsTable,
+        Key: { appId },
+      }),
+    );
     const row = result.Item;
     if (!row) {
-      console.warn('App row not found for sourceProjectId lookup:', appId);
+      console.warn("App row not found for sourceProjectId lookup:", appId);
       return undefined;
     }
     return row.sourceProjectId || undefined;
   } catch (error) {
-    console.warn('Failed to look up sourceProjectId for app (continuing without):', appId, error);
+    console.warn(
+      "Failed to look up sourceProjectId for app (continuing without):",
+      appId,
+      error,
+    );
     return undefined;
   }
 }
 
-async function requestAgentCreation(input: CreateAgentRequest, requestedBy: string, orgId: string | null) {
+async function requestAgentCreation(
+  input: CreateAgentRequest,
+  requestedBy: string,
+  orgId: string | null,
+) {
   const requestId = randomUUID();
 
   // Build the task details with all the information
@@ -297,28 +342,39 @@ Task Description:
 ${input.taskDescription}`;
 
   if (input.tools && input.tools.length > 0) {
-    taskDetails += `\n\nRequired Tools:\n${input.tools.map(t => `- ${t}`).join('\n')}`;
+    taskDetails += `\n\nRequired Tools:\n${input.tools.map((t) => `- ${t}`).join("\n")}`;
   }
 
   if (input.integrations && input.integrations.length > 0) {
-    taskDetails += `\n\nRequired Integrations:\n${input.integrations.map(i => `- ${i}`).join('\n')}`;
+    taskDetails += `\n\nRequired Integrations:\n${input.integrations.map((i) => `- ${i}`).join("\n")}`;
   }
 
   if (input.dataStores && input.dataStores.length > 0) {
-    taskDetails += `\n\nRequired Data Stores:\n${input.dataStores.map(d => `- ${d}`).join('\n')}`;
+    taskDetails += `\n\nRequired Data Stores:\n${input.dataStores.map((d) => `- ${d}`).join("\n")}`;
   }
 
   const sourceProjectId = await resolveSourceProjectId(input.appId);
-  await sendToFabricatorQueue(requestId, taskDetails, 'agent-creation', requestedBy, orgId, sourceProjectId);
+  await sendToFabricatorQueue(
+    requestId,
+    taskDetails,
+    "agent-creation",
+    requestedBy,
+    orgId,
+    sourceProjectId,
+  );
 
   return {
     success: true,
     requestId,
-    message: 'Agent creation request sent to Fabricator successfully',
+    message: "Agent creation request sent to Fabricator successfully",
   };
 }
 
-async function requestToolCreation(input: CreateToolRequest, requestedBy: string, orgId: string | null) {
+async function requestToolCreation(
+  input: CreateToolRequest,
+  requestedBy: string,
+  orgId: string | null,
+) {
   const requestId = randomUUID();
 
   // Build the task details for tool creation
@@ -330,19 +386,26 @@ Tool Description:
 ${input.toolDescription}`;
 
   if (input.integrations && input.integrations.length > 0) {
-    taskDetails += `\n\nRequired Integrations:\n${input.integrations.map(i => `- ${i}`).join('\n')}`;
+    taskDetails += `\n\nRequired Integrations:\n${input.integrations.map((i) => `- ${i}`).join("\n")}`;
   }
 
   if (input.dataStores && input.dataStores.length > 0) {
-    taskDetails += `\n\nRequired Data Stores:\n${input.dataStores.map(d => `- ${d}`).join('\n')}`;
+    taskDetails += `\n\nRequired Data Stores:\n${input.dataStores.map((d) => `- ${d}`).join("\n")}`;
   }
 
   const sourceProjectId = await resolveSourceProjectId(input.appId);
-  await sendToFabricatorQueue(requestId, taskDetails, 'tool-creation', requestedBy, orgId, sourceProjectId);
+  await sendToFabricatorQueue(
+    requestId,
+    taskDetails,
+    "tool-creation",
+    requestedBy,
+    orgId,
+    sourceProjectId,
+  );
 
   return {
     success: true,
     requestId,
-    message: 'Tool creation request sent to Fabricator successfully',
+    message: "Tool creation request sent to Fabricator successfully",
   };
 }

--- a/service/agent_intake_single/tools/fabricate.py
+++ b/service/agent_intake_single/tools/fabricate.py
@@ -41,6 +41,12 @@ REGISTRY_ID = os.getenv("REGISTRY_ID", "")
 # When unset the PENDING status write is skipped so this stays backward-
 # compatible in environments that haven't wired the table yet.
 FABRICATION_JOBS_TABLE = os.getenv("FABRICATION_JOBS_TABLE", "")
+# Projects table — used ONLY to resolve the session's organization (for the
+# orgId stamped onto fabrication-jobs rows below). For intake-driven
+# fabrication, orchestrationId == session_id == projectId (see
+# fabricatorQueueService.ts / the CDK comment on FabricationJobsTable), so
+# the session id is looked up directly as the project id.
+PROJECTS_TABLE = os.getenv("PROJECTS_TABLE", "")
 AWS_REGION = os.getenv("AWS_REGION", "ap-southeast-2")
 
 # ~7 day TTL (epoch seconds) keeps the fabrication-jobs table self-pruning.
@@ -91,6 +97,29 @@ def _reset_registry_client_for_test() -> None:
     _registry_client = None
 
 
+def _resolve_session_organization(session_id: str) -> str | None:
+    """Resolve the intake session's organization for stamping onto the
+    fabrication-jobs row.
+
+    session_id == projectId for intake-driven fabrication (see module-level
+    PROJECTS_TABLE comment). Best-effort: returns None on any failure or
+    when PROJECTS_TABLE is unset — callers must treat None as "omit the
+    orgId attribute", never as an empty-string placeholder, so an
+    unresolvable org reads as absent rather than as a false match.
+    """
+    if not PROJECTS_TABLE:
+        return None
+    try:
+        item = dynamodb.Table(PROJECTS_TABLE).get_item(Key={"id": session_id}).get("Item")
+        org = item.get("organization") if item else None
+        return org if isinstance(org, str) and org.strip() else None
+    except Exception as e:  # noqa: BLE001 — best-effort: never block enqueue
+        logger.warning(
+            "Failed to resolve organization for session=%s: %s", session_id, e,
+        )
+        return None
+
+
 def _write_pending_fabrication_status(session_id: str, agent: dict) -> None:
     """Best-effort PENDING row for an intake-driven fabrication request.
 
@@ -108,7 +137,7 @@ def _write_pending_fabrication_status(session_id: str, agent: dict) -> None:
         return
     now = datetime.now(timezone.utc).isoformat().replace("+00:00", "Z")
     try:
-        dynamodb.Table(FABRICATION_JOBS_TABLE).put_item(Item={
+        item = {
             "orchestrationId": session_id,
             "agentUseId": agent["name"],
             "status": "PENDING",
@@ -119,7 +148,11 @@ def _write_pending_fabrication_status(session_id: str, agent: dict) -> None:
             "submittedAt": now,
             "updatedAt": now,
             "ttl": int(time.time()) + FABRICATION_JOBS_TTL_SECONDS,
-        })
+        }
+        org_id = _resolve_session_organization(session_id)
+        if org_id:
+            item["orgId"] = org_id
+        dynamodb.Table(FABRICATION_JOBS_TABLE).put_item(Item=item)
     except Exception as e:  # noqa: BLE001 — best-effort: never block enqueue
         logger.warning(
             "Failed to write PENDING fabrication status for %s/%s: %s",


### PR DESCRIPTION
## Summary

`getFabricatorQueue` leaked two ways. With a `projectId` it queried by `orchestrationId` with no organization reconciliation, so any caller could read another tenant's fabrication jobs. Without one it ran an **unfiltered `Scan` (Limit 100)** that harvested rows across all tenants, returning tenant-identifying `agentName`, `taskDescription` and `orchestrationId`.

A join-based gate could not fix this: the rows carried no tenant discriminator, and direct-UI rows are written with `orchestrationId='0'`, so their organization is not derivable from anything on the row. The scan path has no `projectId` to gate at all.

- `orgId` is now stamped on the row at **all three write sites** - the arbiter (via `if not_exists` across five call sites, so a later status write never clobbers a producer-set value), intake (resolved from the projects table), and the direct-UI path (persisting the organization it had already derived from the caller's identity, not the client-supplied value in the same message)
- New `OrgIndex` GSI (`orgId` partition, `submittedAt` sort)
- The resolver always queries that index by the **server-derived** caller organization; the raw `ScanCommand` is gone entirely; the `projectId` path filters within the caller's own rows; it fails closed when the organization cannot be resolved
- IAM narrowed to `Query` on the index ARN, with the `Scan` grant **removed** - the harvest path is closed at the permission layer as well as in code

## No backfill, and the premise was verified

Legacy un-stamped rows fall out of the org-scoped query and age out via the table's TTL. That decision rests on TTL actually being enabled, so it was checked against the deployed table rather than the CDK: `describe-time-to-Live` confirms it is enabled on the `ttl` attribute, and the table currently holds zero items, so the interim invisibility window is moot in practice.

## Testing

- Cross-org caller supplying another tenant's `projectid` reads nothing; the `no-projectid` path with two organizations seeded returns only the caller's rows, with a foreign row's
`agentName`, `taskDescription` and `orchestrationId` absent from the response
- `ScanCommand` asserted entirely absent from the resolver source
- Fail-closed proven by mutation, restored byte-identically
- Consumers verified unbroken: intake's `retry_failed_fabrication` and `postfab`'s `check_fabrication_status` both use the base-table key and are unaffected by the additive attribute and new index
- Path-based enumeration guard added (this module has no dispatch switch) asserting scan absence and that both organization resolution and the fail-closed branch precede the query
- tsc, lint exit 0; full backend jest 7579; arbiter pytest 375; intake pytest 358; CI-equivalent synth with cdk-nag enabled clean, no suppression needed; all seven `split:gates` rails pass