### PR TITLE
fix(security): org-scope the governance findings and trace reads

### DIFF
--- a/backend/lib/arbiter-stack.ts
+++ b/backend/lib/arbiter-stack.ts
@@ -2406,6 +2406,25 @@ export class ArbiterStack extends cdk.Stack {
       projectionType: dynamodb.ProjectionType.ALL,
     });
 
+    // Governance ledger read-isolation (decisions 7b3f4fe2 / 2dd461f6,
+    // slice 3): listGovernanceFindings must Query by the caller's
+    // server-derived org rather than Scan-then-filter — a Scan's
+    // LastEvaluatedKey would leak a foreign findingId across a page
+    // boundary, and Limit-before-Filter would leak cross-org page
+    // density. `orgId` is populated on every ledger row that has one
+    // (arbiter/governance/ledger.py); the two permanently-unstamped
+    // write sites (eval-drift writer, supervisor path) simply omit the
+    // attribute, so they never appear in this index — those rows stay
+    // admin-only via the Scan path (getGovernanceMode-adjacent handlers
+    // are unaffected). Sort key mirrors workflow-index's `timestamp` so
+    // recency ordering/pagination behaves identically to the existing GSI.
+    governanceLedgerTable.addGlobalSecondaryIndex({
+      indexName: "org-index",
+      partitionKey: { name: "orgId", type: dynamodb.AttributeType.STRING },
+      sortKey: { name: "timestamp", type: dynamodb.AttributeType.NUMBER },
+      projectionType: dynamodb.ProjectionType.ALL,
+    });
+
     // ============================================================
     // wire governance seed into SeedAgentConfigFunction
     // ============================================================

--- a/backend/src/lambda/__tests__/governance-ui-resolver.test.ts
+++ b/backend/src/lambda/__tests__/governance-ui-resolver.test.ts
@@ -109,7 +109,7 @@ jest.mock("../../services/registry-service", () => {
   };
 });
 
