### PR TITLE
refactor(governance): unify ledger attribute naming and fix org reads

### DIFF
--- a/arbiter/governance/__tests__/test_ledger.py
+++ b/arbiter/governance/__tests__/test_ledger.py
@@ -497,3 +497,47 @@ def test_serialize_finding_emits_camelcase_trace_id_when_present() -> None:
     # stamping.
     assert "ttl" not in item  # ttl is added by write_finding, not _serialize_finding
     assert item["findingId"] == finding.finding_id
+
+
+# ---------------------------------------------------------------------------
+# Attribute-naming convention pin (decision 2dd461f6, slice 1)
+# ---------------------------------------------------------------------------
+#
+# Structural check, not a string search over ledger.py's source text: this
+# builds a REAL item via `_serialize_finding` and inspects the actual dict
+# keys, so a future edit that resurrects a snake_case `finding_id` /
+# `workflow_id` duplicate on the item fails here immediately regardless of
+# what the source looks like on inspection. The TypeScript-side pin lives in
+# backend/src/lambda/utils/__tests__/governance-ledger-attribute-convention.test.ts
+# and covers the three TS writers; this is the Python-side half for the one
+# writer on this side of the boundary (ledger.py::write_finding).
+
+
+def test_serialize_finding_never_duplicates_finding_id_or_workflow_id_snake_case() -> None:
+    """Pins the unified camelCase convention for findingId/workflowId.
+
+    `finding_id`/`workflow_id` (snake_case) must NOT appear as item dict
+    keys — only their camelCase forms (`findingId`/`workflowId`), which are
+    also this table's own key-schema attributes. This does not affect any
+    OTHER dataclass field's existing snake_case name (e.g. `requesting_agent`,
+    `target_agent`, `reason`) — unifying those is out of scope for this
+    slice (decision 2dd461f6 scopes slice 1 to findingId/workflowId + org).
+    """
+    finding = _make_finding()
+    item = ledger._serialize_finding(finding)
+
+    assert "finding_id" not in item
+    assert "workflow_id" not in item
+    assert item["findingId"] == finding.finding_id
+    assert item["workflowId"] == finding.workflow_id
+
+
+def test_serialize_finding_has_no_org_attribute_in_any_form() -> None:
+    """`GovernanceFinding` has no org field (established fact, slice 1 scope
+    guard): neither `org_id` nor `orgId` should appear on the item. Adding
+    the org VALUE to the Python model/writer is slice 2, not this slice."""
+    finding = _make_finding()
+    item = ledger._serialize_finding(finding)
+
+    assert "org_id" not in item
+    assert "orgId" not in item

--- a/arbiter/governance/ledger.py
+++ b/arbiter/governance/ledger.py
@@ -131,19 +131,40 @@ def _normalize_value(value: Any) -> Any:
 def _serialize_finding(finding: GovernanceFinding) -> dict[str, Any]:
     """Flatten a ``GovernanceFinding`` dataclass into a DDB item.
 
-    Dataclass field names are used as-is (``finding_id``, ``workflow_id``)
-    except for the three attributes that participate in the table's key
-    schema / GSI, which are also emitted in camelCase form:
+    Dataclass field names are used as-is for every attribute EXCEPT
+    ``finding_id`` / ``workflow_id``, which are unified to their camelCase
+    forms only (decision 2dd461f6, slice 1: attribute-naming unification
+    across the governance ledger). Historically this method dual-wrote
+    both ``finding_id``/``workflow_id`` (snake_case, straight off
+    ``dataclasses.asdict``) AND ``findingId``/``workflowId`` (camelCase
+    aliases) — every downstream reader across both languages already only
+    reads the camelCase forms for these two fields (they are also the
+    table's own key-schema attributes), so the snake_case duplicates were
+    pure write-time baggage with no reader. They are dropped here; the
+    three attributes that participate in the table's key schema / GSI are
+    emitted ONLY in camelCase form:
 
     * ``findingId``  — table HASH key (write-once condition target)
     * ``workflowId`` — ``workflow-index`` GSI HASH key
     * ``timestamp``  — ``workflow-index`` GSI RANGE key (NUMBER)
+
+    Every OTHER dataclass field (``requesting_agent``, ``target_agent``,
+    ``reason``, ``decided_by``-equivalents, ``scope_evaluated``, etc.) is
+    intentionally left in its existing snake_case form — unifying those is
+    out of scope for this slice (decision 2dd461f6 scopes slice 1 to the
+    org attribute plus findingId/workflowId only).
 
     ``None`` values are stripped because DDB rejects ``None`` for type S / N.
     """
     raw = dataclasses.asdict(finding)
     item: dict[str, Any] = {}
     for key, value in raw.items():
