### PR TITLE
fix(security): derive admin from group membership, not a claim

### DIFF
--- a/backend/lib/backend-stack.ts
+++ b/backend/lib/backend-stack.ts
@@ -841,6 +841,50 @@ export class BackendStack extends cdk.Stack {
     );
 
     // User Pool Client
+    //
+    // writeAttributes/readAttributes are set EXPLICITLY (finding 7aa877f8).
+    // Leaving them unset lets Cognito's permissive default apply: the
+    // client can write ALL mutable, non-developer-only attributes,
+    // including custom:role and custom:organization. Combined with
+    // ALLOW_USER_SRP_AUTH / ALLOW_USER_PASSWORD_AUTH below, that let any
+    // authenticated end user call UpdateUserAttributes and self-grant
+    // custom:role=admin.
+    //
+    // Enumeration of what the app legitimately writes via this client (see
+    // backend/test/backend-stack-user-pool-client-write-attributes.test.ts
+    // for the pinned assertion): no frontend or resolver code calls
+    // updateUserAttributes/UpdateUserAttributesCommand for the caller's own
+    // record — the only attribute write outside this client is
+    // AdminUpdateUserAttributesCommand in assignUserRole
+    // (user-management-resolver.ts), which uses the Admin* API under the
+    // Lambda's IAM role and is NOT gated by client writeAttributes at all.
+    // The allow-list below covers only the standard profile fields
+    // configured as mutable in standardAttributes above (email, given_name,
+    // family_name), so self-service profile editing / email
+    // re-verification keeps working. custom:role and custom:organization
+    // are deliberately excluded — they must only ever be changed by
+    // admin-privileged server-side calls (AdminUpdateUserAttributesCommand,
+    // AdminAddUserToGroupCommand), never by the end user's own token.
+    //
+    // Mutable is NOT set to false on the custom attributes: that property
+    // cannot be changed post-creation without recreating the attribute
+    // (and its data), so the allow-list is the correct control here, not
+    // attribute immutability.
+    const clientWriteAttributes =
+      new cognito.ClientAttributes().withStandardAttributes({
+        email: true,
+        givenName: true,
+        familyName: true,
+      });
+    const clientReadAttributes = new cognito.ClientAttributes()
+      .withStandardAttributes({
+        email: true,
+        givenName: true,
+        familyName: true,
+        emailVerified: true,
+      })
+      .withCustomAttributes("role", "organization");
+
     this.userPoolClient = new cognito.UserPoolClient(this, "UserPoolClient", {
       userPool: this.userPool,
       userPoolClientName: `citadel-client-${props.environment}`,
@@ -861,6 +905,8 @@ export class BackendStack extends cdk.Stack {
           cognito.OAuthScope.PROFILE,
         ],
       },
+      writeAttributes: clientWriteAttributes,
+      readAttributes: clientReadAttributes,
       refreshTokenValidity: cdk.Duration.days(30),
       accessTokenValidity: cdk.Duration.hours(1),
       idTokenValidity: cdk.Duration.hours(1),

--- a/backend/src/lambda/__tests__/agent-code-resolver-authz.test.ts
+++ b/backend/src/lambda/__tests__/agent-code-resolver-authz.test.ts
@@ -113,6 +113,7 @@ describe("agent-code-resolver — authorization (finding 1a9181a4)", () => {
     sub: "admin-1",
     "custom:organization": ORG_B,
     "custom:role": "admin",
+    "cognito:groups": ["admin"],
   };
 
   function expectZeroDataAccess() {

--- a/backend/src/lambda/__tests__/agent-config-resolver-handler-dispatch.test.ts
+++ b/backend/src/lambda/__tests__/agent-config-resolver-handler-dispatch.test.ts
@@ -7,8 +7,14 @@
  *
  * Validates: Requirements 3.6, 11.2, 11.3
  */
-import { DynamoDBDocumentClient, GetCommand, PutCommand, ScanCommand, DeleteCommand } from '@aws-sdk/lib-dynamodb';
-import { mockClient } from 'aws-sdk-client-mock';
+import {
+  DynamoDBDocumentClient,
+  GetCommand,
+  PutCommand,
+  ScanCommand,
+  DeleteCommand,
+} from "@aws-sdk/lib-dynamodb";
+import { mockClient } from "aws-sdk-client-mock";
 
 const dynamoMock = mockClient(DynamoDBDocumentClient);
 
@@ -23,7 +29,9 @@ const mockUpdateResource = jest.fn();
 const mockDeleteResource = jest.fn();
 const mockUpdateResourceStatus = jest.fn();
 const mockSearchResources = jest.fn();
-const mockSerializeCustomMetadata = jest.fn((meta: unknown) => JSON.stringify(meta));
+const mockSerializeCustomMetadata = jest.fn((meta: unknown) =>
+  JSON.stringify(meta),
+);
 const mockDeserializeCustomMetadata = jest.fn(
   (json: string | null, defaults: Record<string, unknown>) => {
     if (!json) return defaults;
@@ -35,8 +43,12 @@ const mockDeserializeCustomMetadata = jest.fn(
   },
 );
 const mockToRegistryStatus = jest.fn((state: string) => {
-  const map: Record<string, string> = { active: 'APPROVED', inactive: 'DEPRECATED', maintenance: 'DRAFT' };
-  return map[state] || 'DEPRECATED';
+  const map: Record<string, string> = {
+    active: "APPROVED",
+    inactive: "DEPRECATED",
+    maintenance: "DRAFT",
+  };
+  return map[state] || "DEPRECATED";
 });
 
 /** Registry record fixture shape consumed by the mock mapper. */
@@ -55,22 +67,28 @@ const mockMapToAgentConfig = jest.fn((record: RegistryRecordFixture) => {
   // don't care about orgId still see a record whose orgId matches the
   // caller's org fixture below.
   const meta = record.customDescriptorContent
-    ? (() => { try { return JSON.parse(record.customDescriptorContent); } catch { return {}; } })()
+    ? (() => {
+        try {
+          return JSON.parse(record.customDescriptorContent);
+        } catch {
+          return {};
+        }
+      })()
     : {};
   return {
     agentId: record.recordId,
-    orgId: meta.orgId ?? '',
-    config: record.description ?? '',
-    state: 'active',
+    orgId: meta.orgId ?? "",
+    config: record.description ?? "",
+    state: "active",
     categories: [],
     createdAt: record.createdAt?.toISOString?.() ?? record.createdAt,
     updatedAt: record.updatedAt?.toISOString?.() ?? record.updatedAt,
   };
 });
 
-jest.mock('../../services/registry-service', () => ({
+jest.mock("../../services/registry-service", () => ({
   RegistryService: jest.fn().mockImplementation(() => ({
-    getRegistryId: () => 'test-registry',
+    getRegistryId: () => "test-registry",
     listResources: mockListResources,
     getResource: mockGetResource,
     createResource: mockCreateResource,
@@ -85,7 +103,7 @@ jest.mock('../../services/registry-service', () => ({
   })),
 }));
 
-import { handler, _resetRegistryService } from '../agent-config-resolver';
+import { handler, _resetRegistryService } from "../agent-config-resolver";
 
 // ---------------------------------------------------------------------------
 
@@ -94,8 +112,8 @@ import { handler, _resetRegistryService } from '../agent-config-resolver';
 // org filter lets them through. Tests that specifically exercise no-org /
 // admin behaviour can supply their own identity.
 const defaultIdentity = {
-  sub: 'test-user',
-  claims: { 'custom:organization': 'test-org-a' },
+  sub: "test-user",
+  claims: { "custom:organization": "test-org-a" },
 };
 
 const makeEvent = (
@@ -109,16 +127,16 @@ const makeEvent = (
 });
 
 const sampleRegistryRecord = {
-  recordId: 'agent-r1',
-  name: 'RegistryAgent',
+  recordId: "agent-r1",
+  name: "RegistryAgent",
   description: '{"name":"RegistryAgent"}',
-  status: 'APPROVED',
-  customDescriptorContent: JSON.stringify({ orgId: 'test-org-a' }),
-  createdAt: new Date('2025-01-01T00:00:00Z'),
-  updatedAt: new Date('2025-01-01T00:00:00Z'),
+  status: "APPROVED",
+  customDescriptorContent: JSON.stringify({ orgId: "test-org-a" }),
+  createdAt: new Date("2025-01-01T00:00:00Z"),
+  updatedAt: new Date("2025-01-01T00:00:00Z"),
 };
 
-describe('handler switch dispatch (task 6.5)', () => {
+describe("handler switch dispatch (task 6.5)", () => {
   const originalEnv = process.env;
 
   beforeEach(() => {
@@ -127,8 +145,8 @@ describe('handler switch dispatch (task 6.5)', () => {
     _resetRegistryService();
     process.env = {
       ...originalEnv,
-      AGENT_CONFIG_TABLE: 'test-agent-config',
-      REGISTRY_ID: 'test-registry',
+      AGENT_CONFIG_TABLE: "test-agent-config",
+      REGISTRY_ID: "test-registry",
     };
   });
 
@@ -138,90 +156,105 @@ describe('handler switch dispatch (task 6.5)', () => {
 
   // ─── REGISTRY_ENABLED=false: routes to DynamoDB ──────────────
 
-  describe('when REGISTRY_ENABLED is false', () => {
+  describe("when REGISTRY_ENABLED is false", () => {
     beforeEach(() => {
-      process.env.REGISTRY_ENABLED = 'false';
+      process.env.REGISTRY_ENABLED = "false";
     });
 
-    test('listAgentConfigs uses DynamoDB scan', async () => {
+    test("listAgentConfigs uses DynamoDB scan", async () => {
       dynamoMock.on(ScanCommand).resolves({
-        Items: [{ agentId: 'a1', config: { name: 'A1' }, state: 'active' }],
+        Items: [{ agentId: "a1", config: { name: "A1" }, state: "active" }],
       });
 
-      const result = await handler(makeEvent('listAgentConfigs'));
+      const result = await handler(makeEvent("listAgentConfigs"));
 
       expect(mockListResources).not.toHaveBeenCalled();
       expect(result).toHaveLength(1);
-      expect(result[0].agentId).toBe('a1');
+      expect(result[0].agentId).toBe("a1");
       // GraphQL response shape: config is stringified
-      expect(typeof result[0].config).toBe('string');
+      expect(typeof result[0].config).toBe("string");
     });
 
-    test('getAgentConfig uses DynamoDB GetItem', async () => {
+    test("getAgentConfig uses DynamoDB GetItem", async () => {
       dynamoMock.on(GetCommand).resolves({
-        Item: { agentId: 'a1', config: { name: 'A1' }, state: 'active' },
+        Item: { agentId: "a1", config: { name: "A1" }, state: "active" },
       });
 
-      const result = await handler(makeEvent('getAgentConfig', { agentId: 'a1' }));
+      const result = await handler(
+        makeEvent("getAgentConfig", { agentId: "a1" }),
+      );
 
       expect(mockGetResource).not.toHaveBeenCalled();
-      expect(result?.agentId).toBe('a1');
-      expect(typeof result?.config).toBe('string');
+      expect(result?.agentId).toBe("a1");
+      expect(typeof result?.config).toBe("string");
     });
 
-    test('createAgentConfig uses DynamoDB Put', async () => {
+    test("createAgentConfig uses DynamoDB Put", async () => {
       dynamoMock.on(PutCommand).resolves({});
 
-      const result = await handler(makeEvent('createAgentConfig', {
-        input: { agentId: 'new', config: '{"name":"N"}', state: 'active' },
-      }));
+      const result = await handler(
+        makeEvent("createAgentConfig", {
+          input: { agentId: "new", config: '{"name":"N"}', state: "active" },
+        }),
+      );
 
       expect(mockCreateResource).not.toHaveBeenCalled();
-      expect(result.agentId).toBe('new');
-      expect(typeof result.config).toBe('string');
+      expect(result.agentId).toBe("new");
+      expect(typeof result.config).toBe("string");
       expect(result.createdAt).toBeDefined();
       expect(result.updatedAt).toBeDefined();
     });
 
-    test('updateAgentConfig uses DynamoDB Put', async () => {
+    test("updateAgentConfig uses DynamoDB Put", async () => {
       dynamoMock.on(GetCommand).resolves({
-        Item: { agentId: 'a1', config: '{"old":true}', state: 'active', createdAt: '2025-01-01' },
+        Item: {
+          agentId: "a1",
+          config: '{"old":true}',
+          state: "active",
+          createdAt: "2025-01-01",
+        },
       });
       dynamoMock.on(PutCommand).resolves({});
 
-      const result = await handler(makeEvent('updateAgentConfig', {
-        input: { agentId: 'a1', config: '{"new":true}' },
-      }));
+      const result = await handler(
+        makeEvent("updateAgentConfig", {
+          input: { agentId: "a1", config: '{"new":true}' },
+        }),
+      );
 
       expect(mockUpdateResource).not.toHaveBeenCalled();
-      expect(result.agentId).toBe('a1');
+      expect(result.agentId).toBe("a1");
     });
 
-    test('deleteAgentConfig uses DynamoDB Delete', async () => {
+    test("deleteAgentConfig uses DynamoDB Delete", async () => {
       dynamoMock.on(DeleteCommand).resolves({});
 
-      const result = await handler(makeEvent('deleteAgentConfig', { agentId: 'a1' }));
+      const result = await handler(
+        makeEvent("deleteAgentConfig", { agentId: "a1" }),
+      );
 
       expect(mockDeleteResource).not.toHaveBeenCalled();
       expect(result.success).toBe(true);
     });
 
-    test('publishAgentManifest uses DynamoDB path', async () => {
+    test("publishAgentManifest uses DynamoDB path", async () => {
       dynamoMock.on(GetCommand).resolves({
-        Item: { agentId: 'a1', config: { name: 'A1' }, state: 'active' },
+        Item: { agentId: "a1", config: { name: "A1" }, state: "active" },
       });
       // The DynamoDB path uses UpdateCommand, reset mock accepts it by default
       const manifest = JSON.stringify({
-        name: 'Test',
-        description: 'desc',
-        version: '1.0.0',
+        name: "Test",
+        description: "desc",
+        version: "1.0.0",
       });
 
       // We only assert the Registry side-effect was not invoked — the
       // DynamoDB path calls UpdateCommand which the mock resolves with
       // default (empty) Attributes. That's sufficient to verify dispatch.
       try {
-        await handler(makeEvent('publishAgentManifest', { agentId: 'a1', manifest }));
+        await handler(
+          makeEvent("publishAgentManifest", { agentId: "a1", manifest }),
+        );
       } catch {
         // Even if the mock doesn't fully satisfy the update path, what
         // matters is that the Registry path wasn't taken.
@@ -233,97 +266,109 @@ describe('handler switch dispatch (task 6.5)', () => {
 
   // ─── REGISTRY_ENABLED=true: routes to Registry ──────────────
 
-  describe('when REGISTRY_ENABLED is true', () => {
+  describe("when REGISTRY_ENABLED is true", () => {
     beforeEach(() => {
-      process.env.REGISTRY_ENABLED = 'true';
+      process.env.REGISTRY_ENABLED = "true";
     });
 
-    test('listAgentConfigs uses RegistryService.listResources (merged with DDB)', async () => {
+    test("listAgentConfigs uses RegistryService.listResources (merged with DDB)", async () => {
       mockListResources.mockResolvedValue([sampleRegistryRecord]);
       dynamoMock.on(ScanCommand).resolves({ Items: [] });
 
-      const result = await handler(makeEvent('listAgentConfigs'));
+      const result = await handler(makeEvent("listAgentConfigs"));
 
-      expect(mockListResources).toHaveBeenCalledWith('agent');
+      expect(mockListResources).toHaveBeenCalledWith("agent");
       expect(result).toHaveLength(1);
-      expect(result[0].agentId).toBe('agent-r1');
+      expect(result[0].agentId).toBe("agent-r1");
     });
 
-    test('getAgentConfig uses RegistryService.getResource', async () => {
+    test("getAgentConfig uses RegistryService.getResource", async () => {
       mockGetResource.mockResolvedValue(sampleRegistryRecord);
 
-      const result = await handler(makeEvent('getAgentConfig', { agentId: 'agent-r1' }));
+      const result = await handler(
+        makeEvent("getAgentConfig", { agentId: "agent-r1" }),
+      );
 
-      expect(mockGetResource).toHaveBeenCalledWith('agent', 'agent-r1');
-      expect(result?.agentId).toBe('agent-r1');
+      expect(mockGetResource).toHaveBeenCalledWith("agent", "agent-r1");
+      expect(result?.agentId).toBe("agent-r1");
     });
 
-    test('createAgentConfig uses RegistryService.createResource', async () => {
+    test("createAgentConfig uses RegistryService.createResource", async () => {
       mockCreateResource.mockResolvedValue(sampleRegistryRecord);
 
-      const result = await handler(makeEvent('createAgentConfig', {
-        input: { agentId: 'agent-r1', config: '{"name":"RegistryAgent"}' },
-      }));
+      const result = await handler(
+        makeEvent("createAgentConfig", {
+          input: { agentId: "agent-r1", config: '{"name":"RegistryAgent"}' },
+        }),
+      );
 
       expect(mockCreateResource).toHaveBeenCalled();
-      expect(result.agentId).toBe('agent-r1');
+      expect(result.agentId).toBe("agent-r1");
       // GraphQL shape: required fields present
       expect(result.state).toBeDefined();
       expect(result.categories).toBeDefined();
     });
 
-    test('updateAgentConfig uses RegistryService.updateResource', async () => {
+    test("updateAgentConfig uses RegistryService.updateResource", async () => {
       mockGetResource.mockResolvedValue(sampleRegistryRecord);
       mockUpdateResource.mockResolvedValue(sampleRegistryRecord);
 
-      const result = await handler(makeEvent('updateAgentConfig', {
-        input: { agentId: 'agent-r1', categories: ['new'] },
-      }));
+      const result = await handler(
+        makeEvent("updateAgentConfig", {
+          input: { agentId: "agent-r1", categories: ["new"] },
+        }),
+      );
 
       expect(mockUpdateResource).toHaveBeenCalled();
-      expect(result.agentId).toBe('agent-r1');
+      expect(result.agentId).toBe("agent-r1");
     });
 
-    test('deleteAgentConfig uses RegistryService.deleteResource', async () => {
+    test("deleteAgentConfig uses RegistryService.deleteResource", async () => {
       mockDeleteResource.mockResolvedValue(undefined);
 
-      const result = await handler(makeEvent('deleteAgentConfig', { agentId: 'agent-r1' }));
+      const result = await handler(
+        makeEvent("deleteAgentConfig", { agentId: "agent-r1" }),
+      );
 
-      expect(mockDeleteResource).toHaveBeenCalledWith('agent', 'agent-r1');
+      expect(mockDeleteResource).toHaveBeenCalledWith("agent", "agent-r1");
       expect(result.success).toBe(true);
     });
 
-    test('publishAgentManifest uses RegistryService.updateResource', async () => {
+    test("publishAgentManifest uses RegistryService.updateResource", async () => {
       mockGetResource.mockResolvedValue(sampleRegistryRecord);
       mockUpdateResource.mockResolvedValue(sampleRegistryRecord);
       const manifest = JSON.stringify({
-        name: 'Test',
-        description: 'desc',
-        version: '1.0.0',
+        name: "Test",
+        description: "desc",
+        version: "1.0.0",
       });
 
-      const result = await handler(makeEvent('publishAgentManifest', {
-        agentId: 'agent-r1',
-        manifest,
-      }));
+      const result = await handler(
+        makeEvent("publishAgentManifest", {
+          agentId: "agent-r1",
+          manifest,
+        }),
+      );
 
       expect(mockUpdateResource).toHaveBeenCalled();
-      expect(result.agentId).toBe('agent-r1');
+      expect(result.agentId).toBe("agent-r1");
     });
   });
 
   // ─── searchAgentConfigs: Registry-only (per requirement 9.3) ────
 
-  describe('searchAgentConfigs is always wired to Registry', () => {
-    test('routes to RegistryService.searchResources regardless of flag', async () => {
-      process.env.REGISTRY_ENABLED = 'true';
+  describe("searchAgentConfigs is always wired to Registry", () => {
+    test("routes to RegistryService.searchResources regardless of flag", async () => {
+      process.env.REGISTRY_ENABLED = "true";
       mockSearchResources.mockResolvedValue([sampleRegistryRecord]);
 
-      const result = await handler(makeEvent('searchAgentConfigs', { query: 'test' }));
+      const result = await handler(
+        makeEvent("searchAgentConfigs", { query: "test" }),
+      );
 
-      expect(mockSearchResources).toHaveBeenCalledWith('agent', 'test');
+      expect(mockSearchResources).toHaveBeenCalledWith("agent", "test");
       expect(result).toHaveLength(1);
-      expect(result[0].agentId).toBe('agent-r1');
+      expect(result[0].agentId).toBe("agent-r1");
     });
   });
 
@@ -336,134 +381,149 @@ describe('handler switch dispatch (task 6.5)', () => {
   //   (d) list-all works for admin via "All Organizations" (no filter)
   //   (e) get cross-org returns Not found
 
-  describe('Phase-2a org scoping', () => {
+  describe("Phase-2a org scoping", () => {
     beforeEach(() => {
-      process.env.REGISTRY_ENABLED = 'true';
+      process.env.REGISTRY_ENABLED = "true";
     });
 
-    test('(a) create: orgId captured from JWT claim and serialized into customMetadata', async () => {
+    test("(a) create: orgId captured from JWT claim and serialized into customMetadata", async () => {
       mockCreateResource.mockResolvedValue(sampleRegistryRecord);
 
-      await handler(makeEvent(
-        'createAgentConfig',
-        { input: { agentId: 'agent-r1', config: '{"name":"RegistryAgent"}' } },
-      ));
+      await handler(
+        makeEvent("createAgentConfig", {
+          input: { agentId: "agent-r1", config: '{"name":"RegistryAgent"}' },
+        }),
+      );
 
       expect(mockSerializeCustomMetadata).toHaveBeenCalledWith(
-        expect.objectContaining({ orgId: 'test-org-a' }),
+        expect.objectContaining({ orgId: "test-org-a" }),
       );
     });
 
-    test('(b) update: existing orgId is preserved, never overwritten by caller org', async () => {
+    test("(b) update: existing orgId is preserved, never overwritten by caller org", async () => {
       const ownedBySomeoneElse = {
         ...sampleRegistryRecord,
-        customDescriptorContent: JSON.stringify({ orgId: 'original-owner-org' }),
+        customDescriptorContent: JSON.stringify({
+          orgId: "original-owner-org",
+        }),
       };
       mockGetResource.mockResolvedValue(ownedBySomeoneElse);
       mockUpdateResource.mockResolvedValue(ownedBySomeoneElse);
 
-      await handler(makeEvent(
-        'updateAgentConfig',
-        { input: { agentId: 'agent-r1', categories: ['x'] } },
-        // different caller from the record owner
-        { claims: { 'custom:organization': 'different-caller-org' } },
-      ));
+      await handler(
+        makeEvent(
+          "updateAgentConfig",
+          { input: { agentId: "agent-r1", categories: ["x"] } },
+          // different caller from the record owner
+          { claims: { "custom:organization": "different-caller-org" } },
+        ),
+      );
 
       expect(mockSerializeCustomMetadata).toHaveBeenCalledWith(
-        expect.objectContaining({ orgId: 'original-owner-org' }),
+        expect.objectContaining({ orgId: "original-owner-org" }),
       );
     });
 
-    test('(c) list: results filtered to caller org', async () => {
+    test("(c) list: results filtered to caller org", async () => {
       const ourOrg = {
         ...sampleRegistryRecord,
-        recordId: 'agent-a',
-        customDescriptorContent: JSON.stringify({ orgId: 'test-org-a' }),
+        recordId: "agent-a",
+        customDescriptorContent: JSON.stringify({ orgId: "test-org-a" }),
       };
       const otherOrg = {
         ...sampleRegistryRecord,
-        recordId: 'agent-b',
-        customDescriptorContent: JSON.stringify({ orgId: 'other-org' }),
+        recordId: "agent-b",
+        customDescriptorContent: JSON.stringify({ orgId: "other-org" }),
       };
       mockListResources.mockResolvedValue([ourOrg, otherOrg]);
       dynamoMock.on(ScanCommand).resolves({ Items: [] });
 
-      const result = await handler(makeEvent('listAgentConfigs'));
+      const result = await handler(makeEvent("listAgentConfigs"));
 
       // Only the record whose orgId matches the caller survives.
       expect(result).toHaveLength(1);
-      expect(result[0].agentId).toBe('agent-a');
+      expect(result[0].agentId).toBe("agent-a");
     });
 
-    test('(d) list: admin bypass returns all orgs (no filter applied)', async () => {
+    test("(d) list: admin bypass returns all orgs (no filter applied)", async () => {
       const ourOrg = {
         ...sampleRegistryRecord,
-        recordId: 'agent-a',
-        customDescriptorContent: JSON.stringify({ orgId: 'test-org-a' }),
+        recordId: "agent-a",
+        customDescriptorContent: JSON.stringify({ orgId: "test-org-a" }),
       };
       const otherOrg = {
         ...sampleRegistryRecord,
-        recordId: 'agent-b',
-        customDescriptorContent: JSON.stringify({ orgId: 'other-org' }),
+        recordId: "agent-b",
+        customDescriptorContent: JSON.stringify({ orgId: "other-org" }),
       };
       mockListResources.mockResolvedValue([ourOrg, otherOrg]);
       dynamoMock.on(ScanCommand).resolves({ Items: [] });
 
       const adminIdentity = {
-        sub: 'admin-user',
-        claims: { 'custom:organization': 'admin-home-org', 'custom:role': 'admin' },
+        sub: "admin-user",
+        claims: {
+          "custom:organization": "admin-home-org",
+          "custom:role": "admin",
+          "cognito:groups": ["admin"],
+        },
       };
-      const result = (await handler(makeEvent('listAgentConfigs', {}, adminIdentity))) as Array<{
+      const result = (await handler(
+        makeEvent("listAgentConfigs", {}, adminIdentity),
+      )) as Array<{
         agentId: string;
       }>;
 
       expect(result).toHaveLength(2);
       const ids = result.map((a) => a.agentId).sort();
-      expect(ids).toEqual(['agent-a', 'agent-b']);
+      expect(ids).toEqual(["agent-a", "agent-b"]);
     });
 
-    test('(e) get: cross-org resource surfaces as Not found (null)', async () => {
+    test("(e) get: cross-org resource surfaces as Not found (null)", async () => {
       const otherOrgRecord = {
         ...sampleRegistryRecord,
-        customDescriptorContent: JSON.stringify({ orgId: 'other-org' }),
+        customDescriptorContent: JSON.stringify({ orgId: "other-org" }),
       };
       mockGetResource.mockResolvedValue(otherOrgRecord);
       // DDB fallback should not matter because the Registry record is present.
       dynamoMock.on(GetCommand).resolves({});
 
-      const result = await handler(makeEvent('getAgentConfig', { agentId: 'agent-r1' }));
+      const result = await handler(
+        makeEvent("getAgentConfig", { agentId: "agent-r1" }),
+      );
       // 404-style — null rather than a thrown authorization error, to avoid
       // leaking existence across tenants.
       expect(result).toBeNull();
     });
 
-    test('(e) get: admin bypass returns cross-org resource', async () => {
+    test("(e) get: admin bypass returns cross-org resource", async () => {
       const otherOrgRecord = {
         ...sampleRegistryRecord,
-        customDescriptorContent: JSON.stringify({ orgId: 'other-org' }),
+        customDescriptorContent: JSON.stringify({ orgId: "other-org" }),
       };
       mockGetResource.mockResolvedValue(otherOrgRecord);
 
       const adminIdentity = {
-        sub: 'admin-user',
-        claims: { 'custom:organization': 'admin-home-org', 'custom:role': 'admin' },
+        sub: "admin-user",
+        claims: {
+          "custom:organization": "admin-home-org",
+          "custom:role": "admin",
+          "cognito:groups": ["admin"],
+        },
       };
-      const result = await handler(makeEvent(
-        'getAgentConfig',
-        { agentId: 'agent-r1' },
-        adminIdentity,
-      ));
+      const result = await handler(
+        makeEvent("getAgentConfig", { agentId: "agent-r1" }, adminIdentity),
+      );
 
-      expect(result?.agentId).toBe('agent-r1');
-      expect(result?.orgId).toBe('other-org');
+      expect(result?.agentId).toBe("agent-r1");
+      expect(result?.orgId).toBe("other-org");
     });
 
-    test('list: non-admin without orgId returns empty list (with warning)', async () => {
+    test("list: non-admin without orgId returns empty list (with warning)", async () => {
       mockListResources.mockResolvedValue([sampleRegistryRecord]);
       dynamoMock.on(ScanCommand).resolves({ Items: [] });
-      const warn = jest.spyOn(console, 'warn').mockImplementation(() => {});
+      const warn = jest.spyOn(console, "warn").mockImplementation(() => {});
 
-      const result = await handler(makeEvent('listAgentConfigs', {}, {}));
+      const result = await handler(makeEvent("listAgentConfigs", {}, {}));
       expect(result).toEqual([]);
       expect(warn).toHaveBeenCalled();
       warn.mockRestore();
@@ -472,8 +532,10 @@ describe('handler switch dispatch (task 6.5)', () => {
 
   // ─── Unknown field ──────────────────────────────────────────
 
-  test('throws on unknown GraphQL field', async () => {
-    process.env.REGISTRY_ENABLED = 'false';
-    await expect(handler(makeEvent('unknownField'))).rejects.toThrow('Unknown field');
+  test("throws on unknown GraphQL field", async () => {
+    process.env.REGISTRY_ENABLED = "false";
+    await expect(handler(makeEvent("unknownField"))).rejects.toThrow(
+      "Unknown field",
+    );
   });
 });

--- a/backend/src/lambda/__tests__/agent-config-resolver-list-org-scoping.test.ts
+++ b/backend/src/lambda/__tests__/agent-config-resolver-list-org-scoping.test.ts
@@ -8,8 +8,8 @@
  * empty-list behavior, cross-org isolation, and dedupe-by-name are locked
  * down as regression guards.
  */
-import { DynamoDBDocumentClient, ScanCommand } from '@aws-sdk/lib-dynamodb';
-import { mockClient } from 'aws-sdk-client-mock';
+import { DynamoDBDocumentClient, ScanCommand } from "@aws-sdk/lib-dynamodb";
+import { mockClient } from "aws-sdk-client-mock";
 
 const dynamoMock = mockClient(DynamoDBDocumentClient);
 
@@ -33,79 +33,98 @@ const mockMapToAgentConfig = jest.fn((record: TestRegistryRecord) => {
   return {
     agentId: record.recordId,
     name: record.name,
-    orgId: typeof meta.orgId === 'string' ? meta.orgId : '',
+    orgId: typeof meta.orgId === "string" ? meta.orgId : "",
     config: record.description,
-    state: 'active',
+    state: "active",
     categories: [] as string[],
   };
 });
 
-jest.mock('../../services/registry-service', () => ({
+jest.mock("../../services/registry-service", () => ({
   RegistryService: jest.fn().mockImplementation(() => ({
     listResources: mockListResources,
     mapToAgentConfig: mockMapToAgentConfig,
   })),
   RegistryRecordStatusValues: {
-    DRAFT: 'DRAFT',
-    PENDING_APPROVAL: 'PENDING_APPROVAL',
-    APPROVED: 'APPROVED',
-    REJECTED: 'REJECTED',
-    DEPRECATED: 'DEPRECATED',
-    CREATING: 'CREATING',
-    UPDATING: 'UPDATING',
-    CREATE_FAILED: 'CREATE_FAILED',
-    UPDATE_FAILED: 'UPDATE_FAILED',
+    DRAFT: "DRAFT",
+    PENDING_APPROVAL: "PENDING_APPROVAL",
+    APPROVED: "APPROVED",
+    REJECTED: "REJECTED",
+    DEPRECATED: "DEPRECATED",
+    CREATING: "CREATING",
+    UPDATING: "UPDATING",
+    CREATE_FAILED: "CREATE_FAILED",
+    UPDATE_FAILED: "UPDATE_FAILED",
   },
 }));
 
-import { listAgentConfigsRegistry, _resetRegistryService } from '../agent-config-resolver';
+import {
+  listAgentConfigsRegistry,
+  _resetRegistryService,
+} from "../agent-config-resolver";
 
 // ---------------------------------------------------------------------------
 // Fixtures
 // ---------------------------------------------------------------------------
 
-const registryRecord = (recordId: string, name: string, orgId: string): TestRegistryRecord => ({
+const registryRecord = (
+  recordId: string,
+  name: string,
+  orgId: string,
+): TestRegistryRecord => ({
   recordId,
   name,
-  status: 'APPROVED',
+  status: "APPROVED",
   description: JSON.stringify({ name }),
   customDescriptorContent: JSON.stringify({ orgId }),
 });
 
 // Registry records: one own-org, one system-shared (orgId ''), one other-org.
 const REGISTRY_RECORDS: TestRegistryRecord[] = [
-  registryRecord('reg-own', 'OwnOrgAgent', 'org-a'),
-  registryRecord('reg-system', 'Echo Demo Agent', ''),
-  registryRecord('reg-other', 'OtherOrgAgent', 'org-b'),
+  registryRecord("reg-own", "OwnOrgAgent", "org-a"),
+  registryRecord("reg-system", "Echo Demo Agent", ""),
+  registryRecord("reg-other", "OtherOrgAgent", "org-b"),
 ];
 
 // Legacy DynamoDB items: one own-org, one system-shared (no orgId → maps to
 // ''), one other-org. Names are distinct from the Registry ones so the
 // dedupe-by-name step does not interfere with the scoping assertions.
 const DYNAMO_ITEMS = [
-  { agentId: 'dyn-own', orgId: 'org-a', config: '{"name":"LegacyOwn"}', state: 'active' },
-  { agentId: 'dyn-system', config: '{"name":"LegacyShared"}', state: 'active' },
-  { agentId: 'dyn-other', orgId: 'org-b', config: '{"name":"LegacyOther"}', state: 'active' },
+  {
+    agentId: "dyn-own",
+    orgId: "org-a",
+    config: '{"name":"LegacyOwn"}',
+    state: "active",
+  },
+  { agentId: "dyn-system", config: '{"name":"LegacyShared"}', state: "active" },
+  {
+    agentId: "dyn-other",
+    orgId: "org-b",
+    config: '{"name":"LegacyOther"}',
+    state: "active",
+  },
 ];
 
 const nonAdminEvent = (orgId: string) => ({
-  identity: { claims: { 'custom:organization': orgId } },
+  identity: { claims: { "custom:organization": orgId } },
 });
-const adminEvent = { identity: { claims: { 'custom:role': 'admin' } } };
+const adminEvent = {
+  identity: { claims: { "custom:role": "admin", "cognito:groups": ["admin"] } },
+};
 const noOrgEvent = { identity: {} };
 
 const agentIdsOf = (configs: Array<{ agentId: string }>): string[] =>
   configs.map((c) => c.agentId).sort();
 
-describe('listAgentConfigsRegistry — orgId scoping with system-shared agents', () => {
+describe("listAgentConfigsRegistry — orgId scoping with system-shared agents", () => {
   const originalEnv = process.env;
 
   beforeEach(() => {
     process.env = {
       ...originalEnv,
-      REGISTRY_ENABLED: 'true',
-      REGISTRY_ID: 'test-registry',
-      AGENT_CONFIG_TABLE: 'test-agents',
+      REGISTRY_ENABLED: "true",
+      REGISTRY_ID: "test-registry",
+      AGENT_CONFIG_TABLE: "test-agents",
     };
     _resetRegistryService();
     jest.clearAllMocks();
@@ -118,35 +137,42 @@ describe('listAgentConfigsRegistry — orgId scoping with system-shared agents',
     process.env = originalEnv;
   });
 
-  test('(a) non-admin with orgId sees own-org registry agents', async () => {
-    const result = await listAgentConfigsRegistry(nonAdminEvent('org-a'));
+  test("(a) non-admin with orgId sees own-org registry agents", async () => {
+    const result = await listAgentConfigsRegistry(nonAdminEvent("org-a"));
 
-    expect(agentIdsOf(result)).toContain('reg-own');
+    expect(agentIdsOf(result)).toContain("reg-own");
   });
 
   test("(b) non-admin with orgId also sees system-shared (orgId='') registry agents", async () => {
-    const result = await listAgentConfigsRegistry(nonAdminEvent('org-a'));
+    const result = await listAgentConfigsRegistry(nonAdminEvent("org-a"));
 
-    expect(agentIdsOf(result)).toContain('reg-system');
+    expect(agentIdsOf(result)).toContain("reg-system");
   });
 
-  test('(c) non-admin with orgId never sees other-org agents (registry or legacy)', async () => {
-    const result = await listAgentConfigsRegistry(nonAdminEvent('org-a'));
+  test("(c) non-admin with orgId never sees other-org agents (registry or legacy)", async () => {
+    const result = await listAgentConfigsRegistry(nonAdminEvent("org-a"));
 
     const ids = agentIdsOf(result);
-    expect(ids).not.toContain('reg-other');
-    expect(ids).not.toContain('dyn-other');
+    expect(ids).not.toContain("reg-other");
+    expect(ids).not.toContain("dyn-other");
   });
 
-  test('(d) admin sees all agents across all orgs, including system-shared (unchanged)', async () => {
+  test("(d) admin sees all agents across all orgs, including system-shared (unchanged)", async () => {
     const result = await listAgentConfigsRegistry(adminEvent);
 
     expect(agentIdsOf(result)).toEqual(
-      ['reg-own', 'reg-system', 'reg-other', 'dyn-own', 'dyn-system', 'dyn-other'].sort(),
+      [
+        "reg-own",
+        "reg-system",
+        "reg-other",
+        "dyn-own",
+        "dyn-system",
+        "dyn-other",
+      ].sort(),
     );
   });
 
-  test('(e) non-admin without orgId still gets an empty list and no registry fetch', async () => {
+  test("(e) non-admin without orgId still gets an empty list and no registry fetch", async () => {
     const result = await listAgentConfigsRegistry(noOrgEvent);
 
     expect(result).toEqual([]);
@@ -154,30 +180,36 @@ describe('listAgentConfigsRegistry — orgId scoping with system-shared agents',
   });
 
   test("(f) legacy-Dynamo merge path: non-admin with orgId sees own-org AND system-shared (orgId='') legacy agents", async () => {
-    const result = await listAgentConfigsRegistry(nonAdminEvent('org-a'));
+    const result = await listAgentConfigsRegistry(nonAdminEvent("org-a"));
 
     const ids = agentIdsOf(result);
-    expect(ids).toContain('dyn-own');
-    expect(ids).toContain('dyn-system');
+    expect(ids).toContain("dyn-own");
+    expect(ids).toContain("dyn-system");
     // Full expected visibility for org-a: own-org + system-shared from both sources.
-    expect(ids).toEqual(['dyn-own', 'dyn-system', 'reg-own', 'reg-system'].sort());
+    expect(ids).toEqual(
+      ["dyn-own", "dyn-system", "reg-own", "reg-system"].sort(),
+    );
   });
 
-  test('(g) dedupe-by-name still holds when a system-shared registry agent and a legacy agent share a name', async () => {
+  test("(g) dedupe-by-name still holds when a system-shared registry agent and a legacy agent share a name", async () => {
     // Legacy duplicate of the system-shared registry agent, sharing the
     // config name 'Echo Demo Agent'. Registry must win; the legacy row
     // must be dropped from the merged result.
     dynamoMock.on(ScanCommand).resolves({
       Items: [
         ...DYNAMO_ITEMS,
-        { agentId: 'dyn-echo-dup', config: '{"name":"Echo Demo Agent"}', state: 'active' },
+        {
+          agentId: "dyn-echo-dup",
+          config: '{"name":"Echo Demo Agent"}',
+          state: "active",
+        },
       ],
     });
 
-    const result = await listAgentConfigsRegistry(nonAdminEvent('org-a'));
+    const result = await listAgentConfigsRegistry(nonAdminEvent("org-a"));
 
     const ids = agentIdsOf(result);
-    expect(ids).toContain('reg-system');
-    expect(ids).not.toContain('dyn-echo-dup');
+    expect(ids).toContain("reg-system");
+    expect(ids).not.toContain("dyn-echo-dup");
   });
 });

--- a/backend/src/lambda/__tests__/cost-budget-handler.property.test.ts
+++ b/backend/src/lambda/__tests__/cost-budget-handler.property.test.ts
@@ -36,7 +36,10 @@ function makeGetBudgetsEvent(
   const claims: Record<string, unknown> = {
     "custom:organization": claimOrg,
   };
-  if (isAdmin) claims["custom:role"] = "admin";
+  if (isAdmin) {
+    claims["custom:role"] = "admin";
+    claims["cognito:groups"] = ["admin"];
+  }
 
   const qsp: Record<string, string> | null =
     queryOrgId !== undefined ? { orgId: queryOrgId } : null;
@@ -64,7 +67,10 @@ function makePutBudgetEvent(
   const claims: Record<string, unknown> = {
     "custom:organization": claimOrg,
   };
-  if (isAdmin) claims["custom:role"] = "admin";
+  if (isAdmin) {
+    claims["custom:role"] = "admin";
+    claims["cognito:groups"] = ["admin"];
+  }
 
   return {
     version: "2.0",

--- a/backend/src/lambda/__tests__/cost-budget-handler.test.ts
+++ b/backend/src/lambda/__tests__/cost-budget-handler.test.ts
@@ -91,7 +91,11 @@ describe("cost-budget-handler routing", () => {
         rawPath: "/budgets",
         queryStringParameters: { orgId: "org-2" },
       } as Partial<APIGatewayProxyEventV2WithJWTAuthorizer>,
-      { "custom:organization": "org-1", "custom:role": "admin" },
+      {
+        "custom:organization": "org-1",
+        "custom:role": "admin",
+        "cognito:groups": ["admin"],
+      },
     );
 
     const res = await handler(event);

--- a/backend/src/lambda/__tests__/cost-query-handler.property.test.ts
+++ b/backend/src/lambda/__tests__/cost-query-handler.property.test.ts
@@ -33,7 +33,10 @@ function makeSummaryEvent(
   const claims: Record<string, unknown> = {
     "custom:organization": claimOrg,
   };
-  if (isAdmin) claims["custom:role"] = "admin";
+  if (isAdmin) {
+    claims["custom:role"] = "admin";
+    claims["cognito:groups"] = ["admin"];
+  }
 
   const qsp: Record<string, string> = { groupBy: "app" };
   if (queryOrgId !== undefined) qsp.orgId = queryOrgId;

--- a/backend/src/lambda/__tests__/datastore-resolver-item-org-scoping.test.ts
+++ b/backend/src/lambda/__tests__/datastore-resolver-item-org-scoping.test.ts
@@ -162,7 +162,11 @@ const SAME_ORG_IDENTITY = {
   sub: "victim-user",
   "custom:organization": "org-victim",
 };
-const ADMIN_IDENTITY = { sub: "admin-1", "custom:role": "admin" };
+const ADMIN_IDENTITY = {
+  sub: "admin-1",
+  "custom:role": "admin",
+  "cognito:groups": ["admin"],
+};
 
 beforeEach(() => {
   jest.clearAllMocks();

--- a/backend/src/lambda/__tests__/integration-resolver-item-org-scoping.test.ts
+++ b/backend/src/lambda/__tests__/integration-resolver-item-org-scoping.test.ts
@@ -158,7 +158,11 @@ const SAME_ORG_IDENTITY = {
   sub: "victim-user",
   "custom:organization": "org-victim",
 };
-const ADMIN_IDENTITY = { sub: "admin-1", "custom:role": "admin" };
+const ADMIN_IDENTITY = {
+  sub: "admin-1",
+  "custom:role": "admin",
+  "cognito:groups": ["admin"],
+};
 
 beforeEach(() => {
   jest.clearAllMocks();

--- a/backend/src/lambda/__tests__/model-config-resolver.test.ts
+++ b/backend/src/lambda/__tests__/model-config-resolver.test.ts
@@ -324,7 +324,11 @@ describe("model-config-resolver", () => {
         makeEvent(
           "setModelCatalogEntryStatus",
           { modelKey: "vendor.model-standard", status: "deprecated" },
-          { username: "role-admin", "custom:role": "admin" },
+          {
+            username: "role-admin",
+            "custom:role": "admin",
+            "cognito:groups": ["admin"],
+          },
         ),
       );
 

--- a/backend/src/lambda/__tests__/organization-resolver.test.ts
+++ b/backend/src/lambda/__tests__/organization-resolver.test.ts
@@ -56,7 +56,11 @@ describe("organization-resolver", () => {
     identity: identity ?? { sub: "user-1" },
   });
 
-  const adminIdentity = { sub: "admin-1", "custom:role": "admin" };
+  const adminIdentity = {
+    sub: "admin-1",
+    "custom:role": "admin",
+    "cognito:groups": ["admin"],
+  };
   const nonAdminIdentity = { sub: "user-1", "custom:role": "project_manager" };
 
   describe("createOrganization — admin authorization gate (finding c79cd4f6)", () => {

--- a/backend/src/lambda/__tests__/pre-token-generation.test.ts
+++ b/backend/src/lambda/__tests__/pre-token-generation.test.ts
@@ -6,7 +6,7 @@
  * onto `claimsToAddOrOverride` while preserving any other
  * `claimsOverrideDetails` keys already set upstream.
  */
-import { handler } from '../pre-token-generation';
+import { handler } from "../pre-token-generation";
 
 type HandlerEvent = Parameters<typeof handler>[0];
 
@@ -18,77 +18,114 @@ interface EventOverrides extends Record<string, unknown> {
 
 function makeEvent(overrides: EventOverrides = {}): HandlerEvent {
   return {
-    version: '1',
-    triggerSource: 'TokenGeneration_HostedAuth',
-    region: 'us-east-1',
-    userPoolId: 'us-east-1_test',
-    userName: 'user-123',
-    callerContext: { awsSdkVersion: '1', clientId: 'client-1' },
+    version: "1",
+    triggerSource: "TokenGeneration_HostedAuth",
+    region: "us-east-1",
+    userPoolId: "us-east-1_test",
+    userName: "user-123",
+    callerContext: { awsSdkVersion: "1", clientId: "client-1" },
     request: {
       userAttributes: {
-        sub: 'user-123',
-        email: 'u@example.com',
+        sub: "user-123",
+        email: "u@example.com",
         ...(overrides.request?.userAttributes || {}),
       },
-      groupConfiguration: { groupsToOverride: [], iamRolesToOverride: [], preferredRole: null },
+      groupConfiguration: {
+        groupsToOverride: [],
+        iamRolesToOverride: [],
+        preferredRole: null,
+      },
     },
     response: overrides.response ?? {},
     ...overrides,
   } as unknown as HandlerEvent;
 }
 
-describe('pre-token-generation', () => {
-  test('adds both custom:organization and custom:role when both attributes are present', async () => {
+describe("pre-token-generation", () => {
+  test("adds custom:organization and custom:role when role is non-admin", async () => {
     const event = makeEvent({
       request: {
         userAttributes: {
-          'custom:organization': 'org-a',
-          'custom:role': 'admin',
+          "custom:organization": "org-a",
+          "custom:role": "project_manager",
         },
       },
     });
 
     const result = await handler(event);
 
-    expect(result.response?.claimsOverrideDetails?.claimsToAddOrOverride).toEqual({
-      'custom:organization': 'org-a',
-      'custom:role': 'admin',
+    expect(
+      result.response?.claimsOverrideDetails?.claimsToAddOrOverride,
+    ).toEqual({
+      "custom:organization": "org-a",
+      "custom:role": "project_manager",
     });
   });
 
-  test('adds only custom:organization when role is missing', async () => {
+  // finding 7aa877f8: custom:role is client-writable; it must never promote
+  // an unearned 'admin' value when the user holds no admin group
+  // membership. This is the KEY ESCALATION TEST for the trigger side.
+  test("KEY ESCALATION TEST: a stored custom:role=admin attribute WITHOUT admin group membership is NOT promoted to the admin claim", async () => {
     const event = makeEvent({
       request: {
         userAttributes: {
-          'custom:organization': 'org-a',
+          "custom:organization": "org-a",
+          "custom:role": "admin",
+        },
+        groupConfiguration: {
+          groupsToOverride: ["project_manager"],
+          iamRolesToOverride: [],
+          preferredRole: null,
         },
       },
     });
 
     const result = await handler(event);
 
-    expect(result.response?.claimsOverrideDetails?.claimsToAddOrOverride).toEqual({
-      'custom:organization': 'org-a',
+    expect(
+      result.response?.claimsOverrideDetails?.claimsToAddOrOverride,
+    ).toEqual({
+      "custom:organization": "org-a",
     });
   });
 
-  test('adds only custom:role when organization is missing', async () => {
+  test("adds only custom:organization when role is missing", async () => {
     const event = makeEvent({
       request: {
         userAttributes: {
-          'custom:role': 'project_manager',
+          "custom:organization": "org-a",
         },
       },
     });
 
     const result = await handler(event);
 
-    expect(result.response?.claimsOverrideDetails?.claimsToAddOrOverride).toEqual({
-      'custom:role': 'project_manager',
+    expect(
+      result.response?.claimsOverrideDetails?.claimsToAddOrOverride,
+    ).toEqual({
+      "custom:organization": "org-a",
     });
   });
 
-  test('produces an empty claimsToAddOrOverride when neither attribute is present', async () => {
+  test("adds only custom:role when organization is missing", async () => {
+    const event = makeEvent({
+      request: {
+        userAttributes: {
+          "custom:role": "project_manager",
+        },
+      },
+    });
+
+    const result = await handler(event);
+
+    expect(
+      result.response?.claimsOverrideDetails?.claimsToAddOrOverride,
+    ).toEqual({
+      "custom:role": "project_manager",
+    });
+  });
+
+  test("produces an empty claimsToAddOrOverride when neither attribute is present", async () => {
     const event = makeEvent({
       request: {
         userAttributes: {},
@@ -97,12 +134,14 @@ describe('pre-token-generation', () => {
 
     const result = await handler(event);
 
-    expect(result.response?.claimsOverrideDetails?.claimsToAddOrOverride).toEqual({});
+    expect(
+      result.response?.claimsOverrideDetails?.claimsToAddOrOverride,
+    ).toEqual({});
   });
 
-  test('preserves existing claimsOverrideDetails keys (e.g. groupOverrideDetails)', async () => {
+  test("preserves existing claimsOverrideDetails keys (e.g. groupOverrideDetails)", async () => {
     const existingGroupOverride = {
-      groupsToOverride: ['admin'],
+      groupsToOverride: ["admin"],
       iamRolesToOverride: [],
       preferredRole: null,
     };
@@ -110,7 +149,7 @@ describe('pre-token-generation', () => {
     const event = makeEvent({
       request: {
         userAttributes: {
-          'custom:organization': 'org-a',
+          "custom:organization": "org-a",
         },
       },
       response: {
@@ -125,7 +164,7 @@ describe('pre-token-generation', () => {
     expect(result.response?.claimsOverrideDetails).toEqual({
       groupOverrideDetails: existingGroupOverride,
       claimsToAddOrOverride: {
-        'custom:organization': 'org-a',
+        "custom:organization": "org-a",
       },
     });
   });
@@ -134,14 +173,14 @@ describe('pre-token-generation', () => {
   // Admin-group → custom:role overlay
   // ---------------------------------------------------------------------
 
-  test('explicit custom:role wins over admin-group membership', async () => {
+  test("group membership is authoritative: admin-group membership forces the admin claim even with a different stored custom:role", async () => {
     const event = makeEvent({
       request: {
         userAttributes: {
-          'custom:role': 'project_manager',
+          "custom:role": "project_manager",
         },
         groupConfiguration: {
-          groupsToOverride: ['admin'],
+          groupsToOverride: ["admin"],
           iamRolesToOverride: [],
           preferredRole: null,
         },
@@ -153,16 +192,16 @@ describe('pre-token-generation', () => {
     expect(
       result.response?.claimsOverrideDetails?.claimsToAddOrOverride,
     ).toEqual({
-      'custom:role': 'project_manager',
+      "custom:role": "admin",
     });
   });
 
-  test('admin group with no custom:role attribute → overlay sets custom:role to admin', async () => {
+  test("admin group with no custom:role attribute → overlay sets custom:role to admin", async () => {
     const event = makeEvent({
       request: {
         userAttributes: {},
         groupConfiguration: {
-          groupsToOverride: ['admin'],
+          groupsToOverride: ["admin"],
           iamRolesToOverride: [],
           preferredRole: null,
         },
@@ -174,16 +213,16 @@ describe('pre-token-generation', () => {
     expect(
       result.response?.claimsOverrideDetails?.claimsToAddOrOverride,
     ).toEqual({
-      'custom:role': 'admin',
+      "custom:role": "admin",
     });
   });
 
-  test('non-admin group without custom:role attribute → no overlay applied', async () => {
+  test("non-admin group without custom:role attribute → no overlay applied", async () => {
     const event = makeEvent({
       request: {
         userAttributes: {},
         groupConfiguration: {
-          groupsToOverride: ['analyst'],
+          groupsToOverride: ["analyst"],
           iamRolesToOverride: [],
           preferredRole: null,
         },
@@ -197,7 +236,7 @@ describe('pre-token-generation', () => {
     ).toEqual({});
   });
 
-  test('groupConfiguration entirely missing → no crash and no overlay', async () => {
+  test("groupConfiguration entirely missing → no crash and no overlay", async () => {
     const event = makeEvent({
       request: {
         userAttributes: {},

--- a/backend/src/lambda/__tests__/project-resolver.test.ts
+++ b/backend/src/lambda/__tests__/project-resolver.test.ts
@@ -284,7 +284,7 @@ describe("project-resolver — organization scoping", () => {
       makeEventWithIdentity(
         "listProjects",
         {},
-        { sub: "admin-1", "custom:role": "admin" },
+        { sub: "admin-1", "custom:role": "admin", "cognito:groups": ["admin"] },
       ),
     )) as unknown as { items: Array<{ id: string; archetypeStatus: string }> };
 
@@ -385,7 +385,7 @@ describe("project-resolver — organization scoping", () => {
       makeEventWithIdentity(
         "getProject",
         { id: "proj-org-b" },
-        { sub: "admin-1", "custom:role": "admin" },
+        { sub: "admin-1", "custom:role": "admin", "cognito:groups": ["admin"] },
       ),
     )) as unknown as { id: string };
 
@@ -437,7 +437,7 @@ describe("project-resolver — organization scoping", () => {
       makeEventWithIdentity(
         "listProjects",
         { nextToken: JSON.stringify(priorKey) },
-        { sub: "admin-1", "custom:role": "admin" },
+        { sub: "admin-1", "custom:role": "admin", "cognito:groups": ["admin"] },
       ),
     )) as unknown as { items: Array<{ id: string }>; nextToken?: string };
 

--- a/backend/src/lambda/__tests__/promotion-policy-resolver.test.ts
+++ b/backend/src/lambda/__tests__/promotion-policy-resolver.test.ts
@@ -145,6 +145,7 @@ describe("handler — AppSync dispatch", () => {
       identity: {
         sub: "admin-1",
         "custom:role": "admin",
+        "cognito:groups": ["admin"],
       },
       arguments: args,
     };

--- a/backend/src/lambda/__tests__/registry-agent-record-resolver-approval-lifecycle.test.ts
+++ b/backend/src/lambda/__tests__/registry-agent-record-resolver-approval-lifecycle.test.ts
@@ -90,6 +90,7 @@ function makeEvent(
           sub: "admin-1",
           claims: { sub: "admin-1", "custom:role": "admin" },
           "custom:role": "admin",
+          "cognito:groups": ["admin"],
         }
       : {
           sub: "user-123",

--- a/backend/src/lambda/__tests__/registry-agent-record-resolver-crud.test.ts
+++ b/backend/src/lambda/__tests__/registry-agent-record-resolver-crud.test.ts
@@ -121,6 +121,7 @@ function makeAdminEvent(
     identity: {
       sub,
       "custom:role": "admin",
+      "cognito:groups": ["admin"],
       claims: { sub, "custom:role": "admin" },
     },
   } as unknown as HandlerEvent;

--- a/backend/src/lambda/__tests__/registry-agent-record-resolver-meta-writes.test.ts
+++ b/backend/src/lambda/__tests__/registry-agent-record-resolver-meta-writes.test.ts
@@ -89,7 +89,12 @@ function makeEvent(
     // the finding-8f8fd119 editor gate (assertManifestAccess) on updateApp
     // via the same-org + implicit-creator-owner fallback path.
     identity: admin
-      ? { sub, claims: { sub, "custom:role": "admin" }, "custom:role": "admin" }
+      ? {
+          sub,
+          claims: { sub, "custom:role": "admin" },
+          "custom:role": "admin",
+          "cognito:groups": ["admin"],
+        }
       : { sub, claims: { sub, "custom:organization": "org-1" } },
   } as unknown as HandlerEvent;
 }

--- a/backend/src/lambda/__tests__/registry-agent-record-resolver-name-resolution.test.ts
+++ b/backend/src/lambda/__tests__/registry-agent-record-resolver-name-resolution.test.ts
@@ -100,7 +100,10 @@ function makeEvent(
   const orgId = "orgId" in opts ? opts.orgId : "org-1";
   const claims: Record<string, unknown> = { sub };
   if (orgId !== undefined) claims["custom:organization"] = orgId;
-  if (admin) claims["custom:role"] = "admin";
+  if (admin) {
+    claims["custom:role"] = "admin";
+    claims["cognito:groups"] = ["admin"];
+  }
   return {
     info: { fieldName },
     arguments: args,

--- a/backend/src/lambda/__tests__/registry-agent-record-resolver-status-events.test.ts
+++ b/backend/src/lambda/__tests__/registry-agent-record-resolver-status-events.test.ts
@@ -94,6 +94,7 @@ function makeAdminEvent(fieldName: string, args: Record<string, unknown>) {
       sub: "admin-1",
       claims: { sub: "admin-1", "custom:role": "admin" },
       "custom:role": "admin",
+      "cognito:groups": ["admin"],
     },
   } as unknown as HandlerEvent;
 }

--- a/backend/src/lambda/__tests__/resolver-list-time-budget.test.ts
+++ b/backend/src/lambda/__tests__/resolver-list-time-budget.test.ts
@@ -56,7 +56,9 @@ import {
   _resetRegistryService as resetToolRegistry,
 } from "../tool-config-resolver";
 
-const adminIdentity = { claims: { "custom:role": "admin" } };
+const adminIdentity = {
+  claims: { "custom:role": "admin", "cognito:groups": ["admin"] },
+};
 
 describe("list resolvers thread the Lambda time budget into listResources", () => {
   const originalEnv = process.env;

--- a/backend/src/lambda/__tests__/tool-approval-resolver.test.ts
+++ b/backend/src/lambda/__tests__/tool-approval-resolver.test.ts
@@ -16,8 +16,24 @@ import { DynamoDBDocumentClient, PutCommand } from "@aws-sdk/lib-dynamodb";
 import { mockClient } from "aws-sdk-client-mock";
 
 // extractOrgFromEvent hits Cognito; stub it to a deterministic caller org.
+// deriveRoles is given a lightweight real-ish implementation (rather than a
+// static stub) so role-gated tests (e.g. "architect role is permitted")
+// still see the fixture's custom:role claim, while admin remains
+// group-authoritative per finding 7aa877f8 — mirrors the real
+// auth-event.ts derivation without pulling in its Cognito dependency.
 jest.mock("../../utils/auth-event", () => ({
   extractOrgFromEvent: jest.fn(),
+  deriveRoles: jest.fn((event: unknown) => {
+    const identity =
+      (event as { identity?: Record<string, unknown> })?.identity || {};
+    const claimRole = identity["custom:role"] as string | undefined;
+    const groups = identity["cognito:groups"];
+    const isGroupAdmin = Array.isArray(groups) && groups.includes("admin");
+    const roles: string[] = [];
+    if (claimRole && claimRole !== "admin") roles.push(claimRole);
+    if (isGroupAdmin) roles.push("admin");
+    return roles;
+  }),
 }));
 import { extractOrgFromEvent } from "../../utils/auth-event";
 

--- a/backend/src/lambda/__tests__/tool-config-resolver-handler-dispatch.test.ts
+++ b/backend/src/lambda/__tests__/tool-config-resolver-handler-dispatch.test.ts
@@ -527,7 +527,11 @@ describe("tool-config-resolver handler switch dispatch (task 7.5)", () => {
 
       const adminIdentity = {
         sub: "admin",
-        claims: { "custom:organization": "admin-home", "custom:role": "admin" },
+        claims: {
+          "custom:organization": "admin-home",
+          "custom:role": "admin",
+          "cognito:groups": ["admin"],
+        },
       };
       const result = await handler(
         makeEvent("listToolConfigs", {}, adminIdentity),

--- a/backend/src/lambda/__tests__/tool-config-resolver-org-scoping.test.ts
+++ b/backend/src/lambda/__tests__/tool-config-resolver-org-scoping.test.ts
@@ -100,7 +100,7 @@ const eventForOrg = (orgId: string | undefined, admin = false) => ({
     sub: "test-user",
     claims: {
       ...(orgId ? { "custom:organization": orgId } : {}),
-      ...(admin ? { "custom:role": "admin" } : {}),
+      ...(admin ? { "custom:role": "admin", "cognito:groups": ["admin"] } : {}),
     },
   },
 });

--- a/backend/src/lambda/__tests__/tool-config-resolver-registry-crud.test.ts
+++ b/backend/src/lambda/__tests__/tool-config-resolver-registry-crud.test.ts
@@ -1050,7 +1050,11 @@ describe("Registry-backed CRUD functions (tasks 7.2–7.6)", () => {
 
       const adminIdentity = {
         sub: "admin",
-        claims: { "custom:organization": "admin-home", "custom:role": "admin" },
+        claims: {
+          "custom:organization": "admin-home",
+          "custom:role": "admin",
+          "cognito:groups": ["admin"],
+        },
       };
       const result = await handler(
         makeEvent("listToolConfigs", {}, adminIdentity),
@@ -1085,7 +1089,11 @@ describe("Registry-backed CRUD functions (tasks 7.2–7.6)", () => {
 
       const adminIdentity = {
         sub: "admin",
-        claims: { "custom:organization": "admin-home", "custom:role": "admin" },
+        claims: {
+          "custom:organization": "admin-home",
+          "custom:role": "admin",
+          "cognito:groups": ["admin"],
+        },
       };
       const result = await handler(
         makeEvent("getToolConfig", { toolId: "tool-x" }, adminIdentity),

--- a/backend/src/lambda/__tests__/tool-sandbox-org-scoping.test.ts
+++ b/backend/src/lambda/__tests__/tool-sandbox-org-scoping.test.ts
@@ -26,6 +26,7 @@ import {
 jest.mock("../../utils/auth-event", () => ({
   extractOrgFromEvent: jest.fn(),
   isAdminFromEvent: jest.fn(),
+  deriveRoles: jest.fn(() => []),
 }));
 jest.mock("../../utils/auth", () => ({
   hasPermission: jest.fn(),

--- a/backend/src/lambda/__tests__/trace-query-handler.test.ts
+++ b/backend/src/lambda/__tests__/trace-query-handler.test.ts
@@ -129,7 +129,11 @@ describe("GET /traces/by-execution/{executionId} — ownership authorization", (
     const event = makeEvent(
       "GET /traces/by-execution/{executionId}",
       { executionId: "exec-3" },
-      { "custom:organization": "org-1", "custom:role": "admin" },
+      {
+        "custom:organization": "org-1",
+        "custom:role": "admin",
+        "cognito:groups": ["admin"],
+      },
     );
 
     const res = await handler(event);
@@ -218,7 +222,11 @@ describe("GET /traces/{traceId} — admin-only (invariant 2)", () => {
     const event = makeEvent(
       "GET /traces/{traceId}",
       { traceId: "1-5f84c7c1-000000000000000000000001" },
-      { "custom:organization": "org-1", "custom:role": "admin" },
+      {
+        "custom:organization": "org-1",
+        "custom:role": "admin",
+        "cognito:groups": ["admin"],
+      },
     );
 
     const res = await handler(event);
@@ -230,7 +238,7 @@ describe("GET /traces/{traceId} — admin-only (invariant 2)", () => {
     const event = makeEvent(
       "GET /traces/{traceId}",
       { traceId: "1-5f84c7c1-000000000000000000000001" },
-      { "custom:role": "admin" },
+      { "custom:role": "admin", "cognito:groups": ["admin"] },
     );
     const res = await handler(event);
     expect(res.statusCode).toBe(403);
@@ -721,7 +729,11 @@ describe("TRACE_BACKEND=spans dispatch (design §3 dual-backend, §1 query mecha
     const event = makeEvent(
       "GET /traces/{traceId}",
       { traceId: "1-5f84c7c1-000000000000000000000002" },
-      { "custom:organization": "org-1", "custom:role": "admin" },
+      {
+        "custom:organization": "org-1",
+        "custom:role": "admin",
+        "cognito:groups": ["admin"],
+      },
     );
 
     const res = await handler(event);
@@ -767,7 +779,11 @@ describe("TRACE_BACKEND=spans dispatch (design §3 dual-backend, §1 query mecha
     const event = makeEvent(
       "GET /traces/{traceId}",
       { traceId: "6a7e5de027c150316d0ff197004e14b1" },
-      { "custom:organization": "org-1", "custom:role": "admin" },
+      {
+        "custom:organization": "org-1",
+        "custom:role": "admin",
+        "cognito:groups": ["admin"],
+      },
     );
 
     const res = await handler(event);
@@ -826,7 +842,11 @@ describe("route param validation (400 arms) + non-Error throw path", () => {
     const event = makeEvent(
       "GET /traces/{traceId}",
       {},
-      { "custom:organization": "org-1", "custom:role": "admin" },
+      {
+        "custom:organization": "org-1",
+        "custom:role": "admin",
+        "cognito:groups": ["admin"],
+      },
     );
     const res = await handler(event);
     expect(res.statusCode).toBe(400);
@@ -1028,7 +1048,11 @@ describe("X-Ray path — remaining freshness/window/response arms", () => {
     const event = makeEvent(
       "GET /traces/{traceId}",
       { traceId: "1-5f84c7c1-00000000000000000000000b" },
-      { "custom:organization": "org-1", "custom:role": "admin" },
+      {
+        "custom:organization": "org-1",
+        "custom:role": "admin",
+        "cognito:groups": ["admin"],
+      },
     );
 
     const res = await handler(event);
@@ -1047,7 +1071,11 @@ describe("X-Ray path — remaining freshness/window/response arms", () => {
       requestContext: {
         authorizer: {
           jwt: {
-            claims: { "custom:organization": "org-1", "custom:role": "admin" },
+            claims: {
+              "custom:organization": "org-1",
+              "custom:role": "admin",
+              "cognito:groups": ["admin"],
+            },
             scopes: null,
           },
         },
@@ -1124,7 +1152,11 @@ describe("TRACE_BACKEND=spans — defensive filter rejects, failed-status mappin
     const event = makeEvent(
       "GET /traces/{traceId}",
       { traceId: 'bad"trace|id' },
-      { "custom:organization": "org-1", "custom:role": "admin" },
+      {
+        "custom:organization": "org-1",
+        "custom:role": "admin",
+        "cognito:groups": ["admin"],
+      },
     );
 
     const res = await handler(event);
@@ -1147,7 +1179,11 @@ describe("TRACE_BACKEND=spans — defensive filter rejects, failed-status mappin
     const event = makeEvent(
       "GET /traces/{traceId}",
       { traceId: "1-5f84c7c1-00000000000000000000000d" },
-      { "custom:organization": "org-1", "custom:role": "admin" },
+      {
+        "custom:organization": "org-1",
+        "custom:role": "admin",
+        "cognito:groups": ["admin"],
+      },
     );
 
     const res = await handler(event);
@@ -1320,7 +1356,11 @@ describe("TRACE_BACKEND=spans — defensive filter rejects, failed-status mappin
     const event = makeEvent(
       "GET /traces/by-execution/{executionId}",
       { executionId: "exec-meta-admin" },
-      { "custom:organization": "org-1", "custom:role": "admin" },
+      {
+        "custom:organization": "org-1",
+        "custom:role": "admin",
+        "cognito:groups": ["admin"],
+      },
       { includeMetadata: "1" },
     );
 
@@ -1377,7 +1417,11 @@ describe("TRACE_BACKEND=spans — defensive filter rejects, failed-status mappin
     const event = makeEvent(
       "GET /traces/by-execution/{executionId}",
       { executionId: "exec-meta-noopt" },
-      { "custom:organization": "org-1", "custom:role": "admin" },
+      {
+        "custom:organization": "org-1",
+        "custom:role": "admin",
+        "cognito:groups": ["admin"],
+      },
     );
 
     const res = await handler(event);
@@ -1396,7 +1440,11 @@ describe("TRACE_BACKEND=spans — defensive filter rejects, failed-status mappin
     const event = makeEvent(
       "GET /traces/{traceId}",
       { traceId: "1-5f84c7c1-00000000000000000000000f" },
-      { "custom:organization": "org-1", "custom:role": "admin" },
+      {
+        "custom:organization": "org-1",
+        "custom:role": "admin",
+        "cognito:groups": ["admin"],
+      },
       { includeMetadata: "1" },
     );
 

--- a/backend/src/lambda/adr-resolver.ts
+++ b/backend/src/lambda/adr-resolver.ts
@@ -1,3 +1,4 @@
+import { deriveRoles } from "../utils/auth-event";
 /**
  * ADR resolver.
  *
@@ -137,12 +138,11 @@ type ADRResolverEvent = GovernanceResolverEvent<ADRResolverArguments>;
 
 function authContextFromEvent(event: ADRResolverEvent): AuthContext {
   const identity: GovernanceEventIdentity = event?.identity || {};
-  const claimRole = identity["custom:role"] ?? identity.claims?.["custom:role"];
   return {
     userId: identity.sub || identity.username || "anonymous",
     username: identity.username,
     groups: identity["cognito:groups"] || [],
-    roles: claimRole ? [claimRole] : [],
+    roles: deriveRoles(event),
   };
 }
 

--- a/backend/src/lambda/agent-design-assessment-resolver.ts
+++ b/backend/src/lambda/agent-design-assessment-resolver.ts
@@ -1,3 +1,4 @@
+import { deriveRoles } from "../utils/auth-event";
 /**
  * AgentDesignAssessment resolver.
  *
@@ -120,12 +121,11 @@ function authContextFromEvent(
   event: AgentDesignAssessmentResolverEvent,
 ): AuthContext {
   const identity: GovernanceEventIdentity = event?.identity || {};
-  const claimRole = identity["custom:role"] ?? identity.claims?.["custom:role"];
   return {
     userId: identity.sub || identity.username || "anonymous",
     username: identity.username,
     groups: identity["cognito:groups"] || [],
-    roles: claimRole ? [claimRole] : [],
+    roles: deriveRoles(event),
   };
 }
 

--- a/backend/src/lambda/environment-release-pointer-resolver.ts
+++ b/backend/src/lambda/environment-release-pointer-resolver.ts
@@ -101,7 +101,7 @@ import { DynamoDBClient } from "@aws-sdk/client-dynamodb";
 import { DynamoDBDocumentClient, GetCommand } from "@aws-sdk/lib-dynamodb";
 import { randomUUID } from "crypto";
 import { hasPermission } from "../utils/auth";
-import { extractOrgFromEvent } from "../utils/auth-event";
+import { extractOrgFromEvent, deriveRoles } from "../utils/auth-event";
 import { getGovernanceEnforce } from "../utils/governance-flag";
 import { getActiveTraceContext } from "../utils/trace-context";
 import { governanceDisposition } from "./utils/governance-disposition";
@@ -1172,12 +1172,11 @@ function authContextFromEvent(
   event: EnvironmentReleasePointerResolverEvent,
 ): AuthContext {
   const identity: GovernanceEventIdentity = event?.identity || {};
-  const claimRole = identity["custom:role"] ?? identity.claims?.["custom:role"];
   return {
     userId: identity.sub || identity.username || "anonymous",
     username: identity.username,
     groups: identity["cognito:groups"] || [],
-    roles: claimRole ? [claimRole as string] : [],
+    roles: deriveRoles(event),
   };
 }
 

--- a/backend/src/lambda/eval-comparison-resolver.ts
+++ b/backend/src/lambda/eval-comparison-resolver.ts
@@ -75,7 +75,7 @@ import {
 import { v5 as uuidv5 } from "uuid";
 import { createHash } from "crypto";
 import { hasPermission } from "../utils/auth";
-import { extractOrgFromEvent } from "../utils/auth-event";
+import { extractOrgFromEvent, deriveRoles } from "../utils/auth-event";
 import { emitGovernanceEvent } from "../utils/notifier-base";
 import { resolveReplayBucketName } from "./utils/eval-artifact-store";
 import { scoreCase, type DimensionScore } from "./utils/eval-scoring";
@@ -188,12 +188,11 @@ type EvalComparisonResolverEvent =
 
 function authContextFromEvent(event: EvalComparisonResolverEvent): AuthContext {
   const identity: GovernanceEventIdentity = event?.identity || {};
-  const claimRole = identity["custom:role"] ?? identity.claims?.["custom:role"];
   return {
     userId: identity.sub || identity.username || "anonymous",
     username: identity.username,
     groups: identity["cognito:groups"] || [],
-    roles: claimRole ? [claimRole] : [],
+    roles: deriveRoles(event),
   };
 }
 

--- a/backend/src/lambda/eval-resolver.ts
+++ b/backend/src/lambda/eval-resolver.ts
@@ -1,3 +1,4 @@
+import { deriveRoles } from "../utils/auth-event";
 /**
  * EvalSuite / EvalCase resolver (CIT-101).
  *
@@ -92,12 +93,11 @@ type EvalResolverEvent = GovernanceResolverEvent<EvalResolverArguments>;
 
 function authContextFromEvent(event: EvalResolverEvent): AuthContext {
   const identity: GovernanceEventIdentity = event?.identity || {};
-  const claimRole = identity["custom:role"] ?? identity.claims?.["custom:role"];
   return {
     userId: identity.sub || identity.username || "anonymous",
     username: identity.username,
     groups: identity["cognito:groups"] || [],
-    roles: claimRole ? [claimRole] : [],
+    roles: deriveRoles(event),
   };
 }
 

--- a/backend/src/lambda/eval-run-resolver.ts
+++ b/backend/src/lambda/eval-run-resolver.ts
@@ -1,3 +1,4 @@
+import { deriveRoles } from "../utils/auth-event";
 /**
  * EvalRun / EvalRunCaseResult resolver (CIT-102 Pass A).
  *
@@ -71,12 +72,11 @@ type EvalRunResolverEvent = GovernanceResolverEvent<EvalRunResolverArguments>;
 
 function authContextFromEvent(event: EvalRunResolverEvent): AuthContext {
   const identity: GovernanceEventIdentity = event?.identity || {};
-  const claimRole = identity["custom:role"] ?? identity.claims?.["custom:role"];
   return {
     userId: identity.sub || identity.username || "anonymous",
     username: identity.username,
     groups: identity["cognito:groups"] || [],
-    roles: claimRole ? [claimRole] : [],
+    roles: deriveRoles(event),
   };
 }
 

--- a/backend/src/lambda/eval-sampling-config-resolver.ts
+++ b/backend/src/lambda/eval-sampling-config-resolver.ts
@@ -1,3 +1,4 @@
+import { deriveRoles } from "../utils/auth-event";
 /**
  * eval-sampling-config-resolver (Phase 2 §2.1) — admin-only GraphQL
  * resolver for EvalSamplingConfig storage/reads, and read-only
@@ -158,12 +159,11 @@ function authContextFromEvent(
   event: EvalSamplingConfigResolverEvent,
 ): AuthContext {
   const identity = event?.identity || {};
-  const claimRole = identity["custom:role"] ?? identity.claims?.["custom:role"];
   return {
     userId: identity.sub || identity.username || "anonymous",
     username: identity.username,
     groups: identity["cognito:groups"] || [],
-    roles: claimRole ? [claimRole] : [],
+    roles: deriveRoles(event),
   };
 }
 

--- a/backend/src/lambda/execspec-resolver.ts
+++ b/backend/src/lambda/execspec-resolver.ts
@@ -1,3 +1,4 @@
+import { deriveRoles } from "../utils/auth-event";
 /**
  * ExecutionSpecification resolver.
  *
@@ -80,19 +81,19 @@
  *                       cross-org caller never triggers a read of another
  *                       tenant's execution-spec rows at all.
  */
-import { DynamoDBClient } from '@aws-sdk/client-dynamodb';
+import { DynamoDBClient } from "@aws-sdk/client-dynamodb";
 import {
   DynamoDBDocumentClient,
   GetCommand,
   PutCommand,
   UpdateCommand,
   QueryCommand,
-} from '@aws-sdk/lib-dynamodb';
-import { v4 as uuidv4 } from 'uuid';
-import { LifecycleManager, EXECSPEC_TRANSITIONS } from '../adapters/lifecycle';
-import { emitGovernanceEvent } from '../utils/notifier-base';
-import { hasPermission } from '../utils/auth';
-import { assertProjectOrgAccess } from '../utils/project-org-access';
+} from "@aws-sdk/lib-dynamodb";
+import { v4 as uuidv4 } from "uuid";
+import { LifecycleManager, EXECSPEC_TRANSITIONS } from "../adapters/lifecycle";
+import { emitGovernanceEvent } from "../utils/notifier-base";
+import { hasPermission } from "../utils/auth";
+import { assertProjectOrgAccess } from "../utils/project-org-access";
 import type {
   AuthContext,
   ExecutionSpecification,
@@ -101,7 +102,7 @@ import type {
   SpecStatusLiteral,
   GovernanceEventIdentity,
   GovernanceResolverEvent,
-} from '../types';
+} from "../types";
 
 const dynamoClient = new DynamoDBClient({});
 const docClient = DynamoDBDocumentClient.from(dynamoClient);
@@ -128,7 +129,7 @@ export const NARRATIVE_URI_ALLOWLIST =
   /^s3:\/\/citadel-governance-transcripts-[a-z0-9-]+-[0-9]+-[a-z0-9-]+\/projects\/[a-zA-Z0-9-]+\/.*/;
 
 export function isNarrativeUriAllowed(uri: unknown): boolean {
-  return typeof uri === 'string' && NARRATIVE_URI_ALLOWLIST.test(uri);
+  return typeof uri === "string" && NARRATIVE_URI_ALLOWLIST.test(uri);
 }
 
 /** Merged view of every argument this resolver's fields receive. */
@@ -143,12 +144,11 @@ type ExecSpecResolverEvent = GovernanceResolverEvent<ExecSpecResolverArguments>;
 
 function authContextFromEvent(event: ExecSpecResolverEvent): AuthContext {
   const identity: GovernanceEventIdentity = event?.identity || {};
-  const claimRole = identity['custom:role'] ?? identity.claims?.['custom:role'];
   return {
-    userId: identity.sub || identity.username || 'anonymous',
+    userId: identity.sub || identity.username || "anonymous",
     username: identity.username,
-    groups: identity['cognito:groups'] || [],
-    roles: claimRole ? [claimRole]: [],
+    groups: identity["cognito:groups"] || [],
+    roles: deriveRoles(event),
   };
 }
 
@@ -157,10 +157,11 @@ function authContextFromEvent(event: ExecSpecResolverEvent): AuthContext {
  * be weaponised to exfiltrate long payloads. Non-string values pass through.
  */
 function sanitizeForLog(input: unknown): unknown {
-  if (!input || typeof input !== 'object') return input;
+  if (!input || typeof input !== "object") return input;
   const out: Record<string, unknown> = {};
   for (const [k, v] of Object.entries(input as Record<string, unknown>)) {
-    out[k] = typeof v === 'string' && v.length > 200 ? v.slice(0, 200) + '…' : v;
+    out[k] =
+      typeof v === "string" && v.length > 200 ? v.slice(0, 200) + "…" : v;
   }
   return out;
 }
@@ -169,7 +170,7 @@ function requireSpecApprovePermission(
   authContext: AuthContext,
   action: string,
 ): void {
-  if (!hasPermission(authContext, 'spec:approve')) {
+  if (!hasPermission(authContext, "spec:approve")) {
     throw new Error(
       `UnauthorizedError: spec:approve permission required to ${action}`,
     );
@@ -178,9 +179,7 @@ function requireSpecApprovePermission(
 
 function validateNarrativeUri(uri: unknown): void {
   if (!isNarrativeUriAllowed(uri)) {
-    throw new Error(
-      'ValidationError: narrativeS3Uri does not match allowlist',
-    );
+    throw new Error("ValidationError: narrativeS3Uri does not match allowlist");
   }
 }
 
@@ -189,19 +188,19 @@ export async function createExecutionSpecification(
   authContext: AuthContext,
   event?: unknown,
 ): Promise<ExecutionSpecification> {
-  requireSpecApprovePermission(authContext, 'create execution specifications');
+  requireSpecApprovePermission(authContext, "create execution specifications");
 
   if (!input.projectId) {
-    throw new Error('ValidationError: projectId is required');
+    throw new Error("ValidationError: projectId is required");
   }
   if (event !== undefined) {
     await assertProjectOrgAccess(input.projectId, event);
   }
   if (!Array.isArray(input.sourceAdrIds) || input.sourceAdrIds.length === 0) {
-    throw new Error('ValidationError: sourceAdrIds must be a non-empty array');
+    throw new Error("ValidationError: sourceAdrIds must be a non-empty array");
   }
-  if (typeof input.structuredPayload !== 'string' || !input.structuredPayload) {
-    throw new Error('ValidationError: structuredPayload is required');
+  if (typeof input.structuredPayload !== "string" || !input.structuredPayload) {
+    throw new Error("ValidationError: structuredPayload is required");
   }
   validateNarrativeUri(input.narrativeS3Uri);
 
@@ -211,7 +210,7 @@ export async function createExecutionSpecification(
     sourceAdrIds: input.sourceAdrIds,
     structuredPayload: input.structuredPayload,
     narrativeS3Uri: input.narrativeS3Uri,
-    status: 'DRAFT',
+    status: "DRAFT",
     version: 1,
     createdAt: new Date().toISOString(),
     createdBy: authContext.userId,
@@ -221,7 +220,7 @@ export async function createExecutionSpecification(
     new PutCommand({
       TableName: EXECUTION_SPECS_TABLE,
       Item: spec,
-      ConditionExpression: 'attribute_not_exists(specId)',
+      ConditionExpression: "attribute_not_exists(specId)",
     }),
   );
   return spec;
@@ -251,9 +250,9 @@ export async function listExecutionSpecifications(
   const res = await docClient.send(
     new QueryCommand({
       TableName: EXECUTION_SPECS_TABLE,
-      IndexName: 'project-index',
-      KeyConditionExpression: 'projectId = :pid',
-      ExpressionAttributeValues: { ':pid': projectId },
+      IndexName: "project-index",
+      KeyConditionExpression: "projectId = :pid",
+      ExpressionAttributeValues: { ":pid": projectId },
     }),
   );
   return (res.Items as ExecutionSpecification[] | undefined) ?? [];
@@ -268,18 +267,15 @@ async function updateStatus(
   // Build SET expression dynamically so the caller can stamp
   // submittedAt/approvedAt/rejectedAt/etc. without repeating the
   // ConditionExpression boilerplate.
-  const setParts: string[] = [
-    '#status = :newStatus',
-    '#version = :newVersion',
-  ];
+  const setParts: string[] = ["#status = :newStatus", "#version = :newVersion"];
   const exprNames: Record<string, string> = {
-    '#status': 'status',
-    '#version': 'version',
+    "#status": "status",
+    "#version": "version",
   };
   const exprValues: Record<string, unknown> = {
-    ':newStatus': nextStatus,
-    ':newVersion': currentVersion + 1,
-    ':currentVersion': currentVersion,
+    ":newStatus": nextStatus,
+    ":newVersion": currentVersion + 1,
+    ":currentVersion": currentVersion,
   };
   for (const [k, v] of Object.entries(extraSet)) {
     const nameKey = `#${k}`;
@@ -292,11 +288,11 @@ async function updateStatus(
     new UpdateCommand({
       TableName: EXECUTION_SPECS_TABLE,
       Key: { specId },
-      UpdateExpression: 'SET ' + setParts.join(', '),
-      ConditionExpression: '#version = :currentVersion',
+      UpdateExpression: "SET " + setParts.join(", "),
+      ConditionExpression: "#version = :currentVersion",
       ExpressionAttributeNames: exprNames,
       ExpressionAttributeValues: exprValues,
-      ReturnValues: 'ALL_NEW',
+      ReturnValues: "ALL_NEW",
     }),
   );
   return res.Attributes as ExecutionSpecification;
@@ -307,14 +303,14 @@ export async function submitExecutionSpecification(
   authContext: AuthContext,
   event?: unknown,
 ): Promise<ExecutionSpecification> {
-  requireSpecApprovePermission(authContext, 'submit execution specifications');
+  requireSpecApprovePermission(authContext, "submit execution specifications");
   const spec = await getExecutionSpecification(specId);
   if (!spec) throw new Error(`ExecutionSpecification not found: ${specId}`);
   if (event !== undefined) {
     await assertProjectOrgAccess(spec.projectId, event);
   }
-  execSpecLifecycle.validateTransition(spec.status, 'PENDING_REVIEW');
-  return updateStatus(specId, spec.version, 'PENDING_REVIEW', {
+  execSpecLifecycle.validateTransition(spec.status, "PENDING_REVIEW");
+  return updateStatus(specId, spec.version, "PENDING_REVIEW", {
     submittedAt: new Date().toISOString(),
   });
 }
@@ -325,7 +321,7 @@ export async function approveExecutionSpecification(
   event?: unknown,
 ): Promise<ExecutionSpecification> {
   // Permission check FIRST — no DDB access, no event, before any state work.
-  requireSpecApprovePermission(authContext, 'approve execution specifications');
+  requireSpecApprovePermission(authContext, "approve execution specifications");
   const spec = await getExecutionSpecification(specId);
   if (!spec) throw new Error(`ExecutionSpecification not found: ${specId}`);
   // Fetch-then-verify: specId is the only client-supplied key, so the org
@@ -336,13 +332,13 @@ export async function approveExecutionSpecification(
   if (event !== undefined) {
     await assertProjectOrgAccess(spec.projectId, event);
   }
-  execSpecLifecycle.validateTransition(spec.status, 'APPROVED');
+  execSpecLifecycle.validateTransition(spec.status, "APPROVED");
   const now = new Date().toISOString();
-  const updated = await updateStatus(specId, spec.version, 'APPROVED', {
+  const updated = await updateStatus(specId, spec.version, "APPROVED", {
     approvedAt: now,
     approvedBy: authContext.userId,
   });
-  await emitGovernanceEvent('governance.specification.approved', {
+  await emitGovernanceEvent("governance.specification.approved", {
     projectId: updated.projectId,
     specId: updated.specId,
     approvedBy: authContext.userId,
@@ -384,44 +380,44 @@ export async function rejectExecutionSpecification(
   event?: unknown,
 ): Promise<ExecutionSpecification> {
   // Step 1: pre-audit input validation.
-  if (typeof reason!== 'string' || !reason) {
-    throw new Error('ValidationError: reason must be a non-empty string');
+  if (typeof reason !== "string" || !reason) {
+    throw new Error("ValidationError: reason must be a non-empty string");
   }
 
   // Step 2: load spec (but do not fail yet — audit the attempt first if
   // missing). If absent, projectId defaults to '' so the audit trail still
   // records who/when.
   const spec = await getExecutionSpecification(specId);
-  const projectId = spec?.projectId ?? '';
+  const projectId = spec?.projectId ?? "";
 
   // Step 3: pre-auth audit line.
   const attemptId = uuidv4();
   const attemptedAt = new Date().toISOString();
   console.log({
-    phase: 'audit',
+    phase: "audit",
     attemptId,
     specId,
     projectId,
     attemptedBy: authContext.userId,
     attemptedAt,
     reason,
-    authResult: 'PENDING',
+    authResult: "PENDING",
   });
 
   // Step 4: permission check.
-  const authorised = hasPermission(authContext, 'spec:approve');
+  const authorised = hasPermission(authContext, "spec:approve");
 
   // Step 5: post-auth audit-outcome line.
   console.log({
-    phase: 'audit-outcome',
+    phase: "audit-outcome",
     attemptId,
     specId,
     attemptedBy: authContext.userId,
-    authResult: authorised ? 'ALLOWED' : 'DENIED',
+    authResult: authorised ? "ALLOWED" : "DENIED",
   });
 
   // Step 6: emit rejection event regardless of outcome.
-  await emitGovernanceEvent('governance.specification.rejected', {
+  await emitGovernanceEvent("governance.specification.rejected", {
     projectId,
     specId,
     reason,
@@ -431,7 +427,7 @@ export async function rejectExecutionSpecification(
   // Step 7: deny-path throws AFTER audit + emit.
   if (!authorised) {
     throw new Error(
-      'UnauthorizedError: spec:approve permission required to reject execution specifications',
+      "UnauthorizedError: spec:approve permission required to reject execution specifications",
     );
   }
 
@@ -450,9 +446,9 @@ export async function rejectExecutionSpecification(
     await assertProjectOrgAccess(spec.projectId, event);
   }
 
-  execSpecLifecycle.validateTransition(spec.status, 'REJECTED');
+  execSpecLifecycle.validateTransition(spec.status, "REJECTED");
 
-  return updateStatus(specId, spec.version, 'REJECTED', {
+  return updateStatus(specId, spec.version, "REJECTED", {
     rejectedAt: attemptedAt,
     rejectedBy: authContext.userId,
     rejectionReason: reason,
@@ -465,9 +461,9 @@ export async function reviseExecutionSpecification(
   authContext: AuthContext,
   event?: unknown,
 ): Promise<ExecutionSpecification> {
-  requireSpecApprovePermission(authContext, 'revise execution specifications');
-  if (typeof input.structuredPayload !== 'string' || !input.structuredPayload) {
-    throw new Error('ValidationError: structuredPayload is required');
+  requireSpecApprovePermission(authContext, "revise execution specifications");
+  if (typeof input.structuredPayload !== "string" || !input.structuredPayload) {
+    throw new Error("ValidationError: structuredPayload is required");
   }
   validateNarrativeUri(input.narrativeS3Uri);
 
@@ -476,54 +472,56 @@ export async function reviseExecutionSpecification(
   if (event !== undefined) {
     await assertProjectOrgAccess(spec.projectId, event);
   }
-  execSpecLifecycle.validateTransition(spec.status, 'DRAFT');
+  execSpecLifecycle.validateTransition(spec.status, "DRAFT");
 
-  return updateStatus(specId, spec.version, 'DRAFT', {
+  return updateStatus(specId, spec.version, "DRAFT", {
     structuredPayload: input.structuredPayload,
     narrativeS3Uri: input.narrativeS3Uri,
   });
 }
 
-export const handler = async (event: ExecSpecResolverEvent): Promise<unknown> => {
+export const handler = async (
+  event: ExecSpecResolverEvent,
+): Promise<unknown> => {
   const fieldName = event?.info?.fieldName;
   const authContext = authContextFromEvent(event);
   try {
     switch (fieldName) {
-      case 'createExecutionSpecification':
+      case "createExecutionSpecification":
         return await createExecutionSpecification(
           event.arguments.input as ExecutionSpecificationInput,
           authContext,
           event,
         );
-      case 'submitExecutionSpecification':
+      case "submitExecutionSpecification":
         return await submitExecutionSpecification(
           event.arguments.specId,
           authContext,
           event,
         );
-      case 'approveExecutionSpecification':
+      case "approveExecutionSpecification":
         return await approveExecutionSpecification(
           event.arguments.specId,
           authContext,
           event,
         );
-      case 'rejectExecutionSpecification':
+      case "rejectExecutionSpecification":
         return await rejectExecutionSpecification(
           event.arguments.specId,
           event.arguments.reason,
           authContext,
           event,
         );
-      case 'reviseExecutionSpecification':
+      case "reviseExecutionSpecification":
         return await reviseExecutionSpecification(
           event.arguments.specId,
           event.arguments.input as ReviseExecutionSpecificationInput,
           authContext,
           event,
         );
-      case 'getExecutionSpecification':
+      case "getExecutionSpecification":
         return await getExecutionSpecification(event.arguments.specId, event);
-      case 'listExecutionSpecifications':
+      case "listExecutionSpecifications":
         return await listExecutionSpecifications(
           event.arguments.projectId,
           event,
@@ -532,7 +530,7 @@ export const handler = async (event: ExecSpecResolverEvent): Promise<unknown> =>
         throw new Error(`Unsupported field: ${fieldName}`);
     }
   } catch (err: unknown) {
-    console.error('execspec-resolver error', {
+    console.error("execspec-resolver error", {
       fieldName,
       message: err instanceof Error ? err.message : undefined,
       args: sanitizeForLog(event?.arguments),

--- a/backend/src/lambda/interrogation-round-resolver.ts
+++ b/backend/src/lambda/interrogation-round-resolver.ts
@@ -1,3 +1,4 @@
+import { deriveRoles } from "../utils/auth-event";
 /**
  * InterrogationRound resolver.
  *
@@ -131,12 +132,11 @@ function authContextFromEvent(
   event: InterrogationRoundResolverEvent,
 ): AuthContext {
   const identity: GovernanceEventIdentity = event?.identity || {};
-  const claimRole = identity["custom:role"] ?? identity.claims?.["custom:role"];
   return {
     userId: identity.sub || identity.username || "anonymous",
     username: identity.username,
     groups: identity["cognito:groups"] || [],
-    roles: claimRole ? [claimRole] : [],
+    roles: deriveRoles(event),
   };
 }
 

--- a/backend/src/lambda/organization-resolver.ts
+++ b/backend/src/lambda/organization-resolver.ts
@@ -1,3 +1,4 @@
+import { deriveRoles } from "../utils/auth-event";
 import { DynamoDBClient } from "@aws-sdk/client-dynamodb";
 import {
   DynamoDBDocumentClient,
@@ -67,12 +68,11 @@ function requireAdmin(authContext: AuthContext, action: string): void {
 
 function authContextFromEvent(event: OrganizationResolverEvent): AuthContext {
   const identity = event?.identity || {};
-  const claimRole = identity["custom:role"] ?? identity.claims?.["custom:role"];
   return {
     userId: identity.sub || identity.username || "anonymous",
     username: identity.username,
     groups: identity["cognito:groups"] || [],
-    roles: claimRole ? [claimRole] : [],
+    roles: deriveRoles(event),
   };
 }
 

--- a/backend/src/lambda/pre-token-generation.ts
+++ b/backend/src/lambda/pre-token-generation.ts
@@ -5,16 +5,30 @@
  * pool into JWT claims so downstream resolvers can read org/role identity
  * without an AdminGetUserCommand call per request.
  *
- * Admin-group overlay: when a user is in the Cognito `admin` group but has
- * no `custom:role` attribute, we synthesise `custom:role: 'admin'` here so
- * downstream code that only inspects the role claim sees a consistent view.
- * The runtime `isAdminFromEvent` helper (commit b279257) already covers the
- * read-time case via `cognito:groups`, so deploying this overlay is purely
- * additive — existing tokens keep working until they expire and refresh.
+ * Admin-group overlay (finding 7aa877f8, revised): group membership is
+ * ALWAYS authoritative for the synthesised admin claim. `custom:role` is a
+ * client-writable attribute (absent an explicit Cognito client
+ * WriteAttributes allow-list — since fixed separately — any authenticated
+ * user could self-grant `custom:role=admin` via UpdateUserAttributes), so
+ * it must never be allowed to assert 'admin' independently of group
+ * membership. Concretely:
+ *   - If the user IS in the `admin` group, the promoted `custom:role` claim
+ *     is forced to 'admin' regardless of what the stored attribute says.
+ *   - If the user is NOT in the `admin` group, any stored
+ *     `custom:role=admin` attribute value is downgraded/dropped rather than
+ *     promoted verbatim — an explicit attribute must never assert admin on
+ *     its own.
+ *   - Non-admin custom:role values (e.g. 'architect') are promoted as-is
+ *     when the user holds no admin group membership, preserving existing
+ *     non-admin role-claim behaviour.
+ *
+ * The runtime `isAdminFromEvent`/`deriveRoles` helpers (this finding) have
+ * independently stopped trusting `custom:role` for admin-ness at read time,
+ * so this trigger-side change is defense-in-depth, not the sole control.
  *
  * Part of the Phase 1 org-scoping foundation.
  */
-import type { PreTokenGenerationTriggerEvent } from 'aws-lambda';
+import type { PreTokenGenerationTriggerEvent } from "aws-lambda";
 
 export const handler = async (
   event: PreTokenGenerationTriggerEvent,
@@ -22,20 +36,24 @@ export const handler = async (
   const userAttributes = event.request.userAttributes || {};
   const claimsToAddOrOverride: Record<string, string> = {};
 
-  const org = userAttributes['custom:organization'];
-  if (org) claimsToAddOrOverride['custom:organization'] = org;
+  const org = userAttributes["custom:organization"];
+  if (org) claimsToAddOrOverride["custom:organization"] = org;
 
-  let role = userAttributes['custom:role'];
-  if (!role) {
-    // Promote admin group membership to custom:role for downstream code
-    // that only checks the role claim. An explicit attribute always wins
-    // over the group-derived value.
-    const groups = event.request.groupConfiguration?.groupsToOverride ?? [];
-    if (groups.includes('admin')) {
-      role = 'admin';
-    }
+  const groups = event.request.groupConfiguration?.groupsToOverride ?? [];
+  const isGroupAdmin = groups.includes("admin");
+
+  let role: string | undefined = userAttributes["custom:role"];
+  if (isGroupAdmin) {
+    // Group membership is authoritative: force the promoted claim to
+    // 'admin' regardless of the stored attribute value.
+    role = "admin";
+  } else if (role === "admin") {
+    // The stored attribute claims admin but group membership disagrees.
+    // Never promote an unearned admin claim — drop it rather than trust
+    // the client-writable attribute on its own.
+    role = undefined;
   }
-  if (role) claimsToAddOrOverride['custom:role'] = role;
+  if (role) claimsToAddOrOverride["custom:role"] = role;
 
   event.response = event.response || {};
   event.response.claimsOverrideDetails = {

--- a/backend/src/lambda/program-review-resolver.ts
+++ b/backend/src/lambda/program-review-resolver.ts
@@ -1,3 +1,4 @@
+import { deriveRoles } from "../utils/auth-event";
 /**
  * ProgramReview resolver.
  *
@@ -561,12 +562,11 @@ type ProgramReviewResolverEvent =
 
 function authContextFromEvent(event: ProgramReviewResolverEvent): AuthContext {
   const identity: GovernanceEventIdentity = event?.identity || {};
-  const claimRole = identity["custom:role"] ?? identity.claims?.["custom:role"];
   return {
     userId: identity.sub || identity.username || "anonymous",
     username: identity.username,
     groups: identity["cognito:groups"] || [],
-    roles: claimRole ? [claimRole] : [],
+    roles: deriveRoles(event),
   };
 }
 

--- a/backend/src/lambda/promotion-policy-resolver.ts
+++ b/backend/src/lambda/promotion-policy-resolver.ts
@@ -1,3 +1,4 @@
+import { deriveRoles } from "../utils/auth-event";
 /**
  * promotion-policy-resolver.ts — admin-only GraphQL resolver for
  * PromotionPolicyConfig storage/reads. Mirrors
@@ -168,12 +169,11 @@ function authContextFromEvent(
   event: PromotionPolicyResolverEvent,
 ): AuthContext {
   const identity = event?.identity || {};
-  const claimRole = identity["custom:role"] ?? identity.claims?.["custom:role"];
   return {
     userId: identity.sub || identity.username || "anonymous",
     username: identity.username,
     groups: identity["cognito:groups"] || [],
-    roles: claimRole ? [claimRole] : [],
+    roles: deriveRoles(event),
   };
 }
 

--- a/backend/src/lambda/release-resolver.ts
+++ b/backend/src/lambda/release-resolver.ts
@@ -91,6 +91,7 @@ import { hasPermission } from "../utils/auth";
 import {
   extractOrgFromEvent,
   lookupUserOrganization,
+  deriveRoles,
 } from "../utils/auth-event";
 import { putRelease } from "./release-store";
 import { RegistryService } from "../services/registry-service";
@@ -449,12 +450,11 @@ type ReleaseResolverEvent = GovernanceResolverEvent<ReleaseResolverArguments>;
 
 function authContextFromEvent(event: ReleaseResolverEvent): AuthContext {
   const identity: GovernanceEventIdentity = event?.identity || {};
-  const claimRole = identity["custom:role"] ?? identity.claims?.["custom:role"];
   return {
     userId: identity.sub || identity.username || "anonymous",
     username: identity.username,
     groups: identity["cognito:groups"] || [],
-    roles: claimRole ? [claimRole] : [],
+    roles: deriveRoles(event),
   };
 }
 

--- a/backend/src/lambda/tool-approval-resolver.ts
+++ b/backend/src/lambda/tool-approval-resolver.ts
@@ -19,7 +19,7 @@
  * resume approval — see docs/APPROVAL_GATING.md.
  */
 import { hasPermission } from "../utils/auth";
-import { extractOrgFromEvent } from "../utils/auth-event";
+import { extractOrgFromEvent, deriveRoles } from "../utils/auth-event";
 import {
   writeToolApprovalGrant,
   type ToolApprovalGrantInput,
@@ -47,12 +47,11 @@ type DecideToolApprovalEvent =
 
 function authContextFromEvent(event: DecideToolApprovalEvent): AuthContext {
   const identity = event?.identity || {};
-  const claimRole = identity["custom:role"] ?? identity.claims?.["custom:role"];
   return {
     userId: identity.sub || identity.username || "anonymous",
     username: identity.username,
     groups: identity["cognito:groups"] || [],
-    roles: claimRole ? [claimRole as string] : [],
+    roles: deriveRoles(event),
   };
 }
 

--- a/backend/src/lambda/tool-sandbox.ts
+++ b/backend/src/lambda/tool-sandbox.ts
@@ -13,7 +13,11 @@ import { DynamoDBClient } from "@aws-sdk/client-dynamodb";
 import { DynamoDBDocumentClient, GetCommand } from "@aws-sdk/lib-dynamodb";
 import { S3Client, GetObjectCommand } from "@aws-sdk/client-s3";
 import * as vm from "vm";
-import { extractOrgFromEvent, isAdminFromEvent } from "../utils/auth-event";
+import {
+  extractOrgFromEvent,
+  isAdminFromEvent,
+  deriveRoles,
+} from "../utils/auth-event";
 import { hasPermission } from "../utils/auth";
 import type { AuthContext } from "../types";
 
@@ -347,14 +351,11 @@ interface ToolSandboxEventIdentity {
 function authContextFromEvent(
   identity: ToolSandboxEventIdentity | undefined,
 ): AuthContext {
-  const claimRole =
-    identity?.["custom:role"] ??
-    (identity?.claims?.["custom:role"] as string | undefined);
   return {
     userId: identity?.sub || identity?.username || "anonymous",
     username: identity?.username,
     groups: identity?.["cognito:groups"] || [],
-    roles: claimRole ? [claimRole] : [],
+    roles: deriveRoles({ identity }),
   };
 }
 

--- a/backend/src/lambda/utils/__tests__/auth-http-event.test.ts
+++ b/backend/src/lambda/utils/__tests__/auth-http-event.test.ts
@@ -49,8 +49,27 @@ describe("extractOrgFromHttpEvent", () => {
 });
 
 describe("isAdminFromHttpEvent", () => {
-  test("true when custom:role === 'admin'", () => {
+  // finding 7aa877f8: custom:role alone is not a trustworthy admin signal
+  // (client-writable via UpdateUserAttributes absent an explicit Cognito
+  // WriteAttributes allow-list). Admin must be group-derived.
+  test("KEY ESCALATION TEST: false when custom:role === 'admin' but cognito:groups does not include admin", () => {
+    const event = makeEvent({
+      "custom:role": "admin",
+      "cognito:groups": ["viewer"],
+    });
+    expect(isAdminFromHttpEvent(event)).toBe(false);
+  });
+
+  test("KEY ESCALATION TEST: false when custom:role === 'admin' and cognito:groups is absent", () => {
     const event = makeEvent({ "custom:role": "admin" });
+    expect(isAdminFromHttpEvent(event)).toBe(false);
+  });
+
+  test("true for a genuine group admin regardless of custom:role", () => {
+    const event = makeEvent({
+      "custom:role": "developer",
+      "cognito:groups": ["admin"],
+    });
     expect(isAdminFromHttpEvent(event)).toBe(true);
   });
 

--- a/backend/src/lambda/utils/__tests__/cost-http-shared.test.ts
+++ b/backend/src/lambda/utils/__tests__/cost-http-shared.test.ts
@@ -78,6 +78,7 @@ describe("resolveScopedOrg", () => {
     const event = makeEvent({
       "custom:organization": "org-1",
       "custom:role": "admin",
+      "cognito:groups": ["admin"],
     });
     expect(resolveScopedOrg(event, "org-2")).toEqual({
       ok: true,

--- a/backend/src/lambda/utils/auth-http-event.ts
+++ b/backend/src/lambda/utils/auth-http-event.ts
@@ -40,18 +40,23 @@ export function extractOrgFromHttpEvent(
 }
 
 /**
- * True when the caller is an admin, via either:
- *  1. `custom:role === 'admin'`
- *  2. `cognito:groups` membership includes `'admin'` — tolerant of both the
- *     JS-array shape (standard JWT decoding) and a comma-separated-string
- *     shape (some proxy/authorizer configurations flatten it).
+ * True when the caller is an admin, determined SOLELY by
+ * `cognito:groups` membership — tolerant of both the JS-array shape
+ * (standard JWT decoding) and a comma-separated-string shape (some
+ * proxy/authorizer configurations flatten it).
+ *
+ * `custom:role === 'admin'` is deliberately NOT honoured here (finding
+ * 7aa877f8): absent an explicit Cognito client WriteAttributes allow-list,
+ * custom:role is a client-writable attribute that any authenticated user
+ * can set via UpdateUserAttributes, so it cannot be trusted as an
+ * authorization signal. Group membership can only be changed via the
+ * Admin* Cognito API. Mirrors backend/src/utils/auth-event.ts's
+ * isAdminFromEvent, which received the same fix.
  */
 export function isAdminFromHttpEvent(
   event: APIGatewayProxyEventV2WithJWTAuthorizer,
 ): boolean {
   const claims = readClaims(event);
-
-  if (claims["custom:role"] === "admin") return true;
 
   const groups = claims["cognito:groups"];
   if (Array.isArray(groups)) {

--- a/backend/src/utils/__tests__/auth-event.test.ts
+++ b/backend/src/utils/__tests__/auth-event.test.ts
@@ -17,6 +17,7 @@ import {
   hasRoleFromEvent,
   assertRowOrg,
   CrossOrgAccessError,
+  deriveRoles,
 } from "../auth-event";
 
 const cognitoMock = mockClient(CognitoIdentityProviderClient);
@@ -129,14 +130,45 @@ describe("auth-event", () => {
   });
 
   describe("isAdminFromEvent", () => {
-    test('returns true when identity["custom:role"] is "admin"', () => {
+    // finding 7aa877f8: custom:role is a client-writable attribute (absent
+    // an explicit Cognito WriteAttributes allow-list, ANY authenticated
+    // user can set it via UpdateUserAttributes). Treating it as a valid
+    // admin signal on its own is the escalation. Group membership
+    // (cognito:groups) is the only authoritative signal because group
+    // membership can only be changed server-side (Admin* API).
+    test('KEY ESCALATION TEST: returns false when custom:role is "admin" but cognito:groups does NOT include admin', () => {
+      const event = {
+        identity: {
+          "custom:role": "admin",
+          "cognito:groups": ["project_manager"],
+        },
+      };
+      expect(isAdminFromEvent(event)).toBe(false);
+    });
+
+    test('KEY ESCALATION TEST: returns false when custom:role is "admin" and cognito:groups is empty/absent', () => {
       const event = { identity: { "custom:role": "admin" } };
+      expect(isAdminFromEvent(event)).toBe(false);
+    });
+
+    test("returns true for a genuine group admin (cognito:groups array contains admin), regardless of custom:role", () => {
+      const event = {
+        identity: {
+          "custom:role": "project_manager",
+          "cognito:groups": ["admin"],
+        },
+      };
       expect(isAdminFromEvent(event)).toBe(true);
     });
 
-    test('returns true when identity.claims["custom:role"] is "admin"', () => {
+    test('returns false when identity["custom:role"] is "admin" alone (no groups claim at all)', () => {
+      const event = { identity: { "custom:role": "admin" } };
+      expect(isAdminFromEvent(event)).toBe(false);
+    });
+
+    test('returns false when identity.claims["custom:role"] is "admin" alone (no groups claim at all)', () => {
       const event = { identity: { claims: { "custom:role": "admin" } } };
-      expect(isAdminFromEvent(event)).toBe(true);
+      expect(isAdminFromEvent(event)).toBe(false);
     });
 
     test('returns false when role is "project_manager"', () => {
@@ -200,11 +232,56 @@ describe("auth-event", () => {
       expect(isAdminFromEvent(event)).toBe(true);
     });
 
-    test('custom:role "admin" wins even when cognito:groups is empty/absent', () => {
+    test('custom:role "admin" does NOT win when cognito:groups is empty/absent (post 7aa877f8)', () => {
       const event = {
         identity: { "custom:role": "admin", "cognito:groups": [] },
       };
-      expect(isAdminFromEvent(event)).toBe(true);
+      expect(isAdminFromEvent(event)).toBe(false);
+    });
+  });
+
+  describe("deriveRoles (shared AuthContext.roles derivation, finding 7aa877f8)", () => {
+    // deriveRoles is the single shared point every authContextFromEvent
+    // copy (14 resolver files) plus auth.ts's createAuthContext /
+    // validateCognitoToken now delegate to, so admin group-membership
+    // becomes authoritative everywhere `roles.includes("admin")` is
+    // checked (hasPermission, every local requireAdmin), without each
+    // caller having to re-implement the fold.
+
+    test("KEY ESCALATION TEST: custom:role='admin' alone (no admin group) does NOT produce roles containing admin", () => {
+      const event = { identity: { "custom:role": "admin" } };
+      expect(deriveRoles(event)).not.toContain("admin");
+    });
+
+    test("group membership 'admin' is present in roles even without a custom:role claim", () => {
+      const event = { identity: { "cognito:groups": ["admin"] } };
+      expect(deriveRoles(event)).toContain("admin");
+    });
+
+    test("a genuine group admin whose custom:role is a different value still gets admin in roles", () => {
+      const event = {
+        identity: { "custom:role": "developer", "cognito:groups": ["admin"] },
+      };
+      const roles = deriveRoles(event);
+      expect(roles).toContain("admin");
+    });
+
+    test("non-admin custom:role values (e.g. architect) are preserved for non-admin permission checks", () => {
+      const event = { identity: { "custom:role": "architect" } };
+      expect(deriveRoles(event)).toEqual(["architect"]);
+    });
+
+    test("no roles when neither claim is present", () => {
+      const event = { identity: { sub: "u1" } };
+      expect(deriveRoles(event)).toEqual([]);
+    });
+
+    test("does not duplicate 'admin' when both custom:role and group say admin", () => {
+      const event = {
+        identity: { "custom:role": "admin", "cognito:groups": ["admin"] },
+      };
+      const roles = deriveRoles(event);
+      expect(roles.filter((r) => r === "admin").length).toBe(1);
     });
   });
 
@@ -251,7 +328,7 @@ describe("auth-event", () => {
     });
 
     test("does not treat an admin caller as holding other roles", () => {
-      const event = { identity: { "custom:role": "admin" } };
+      const event = { identity: { "cognito:groups": ["admin"] } };
       expect(hasRoleFromEvent(event, "architect")).toBe(false);
     });
   });
@@ -296,11 +373,26 @@ describe("auth-event", () => {
       ).rejects.toBeInstanceOf(CrossOrgAccessError);
     });
 
-    test("admin bypasses the org check entirely, even for a cross-org row", async () => {
-      const event = { identity: { sub: "admin-1", "custom:role": "admin" } };
+    test("admin bypasses the org check entirely, even for a cross-org row (group-derived admin)", async () => {
+      const event = {
+        identity: { sub: "admin-1", "cognito:groups": ["admin"] },
+      };
       await expect(
         assertRowOrg({ orgId: "org-completely-different" }, event),
       ).resolves.toBeUndefined();
+    });
+
+    test("KEY ESCALATION TEST: a custom:role=admin claim WITHOUT group membership does NOT bypass the org check", async () => {
+      const event = {
+        identity: {
+          sub: "u1",
+          "custom:role": "admin",
+          "custom:organization": "org-a",
+        },
+      };
+      await expect(
+        assertRowOrg({ orgId: "org-completely-different" }, event),
+      ).rejects.toBeInstanceOf(CrossOrgAccessError);
     });
 
     test('CrossOrgAccessError carries the "Access denied" message used by resolvers', async () => {

--- a/backend/src/utils/__tests__/project-org-access.test.ts
+++ b/backend/src/utils/__tests__/project-org-access.test.ts
@@ -109,7 +109,11 @@ describe("assertProjectOrgAccess", () => {
       Item: { id: "proj-1", owner: "owner-1", organization: "org-a" },
     });
     const event = {
-      identity: { sub: "admin-1", "custom:role": "admin" },
+      identity: {
+        sub: "admin-1",
+        "custom:role": "admin",
+        "cognito:groups": ["admin"],
+      },
     };
     await expect(
       assertProjectOrgAccess("proj-1", event),
@@ -120,7 +124,13 @@ describe("assertProjectOrgAccess", () => {
     // Sanity: the admin bypass short-circuits before the fetch, matching
     // assertRowOrg's isAdminFromEvent(event) early-return convention.
     ddbMock.on(GetCommand).rejects(new Error("should not be called"));
-    const event = { identity: { sub: "admin-1", "custom:role": "admin" } };
+    const event = {
+      identity: {
+        sub: "admin-1",
+        "custom:role": "admin",
+        "cognito:groups": ["admin"],
+      },
+    };
     await expect(
       assertProjectOrgAccess("proj-1", event),
     ).resolves.toBeUndefined();

--- a/backend/src/utils/auth-event.ts
+++ b/backend/src/utils/auth-event.ts
@@ -92,21 +92,29 @@ export async function extractOrgFromEvent(
 }
 
 /**
- * True when the caller is an admin. Two paths are honoured:
- *  1. JWT claim `custom:role === 'admin'` (legacy / explicit role attribute).
- *  2. Cognito group membership `admin` via the `cognito:groups` claim.
+ * True when the caller is an admin, determined SOLELY by Cognito group
+ * membership (`cognito:groups` claim includes `admin`).
+ *
+ * Prior to finding 7aa877f8 this also honoured an explicit
+ * `custom:role === 'admin'` claim. That was an escalation vector: absent
+ * an explicit Cognito client WriteAttributes allow-list, `custom:role` is
+ * a client-writable attribute — ANY authenticated user could call
+ * UpdateUserAttributes and self-grant `custom:role=admin`, which this
+ * function (and the ~16 resolvers gating on it) then treated as real
+ * admin. Group membership can only be changed via the Admin* Cognito API
+ * (server-side, e.g. `assignUserRole`), so it is the only signal a caller
+ * cannot forge with their own token.
+ *
+ * The pre-token-generation trigger still promotes group membership into
+ * `custom:role` for legacy/display purposes, but that promoted claim MUST
+ * NOT be read back here as an authorization signal — doing so would just
+ * reintroduce the same trust-the-writable-attribute problem one hop away.
  *
  * The groups claim arrives in different shapes depending on AppSync auth
  * mode: a JS array under standard JWT decoding, but some proxies/auth modes
  * flatten it to a comma-separated string. Both shapes are tolerated.
  */
 export function isAdminFromEvent(event: unknown): boolean {
-  // Path 1: explicit custom:role claim equals 'admin'.
-  if (readClaim(event, "custom:role") === "admin") return true;
-
-  // Path 2: cognito:groups membership includes 'admin'. Cognito issues this
-  // claim as an array in standard JWT, but some AppSync auth modes flatten
-  // it to a comma-separated string. Tolerate both.
   const groups = readClaim(event, "cognito:groups");
   if (Array.isArray(groups)) {
     return groups.some((g) => typeof g === "string" && g === "admin");
@@ -119,6 +127,47 @@ export function isAdminFromEvent(event: unknown): boolean {
   }
 
   return false;
+}
+
+/**
+ * Derives the `AuthContext.roles` array for permission checks
+ * (`hasPermission`, every resolver-local `requireAdmin`), folding Cognito
+ * group membership into the returned roles so `roles.includes('admin')` is
+ * group-authoritative rather than trusting the client-writable
+ * `custom:role` attribute alone (finding 7aa877f8).
+ *
+ * This is the ONE shared derivation every `authContextFromEvent` copy
+ * across the governance resolvers (ADR, ExecutionSpecification,
+ * InterrogationRound, AgentDesignAssessment, ProgramReview, Release,
+ * EvalRun, EvalComparison, Eval, EvalSamplingConfig, PromotionPolicy,
+ * Organization, ToolApproval, ToolSandbox, EnvironmentReleasePointer) and
+ * auth.ts's `createAuthContext`/`validateCognitoToken` now delegate to,
+ * instead of each re-deriving `roles` from `custom:role` in isolation.
+ *
+ * Behaviour:
+ *  - `cognito:groups` membership in `admin` is ALWAYS included in the
+ *    result — this is the sole authoritative admin signal (group
+ *    membership can only be changed server-side via the Admin* Cognito
+ *    API, e.g. `assignUserRole`).
+ *  - The `custom:role` claim is preserved verbatim for non-admin role
+ *    checks (e.g. `architect`, `project_manager`, `developer`) so
+ *    existing non-admin permission behaviour is unchanged — only the
+ *    ADMIN signal is stripped of its trust in the writable attribute.
+ *  - No duplicate `'admin'` entry when both sources agree.
+ */
+export function deriveRoles(event: unknown): string[] {
+  const roles: string[] = [];
+
+  const claimRole = readClaim(event, "custom:role");
+  if (typeof claimRole === "string" && claimRole && claimRole !== "admin") {
+    roles.push(claimRole);
+  }
+
+  if (isAdminFromEvent(event)) {
+    roles.push("admin");
+  }
+
+  return roles;
 }
 
 /**

--- a/backend/src/utils/auth.ts
+++ b/backend/src/utils/auth.ts
@@ -3,6 +3,7 @@ import {
   GetUserCommand,
 } from "@aws-sdk/client-cognito-identity-provider";
 import { AuthContext } from "../types";
+import { isAdminFromEvent } from "./auth-event";
 
 const cognitoClient = new CognitoIdentityProviderClient({});
 
@@ -21,12 +22,25 @@ export async function validateCognitoToken(
 
     const groups: string[] = [];
     const roles: string[] = [];
+    let claimRole: string | undefined;
 
     // Extract custom attributes
     for (const attr of attributes) {
       if (attr.Name === "custom:role") {
-        roles.push(attr.Value!);
+        claimRole = attr.Value;
       }
+    }
+
+    // finding 7aa877f8: custom:role is a client-writable attribute (absent
+    // an explicit Cognito client WriteAttributes allow-list, any
+    // authenticated user could self-grant custom:role=admin via
+    // UpdateUserAttributes). GetUserCommand does not return group
+    // membership, so admin cannot be verified group-authoritatively from
+    // this attributes-only response — treat 'admin' as untrusted here and
+    // never push it into roles. Non-admin role claims are preserved for
+    // permission checks that don't gate on the admin bypass.
+    if (claimRole && claimRole !== "admin") {
+      roles.push(claimRole);
     }
 
     return {
@@ -171,10 +185,22 @@ export function extractUserIdFromEvent(event: unknown): string {
 export function createAuthContext(event: unknown): AuthContext {
   const identity: IdentityBag = (event as EventWithIdentity).identity || {};
 
+  // finding 7aa877f8: admin must be group-authoritative (isAdminFromEvent),
+  // never derived from the client-writable custom:role attribute alone.
+  // Non-admin custom:role claims are preserved for other permission checks.
+  const claimRole = identity["custom:role"] as string | undefined;
+  const roles: string[] = [];
+  if (claimRole && claimRole !== "admin") {
+    roles.push(claimRole);
+  }
+  if (isAdminFromEvent(event)) {
+    roles.push("admin");
+  }
+
   return {
     userId: identity.sub || identity.username || "anonymous",
     username: identity.username,
     groups: (identity["cognito:groups"] as string[] | undefined) || [],
-    roles: identity["custom:role"] ? [identity["custom:role"] as string] : [],
+    roles,
   };
 }

--- a/backend/test/backend-stack-user-pool-client-write-attributes.test.ts
+++ b/backend/test/backend-stack-user-pool-client-write-attributes.test.ts
@@ -1,0 +1,91 @@
+/**
+ * CDK test for finding 7aa877f8 (Layer 1 — Cognito).
+ *
+ * The user pool client previously declared no `writeAttributes` /
+ * `readAttributes`, so Cognito's permissive default applied: the client
+ * could write ALL mutable, non-developer-only attributes, including
+ * `custom:role` and `custom:organization`. Combined with
+ * ALLOW_USER_SRP_AUTH / ALLOW_USER_PASSWORD_AUTH (end users hold tokens
+ * with UpdateUserAttributes scope), any authenticated user could
+ * self-grant `custom:role=admin`.
+ *
+ * This test pins an EXPLICIT WriteAttributes allow-list that excludes both
+ * custom attributes, so the permissive default cannot silently return
+ * (e.g. via a future CDK/L1 refactor that drops the `writeAttributes`
+ * prop). ReadAttributes is intentionally not asserted narrow here — read
+ * exposure of these attributes is not the escalation vector; only WRITE
+ * is.
+ */
+
+import * as cdk from "aws-cdk-lib";
+import { Template, Match } from "aws-cdk-lib/assertions";
+import * as path from "path";
+import * as fs from "fs";
+
+const assetDirs = [
+  path.resolve(__dirname, "../src/schema"),
+  path.resolve(__dirname, "../dist/lambda"),
+  path.resolve(__dirname, "../src/lambda/seed-admin-user"),
+  path.resolve(__dirname, "../src/lambda/seed-organizations"),
+];
+for (const dir of assetDirs) {
+  if (!fs.existsSync(dir)) fs.mkdirSync(dir, { recursive: true });
+}
+
+import { BackendStack } from "../lib/backend-stack";
+
+describe("BackendStack — UserPoolClient WriteAttributes allow-list (finding 7aa877f8)", () => {
+  let template: Template;
+
+  beforeAll(() => {
+    const app = new cdk.App({
+      context: {
+        adminEmail: "test-admin@example.com",
+      },
+    });
+    const stack = new BackendStack(app, "TestBackendStack", {
+      environment: "test",
+      env: { account: "123456789012", region: "us-east-1" },
+    });
+    template = Template.fromStack(stack);
+  });
+
+  test("UserPoolClient declares an explicit WriteAttributes list", () => {
+    template.hasResourceProperties("AWS::Cognito::UserPoolClient", {
+      WriteAttributes: Match.anyValue(),
+    });
+  });
+
+  test("WriteAttributes excludes custom:role and custom:organization", () => {
+    const clients = template.findResources("AWS::Cognito::UserPoolClient");
+    const ids = Object.keys(clients);
+    expect(ids.length).toBeGreaterThan(0);
+
+    for (const id of ids) {
+      const writeAttrs: string[] = clients[id].Properties.WriteAttributes;
+      expect(Array.isArray(writeAttrs)).toBe(true);
+      expect(writeAttrs).not.toContain("custom:role");
+      expect(writeAttrs).not.toContain("custom:organization");
+    }
+  });
+
+  test("WriteAttributes still includes the standard attributes the app legitimately writes", () => {
+    // Enumeration (see PR description): no frontend/resolver code path calls
+    // updateUserAttributes for the caller's own record. The only
+    // AdminUpdateUserAttributesCommand call is server-side, admin-only,
+    // via Admin* API (assignUserRole in user-management-resolver.ts),
+    // which is not gated by the client's WriteAttributes at all. The
+    // standard profile fields configured as mutable standardAttributes
+    // (email, given_name, family_name) are kept writable for self-service
+    // profile editing/verification flows Cognito itself may exercise
+    // (e.g. email re-verification).
+    const clients = template.findResources("AWS::Cognito::UserPoolClient");
+    const ids = Object.keys(clients);
+    for (const id of ids) {
+      const writeAttrs: string[] = clients[id].Properties.WriteAttributes;
+      expect(writeAttrs).toEqual(
+        expect.arrayContaining(["email", "given_name", "family_name"]),
+      );
+    }
+  });
+});


### PR DESCRIPTION
## Summary

**Any authenticated user could grant themselves admin.** Confirmed against the deployed pool, not inferred: the user pool client had **no `WriteAttributes`** restriction, so Cognito's permissive default allowed it to write every mutable attribute - including `custom:role` and `custom:organization`, both `Mutable` and not developer-only. With `ALLOW_USER_SRP_AUTH` and
`ALLOW_USER_PASSWORD_AUTH` enabled, an end user holds a token permitting self-service `UpdateUserAttributes`, so the escalation needed no backend call at all.

Because `isAdminFromEvent` treated `custom:role === 'admin'` as admin - and the pre-token-generation trigger let an explicit attribute beat group membership - that claim satisfied admin checks across roughly sixteen resolvers, **including the tenant-isolation gates added earlier in this remediation series**.

Fixed at both layers, since neither alone is sufficient:

**Cognito** - explicit `writeAttributes` allow-list of `email`, `given_name`, `family_name` excluding both custom attributes, pinned by a CDK assertion that fails if the list is removed. The list was derived by enumeration: no frontend or resolver writes the caller's own attributes, the only attribute write is server-side `AdminUpdateUserAttributes` in `assignUserRole`, which client write attributes do not govern - so profile editing is unaffected.

**Authorization** - admin now derives from Cognito **group** membership in `isAdminFromEvent`
`isAdminFromHttpEvent`, `auth.ts`'s `createAuthContext` and `validateCognitoToken`, and the
pre-token trigger, where group membership is authoritative and an unearned `custom:rolesadmin` is downgraded rather than promoted. A shared `deriveRoles()` folds group-admin into `AuthContext.roles`, and all fourteen `authContextFromEvent` copies delegate to it.
`assignUserRole` writes a Cognito group plus `custom:organization`, confirming the group is the sanctioned carrier and `custom:role` was legacy - never a legitimate trust source.

## Testing

- Key escalation tests: a token whose `custom:role` says admin but whose groups do not include admin is **not** treated as admin; a genuine group admin still is. Both bite-proven by reverting the derivation and confirming admin is granted
- CDK assertion bite-proven by removing `writeAttributes`
- Blast-radius spot-checks: a claim-spoofed admin no longer satisfies the ADR, execspec or promotion-policy gates
- Roughly **25 existing test files** carried `custom:role`-only admin fixtures - the suite had encoded the escalation as expected behaviour - and were updated to include group membership
- From `backend/`: tsc 0, lint 0, full jest 7652, nag-enabled synth across 9 stacks with 0 findings 
 
## Notes
- **Requires a deploy to take effect.** The client configuration lives in Cognito, so the escalation remains open until deployed
- Affects any consumer deploying the sample unmodified, so it belongs in the external security response
- A critique had suggested `promotion-policy-resolver`'s `requireAdmin` diverged from its siblings; that was **not** borne out - all fourteen read `custom:role` identically, which is why the fix is uniform rather than a one-off