### PR TITLE
feat(governance): stamp the organisation on findings where it exists

### DIFF
--- a/arbiter/governance/__tests__/test_ledger_org_id.py
+++ b/arbiter/governance/__tests__/test_ledger_org_id.py
@@ -1,0 +1,191 @@
+"""Unit + property tests for org_id serialization in
+arbiter/governance/ledger.py (Governance ledger SLICE 2, decision
+7b3f4fe2 supplies the eventual read-side filter; this slice supplies the
+VALUE).
+
+Mirrors test_ledger_run_id.py's byte-identity property and the
+camelCase-alias-when-present test, extended for the new ``org_id`` field —
+same fail-closed non-regression discipline: an absent org_id must produce a
+ledger item byte-identical to the pre-org-stamping shape.
+
+NOTE on naming: decision 2dd461f6 (slice 1) unified findingId/workflowId to
+camelCase-ONLY (no snake_case duplicate). org_id is NOT part of that
+unification list — it is a NEW field added in this slice, so it follows the
+SAME additive discipline as trace_id/run_id/eval_run_id: the top-level
+``dataclasses.asdict`` flattening loop in ``_serialize_finding`` naturally
+emits the snake_case ``org_id`` key (like every other non-unified field),
+and an explicit ``item["orgId"] = ...`` camelCase alias is added ONLY when
+``finding.org_id is not None`` — never a null placeholder, never an empty
+string standing in for "unavailable".
+"""
+from __future__ import annotations
+
+import dataclasses
+import os
+import sys
+import uuid
+from typing import Any
+
+from hypothesis import HealthCheck, given, settings, strategies as st
+
+_PROJECT_ROOT = os.path.abspath(
+    os.path.join(os.path.dirname(__file__), "..", "..", "..")
+)
+if _PROJECT_ROOT not in sys.path:
+    sys.path.insert(0, _PROJECT_ROOT)
+
+from arbiter.governance import ledger  # noqa: E402
+from arbiter.governance.models import (  # noqa: E402
+    ArbitrationDecision,
+    GovernanceFinding,
+)
+
+
+def _make_finding(**overrides: Any) -> GovernanceFinding:
+    defaults: dict[str, Any] = {
+        "workflow_id": "wf-test-001",
+        "decision": ArbitrationDecision.PERMIT,
+        "requesting_agent": "agent-a",
+        "target_agent": "agent-b",
+        "reason": "scope covers request",
+        "finding_id": str(uuid.uuid4()),
+        "timestamp": 1_700_000_000.0,
+        "scope_evaluated": "unit-001",
+        "contract_evaluated": None,
+        "escalation_target": None,
+        "residual_authority_denial": False,
+        "trace_id": None,
+        "run_id": None,
+        "eval_run_id": None,
+        "org_id": None,
+    }
+    defaults.update(overrides)
+    return GovernanceFinding(**defaults)
+
+
+_decision_strategy = st.sampled_from(list(ArbitrationDecision))
+_optional_str = st.one_of(st.none(), st.text(min_size=1, max_size=40))
+_required_str = st.text(min_size=1, max_size=40).filter(lambda s: s.strip() != "")
+
+
+def _finding_strategy_with_org_id_none() -> st.SearchStrategy[GovernanceFinding]:
+    """Same shape as the run_id/eval_run_id byte-identity strategies, but
+    for org_id — independently drawn everything else, org_id pinned to None
+    so the property below checks the absent-org_id write shape."""
+
+    @st.composite
+    def _inner(draw: st.DrawFn) -> GovernanceFinding:
+        return GovernanceFinding(
+            workflow_id=draw(_required_str),
+            decision=draw(_decision_strategy),
+            requesting_agent=draw(_required_str),
+            target_agent=draw(_required_str),
+            reason=draw(_required_str),
+            finding_id=str(uuid.uuid4()),
+            timestamp=draw(st.floats(min_value=0.0, max_value=2e9)),
+            scope_evaluated=draw(_optional_str),
+            contract_evaluated=draw(_optional_str),
+            escalation_target=draw(_optional_str),
+            residual_authority_denial=draw(st.booleans()),
+            trace_id=None,
+            run_id=None,
+            eval_run_id=None,
+            org_id=None,
+        )
+
+    return _inner()
+
+
+@settings(
+    max_examples=100,
+    deadline=None,
+    suppress_health_check=[HealthCheck.function_scoped_fixture],
+)
+@given(finding=_finding_strategy_with_org_id_none())
+def test_property_serialize_finding_byte_identical_when_org_id_none(
+    finding: GovernanceFinding,
+) -> None:
+    """[FAIL-CLOSED NON-REGRESSION property] For an arbitrary finding with
+    ``org_id=None`` (the default / no-org-available case — e.g. a
+    platform-internal finding with no tenant context), the serialized
+    ledger item contains neither ``org_id`` nor ``orgId`` — an absent
+    org_id produces a byte-identical write to the pre-org-stamping
+    serialization, mirroring the run_id/eval_run_id properties.
+    """
+    assert finding.org_id is None
+    item = ledger._serialize_finding(finding)
+
+    assert "org_id" not in item
+    assert "orgId" not in item
+
+    raw = dataclasses.asdict(finding)
+    assert raw["org_id"] is None
+
+
+def test_serialize_finding_emits_camelcase_org_id_when_present() -> None:
+    finding = _make_finding(org_id="org-abc123")
+    item = ledger._serialize_finding(finding)
+
+    assert item["orgId"] == "org-abc123"
+    # snake_case raw field is present too (same top-level-loop flattening
+    # behavior documented for trace_id/run_id/eval_run_id).
+    assert item.get("org_id") == "org-abc123"
+
+    assert "ttl" not in item  # ttl is added by write_finding, not _serialize_finding
+    assert item["findingId"] == finding.finding_id
+
+
+def test_org_id_absent_and_run_id_present_do_not_interfere() -> None:
+    """Independence check: the optional stamps (run_id, org_id) are
+    serialized independently — one present, one absent, in either
+    combination, without cross-contamination."""
+    finding = _make_finding(run_id="run-abc123", org_id=None)
+    item = ledger._serialize_finding(finding)
+    assert item["runId"] == "run-abc123"
+    assert "orgId" not in item
+
+    finding2 = _make_finding(run_id=None, org_id="org-def456")
+    item2 = ledger._serialize_finding(finding2)
+    assert item2["orgId"] == "org-def456"
+    assert "runId" not in item2
+
+
+def test_governance_finding_org_id_defaults_to_none() -> None:
+    finding = GovernanceFinding(
+        workflow_id="wf-1",
+        decision=ArbitrationDecision.PERMIT,
+        requesting_agent="arbiter",
+        target_agent="agent-1",
+        reason="within scope",
+    )
+    assert finding.org_id is None
+
+
+def test_governance_finding_create_org_id_kwarg_round_trips() -> None:
+    finding = GovernanceFinding.create(
+        workflow_id="wf-1",
+        decision=ArbitrationDecision.PERMIT,
+        requesting_agent="arbiter",
+        target_agent="agent-1",
+        reason="within scope",
+        org_id="org-xyz",
+    )
+    assert finding.org_id == "org-xyz"
+
+
+def test_governance_finding_org_id_mutable_post_construction() -> None:
+    """Mirrors trace_id's post-construction stamping discipline
+    (test_governance_finding_trace_id_mutable_post_construction): the
+    supervisor stamps org_id AFTER construction, between engine.evaluate()
+    and write_finding(), when org context becomes available only after the
+    finding object exists."""
+    finding = GovernanceFinding.create(
+        workflow_id="wf-1",
+        decision=ArbitrationDecision.PERMIT,
+        requesting_agent="arbiter",
+        target_agent="agent-1",
+        reason="within scope",
+    )
+    assert finding.org_id is None
+    finding.org_id = "org-xyz"
+    assert finding.org_id == "org-xyz"