-import { isAdminFromEvent } from "../../utils/auth-event";
+import { isAdminFromEvent, extractOrgFromEvent } from "../../utils/auth-event";
 import {
   getGovernanceEnforce,
   getGovernanceEffectiveAt,
@@ -150,6 +150,9 @@ const stsMock = mockClient(STSClient);
 const isAdminFromEventMock = isAdminFromEvent as jest.MockedFunction<
   typeof isAdminFromEvent
 >;
+const extractOrgFromEventMock = extractOrgFromEvent as jest.MockedFunction<
+  typeof extractOrgFromEvent
+>;
 const getGovernanceEnforceMock = getGovernanceEnforce as jest.MockedFunction<
   typeof getGovernanceEnforce
 >;
@@ -166,6 +169,7 @@ beforeEach(() => {
   iamMock.reset();
   stsMock.reset();
   isAdminFromEventMock.mockReset();
+  extractOrgFromEventMock.mockReset();
   getGovernanceEnforceMock.mockReset();
   getGovernanceEffectiveAtMock.mockReset();
   getResourceMock.mockReset();
@@ -419,21 +423,83 @@ describe("getGovernanceMode", () => {
 // ---------------------------------------------------------------------------
 
 describe("listGovernanceFindings", () => {
-  test("default Scan returns items + null cursor when no LastEvaluatedKey", async () => {
-    ddbMock.on(ScanCommand).resolves({
-      Items: [makeDdbRow({ findingId: "f1" }), makeDdbRow({ findingId: "f2" })],
+  test("non-admin caller: Queries org-index by server-derived orgId, never Scans", async () => {
+    isAdminFromEventMock.mockReturnValue(false);
+    extractOrgFromEventMock.mockResolvedValue("org-a");
+    ddbMock.on(QueryCommand).resolves({
+      Items: [makeDdbRow({ findingId: "f1", orgId: "org-a" })],
     });
 
     const result = (await handler(
       makeEvent({ fieldName: "listGovernanceFindings", args: {} }),
     )) as { items: { findingId: string }[]; nextCursor: string | null };
 
-    expect(result.items).toHaveLength(2);
-    expect(result.items[0].findingId).toBe("f1");
+    expect(result.items).toHaveLength(1);
+    expect(ddbMock.commandCalls(ScanCommand)).toHaveLength(0);
+    const queryCalls = ddbMock.commandCalls(QueryCommand);
+    expect(queryCalls).toHaveLength(1);
+    const input = queryCalls[0].args[0].input;
+    expect(input.IndexName).toBe("org-index");
+    expect(input.KeyConditionExpression).toBe("orgId = :orgId");
+    expect(input.ExpressionAttributeValues).toMatchObject({
+      ":orgId": "org-a",
+    });
+  });
+
+  test("non-admin caller: client-supplied orgId-like args are ignored — org comes from the server", async () => {
+    isAdminFromEventMock.mockReturnValue(false);
+    extractOrgFromEventMock.mockResolvedValue("org-a");
+    ddbMock.on(QueryCommand).resolves({ Items: [] });
+
+    await handler(
+      makeEvent({
+        fieldName: "listGovernanceFindings",
+        // @ts-expect-error — args do not declare orgId; verifying it can't be smuggled in.
+        args: { orgId: "org-b" },
+      }),
+    );
+
+    const input = ddbMock.commandCalls(QueryCommand)[0].args[0].input;
+    expect(input.ExpressionAttributeValues).toMatchObject({
+      ":orgId": "org-a",
+    });
+  });
+
+  test("non-admin caller with no resolvable org: returns empty page, does not Scan or Query without a key", async () => {
+    isAdminFromEventMock.mockReturnValue(false);
+    extractOrgFromEventMock.mockResolvedValue(null);
+
+    const result = (await handler(
+      makeEvent({ fieldName: "listGovernanceFindings", args: {} }),
+    )) as { items: unknown[]; nextCursor: string | null };
+
+    expect(result.items).toHaveLength(0);
+    expect(result.nextCursor).toBeNull();
+    expect(ddbMock.commandCalls(ScanCommand)).toHaveLength(0);
+    expect(ddbMock.commandCalls(QueryCommand)).toHaveLength(0);
+  });
+
+  test("admin caller: still uses Scan (cross-org visibility retained), sees un-stamped rows", async () => {
+    isAdminFromEventMock.mockReturnValue(true);
+    ddbMock.on(ScanCommand).resolves({
+      Items: [
+        makeDdbRow({ findingId: "f1", orgId: "org-a" }),
+        makeDdbRow({ findingId: "f2", orgId: "org-b" }),
+        makeDdbRow({ findingId: "f3" }), // un-stamped
+      ],
+    });
+
+    const result = (await handler(
+      makeEvent({ fieldName: "listGovernanceFindings", args: {} }),
+    )) as { items: { findingId: string }[]; nextCursor: string | null };
+
+    expect(result.items).toHaveLength(3);
+    expect(ddbMock.commandCalls(QueryCommand)).toHaveLength(0);
     expect(result.nextCursor).toBeNull();
   });
 
-  test("default Scan returns base64 cursor when LastEvaluatedKey present", async () => {
+  test("admin default Scan returns base64 cursor when LastEvaluatedKey present", async () => {
+    isAdminFromEventMock.mockReturnValue(true);
     const lastKey = { findingId: "f-last" };
     ddbMock.on(ScanCommand).resolves({
       Items: [makeDdbRow({ findingId: "f1" })],
@@ -451,8 +517,40 @@ describe("listGovernanceFindings", () => {
     expect(decoded).toEqual(lastKey);
   });
 
-  test("workflowId path uses QueryCommand against workflow-index GSI", async () => {
-    ddbMock.on(QueryCommand).resolves({ Items: [makeDdbRow()] });
+  test("non-admin cursor never carries a foreign findingId across pages: LastEvaluatedKey is scoped to the org-index key shape", async () => {
+    isAdminFromEventMock.mockReturnValue(false);
+    extractOrgFromEventMock.mockResolvedValue("org-a");
+    const lastKey = {
+      orgId: "org-a",
+      timestamp: 1700000001,
+      findingId: "f-last-a",
+    };
+    ddbMock.on(QueryCommand).resolves({
+      Items: [makeDdbRow({ findingId: "f1", orgId: "org-a" })],
+      LastEvaluatedKey: lastKey,
+    });
+
+    const result = (await handler(
+      makeEvent({ fieldName: "listGovernanceFindings", args: {} }),
+    )) as { nextCursor: string | null };
+
+    const decoded = JSON.parse(
+      Buffer.from(result.nextCursor as string, "base64").toString("utf8"),
+    );
+    // The returned cursor's key is exactly the org-scoped LastEvaluatedKey —
+    // it cannot be replayed against a different org's partition because
+    // orgId is baked into the key itself, and the resolver always re-derives
+    // orgId server-side on the next page rather than trusting the cursor.
+    expect(decoded).toEqual(lastKey);
+    expect(decoded.orgId).toBe("org-a");
+  });
+
+  test("workflowId path still uses QueryCommand against workflow-index GSI (unchanged) and is org-checked post-fetch for non-admins", async () => {
+    isAdminFromEventMock.mockReturnValue(false);
+    extractOrgFromEventMock.mockResolvedValue("org-a");
+    ddbMock.on(QueryCommand).resolves({
+      Items: [makeDdbRow({ orgId: "org-a" })],
+    });
 
     await handler(
       makeEvent({
@@ -467,11 +565,33 @@ describe("listGovernanceFindings", () => {
     expect(input.IndexName).toBe("workflow-index");
     expect(input.KeyConditionExpression).toBe("workflowId = :wid");
     expect(input.ExpressionAttributeValues).toMatchObject({ ":wid": "wf-42" });
-    // Scan should NOT have been used.
     expect(ddbMock.commandCalls(ScanCommand)).toHaveLength(0);
   });
 
+  test("workflowId path filters out foreign-org rows for non-admin callers", async () => {
+    isAdminFromEventMock.mockReturnValue(false);
+    extractOrgFromEventMock.mockResolvedValue("org-a");
+    ddbMock.on(QueryCommand).resolves({
+      Items: [
+        makeDdbRow({ findingId: "f1", orgId: "org-a" }),
+        makeDdbRow({ findingId: "f2", orgId: "org-b" }),
+        makeDdbRow({ findingId: "f3" }), // un-stamped, admin-only
+      ],
+    });
+
+    const result = (await handler(
+      makeEvent({
+        fieldName: "listGovernanceFindings",
+        args: { workflowId: "wf-42" },
+      }),
+    )) as { items: { findingId: string }[] };
+
+    expect(result.items).toHaveLength(1);
+    expect(result.items[0].findingId).toBe("f1");
+  });
+
   test("workflowId path adds sinceTs as SK comparator with #ts placeholder", async () => {
+    isAdminFromEventMock.mockReturnValue(true);
     ddbMock.on(QueryCommand).resolves({ Items: [] });
 
     await handler(
@@ -493,7 +613,30 @@ describe("listGovernanceFindings", () => {
     });
   });
 
-  test("decision filter applied on Scan path", async () => {
+  test("decision filter applied on org-index Query path for non-admins", async () => {
+    isAdminFromEventMock.mockReturnValue(false);
+    extractOrgFromEventMock.mockResolvedValue("org-a");
+    ddbMock.on(QueryCommand).resolves({ Items: [] });
+
+    await handler(
+      makeEvent({
+        fieldName: "listGovernanceFindings",
+        args: { decision: "deny" },
+      }),
+    );
+
+    const input = ddbMock.commandCalls(QueryCommand)[0].args[0].input;
+    expect(input.FilterExpression).toContain("#decision = :decision");
+    expect(input.ExpressionAttributeNames).toMatchObject({
+      "#decision": "decision",
+    });
+    expect(input.ExpressionAttributeValues).toMatchObject({
+      ":decision": "deny",
+    });
+  });
+
+  test("decision filter applied on admin Scan path", async () => {
+    isAdminFromEventMock.mockReturnValue(true);
     ddbMock.on(ScanCommand).resolves({ Items: [] });
 
     await handler(
@@ -513,7 +656,8 @@ describe("listGovernanceFindings", () => {
     });
   });
 
-  test("limit is clamped to 200", async () => {
+  test("limit is clamped to 200 on both admin Scan and non-admin Query paths", async () => {
+    isAdminFromEventMock.mockReturnValue(true);
     ddbMock.on(ScanCommand).resolves({ Items: [] });
 
     await handler(
@@ -524,9 +668,24 @@ describe("listGovernanceFindings", () => {
     );
 
     expect(ddbMock.commandCalls(ScanCommand)[0].args[0].input.Limit).toBe(200);
+
+    ddbMock.reset();
+    isAdminFromEventMock.mockReturnValue(false);
+    extractOrgFromEventMock.mockResolvedValue("org-a");
+    ddbMock.on(QueryCommand).resolves({ Items: [] });
+
+    await handler(
+      makeEvent({
+        fieldName: "listGovernanceFindings",
+        args: { limit: 9999 },
+      }),
+    );
+
+    expect(ddbMock.commandCalls(QueryCommand)[0].args[0].input.Limit).toBe(200);
   });
 
-  test("cursor is base64-decoded into ExclusiveStartKey", async () => {
+  test("cursor is base64-decoded into ExclusiveStartKey on the admin Scan path", async () => {
+    isAdminFromEventMock.mockReturnValue(true);
     ddbMock.on(ScanCommand).resolves({ Items: [] });
 
     const startKey = { findingId: "page-2-start" };
@@ -544,6 +703,31 @@ describe("listGovernanceFindings", () => {
     const input = ddbMock.commandCalls(ScanCommand)[0].args[0].input;
     expect(input.ExclusiveStartKey).toEqual(startKey);
   });
+
+  test("cursor is base64-decoded into ExclusiveStartKey on the non-admin org-index Query path", async () => {
+    isAdminFromEventMock.mockReturnValue(false);
+    extractOrgFromEventMock.mockResolvedValue("org-a");
+    ddbMock.on(QueryCommand).resolves({ Items: [] });
+
+    const startKey = {
+      orgId: "org-a",
+      timestamp: 1700000000,
+      findingId: "page-2-start",
+    };
+    const cursor = Buffer.from(JSON.stringify(startKey), "utf8").toString(
+      "base64",
+    );
+
+    await handler(
+      makeEvent({
+        fieldName: "listGovernanceFindings",
+        args: { cursor },
+      }),
+    );
+
+    const input = ddbMock.commandCalls(QueryCommand)[0].args[0].input;
+    expect(input.ExclusiveStartKey).toEqual(startKey);
+  });
 });
 
 // ---------------------------------------------------------------------------
@@ -552,6 +736,8 @@ describe("listGovernanceFindings", () => {
 
 describe("getGovernanceFinding", () => {
   test("returns null when DDB returns no item", async () => {
+    isAdminFromEventMock.mockReturnValue(false);
+    extractOrgFromEventMock.mockResolvedValue("org-a");
     ddbMock.on(GetCommand).resolves({});
 
     const result = await handler(
@@ -563,8 +749,10 @@ describe("getGovernanceFinding", () => {
     expect(result).toBeNull();
   });
 
-  test("returns projected item with camelCase fields", async () => {
-    ddbMock.on(GetCommand).resolves({ Item: makeDdbRow() });
+  test("returns projected item with camelCase fields for same-org caller", async () => {
+    isAdminFromEventMock.mockReturnValue(false);
+    extractOrgFromEventMock.mockResolvedValue("org-a");
+    ddbMock.on(GetCommand).resolves({ Item: makeDdbRow({ orgId: "org-a" }) });
 
     const result = (await handler(
       makeEvent({
@@ -576,6 +764,104 @@ describe("getGovernanceFinding", () => {
     expect(result.findingId).toBe("finding-1");
     expect(result.requestingAgent).toBe("agent-a");
     expect(result.targetAgent).toBe("agent-b");
+  });
+
+  test("returns null (not a throw) when row belongs to a foreign org", async () => {
+    isAdminFromEventMock.mockReturnValue(false);
+    extractOrgFromEventMock.mockResolvedValue("org-a");
+    ddbMock.on(GetCommand).resolves({ Item: makeDdbRow({ orgId: "org-b" }) });
+
+    const result = await handler(
+      makeEvent({
+        fieldName: "getGovernanceFinding",
+        args: { findingId: "finding-1" },
+      }),
+    );
+    expect(result).toBeNull();
+  });
+
+  test("returns null (not a throw) for an un-stamped row when caller is non-admin", async () => {
+    isAdminFromEventMock.mockReturnValue(false);
+    extractOrgFromEventMock.mockResolvedValue("org-a");
+    ddbMock.on(GetCommand).resolves({ Item: makeDdbRow({ orgId: undefined }) });
+
+    const result = await handler(
+      makeEvent({
+        fieldName: "getGovernanceFinding",
+        args: { findingId: "finding-1" },
+      }),
+    );
+    expect(result).toBeNull();
+  });
+
+  test("not-found and not-yours produce identical shape (null) — no existence oracle via error message", async () => {
+    isAdminFromEventMock.mockReturnValue(false);
+    extractOrgFromEventMock.mockResolvedValue("org-a");
+
+    ddbMock.on(GetCommand).resolves({});
+    const notFound = await handler(
+      makeEvent({
+        fieldName: "getGovernanceFinding",
+        args: { findingId: "missing" },
+      }),
+    );
+
+    ddbMock.reset();
+    ddbMock.on(GetCommand).resolves({ Item: makeDdbRow({ orgId: "org-b" }) });
+    const notYours = await handler(
+      makeEvent({
+        fieldName: "getGovernanceFinding",
+        args: { findingId: "finding-1" },
+      }),
+    );
+
+    expect(notFound).toBeNull();
+    expect(notYours).toBeNull();
+    expect(notFound).toEqual(notYours);
+  });
+
+  test("admin bypasses org check and sees a foreign-org row", async () => {
+    isAdminFromEventMock.mockReturnValue(true);
+    ddbMock.on(GetCommand).resolves({ Item: makeDdbRow({ orgId: "org-b" }) });
+
+    const result = (await handler(
+      makeEvent({
+        fieldName: "getGovernanceFinding",
+        args: { findingId: "finding-1" },
+      }),
+    )) as { findingId: string };
+
+    expect(result.findingId).toBe("finding-1");
+    // Admin path must not need to resolve the caller's own org.
+    expect(extractOrgFromEventMock).not.toHaveBeenCalled();
+  });
+
+  test("admin sees an un-stamped row", async () => {
+    isAdminFromEventMock.mockReturnValue(true);
+    ddbMock.on(GetCommand).resolves({ Item: makeDdbRow({ orgId: undefined }) });
+
+    const result = (await handler(
+      makeEvent({
+        fieldName: "getGovernanceFinding",
+        args: { findingId: "finding-1" },
+      }),
+    )) as { findingId: string };
+
+    expect(result.findingId).toBe("finding-1");
+  });
+
+  test("returns null (fail closed) when the row has an org but the caller org cannot be resolved", async () => {
+    isAdminFromEventMock.mockReturnValue(false);
+    extractOrgFromEventMock.mockResolvedValue(null);
+    ddbMock.on(GetCommand).resolves({ Item: makeDdbRow({ orgId: "org-a" }) });
+
+    const result = await handler(
+      makeEvent({
+        fieldName: "getGovernanceFinding",
+        args: { findingId: "finding-1" },
+      }),
+    );
+    expect(result).toBeNull();
   });
 });
 
@@ -2745,6 +3031,15 @@ describe("getRolloutReadiness verification overlay (Wave 2.B.2)", () => {
 // ---------------------------------------------------------------------------
 
 describe("getDecisionTrace", () => {
+  // Default every pre-existing pipeline-mechanics test in this block to an
+  // admin caller so the org-isolation gate (added slice 3, decisions
+  // 7b3f4fe2 / 2dd461f6) doesn't interfere with tests that assert on step
+  // derivation and are indifferent to org. The dedicated org-isolation
+  // tests below override this to `false` explicitly.
+  beforeEach(() => {
+    isAdminFromEventMock.mockReturnValue(true);
+  });
+
   function ledgerRow(
     overrides: Record<string, unknown> = {},
   ): Record<string, unknown> {
@@ -2781,6 +3076,8 @@ describe("getDecisionTrace", () => {
   }
 
   test("returns null when finding not found", async () => {
+    isAdminFromEventMock.mockReturnValue(false);
+    extractOrgFromEventMock.mockResolvedValue("org-a");
     ddbMock.on(GetCommand).resolves({});
 
     const result = await handler(
@@ -2790,6 +3087,50 @@ describe("getDecisionTrace", () => {
       }),
     );
     expect(result).toBeNull();
+  });
+
+  test("returns null (not a throw) when the finding belongs to a foreign org", async () => {
+    isAdminFromEventMock.mockReturnValue(false);
+    extractOrgFromEventMock.mockResolvedValue("org-a");
+    ddbMock.on(GetCommand).resolves({
+      Item: ledgerRow({ orgId: "org-b" }),
+    });
+
+    const result = await handler(
+      makeEvent({
+        fieldName: "getDecisionTrace",
+        args: { findingId: "finding-1" },
+      }),
+    );
+    expect(result).toBeNull();
+  });
+
+  test("returns null (not a throw) for an un-stamped finding when caller is non-admin", async () => {
+    isAdminFromEventMock.mockReturnValue(false);
+    extractOrgFromEventMock.mockResolvedValue("org-a");
+    ddbMock.on(GetCommand).resolves({ Item: ledgerRow({ orgId: undefined }) });
+
+    const result = await handler(
+      makeEvent({
+        fieldName: "getDecisionTrace",
+        args: { findingId: "finding-1" },
+      }),
+    );
+    expect(result).toBeNull();
+  });
+
+  test("admin bypasses org check and can trace a foreign-org / un-stamped finding", async () => {
+    isAdminFromEventMock.mockReturnValue(true);
+    ddbMock.on(GetCommand).resolves({ Item: ledgerRow({ orgId: undefined }) });
+
+    const result = (await handler(
+      makeEvent({
+        fieldName: "getDecisionTrace",
+        args: { findingId: "finding-1" },
+      }),
+    )) as { findingId: string };
+
+    expect(result.findingId).toBe("finding-1");
   });
 
   test("case-law match: step 1 matched, terminal=1, others skipped", async () => {

--- a/backend/src/lambda/governance-ui-resolver.ts
+++ b/backend/src/lambda/governance-ui-resolver.ts
@@ -4,10 +4,20 @@
  * AppSync resolver backing the five queries defined in
  * .kiro/specs/governance-ui/graphql-contract.md:
  *   - getGovernanceMode      (any authenticated user; fail-open per contract)
- *   - listGovernanceFindings (any authenticated user; GSI Query when workflowId is set, else Scan)
- *   - getGovernanceFinding   (any authenticated user; returns null on miss)
+ *   - listGovernanceFindings (org-isolated for non-admins: Query on
+ *                             org-index by server-derived orgId, never a
+ *                             Scan; admins Scan cross-org incl. un-stamped
+ *                             rows — decisions 7b3f4fe2 / 2dd461f6)
+ *   - getGovernanceFinding   (org-isolated for non-admins: null on a
+ *                             foreign-org/un-stamped/missing row — never
+ *                             a thrown error, which would be an existence
+ *                             oracle; admins bypass)
  *   - getReconcilerStatus    (admin only; returns zero defaults when SSM blob is absent or unparseable)
  *   - getRolloutReadiness    (admin only; 11-check readiness report)
+ *
+ * `getDecisionTrace` (Wave 3.B, below) follows the same org-isolation
+ * posture as `getGovernanceFinding` — null on a foreign-org/un-stamped
+ * row, admin bypass.
  *
  * The ledger DynamoDB table is owned by ArbiterStack (`citadel-governance-ledger-{env}`),
  * which is also where this Lambda is wired so cross-stack cycles with BackendStack
@@ -44,7 +54,7 @@ import {
   getGovernanceEnforce,
   getGovernanceEffectiveAt,
 } from "../utils/governance-flag";
-import { isAdminFromEvent } from "../utils/auth-event";
+import { isAdminFromEvent, extractOrgFromEvent } from "../utils/auth-event";
 import { emitGovernanceEvent } from "../utils/notifier-base";
 import {
   RegistryService,
@@ -440,7 +450,10 @@ async function getGovernanceMode(): Promise<{
   }
 }
 
-async function listGovernanceFindings(args: ListFindingsArgs): Promise<{
+async function listGovernanceFindings(
+  args: ListFindingsArgs,
+  event: AppSyncResolverEvent<unknown>,
+): Promise<{
   items: GovernanceFindingProjected[];
   nextCursor: string | null;
 }> {
@@ -451,11 +464,31 @@ async function listGovernanceFindings(args: ListFindingsArgs): Promise<{
 
   const limit = clampLimit(args.limit);
   const exclusiveStartKey = decodeCursor(args.cursor);
+  const isAdmin = isAdminFromEvent(event);
+
+  // Non-admin org isolation (decisions 7b3f4fe2 / 2dd461f6, slice 3).
+  // The caller's org is ALWAYS server-derived (extractOrgFromEvent) —
+  // there is no `orgId` argument on this query, so a client cannot
+  // smuggle in a different org to page through. A caller with no
+  // resolvable org gets an empty page rather than an error or a
+  // cross-org Scan.
+  let callerOrgId: string | null = null;
+  if (!isAdmin) {
+    callerOrgId = await extractOrgFromEvent(event);
+    if (!callerOrgId) {
+      return { items: [], nextCursor: null };
+    }
+  }
 
   let result: { Items?: DdbRow[]; LastEvaluatedKey?: Record<string, unknown> };
 
   if (args.workflowId) {
-    // GSI Query path — significantly cheaper than a Scan.
+    // GSI Query path — significantly cheaper than a Scan. Unchanged
+    // shape for admins; non-admins additionally get every row's org
+    // checked post-fetch below (this GSI has no org in its key, so the
+    // isolation has to happen after the page comes back — the page
+    // itself is already bounded by workflowId, so this cannot leak
+    // cross-org page density the way a bare Scan would).
     const expressionAttributeValues: Record<string, unknown> = {
       ":wid": args.workflowId,
     };
@@ -489,8 +522,19 @@ async function listGovernanceFindings(args: ListFindingsArgs): Promise<{
     });
 
     result = await dynamodb.send(cmd);
-  } else {
-    // Scan path with optional decision and sinceTs filters.
+
+    if (!isAdmin) {
+      const rows = result.Items ?? [];
+      result = {
+        ...result,
+        Items: rows.filter(
+          (row) => readLedgerAttr(row, "orgId", "org_id") === callerOrgId,
+        ),
+      };
+    }
+  } else if (isAdmin) {
+    // Admin Scan path — cross-org visibility retained by design (admin
+    // is the legitimate cross-org operator), including un-stamped rows.
     const filterClauses: string[] = [];
     const expressionAttributeNames: Record<string, string> = {};
     const expressionAttributeValues: Record<string, unknown> = {};
@@ -520,6 +564,47 @@ async function listGovernanceFindings(args: ListFindingsArgs): Promise<{
     });
 
     result = await dynamodb.send(cmd);
+  } else {
+    // Non-admin org-index Query path (decisions 7b3f4fe2 / 2dd461f6,
+    // slice 3). Deliberately NOT filter-after-Scan: a Scan's
+    // LastEvaluatedKey would leak a foreign findingId across the page
+    // boundary, and Limit-before-Filter would leak cross-org page
+    // density (the design explicitly rejected both). Un-stamped rows
+    // have no `orgId` attribute at all, so they can never appear on
+    // this index — they stay admin-only via the Scan branch above.
+    const filterClauses: string[] = [];
+    const expressionAttributeNames: Record<string, string> = {};
+    const expressionAttributeValues: Record<string, unknown> = {
+      ":orgId": callerOrgId,
+    };
+
+    if (args.decision) {
+      filterClauses.push("#decision = :decision");
+      expressionAttributeNames["#decision"] = "decision";
+      expressionAttributeValues[":decision"] = args.decision;
+    }
+    if (typeof args.sinceTs === "number") {
+      filterClauses.push("#ts >= :since");
+      expressionAttributeNames["#ts"] = "timestamp";
+      expressionAttributeValues[":since"] = args.sinceTs;
+    }
+
+    const cmd = new QueryCommand({
+      TableName: tableName,
+      IndexName: "org-index",
+      KeyConditionExpression: "orgId = :orgId",
+      ExpressionAttributeValues: expressionAttributeValues,
+      ...(Object.keys(expressionAttributeNames).length > 0
+        ? { ExpressionAttributeNames: expressionAttributeNames }
+        : {}),
+      ...(filterClauses.length > 0
+        ? { FilterExpression: filterClauses.join(" AND ") }
+        : {}),
+      Limit: limit,
+      ...(exclusiveStartKey ? { ExclusiveStartKey: exclusiveStartKey } : {}),
+    });
+
+    result = await dynamodb.send(cmd);
   }
 
   const items = (result.Items ?? []).map(projectFinding);
@@ -528,31 +613,50 @@ async function listGovernanceFindings(args: ListFindingsArgs): Promise<{
 
 async function getGovernanceFinding(
   args: GetFindingArgs,
+  event: AppSyncResolverEvent<unknown>,
 ): Promise<GovernanceFindingProjected | null> {
-  return loadFinding(args.findingId);
+  const row = await loadFindingRow(args.findingId);
+  if (!row) return null;
+  if (!(await callerCanSeeRow(row, event))) return null;
+  return projectFinding(row);
 }
 
 /**
- * Shared helper: fetch a finding from the ledger and project it to the
- * GraphQL shape. Returns null when the row is missing. Centralised so
- * both `getGovernanceFinding` and `getDecisionTrace` use the same code
- * path — identical projection behaviour, identical missing-row policy.
+ * Row-visibility gate shared by the by-id governance reads
+ * (`getGovernanceFinding`, `getDecisionTrace`). Returns a boolean rather
+ * than throwing — per decisions 7b3f4fe2 / 2dd461f6, a foreign-org or
+ * un-stamped row must degrade to the SAME "not found" (null) response a
+ * caller gets for a missing row, so a thrown error never becomes an
+ * existence oracle that lets a caller distinguish "doesn't exist" from
+ * "exists but isn't yours".
+ *
+ * Admins always see the row (cross-org + un-stamped). Non-admins need a
+ * resolvable caller org AND a matching, present `orgId` on the row —
+ * fails closed (false) when either is missing, which is exactly the
+ * un-stamped-row case (2dd461f6: legacy/un-stamped rows are admin-only,
+ * not backfilled, not visible to everyone).
  */
-async function loadFinding(
-  findingId: string,
-): Promise<GovernanceFindingProjected | null> {
-  const raw = await loadFindingRow(findingId);
-  return raw ? projectFinding(raw) : null;
+async function callerCanSeeRow(
+  row: DdbRow,
+  event: AppSyncResolverEvent<unknown>,
+): Promise<boolean> {
+  if (isAdminFromEvent(event)) return true;
+
+  const rowOrgId = readLedgerAttr(row, "orgId", "org_id");
+  if (!rowOrgId) return false;
+
+  const callerOrgId = await extractOrgFromEvent(event);
+  return callerOrgId === rowOrgId;
 }
 
 /**
- * Internal variant of `loadFinding` that returns the raw (unprojected)
- * DDB row. `getDecisionTrace` needs the row's `orgId` — present on the
- * ledger row but intentionally NOT part of the public
- * `GovernanceFindingProjected` GraphQL shape — to org-check the
- * findings->execution pivot (`findExecutionIdByRunId`). Kept private so
- * the org attribute never leaks through `getGovernanceFinding`'s public
- * projection.
+ * Fetches the raw (unprojected) ledger row by findingId. Kept separate
+ * from `projectFinding` so `getDecisionTrace` and `callerCanSeeRow` can
+ * read the row's `orgId` — present on the ledger row but intentionally
+ * NOT part of the public `GovernanceFindingProjected` GraphQL shape — to
+ * org-check the row before (or independently of) building the public
+ * projection. The org attribute never leaks through `getGovernanceFinding`'s
+ * public projection.
  */
 async function loadFindingRow(findingId: string): Promise<DdbRow | null> {
   const tableName = process.env.GOVERNANCE_LEDGER_TABLE;
@@ -577,8 +681,10 @@ async function loadFindingRow(findingId: string): Promise<DdbRow | null> {
 // Reconstructs the engine's 8-step pipeline state from a single finding's
 // reason / scope / contract fields. Pure parsing — no extra DDB or registry
 // reads beyond loading the finding itself. Mirrors getGovernanceFinding's
-// auth posture (any authenticated user; admin gating not required because
-// the engine semantics are public to admins via the ledger anyway).
+// auth posture exactly (slice 3, decisions 7b3f4fe2 / 2dd461f6): non-admins
+// get null on a foreign-org, un-stamped, or missing finding — never a
+// thrown error, since a throw would let a caller distinguish "doesn't
+// exist" from "exists but isn't yours". Admins bypass the org check.
 //
 // Reason format is owned by the backend (arbiter/governance/engine.py). When
 // an unrecognised prefix arrives, the resolver degrades gracefully: every
@@ -965,9 +1071,15 @@ async function findExecutionIdByRunId(
 
 async function getDecisionTrace(
   args: GetDecisionTraceArgs,
+  event: AppSyncResolverEvent<unknown>,
 ): Promise<DecisionTraceProjected | null> {
   const findingRow = await loadFindingRow(args.findingId);
   if (!findingRow) return null;
+  // Row-org gate (decisions 7b3f4fe2 / 2dd461f6, slice 3): returns null
+  // rather than throwing — mirrors getGovernanceFinding's posture so a
+  // foreign-org or un-stamped finding is indistinguishable from a missing
+  // one. Checked BEFORE any further parsing/derivation work below.
+  if (!(await callerCanSeeRow(findingRow, event))) return null;
   const finding = projectFinding(findingRow);
 
   const tokens = parseReasonTokens(finding.reason);
@@ -980,11 +1092,10 @@ async function getDecisionTrace(
     scopeReduction,
   );
   // orgId is unified (decision 2dd461f6, slice 1) — see readLedgerAttr's
-  // doc comment. No live row is stamped with either name yet (org
-  // filtering is slice 2), so this currently always resolves to
-  // undefined either way — the fallback exists so this call site is
-  // ALREADY capable of reading a stamped value the moment slice 2 lands,
-  // without a further code change here.
+  // doc comment. By this point `callerCanSeeRow` above has already
+  // confirmed the caller may see this finding (same org, or admin), so
+  // `findingOrgId` here is just re-read for the findings->execution pivot
+  // below — it is never used as the access-control decision itself.
   const findingOrgId = readLedgerAttr(findingRow, "orgId", "org_id");
   const linkedExecutionId = await findExecutionIdByRunId(
     finding.runId,
@@ -7046,12 +7157,17 @@ export async function handler(
     case "listGovernanceFindings":
       return listGovernanceFindings(
         (event.arguments as ListFindingsArgs | undefined) ?? {},
+        event,
       );
     case "getGovernanceFinding":
-      return getGovernanceFinding(event.arguments as unknown as GetFindingArgs);
+      return getGovernanceFinding(
+        event.arguments as unknown as GetFindingArgs,
+        event,
+      );
     case "getDecisionTrace":
       return getDecisionTrace(
         event.arguments as unknown as GetDecisionTraceArgs,
+        event,
       );
     case "getReconcilerStatus":
       return getReconcilerStatus(event);


### PR DESCRIPTION
## Summary

Slice 3 of the governance-UI isolation work, and the slice that actually closes the exposure - the previous two made it possible. `ListGovernanceFindings` enumerated findings across every organisation, and the two by-id reads returned any tenant's finding or decision trace.

- **`ListGovernanceFindings`** - new `orgId` + timestamp index; non-admins Query it with the **server-derived** caller organisation in the key condition, so foreign rows are never fetched. Admins keep cross-organisation visibility
- **`getGovernanceFinding` / `getDecisionTrace`** - a shared `callerCanSeeRow` gate returns **null** rather than throwing for a foreign, un-stamped or unresolvable-organisation row, so these reads cannot be used as existence oracles to probe which finding ids exist elsewhere
- **Un-stamped rows are admin-only**, per the ruling: absent for tenants, present for admins
- Fails closed when the caller organisation cannot be resolved - empty results, never unfiltered

## Why not filter after a scan

Filter-after-Scan was considered and rejected: the pagination cursor (`LastEvaluatedKey`) would a foreign `findingId`, and a `Limit` applied before a carry `FilterExpression` leaks page density even when the rows themselves are hidden. Constraining the key condition avoids both, and costs less.

Cursor safety was verified rather than assumed - the index key carries the organisation and organisation is re-derived server-side on every page, so a cursor cannot be replayed against another tenant.

## Two populations are admin-only, not one

Legacy rows will age out via the ledger's 90-day TTL. But the two write sites identified in slice 2-the eval-drift writer and the supervisor path - can never be stamped truthfully, so they remain admin-visible **permanently**. That preserves the audit trail for the platform operator instead of making governance history disappear.

## Testing

- Findings seeded in two organisations plus an un-stamped row: a non-admin sees only their own, never the un-stamped one; an admin sees all three
- By-id reads for foreign and un-stamped rows return null, with a response shape indistinguishable from a genuine not-found
- Cursor-replay attempted against another organisation and blocked by the key structure
- Fail-closed path proven by mutation; bite proof on the organisation condition, restored byte-identically
- Admin aggregates (heatmap, revoke-impact, retrospective, rule-stats) unchanged by diff - admin is the legitimate cross-organisation operator
- tsc, lint 0; targeted 24; full backend jest 7718; nag-enabled synth clean; all seven "split:gates" rails pass with **no new IAM statement** - the table's existing index-wildcard Query grant already covers the new GSI

## Notes

`getGovernanceMode` is deliberately untouched: whether the governance-mode badge should be public or admin-only is an owner decision, not one to make inside a security fix. Slice 4 adds the module's missing dispatch guard and settles it.