+        if key in ("finding_id", "workflow_id"):
+            # Unified to camelCase only — see docstring above. Skipped here
+            # (rather than written then deleted) so a future dataclass
+            # field rename can't silently resurrect the snake_case
+            # duplicate through this loop.
+            continue
         normalised = _normalize_value(value)
         if normalised is None:
             continue
@@ -151,7 +172,9 @@ def _serialize_finding(finding: GovernanceFinding) -> dict[str, Any]:
 
     # Key-schema aliases. These MUST always be present on the written item:
     # findingId is the table HASH and the write-once condition target;
-    # workflowId / timestamp are the workflow-index GSI keys.
+    # workflowId / timestamp are the workflow-index GSI keys. These are now
+    # the ONLY form in which finding_id/workflow_id appear on the item
+    # (decision 2dd461f6, slice 1) — see docstring above.
     item["findingId"] = finding.finding_id
     item["workflowId"] = finding.workflow_id
     item["timestamp"] = float(finding.timestamp)

--- a/backend/src/lambda/__tests__/eval-drift-finding-writer.test.ts
+++ b/backend/src/lambda/__tests__/eval-drift-finding-writer.test.ts
@@ -65,8 +65,17 @@ describe("handleDriftDetected", () => {
     expect(typeof item.findingId).toBe("string");
     expect(item.workflowId).toBe("EVAL_DRIFT#agent-1#policy_compliance");
     expect(typeof item.timestamp).toBe("number");
-    // Dataclass field names (snake_case), same as the Python writer.
-    expect(item.workflow_id).toBe("EVAL_DRIFT#agent-1#policy_compliance");
+    // Unified camelCase convention (decision 2dd461f6, slice 1): the
+    // legacy snake_case workflow_id/finding_id duplicates are retired —
+    // workflowId/findingId above are now the ONLY forms. Every OTHER
+    // dataclass-style field (requesting_agent/target_agent) stays
+    // snake_case — unifying those is out of scope for this slice.
+    expect(Object.prototype.hasOwnProperty.call(item, "workflow_id")).toBe(
+      false,
+    );
+    expect(Object.prototype.hasOwnProperty.call(item, "finding_id")).toBe(
+      false,
+    );
     expect(item.decision).toBe("escalate");
     expect(item.requesting_agent).toBe("eval-drift-detector");
     expect(item.target_agent).toBe("agent-1");

--- a/backend/src/lambda/__tests__/governance-ui-resolver.test.ts
+++ b/backend/src/lambda/__tests__/governance-ui-resolver.test.ts
@@ -292,6 +292,31 @@ describe("projectFinding", () => {
     expect(projected.escalationTarget).toBeNull();
   });
 
+  // Decision 2dd461f6, slice 1: unified attribute naming. Live rows today
+  // carry BOTH workflowId and workflow_id (established fact), but the
+  // reader must tolerate a row that carries ONLY the legacy snake_case
+  // name — e.g. a row written by a pre-unification code path, or a
+  // future defensive scenario — for the 90-day TTL transition window.
+  // See readLedgerAttr's doc comment (governance-ui-resolver.ts) for the
+  // fallback/removal-date policy.
+  test("falls back to legacy workflow_id when camelCase workflowId is absent", () => {
+    const row = makeDdbRow({ workflowId: undefined, workflow_id: "wf-legacy" });
+    const projected = projectFinding(row);
+    expect(projected.workflowId).toBe("wf-legacy");
+  });
+
+  test("prefers camelCase workflowId over legacy workflow_id when both are present", () => {
+    const row = makeDdbRow({ workflowId: "wf-new", workflow_id: "wf-legacy" });
+    const projected = projectFinding(row);
+    expect(projected.workflowId).toBe("wf-new");
+  });
+
+  test("workflowId is empty string when neither camelCase nor legacy name is present", () => {
+    const row = makeDdbRow({ workflowId: undefined });
+    const projected = projectFinding(row);
+    expect(projected.workflowId).toBe("");
+  });
+
   // P1 test 6 (architect task 9b3f4f78 — decision<->runtime trace linking).
   test("maps traceId when present on the DDB row", () => {
     const row = makeDdbRow({ traceId: "1-5f2f0000-abcdef0123456789abcdef01" });
@@ -3389,6 +3414,85 @@ describe("getDecisionTrace", () => {
       )) as { linkedExecutionId: string | null };
 
       expect(result.linkedExecutionId).toBeNull();
+    });
+
+    // Decision 2dd461f6, slice 1, task item 4: proves the reader is
+    // CAPABLE of reading a stamped org value once slice 2 lands, without
+    // being able to add the value itself. No live row is stamped with
+    // either orgId or org_id today (established fact) — this test feeds
+    // a synthetic stamped row through the SAME code path
+    // (getDecisionTrace -> findExecutionIdByRunId's cross-org check) to
+    // prove both the new (camelCase) and legacy (snake_case) attribute
+    // names are read correctly.
+    test("ledger row stamped with legacy org_id (snake_case) is read via fallback and still enforces cross-org skip", async () => {
+      ddbMock
+        .on(GetCommand, { TableName: "citadel-governance-ledger-test" })
+        .resolves({
+          Item: ledgerRow({
+            findingId: "f-92",
+            decision: "permit",
+            reason: "scope_match:unit-1",
+            runId: "run-92929292-9292-9292-9292-929292929292",
+            org_id: "org-1", // legacy snake_case only — no camelCase orgId
+          }),
+        });
+      ddbMock.on(ScanCommand).resolves({
+        Items: [
+          {
+            executionId: "exec-run-92",
+            orgId: "org-2",
+            runId: "run-92929292-9292-9292-9292-929292929292",
+          },
+        ],
+      });
+
+      const result = (await handler(
+        makeEvent({
+          fieldName: "getDecisionTrace",
+          args: { findingId: "f-92" },
+        }),
+      )) as { linkedExecutionId: string | null };
+
+      // The legacy org_id ("org-1") was successfully read from the
+      // finding row and compared against the execution row's orgId
+      // ("org-2") -> mismatch -> skipped -> null. Had the fallback NOT
+      // worked, findingOrgId would resolve to undefined and the
+      // (deliberately permissive) undefined-expectedOrgId branch in
+      // findExecutionIdByRunId would instead RETURN the execution row —
+      // so a non-null result here would indicate the fallback is broken.
+      expect(result.linkedExecutionId).toBeNull();
+    });
+
+    test("ledger row stamped with new camelCase orgId matching the execution row's org resolves the link", async () => {
+      ddbMock
+        .on(GetCommand, { TableName: "citadel-governance-ledger-test" })
+        .resolves({
+          Item: ledgerRow({
+            findingId: "f-93",
+            decision: "permit",
+            reason: "scope_match:unit-1",
+            runId: "run-93939393-9393-9393-9393-939393939393",
+            orgId: "org-1",
+          }),
+        });
+      ddbMock.on(ScanCommand).resolves({
+        Items: [
+          {
+            executionId: "exec-run-93",
+            orgId: "org-1",
+            runId: "run-93939393-9393-9393-9393-939393939393",
+          },
+        ],
+      });
+
+      const result = (await handler(
+        makeEvent({
+          fieldName: "getDecisionTrace",
+          args: { findingId: "f-93" },
+        }),
+      )) as { linkedExecutionId: string | null };
+
+      expect(result.linkedExecutionId).toBe("exec-run-93");
     });
   });
 