--- a/arbiter/governance/ledger.py
+++ b/arbiter/governance/ledger.py
@@ -206,6 +206,19 @@ def _serialize_finding(finding: GovernanceFinding) -> dict[str, Any]:
     # — byte-identical to the pre-CIT-102 shape.
     if finding.eval_run_id is not None:
         item["evalRunId"] = finding.eval_run_id
+
+    # Optional camelCase alias for the Governance ledger SLICE 2 org
+    # stamp. Same byte-identical-when-absent discipline as traceId/runId/
+    # evalRunId immediately above: emitted ONLY when finding.org_id is not
+    # None. The top-level loop already stripped the None-valued `org_id`
+    # dataclass field, so a finding with no tenant context available at
+    # its write site (a platform-internal finding — see per-site
+    # enumeration in the slice-2 write sites) writes an item with neither
+    # `org_id` nor `orgId` — byte-identical to the pre-org-stamping shape,
+    # and such rows remain admin-only by construction (decision 2dd461f6's
+    # legacy-row ruling), never defaulted to a placeholder org.
+    if finding.org_id is not None:
+        item["orgId"] = finding.org_id
     return item
 
 

--- a/arbiter/governance/models.py
+++ b/arbiter/governance/models.py
@@ -244,6 +244,31 @@ class GovernanceFinding:
                                                    # the dispatch carries no evalRunId
                                                    # (the overwhelming majority of
                                                    # non-eval dispatches).
+    org_id: str | None = None                     # Governance ledger SLICE 2
+                                                   # (decision 7b3f4fe2 supplies the
+                                                   # read-side filter this stamps the
+                                                   # value for). Serialized as
+                                                   # camelCase `orgId` (ledger.py)
+                                                   # ONLY when present — same
+                                                   # additive, best-effort, never-
+                                                   # gates-decision discipline as
+                                                   # trace_id/run_id/eval_run_id
+                                                   # above. Sources vary by write
+                                                   # site (worker-tool-call path:
+                                                   # server-resolved from the
+                                                   # EXECUTIONS_TABLE row via
+                                                   # _resolve_execution_org_id;
+                                                   # tool-breaker transitions: the
+                                                   # same CITADEL_ORG_ID env
+                                                   # threaded to the subprocess).
+                                                   # None when no tenant context
+                                                   # exists at the write site (a
+                                                   # platform-internal finding) —
+                                                   # such findings are admin-only
+                                                   # by construction (decision
+                                                   # 2dd461f6's legacy-row ruling),
+                                                   # NEVER defaulted to a
+                                                   # placeholder org.
 
     @classmethod
     def create(

--- a/arbiter/supervisor/index.py
+++ b/arbiter/supervisor/index.py
@@ -773,6 +773,24 @@ def governed_process_agent_call(
 
     # 5. Write finding (fail-closed per D9). Any exception halts dispatch,
     # in every mode.
+    #
+    # Governance ledger SLICE 2 (decision 7b3f4fe2 / 2dd461f6): deliberately
+    # NOT stamping finding.org_id here. Unlike trace_id/run_id/eval_run_id
+    # immediately above, there is no genuine per-request org identity
+    # reaching this dispatch path today — see the "Named seam, not a
+    # fabricated multi-tenancy layer" comment near RELEASE_DEFAULT_ORG_ID's
+    # definition earlier in this module: neither `orchestration` nor
+    # load_config_from_dynamodb()/load_app_scoped_agents() (agent_config.py)
+    # carries an orgId anywhere. RELEASE_DEFAULT_ORG_ID is an explicit,
+    # documented DEPLOYMENT-WIDE seam (one org id per deployment's release
+    # pointers), not a per-request caller identity — stamping it onto every
+    # finding here would misrepresent a deployment-wide default as a
+    # genuine tenant attribution, which decision 2dd461f6's discipline
+    # (never invent/default an org) forbids. This finding is therefore
+    # written WITHOUT an org — admin-only by construction, consistent with
+    # the legacy-row ruling, until a future story threads real per-request
+    # org identity into the arbiter (the same future story
+    # RELEASE_DEFAULT_ORG_ID's own comment anticipates).
     write_finding(finding)
 
     # 5b. Release-aware dispatch (this story). A completely separate,

--- a/arbiter/workerWrapper/__tests__/test_governance_evaluator_org_id.py
+++ b/arbiter/workerWrapper/__tests__/test_governance_evaluator_org_id.py
@@ -1,0 +1,103 @@
+"""Governance ledger SLICE 2 — GovernanceEvaluator (governance_tool_hook.py)
+org_id stamping tests.
+
+``GovernanceEvaluator.__init__`` already accepts ``org_id`` (threaded from
+``CITADEL_ORG_ID`` / ``_resolve_execution_org_id`` — see agent_runner.py) and
+already USES it for approval-scope gating (the (org, workflowDef, node,
+tool) grant tuple). This slice threads the SAME already-available value onto
+every finding the evaluator writes (deny-list PERMIT/DENY, and the
+always-visible approval PERMIT/DENY findings) — it was previously computed
+and stored but never passed to ``build_governance_finding`` /
+``build_approval_finding``.
+
+Uses plain duck-typed objects for the BeforeToolCallEvent seam (tool_use /
+selected_tool attributes), same minimal-fake style as
+test_governed_tool_handler_org_id.py, to avoid depending on the strands
+runtime being importable.
+"""
+from __future__ import annotations
+
+import os
+import sys
+from unittest.mock import patch
+
+_WORKER_DIR = os.path.abspath(os.path.join(os.path.dirname(__file__), '..'))
+if _WORKER_DIR not in sys.path:
+    sys.path.insert(0, _WORKER_DIR)
+
+from governance_tool_hook import GovernanceEvaluator  # noqa: E402
+from governance.models import ArbitrationDecision  # noqa: E402
+
+
+class _FakeToolUse(dict):
+    """Plain dict subclass — duck-typed as the strands ToolUse mapping."""
+
+
+class _FakeEvent:
+    def __init__(self, name: str, tool_use_id: str, selected_tool=object()):
+        self.tool_use = _FakeToolUse({'name': name, 'toolUseId': tool_use_id})
+        self.selected_tool = selected_tool
+
+
+def test_evaluate_denylist_permit_finding_stamped_with_org_id():
+    evaluator = GovernanceEvaluator(
+        agent_id='agent-1', workflow_id='wf-1', denied_tools=set(),
+        org_id='org-1',
+    )
+    with patch('governed_tool_handler.write_finding') as mock_write:
+        outcome = evaluator.evaluate_denylist(_FakeEvent('safe_tool', 'tu-1'))
+
+    assert outcome.refused is False
+    (written_finding,), _ = mock_write.call_args
+    assert written_finding.decision == ArbitrationDecision.PERMIT
+    assert written_finding.org_id == 'org-1'
+
+
+def test_evaluate_denylist_deny_finding_stamped_with_org_id():
+    evaluator = GovernanceEvaluator(
+        agent_id='agent-1', workflow_id='wf-1', denied_tools={'bad_tool'},
+        org_id='org-2',
+    )
+    with patch('governed_tool_handler.write_finding') as mock_write:
+        outcome = evaluator.evaluate_denylist(_FakeEvent('bad_tool', 'tu-2'))
+
+    assert outcome.refused is True
+    (written_finding,), _ = mock_write.call_args
+    assert written_finding.decision == ArbitrationDecision.DENY
+    assert written_finding.org_id == 'org-2'
+
+
+def test_evaluate_denylist_finding_org_id_none_when_absent():
+    """Default org_id ("") on GovernanceEvaluator normalises to None on the
+    finding — never an empty-string placeholder standing in for
+    'unavailable'."""
+    evaluator = GovernanceEvaluator(
+        agent_id='agent-1', workflow_id='wf-1', denied_tools=set(),
+    )
+    with patch('governed_tool_handler.write_finding') as mock_write:
+        evaluator.evaluate_denylist(_FakeEvent('safe_tool', 'tu-3'))
+
+    (written_finding,), _ = mock_write.call_args
+    assert written_finding.org_id is None
+
+
+def test_approval_refuse_finding_stamped_with_org_id_via_incomplete_context():
+    """The fail-safe DENY branch (incomplete (org, workflowDef, node, exec)
+    context) is deterministic without a real approval store — it is hit
+    whenever ANY of the four scope fields is falsy. Drive it with org_id set
+    but node_id/execution_id absent so `_refuse` -> `record_approval_finding`
+    runs, and assert the written DENY finding carries org_id."""
+    evaluator = GovernanceEvaluator(
+        agent_id='agent-1', workflow_id='wf-1', denied_tools=set(),
+        approval_required_tools={'gated_tool'},
+        org_id='org-4', workflow_definition_id='wfdef-1',
+        execution_id='', node_id='',
+    )
+    with patch('governed_tool_handler.write_finding') as mock_write:
+        refused = evaluator._evaluate_approval(
+            _FakeEvent('gated_tool', 'tu-5'), object(), 'gated_tool', 'tu-5',
+        )
+    assert refused is True
+    (written_finding,), _ = mock_write.call_args
+    assert written_finding.decision == ArbitrationDecision.DENY
+    assert written_finding.org_id == 'org-4'

--- a/arbiter/workerWrapper/__tests__/test_governed_tool_handler_org_id.py
+++ b/arbiter/workerWrapper/__tests__/test_governed_tool_handler_org_id.py
@@ -1,0 +1,121 @@
+"""Governance ledger SLICE 2 — GovernedToolHandler org_id stamping tests.
+
+Mirrors test_governed_tool_handler_eval_run_id.py's structure. org_id here
+comes from the SAME server-resolved source already threaded to this worker
+subprocess for the live BeforeToolCallEvent seam (governance_tool_hook.py's
+GovernanceToolHook, whose __init__ already accepts org_id sourced from
+CITADEL_ORG_ID / _resolve_execution_org_id) — this test file extends the
+legacy GovernedToolHandler seam (and the shared build_governance_finding /
+build_approval_finding / record_governance_decision helpers both seams call
+through) with the same optional, additive, never-gates-decision org_id
+parameter.
+"""
+from __future__ import annotations
+
+import os
+import sys
+from unittest.mock import patch
+
+_WORKER_DIR = os.path.abspath(os.path.join(os.path.dirname(__file__), '..'))
+if _WORKER_DIR not in sys.path:
+    sys.path.insert(0, _WORKER_DIR)
+
+from governed_tool_handler import (  # noqa: E402
+    GovernedToolHandler,
+    build_approval_finding,
+    build_governance_finding,
+    record_governance_decision,
+)
+from governance.models import ArbitrationDecision  # noqa: E402
+
+
+def test_ctor_defaults_org_id_to_none():
+    handler = GovernedToolHandler(denied_tools=set())
+    assert handler.org_id is None
+
+
+def test_deny_finding_stamped_with_org_id_when_present():
+    handler = GovernedToolHandler(
+        agent_id='agent-42',
+        workflow_id='wf-123',
+        denied_tools={'dangerous_tool'},
+        org_id='org-99',
+    )
+
+    with patch('governed_tool_handler.write_finding') as mock_write:
+        result = handler.preprocess({'name': 'dangerous_tool', 'toolUseId': 'tu-1'})
+
+    assert isinstance(result, dict)
+    assert result['status'] == 'error'
+    (written_finding,), _ = mock_write.call_args
+    assert written_finding.decision == ArbitrationDecision.DENY
+    assert written_finding.org_id == 'org-99'
+
+
+def test_permit_finding_stamped_with_org_id_when_present():
+    handler = GovernedToolHandler(
+        agent_id='agent-a', workflow_id='wf-b', denied_tools=set(),
+        org_id='org-100',
+    )
+
+    with patch('governed_tool_handler.write_finding') as mock_write:
+        result = handler.preprocess({'name': 'safe_tool'})
+
+    assert result is None
+    (written_finding,), _ = mock_write.call_args
+    assert written_finding.decision == ArbitrationDecision.PERMIT
+    assert written_finding.org_id == 'org-100'
+
+
+def test_finding_org_id_none_when_absent():
+    """No org context available at this write site (e.g. a
+    platform-internal invocation): finding.org_id stays None — byte
+    -identical to pre-slice-2 behavior. Never defaulted to a placeholder."""
+    handler = GovernedToolHandler(denied_tools={'blocked'})
+
+    with patch('governed_tool_handler.write_finding') as mock_write:
+        handler.preprocess({'name': 'blocked', 'toolUseId': 'tu-x'})
+
+    (written_finding,), _ = mock_write.call_args
+    assert written_finding.org_id is None
+
+
+def test_build_governance_finding_accepts_org_id_kwarg():
+    finding = build_governance_finding(
+        'tool-a', denied=False, agent_id='a', workflow_id='w', org_id='org-1',
+    )
+    assert finding.org_id == 'org-1'
+
+
+def test_build_governance_finding_org_id_defaults_to_none():
+    finding = build_governance_finding(
+        'tool-a', denied=False, agent_id='a', workflow_id='w',
+    )
+    assert finding.org_id is None
+
+
+def test_build_approval_finding_accepts_org_id_kwarg():
+    finding = build_approval_finding(
+        'tool-a', permitted=True, reason_code='approval_consumed',
+        agent_id='a', workflow_id='w', org_id='org-2',
+    )
+    assert finding.org_id == 'org-2'
+
+
+def test_build_approval_finding_org_id_defaults_to_none():
+    finding = build_approval_finding(
+        'tool-a', permitted=True, reason_code='approval_consumed',
+        agent_id='a', workflow_id='w',
+    )
+    assert finding.org_id is None
+
+
+def test_record_governance_decision_threads_org_id():
+    with patch('governed_tool_handler.write_finding') as mock_write:
+        record_governance_decision(
+            'tool-a', 'tu-1',
+            agent_id='a', workflow_id='w', denied_tools=set(),
+            org_id='org-3',
+        )
+    (written_finding,), _ = mock_write.call_args
+    assert written_finding.org_id == 'org-3'

--- a/arbiter/workerWrapper/governance_tool_hook.py
+++ b/arbiter/workerWrapper/governance_tool_hook.py
@@ -240,6 +240,12 @@ class GovernanceEvaluator:
             workflow_id=self._workflow_id,
             denied_tools=self._denied_tools,
             eval_run_id=self._eval_run_id,
+            # Governance ledger SLICE 2: self._org_id defaults to "" (see
+            # __init__) as a valid "disabled" sentinel for approval-scope
+            # gating; normalise the empty string to None here so an
+            # unconfigured org never writes a placeholder value onto the
+            # finding — only a genuinely non-empty org id is stamped.
+            org_id=self._org_id or None,
         )
         if denied and error_result is not None:
             event.selected_tool = _GovernanceDeniedTool(selected, error_result)
@@ -302,6 +308,7 @@ class GovernanceEvaluator:
                     tool_name, permitted=False, reason_code=reason_code,
                     agent_id=self._agent_id, workflow_id=self._workflow_id,
                     eval_run_id=self._eval_run_id,
+                    org_id=self._org_id or None,
                 )
             except LedgerWriteError as write_exc:
                 if _record_governance_refusal is not None:
@@ -370,6 +377,7 @@ class GovernanceEvaluator:
                 tool_name, permitted=True, reason_code="approval_consumed",
                 agent_id=self._agent_id, workflow_id=self._workflow_id,
                 eval_run_id=self._eval_run_id,
+                org_id=self._org_id or None,
             )
         except LedgerWriteError as exc:
             return _refuse(exc, "approval_permit_finding_unwritable", infra=True)
@@ -392,10 +400,12 @@ class GovernanceToolHook:
         workflow_id: str,
         denied_tools: set[str] | None = None,
         eval_run_id: str | None = None,
+        org_id: str | None = None,
     ):
         self._evaluator = GovernanceEvaluator(
             agent_id=agent_id, workflow_id=workflow_id,
             denied_tools=denied_tools, eval_run_id=eval_run_id,
+            org_id=org_id or "",
         )
 
     @property

--- a/arbiter/workerWrapper/governed_tool_handler.py
+++ b/arbiter/workerWrapper/governed_tool_handler.py
@@ -144,11 +144,20 @@ def build_approval_finding(
     agent_id: str,
     workflow_id: str,
     eval_run_id: str | None = None,
+    org_id: str | None = None,
 ) -> GovernanceFinding:
     """Build the ALWAYS-visible ``worker-tool-approval``-scope finding for an
     approval decision (decision c0ca4576: an APPROVAL_REQUIRED record is written
     either way — on a consumed approval AND on a refusal). ``permitted`` maps to
-    PERMIT (approval consumed) vs DENY (approval absent/expired/consumed)."""
+    PERMIT (approval consumed) vs DENY (approval absent/expired/consumed).
+
+    ``org_id`` (Governance ledger SLICE 2) is optional and additive, same
+    discipline as ``eval_run_id``: the caller is the ``GovernanceToolHook``/
+    ``GovernedToolHandler`` seam, which already receives ``org_id`` server
+    -resolved from the execution row (``_resolve_execution_org_id`` via
+    ``CITADEL_ORG_ID``) for approval-scope gating — this just threads the
+    same value onto the finding. ``None`` when no org context exists at the
+    call site (platform-internal invocation); never a placeholder."""
     decision = ArbitrationDecision.PERMIT if permitted else ArbitrationDecision.DENY
     return GovernanceFinding.create(
         workflow_id=workflow_id,
@@ -159,6 +168,7 @@ def build_approval_finding(
         scope_evaluated=SCOPE_WORKER_TOOL_APPROVAL,
         contract_evaluated=None,
         eval_run_id=eval_run_id,
+        org_id=org_id,
     )
 
 
@@ -264,12 +274,17 @@ def build_governance_finding(
     agent_id: str,
     workflow_id: str,
     eval_run_id: str | None = None,
+    org_id: str | None = None,
 ) -> GovernanceFinding:
     """Build the worker-tool-handler-scope ``GovernanceFinding`` for one tool
     call. Shared by the legacy ``GovernedToolHandler.preprocess`` and the
     hooks-based ``GovernanceToolHook`` so both layers emit byte-identical
     findings (QD-5: scope ``worker-tool-handler``, distinct from
-    ``worker-pre-filter``). PERMIT and DENY both produce a finding."""
+    ``worker-pre-filter``). PERMIT and DENY both produce a finding.
+
+    ``org_id`` (Governance ledger SLICE 2) is optional and additive — see
+    ``build_approval_finding``'s doc comment for the sourcing discipline
+    and the admin-only-when-absent rationale."""
     decision = ArbitrationDecision.DENY if denied else ArbitrationDecision.PERMIT
     return GovernanceFinding.create(
         workflow_id=workflow_id,
@@ -284,6 +299,7 @@ def build_governance_finding(
         scope_evaluated=SCOPE_WORKER_TOOL_HANDLER,
         contract_evaluated=None,
         eval_run_id=eval_run_id,
+        org_id=org_id,
     )
 
 
@@ -295,6 +311,7 @@ def record_governance_decision(
     workflow_id: str,
     denied_tools: set[str],
     eval_run_id: str | None = None,
+    org_id: str | None = None,
 ) -> tuple[bool, dict | None]:
     """Evaluate the deny-list decision, write the audit finding, and return
     ``(denied_or_blocked, error_result_or_None)``.
@@ -334,6 +351,7 @@ def record_governance_decision(
     finding = build_governance_finding(
         tool_name, denied,
         agent_id=agent_id, workflow_id=workflow_id, eval_run_id=eval_run_id,
+        org_id=org_id,
     )
     try:
         write_finding(finding)
@@ -360,6 +378,7 @@ def record_approval_finding(
     agent_id: str,
     workflow_id: str,
     eval_run_id: str | None = None,
+    org_id: str | None = None,
 ) -> None:
     """Write the ALWAYS-visible ``worker-tool-approval`` audit finding for an
     approval decision (decision c0ca4576). Uses the module-local ``write_finding``
@@ -369,6 +388,7 @@ def record_approval_finding(
     write_finding(build_approval_finding(
         tool_name, permitted, reason_code,
         agent_id=agent_id, workflow_id=workflow_id, eval_run_id=eval_run_id,
+        org_id=org_id,
     ))
 
 
@@ -388,6 +408,7 @@ class GovernedToolHandler(AgentToolHandler):  # type: ignore[misc]
         workflow_id: str = 'unknown-workflow',
         denied_tools: set[str] | None = None,
         eval_run_id: str | None = None,
+        org_id: str | None = None,
     ):
         # Strands ``AgentToolHandler.__init__`` may require specific kwargs
         # and the signature has drifted across SDK releases. Fall back
@@ -417,6 +438,13 @@ class GovernedToolHandler(AgentToolHandler):  # type: ignore[misc]
         # replay-package findings. None (the default) for every non-eval
         # invocation — byte-identical finding/ledger-write behavior.
         self.eval_run_id = eval_run_id
+        # Governance ledger SLICE 2: per-run org id, stamped on every
+        # finding this handler writes (PERMIT and DENY alike), same
+        # additive/optional discipline as eval_run_id above. None (the
+        # default) when no org context is available at this call site —
+        # such findings remain admin-only by construction, never a
+        # placeholder org.
+        self.org_id = org_id
 
     def preprocess(
         self,
@@ -449,6 +477,7 @@ class GovernedToolHandler(AgentToolHandler):  # type: ignore[misc]
             workflow_id=self.workflow_id,
             denied_tools=self.denied_tools,
             eval_run_id=self.eval_run_id,
+            org_id=self.org_id,
         )
         # error_result is the ToolResult-shaped deny dict on DENY, else None
         # (PERMIT → fall through to the default handler).

--- a/arbiter/workerWrapper/tool_breaker_hook.py
+++ b/arbiter/workerWrapper/tool_breaker_hook.py
@@ -261,6 +261,17 @@ def _emit_finding(
             scope_evaluated=SCOPE_TOOL_TARGET_BREAKER,
             contract_evaluated=None,
             eval_run_id=eval_run_id,
+            # Governance ledger SLICE 2: org_id is already threaded to this
+            # function's caller (build_transition_emitter's own org_id
+            # param, sourced from CITADEL_ORG_ID — see agent_runner.py) and
+            # was already being used for the EventBridge event below; it
+            # was never passed into the finding itself. Stamped here as an
+            # empty-string-to-None normalisation (mirrors org_id's "" ->
+            # unavailable convention already used by
+            # build_transition_emitter/_resolve_execution_org_id) so a
+            # deployment with no org configured writes a byte-identical,
+            # unstamped finding rather than an empty-string orgId.
+            org_id=org_id or None,
         ))
     except Exception as exc:  # noqa: BLE001 — best-effort; single-writer keeps it storm-proof
         logger.error("tool-breaker finding write failed %s->%s: %s", t.from_state, t.to_state, exc)