--- a/backend/src/lambda/eval-drift-finding-writer.ts
+++ b/backend/src/lambda/eval-drift-finding-writer.ts
@@ -136,18 +136,20 @@ export async function handleDriftDetected(
   const item: Record<string, unknown> = {
     // Key-schema aliases (camelCase), required by the table's key schema
     // and the workflow-index GSI — mirrors ledger.py::_serialize_finding.
+    // Unified camelCase convention (decision 2dd461f6, slice 1): the
+    // pre-slice-1 snake_case duplicates (finding_id/workflow_id) are
+    // retired — see release-gate-finding-writer.ts's identical comment
+    // and governance-ledger-attribute-convention.test.ts. This writer
+    // never had an org field, so there is no orgId to add here (slice 1
+    // is naming only — adding an org VALUE to this writer, if ever
+    // warranted, is out of scope).
     findingId,
     workflowId,
     timestamp,
-    // Dataclass field names (snake_case), matching every OTHER finding
-    // already in this ledger so governance-ui-resolver.ts's existing
-    // snake_case reads (requesting_agent/target_agent) work unmodified.
-    workflow_id: workflowId,
     decision: "escalate",
     requesting_agent: "eval-drift-detector",
     target_agent: detail.agentId,
     reason: buildReason(detail),
-    finding_id: findingId,
     // Additive, non-arbitration filter hint — see module doc. Never read
     // by projectFinding today; present only on drift findings.
     category: "eval-drift",

--- a/backend/src/lambda/governance-ui-resolver.ts
+++ b/backend/src/lambda/governance-ui-resolver.ts
@@ -288,6 +288,34 @@ type DdbRow = Record<string, unknown>;
 
 // --- Helpers ---
 
+/**
+ * Reads a governance-ledger attribute that was unified from a legacy
+ * snake_case name to a camelCase name (decision 2dd461f6, slice 1:
+ * findingId/workflowId/orgId). Prefers the NEW (camelCase) attribute;
+ * falls back to the OLD (snake_case) attribute for rows written before
+ * the unification landed.
+ *
+ * COMPATIBILITY WINDOW: the ledger table has a 90-day TTL (QT1-10), so
+ * every pre-unification row will have expired and been purged by DynamoDB
+ * on its own by approximately 2026-12-08 (90 days after this slice
+ * landed, 2026-09-08). This fallback may be REMOVED after that date —
+ * at that point every live row will already carry the new name and the
+ * legacy branch is dead weight. Do not remove it before then: rows
+ * written up to the moment this slice deployed still carry ONLY the old
+ * name and must keep being readable until they age out.
+ */
+function readLedgerAttr(
+  row: DdbRow,
+  camelKey: string,
+  legacySnakeKey: string,
+): string | undefined {
+  const camelValue = row[camelKey];
+  if (typeof camelValue === "string") return camelValue;
+  const snakeValue = row[legacySnakeKey];
+  if (typeof snakeValue === "string") return snakeValue;
+  return undefined;
+}
+
 function zeroReconcilerStatus(): ReconcilerStatus {
   return {
     lastRunAt: null,
@@ -336,7 +364,9 @@ export function projectFinding(row: DdbRow): GovernanceFindingProjected {
 
   return {
     findingId: typeof row.findingId === "string" ? row.findingId : "",
-    workflowId: typeof row.workflowId === "string" ? row.workflowId : "",
+    // workflowId is unified (decision 2dd461f6, slice 1) — see
+    // readLedgerAttr's doc comment for the fallback/removal-date policy.
+    workflowId: readLedgerAttr(row, "workflowId", "workflow_id") ?? "",
     decision: typeof row.decision === "string" ? row.decision : "",
     reason: typeof row.reason === "string" ? row.reason : "",
     requestingAgent:
@@ -949,8 +979,13 @@ async function getDecisionTrace(
     arbitrationPattern,
     scopeReduction,
   );
-  const findingOrgId =
-    typeof findingRow.orgId === "string" ? findingRow.orgId : undefined;
+  // orgId is unified (decision 2dd461f6, slice 1) — see readLedgerAttr's
+  // doc comment. No live row is stamped with either name yet (org
+  // filtering is slice 2), so this currently always resolves to
+  // undefined either way — the fallback exists so this call site is
+  // ALREADY capable of reading a stamped value the moment slice 2 lands,
+  // without a further code change here.
+  const findingOrgId = readLedgerAttr(findingRow, "orgId", "org_id");
   const linkedExecutionId = await findExecutionIdByRunId(
     finding.runId,
     findingOrgId,
@@ -6332,8 +6367,11 @@ async function getD4RetrospectiveReport(
         break;
       }
       scanned++;
-      const workflowId =
-        typeof row.workflow_id === "string" ? row.workflow_id : "";
+      // workflowId is unified (decision 2dd461f6, slice 1) — the dedup
+      // key here previously read ONLY the legacy `workflow_id`; it now
+      // prefers the new camelCase name and falls back for old rows. See
+      // readLedgerAttr's doc comment for the fallback/removal-date policy.
+      const workflowId = readLedgerAttr(row, "workflowId", "workflow_id") ?? "";
       const reason = typeof row.reason === "string" ? row.reason : "";
       const key = `${workflowId}|${reason}`;
       const scope =

--- a/backend/src/lambda/utils/__tests__/governance-ledger-attribute-convention.test.ts
+++ b/backend/src/lambda/utils/__tests__/governance-ledger-attribute-convention.test.ts
@@ -1,0 +1,132 @@
+/**
+ * governance-ledger-attribute-convention.test.ts — pins the unified
+ * attribute-naming convention for the governance ledger table (decision
+ * 2dd461f6, slice 1: naming/readability only, NOT filtering).
+ *
+ * Convention chosen: camelCase for every attribute this table's writers
+ * emit and its readers project — `findingId`, `workflowId`, `orgId` —
+ * matching (a) the table's OWN key schema, where `findingId` is already
+ * the HASH key and `workflowId` the `workflow-index` GSI HASH key
+ * (arbiter/governance/ledger.py::_serialize_finding's own comment), and
+ * (b) the dominant convention across the REST of the repo's DynamoDB
+ * tables: 16 CDK table definitions use `orgId` as a literal attribute/key
+ * name versus zero tables using `org_id` anywhere in a key schema.
+ *
+ * This is a STRUCTURAL check, not a string search over source text: each
+ * writer is invoked with a real input and the *actual PutCommand Item* it
+ * sends to DynamoDB is inspected. A future writer that reintroduces
+ * `org_id` / `finding_id` / `workflow_id` (the pre-slice-1 legacy
+ * snake_case duplicates for these three attributes) fails this test the
+ * moment it's wired up, regardless of what the source code text looks
+ * like.
+ *
+ * NOT covered here (deliberately, per slice 1 scope):
+ *  - eval-drift-finding-writer.ts has no org field at all (never did) —
+ *    it is covered by its own test file's shape assertion, not duplicated
+ *    here.
+ *  - The Python writer (arbiter/governance/ledger.py) is NOT covered by
+ *    this file — it is a separate runtime/test toolchain (pytest, not
+ *    Vitest) and covering it structurally here is not practical. The
+ *    Python side already emits ONLY camelCase key-schema aliases
+ *    (findingId/workflowId) via `_serialize_finding` and never emits an
+ *    org attribute today (models.py::GovernanceFinding has no org field),
+ *    so there is nothing to pin snake-case-wise on that side yet; slice 2
+ *    (which adds the org value) is where a Python-side pin belongs.
+ *  - Readers' OLD-name fallback (this slice's compatibility requirement)
+ *    is covered in governance-ui-resolver.test.ts, not here — this file
+ *    only pins what NEW writes look like.
+ */
+import { DynamoDBDocumentClient, PutCommand } from "@aws-sdk/lib-dynamodb";
+import { mockClient } from "aws-sdk-client-mock";
+
+process.env.GOVERNANCE_LEDGER_TABLE = "citadel-governance-ledger-test";
+
+import { writeReleaseGateFinding } from "../release-gate-finding-writer";
+import { writeReleasePromotionApprovalFinding } from "../release-promotion-approval-writer";
+import { writeAutoRollbackFinding } from "../auto-rollback-finding-writer";
+
+const ddbMock = mockClient(DynamoDBDocumentClient);
+
+beforeEach(() => {
+  ddbMock.reset();
+  ddbMock.on(PutCommand).resolves({});
+});
+
+/** The pre-slice-1 legacy snake_case duplicates being retired by this
+ * slice. A writer item must never contain these keys going forward —
+ * only their camelCase equivalents (`findingId`, `workflowId`, `orgId`). */
+const BANNED_LEGACY_DUPLICATE_KEYS = ["finding_id", "workflow_id", "org_id"];
+
+function assertUnifiedConvention(item: Record<string, unknown>): void {
+  for (const bannedKey of BANNED_LEGACY_DUPLICATE_KEYS) {
+    expect(Object.prototype.hasOwnProperty.call(item, bannedKey)).toBe(false);
+  }
+  // The camelCase forms MUST be present — this isn't just "absence of the
+  // old name", it's "presence of the unified name".
+  expect(typeof item.findingId).toBe("string");
+  expect(typeof item.workflowId).toBe("string");
+  expect(typeof item.orgId).toBe("string");
+}
+
+describe("governance ledger attribute-naming convention (decision 2dd461f6, slice 1)", () => {
+  test("release-gate-finding-writer emits only the unified camelCase attributes", async () => {
+    await writeReleaseGateFinding({
+      orgId: "org-1",
+      agentTargetId: "agent-1",
+      environment: "PROD",
+      releaseId: "release-1",
+      decidedBy: "user-architect",
+      decision: "deny",
+      reasons: ["MATERIAL_REGRESSION"],
+      scoreVector: [
+        { dimension: "task_success", passRate: 0.5, scoredCount: 10 },
+      ],
+      mode: "strict",
+    });
+    const item = ddbMock.commandCalls(PutCommand)[0].args[0].input
+      .Item as Record<string, unknown>;
+    assertUnifiedConvention(item);
+  });
+
+  test("release-promotion-approval-writer emits only the unified camelCase attributes", async () => {
+    await writeReleasePromotionApprovalFinding({
+      orgId: "org-1",
+      agentTargetId: "agent-1",
+      environment: "PROD",
+      releaseId: "release-1",
+      decidedBy: "user-architect",
+      decision: "permit",
+    });
+    const item = ddbMock.commandCalls(PutCommand)[0].args[0].input
+      .Item as Record<string, unknown>;
+    assertUnifiedConvention(item);
+  });
+
+  test("auto-rollback-finding-writer emits only the unified camelCase attributes", async () => {
+    await writeAutoRollbackFinding({
+      orgId: "org-1",
+      agentTargetId: "agent-1",
+      environment: "PROD",
+      fromVersion: 3,
+      action: "AUTO_ROLLBACK",
+      evidence: {
+        metric: "errorRate",
+        arm: "candidate",
+        observedValue: 0.5,
+        threshold: 0.1,
+        sampleCount: 100,
+        windowStart: "2026-01-01T00:00:00Z",
+        windowEnd: "2026-01-01T01:00:00Z",
+        candidateReleaseId: "release-2",
+        stableReleaseId: "release-1",
+        fromReleaseId: "release-1",
+        toReleaseId: "release-2",
+        action: "AUTO_ROLLBACK",
+        fromVersion: 3,
+      },
+    });
+    const item = ddbMock.commandCalls(PutCommand)[0].args[0].input
+      .Item as Record<string, unknown>;
+    assertUnifiedConvention(item);
+  });
+});

--- a/backend/src/lambda/utils/__tests__/release-gate-finding-writer.test.ts
+++ b/backend/src/lambda/utils/__tests__/release-gate-finding-writer.test.ts
@@ -159,20 +159,21 @@ describe("writeReleaseGateFinding", () => {
     expect(Object.prototype.hasOwnProperty.call(item, "evalRunId")).toBe(false);
 
     // Exhaustive shape check: the pre-stamping key set, nothing more.
+    // Unified camelCase convention (decision 2dd461f6, slice 1): the
+    // legacy snake_case duplicates workflow_id/finding_id/org_id are
+    // retired — findingId/workflowId/orgId are now the ONLY forms.
     expect(Object.keys(item).sort()).toEqual(
       [
         "findingId",
         "workflowId",
         "timestamp",
-        "workflow_id",
         "decision",
         "requesting_agent",
         "target_agent",
         "reason",
-        "finding_id",
         "decided_by",
         "category",
-        "org_id",
+        "orgId",
         "environment",
         "release_id",
         "enforcement_mode",

--- a/backend/src/lambda/utils/__tests__/release-promotion-approval-writer.test.ts
+++ b/backend/src/lambda/utils/__tests__/release-promotion-approval-writer.test.ts
@@ -1,0 +1,152 @@
+/**
+ * release-promotion-approval-writer.test.ts — write-once GovernanceFinding
+ * writer for an interim human-approval decision on a release promotion.
+ *
+ * This file did not exist before decision 2dd461f6, slice 1. It was added
+ * as part of that slice because the writer's item shape is directly
+ * relevant to the attribute-naming unification (org_id -> orgId) and had
+ * no dedicated test coverage prior to this change — see
+ * release-gate-finding-writer.test.ts (its sibling/template) for the
+ * conventions mirrored here.
+ */
+process.env.GOVERNANCE_LEDGER_TABLE = "citadel-governance-ledger-test";
+
+import { DynamoDBDocumentClient, PutCommand } from "@aws-sdk/lib-dynamodb";
+import { mockClient } from "aws-sdk-client-mock";
+import {
+  writeReleasePromotionApprovalFinding,
+  type ReleasePromotionApprovalInput,
+} from "../release-promotion-approval-writer";
+
+const ddbMock = mockClient(DynamoDBDocumentClient);
+
+beforeEach(() => {
+  ddbMock.reset();
+});
+
+function approvalInput(
+  overrides: Partial<ReleasePromotionApprovalInput> = {},
+): ReleasePromotionApprovalInput {
+  return {
+    orgId: "org-1",
+    agentTargetId: "agent-1",
+    environment: "PROD",
+    releaseId: "release-1",
+    decidedBy: "user-architect",
+    decision: "permit",
+    ...overrides,
+  };
+}
+
+describe("writeReleasePromotionApprovalFinding", () => {
+  test("writes a finding with the approval category, distinct from the gate's own category", async () => {
+    ddbMock.on(PutCommand).resolves({});
+    await writeReleasePromotionApprovalFinding(approvalInput());
+
+    const calls = ddbMock.commandCalls(PutCommand);
+    expect(calls).toHaveLength(1);
+    const item = calls[0].args[0].input.Item as Record<string, unknown>;
+
+    expect(item.category).toBe("release-promotion-approval");
+    expect(item.decision).toBe("permit");
+    expect(item.requesting_agent).toBe("release-promotion-approval");
+    expect(item.target_agent).toBe("agent-1");
+    expect(item.decided_by).toBe("user-architect");
+  });
+
+  test("write-once: is idempotent via attribute_not_exists(findingId) condition", async () => {
+    ddbMock.on(PutCommand).resolves({});
+    await writeReleasePromotionApprovalFinding(approvalInput());
+    const call = ddbMock.commandCalls(PutCommand)[0].args[0].input;
+    expect(call.ConditionExpression).toBe("attribute_not_exists(findingId)");
+  });
+
+  test("swallows the expected ConditionalCheckFailedException (dedupe, not a failure)", async () => {
+    const conditionalError = Object.assign(
+      new Error("The conditional request failed"),
+      { name: "ConditionalCheckFailedException" },
+    );
+    ddbMock.on(PutCommand).rejects(conditionalError);
+
+    await expect(
+      writeReleasePromotionApprovalFinding(approvalInput()),
+    ).resolves.toBeUndefined();
+  });
+
+  test("rethrows any OTHER DynamoDB error — FAIL-CLOSED, same standing decision as the gate finding", async () => {
+    ddbMock
+      .on(PutCommand)
+      .rejects(new Error("ProvisionedThroughputExceededException"));
+
+    await expect(
+      writeReleasePromotionApprovalFinding(approvalInput()),
+    ).rejects.toThrow(/ProvisionedThroughputExceededException/);
+  });
+
+  test("same decision inputs produce the same findingId (deterministic dedupe key), distinct from the gate's findingId for the same release", async () => {
+    ddbMock.on(PutCommand).resolves({});
+    await writeReleasePromotionApprovalFinding(approvalInput());
+    await writeReleasePromotionApprovalFinding(approvalInput());
+
+    const calls = ddbMock.commandCalls(PutCommand);
+    const id1 = (calls[0].args[0].input.Item as Record<string, unknown>)
+      .findingId;
+    const id2 = (calls[1].args[0].input.Item as Record<string, unknown>)
+      .findingId;
+    expect(id1).toBe(id2);
+  });
+
+  test("optional justification/traceId/runId/diff are stamped verbatim when present, absent otherwise", async () => {
+    ddbMock.on(PutCommand).resolves({});
+    await writeReleasePromotionApprovalFinding(
+      approvalInput({
+        justification: "verified by hand",
+        traceId: "1-abcdef01-0123456789abcdef01234567",
+        runId: "run-abc-123",
+        diff: { added: 1 },
+      }),
+    );
+    const item = ddbMock.commandCalls(PutCommand)[0].args[0].input
+      .Item as Record<string, unknown>;
+    expect(item.justification).toBe("verified by hand");
+    expect(item.traceId).toBe("1-abcdef01-0123456789abcdef01234567");
+    expect(item.runId).toBe("run-abc-123");
+    expect(item.diff).toEqual({ added: 1 });
+  });
+
+  test("identifiers absent -> persisted item is byte-identical to the pre-stamping shape, unified camelCase convention (decision 2dd461f6, slice 1)", async () => {
+    ddbMock.on(PutCommand).resolves({});
+    await writeReleasePromotionApprovalFinding(approvalInput());
+    const item = ddbMock.commandCalls(PutCommand)[0].args[0].input
+      .Item as Record<string, unknown>;
+
+    expect(Object.prototype.hasOwnProperty.call(item, "traceId")).toBe(false);
+    expect(Object.prototype.hasOwnProperty.call(item, "runId")).toBe(false);
+    expect(Object.prototype.hasOwnProperty.call(item, "diff")).toBe(false);
+    expect(Object.prototype.hasOwnProperty.call(item, "justification")).toBe(
+      false,
+    );
+
+    // Legacy snake_case duplicates (finding_id/workflow_id/org_id) are
+    // retired — findingId/workflowId/orgId are now the ONLY forms. See
+    // governance-ledger-attribute-convention.test.ts, which pins this
+    // structurally across all three TS writers.
+    expect(Object.keys(item).sort()).toEqual(
+      [
+        "findingId",
+        "workflowId",
+        "timestamp",
+        "decision",
+        "requesting_agent",
+        "target_agent",
+        "reason",
+        "decided_by",
+        "category",
+        "orgId",
+        "environment",
+        "release_id",
+        "ttl",
+      ].sort(),
+    );
+  });
+});

--- a/backend/src/lambda/utils/auto-rollback-finding-writer.ts
+++ b/backend/src/lambda/utils/auto-rollback-finding-writer.ts
@@ -118,18 +118,19 @@ export async function writeAutoRollbackFinding(
   const ttl = timestamp + TTL_DAYS * 86400;
 
   const item: Record<string, unknown> = {
+    // Unified camelCase convention (decision 2dd461f6, slice 1) — see
+    // release-gate-finding-writer.ts's identical comment and
+    // governance-ledger-attribute-convention.test.ts.
     findingId,
     workflowId,
     timestamp,
-    workflow_id: workflowId,
     decision: "deny",
     requesting_agent: REQUESTING_AGENT,
     target_agent: input.agentTargetId,
     reason: buildReason(input),
-    finding_id: findingId,
     decided_by: RELEASE_ROLLBACK_DECIDED_BY,
     category: "auto-rollback",
-    org_id: input.orgId,
+    orgId: input.orgId,
     environment: input.environment,
     release_id: input.evidence.fromReleaseId,
     rollback_evidence: input.evidence,

--- a/backend/src/lambda/utils/release-gate-finding-writer.ts
+++ b/backend/src/lambda/utils/release-gate-finding-writer.ts
@@ -182,18 +182,23 @@ export async function writeReleaseGateFinding(
   const ttl = timestamp + TTL_DAYS * 86400;
 
   const item: Record<string, unknown> = {
+    // Unified camelCase convention (decision 2dd461f6, slice 1): findingId
+    // and workflowId were already the table's own key-schema attributes
+    // (HASH key / workflow-index GSI HASH key); orgId now follows the same
+    // convention, matching the 16 other tables in this repo that already
+    // key on `orgId`. The pre-slice-1 snake_case duplicates
+    // (finding_id/workflow_id/org_id) are retired — see
+    // governance-ledger-attribute-convention.test.ts, which pins this.
     findingId,
     workflowId,
     timestamp,
-    workflow_id: workflowId,
     decision: input.decision,
     requesting_agent: REQUESTING_AGENT,
     target_agent: input.agentTargetId,
     reason: buildReason(input),
-    finding_id: findingId,
     decided_by: input.decidedBy,
     category: "release-promotion",
-    org_id: input.orgId,
+    orgId: input.orgId,
     environment: input.environment,
     release_id: input.releaseId,
     enforcement_mode: input.mode,

--- a/backend/src/lambda/utils/release-promotion-approval-writer.ts
+++ b/backend/src/lambda/utils/release-promotion-approval-writer.ts
@@ -123,18 +123,19 @@ export async function writeReleasePromotionApprovalFinding(
   const ttl = timestamp + TTL_DAYS * 86400;
 
   const item: Record<string, unknown> = {
+    // Unified camelCase convention (decision 2dd461f6, slice 1) — see
+    // release-gate-finding-writer.ts's identical comment and
+    // governance-ledger-attribute-convention.test.ts.
     findingId,
     workflowId,
     timestamp,
-    workflow_id: workflowId,
     decision: input.decision,
     requesting_agent: REQUESTING_AGENT,
     target_agent: input.agentTargetId,
     reason: buildReason(input),
-    finding_id: findingId,
     decided_by: input.decidedBy,
     category: "release-promotion-approval",
-    org_id: input.orgId,
+    orgId: input.orgId,
     environment: input.environment,
     release_id: input.releaseId,
     ttl,


### PR DESCRIPTION
## Summary

The governance ledger had two naming conventions in the same rows, and the organisation attribute was unreadable as written. Live rows carry **both** `findingId` and `finding_id`, and `workflowId` and `workflow_id`. Separately, three writers stored `orgId` while the resolver read `orgId` through a document client that does not rename keys - so **always `undefined`**, making the cross-org skip in `findingRow.orgId` was `findExecutionIdByRunId` dead code for every row.

This is slice 1 of the governance-UI isolation work: naming and readability only. No authorization or filtering behaviour changes.

- One convention, chosen on evidence: **camelCase**. `findingId` and `workflowId` are already this table's own key-schema attribute names, and 16 other CDK tables key on `orgId` while none use `org_id`
- All five writers now emit camelCase only, dropping the snake_case duplicates - the three release/rollback writers, the eval-drift writer, and the Python Ledger serializer
- The three organisation-writing TypeScript writers switch
`org_id` → `orgId`; a rename only, no value Logic touched

## Existing rows stay readable

Readers route `findingId`, `workflowId` and `orgId` through a new `readLedgerAttr` helper that prefers the new name and falls back to the old, with a dated removal comment (~2026-12-08) tied to the ledger's 90-day TTL. Without that, changing the writers would have silently broken reads of the existing audit trail.

## The dead-code bug is provably fixed

A row carrying a stamped organisation now resolves through the resolver read path - asserted on the linked execution id - where it previously always read `undefined`. That had to work before any org-filtering could mean anything.

## Testing

- Both old-name and new-name rows fed through every reader, tested rather than reasoned about
- Structural convention pins in **both** languages, bite-proven: a writer reintroducing a snake_case duplicate fails immediately. This is how the mismatch survived unnoticed, so the pin matters as much as the fix
- `release-promotion-approval-writer` was previously untested and is now covered
- From `backend/`: tsc 0, lint 0, targeted jest 379, full backend jest 7667; arbiter governance
pytest 306, wider arbiter pytest 1619

## Scope

Deliberately excluded: adding or deriving any organisation value (slice 2), any filtering or authorization change (slice 3), and the other snake_case fields such as `requesting_agent` and `reason`, which are not implicated in a read mismatch.

Remaining slides: stamp the organisation at every write site - the Python `GovernanceFinding` model has no such field at all - then add the index plus caller-org query with admin-only visibility for legacy rows, then the module's missing dispatch guard.