--- a/backend/src/lambda/__tests__/eval-drift-finding-writer.test.ts
+++ b/backend/src/lambda/__tests__/eval-drift-finding-writer.test.ts
@@ -132,4 +132,13 @@ describe("handleDriftDetected", () => {
     const item = ddbMock.call(0).args[0].input.Item as Record<string, unknown>;
     expect(item.reason as string).toContain("0.42");
   });
+
+  it("SLICE 2 determination (decision 7b3f4fe2 / 2dd461f6): never emits an org attribute — the upstream detector has no org-scoped data to source it from", async () => {
+    ddbMock.on(PutCommand).resolves({});
+    await handleDriftDetected(detail());
+
+    const item = ddbMock.call(0).args[0].input.Item as Record<string, unknown>;
+    expect(Object.prototype.hasOwnProperty.call(item, "orgId")).toBe(false);
+    expect(Object.prototype.hasOwnProperty.call(item, "org_id")).toBe(false);
+  });
 });

--- a/backend/src/lambda/eval-drift-finding-writer.ts
+++ b/backend/src/lambda/eval-drift-finding-writer.ts
@@ -155,6 +155,22 @@ export async function handleDriftDetected(
     category: "eval-drift",
     dimension: detail.dimension,
     ttl,
+    // Governance ledger SLICE 2 (decision 7b3f4fe2 / 2dd461f6) determination:
+    // deliberately NOT stamping orgId here. The upstream detector
+    // (eval-drift-detector.ts) resolves the `agentIds` it scans EXCLUSIVELY
+    // from an operator-supplied env var (`agentIdsFromEnv`) and queries the
+    // `EvalProdSamples.AgentDimTimeIndex` GSI without any org scoping
+    // anywhere in that query path or in the `governance.eval.drift.detected`
+    // event payload this writer consumes (see DriftDetectedDetail above —
+    // no orgId field). There is therefore no genuine per-finding org value
+    // available at this write site today; inventing one (e.g. from a
+    // registry lookup by agentId this writer has never done, or a
+    // deployment-wide default) is out of scope for this slice and would
+    // misrepresent an unverified guess as a tenant attribution. This
+    // finding is written WITHOUT an org — admin-only by construction,
+    // consistent with the legacy-row ruling (decision 2dd461f6) — until a
+    // future story threads a real per-agent org lookup (or an orgId field
+    // on the drift-detected event) through the detector.
   };
 
   try {


### PR DESCRIPTION
## Summary

Slice 2 of the governance-Ul isolation work. Slice 1 unified the ledger attribute naming and made a stamped `orgId` genuinely readable; this slice supplies the value. `GovernanceFinding` gains optional, serialized as camelCase `orgId` **only when present**, mirroring the existing `trace_id` / `run_id` / `eval_run_id` discipline.

No index, no read filtering, no authorization change - those are slice 3. This slice only makes the data correct.

## The organisation was often already in hand

- **`tool_breaker_hook`** already received the organisation and passed it to the EventBridge event, then dropped it before writing the finding
- **`GovernanceEvaluator`** had it constructor-supplied - resolved server-side from the executions table and already used for approval-scope gating but never stamped it
- **`governed_tool_handler`** now threads it through `record_governance_decision`, `build_governance_finding`, `record_approval_finding` and `build_approval_finding`

Every stamped value is server-derived; none comes from a client field, a default or a constant, so a caller cannot mislabel a finding's tenant.

## Two sites are deliberately left unstamped

- **`eval-drift-finding-writer`** - the detector resolves agent ids from an operator environment variable and its samples query has no organisation scoping at all, so there is nothing truthful to stamp
- **`supervisor_governed_process_agent_call`** - no per-request organisation reaches this path. The orchestration dict and agent-config loaders carry none, and `RELEASE_DEFAULT_ORG_ID` was available but is a deployment-wide seam rather than caller identity; using it would have mislabelled tenancy on governance records

Both are documented at the write site as admin-only by construction, consistent with the ruling on Legacy rows. They stay admin-only permanently, not just during the TTL drain.

## Testing

- Red-first in both languages, roughly 30 new Python tests across six files
- **Serialization compatibility proven by a hypothesis property test**: an absent organisation yields byte-identical items across arbitrary findings, so existing rows and comparisons elsewhere are unaffected
- Review independently enumerated all eight write sites, confirmed no stamped value is client-supplied, and verified end-to-end readability through slice 1's reader
- A pinning test asserts the eval-drift writer emits no organisation attribute, so its unstamped status is deliberate rather than drift
- From `backend`/: tsc 0, lint 0, full jest 7702; pytest 897 across governance, workerwrapper and supervisor

## Next

Slice 3 adds the index and the caller-org query, with admin-only visibility for un-stamped rows; slice 4 adds the module's missing dispatch guard and settles whether `getGovernanceMode` is public or admin-only.