### PR TITLE
ci: enforce split:gates on pull requests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -151,6 +151,75 @@ jobs:
           path: backend/cdk.out/
           retention-days: 1
 
+  # ── Split gates: 7-rail IAM/policy safety gate for the backend-stack split ──
+  # split:gates (backend/scripts/split-gates.sh) runs its OWN internal `cdk
+  # synth` per stack (backend + 2 satellites) and a second nag-enabled synth
+  # for rail 5 — it cannot reuse Backend Build + Synth's cdk.out artifact.
+  # That artifact is synthesized with ENVIRONMENT=test, but split-gates.sh's
+  # own --env arg (default "dev", used here) only controls the *stack-name
+  # suffix* it looks up, independently of ENVIRONMENT; run-rails.ts's
+  # move-manifest.ts hardcodes its satellite stack names/MOVED_RESOLVERS
+  # mapping to the "-dev" suffix, so invoking with --env test breaks the
+  # backend<->satellite resolver/IAM join (62/22/62 false-positive
+  # violations, verified) even though it is not real drift. dev-env synth
+  # with ENVIRONMENT unset is therefore the only currently-correct
+  # invocation, which is a genuinely separate synth from Backend Build +
+  # Synth's test-env one — a new job, not a fold-in, despite the general
+  # preference to avoid a duplicate synth.
+  split-gates:
+    name: Split Gates (IAM/policy)
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: backend
+    steps:
+      - uses: actions/checkout@v5
+
+      - uses: actions/setup-node@v5
+        with:
+          node-version: ${{ env.NODE_VERSION }}
+          cache: npm
+          cache-dependency-path: package-lock.json
+
+      - name: Install workspaces (root lockfile)
+        run: npm ci
+        working-directory: ${{ github.workspace }}
+
+      - name: Build Lambda bundles
+        run: npm run build:lambda
+
+      - name: Build CDK
+        run: npm run build
+
+      - uses: actions/setup-node@v5
+        with:
+          node-version: ${{ env.NODE_VERSION }}
+          cache: npm
+          cache-dependency-path: frontend/package-lock.json
+
+      - name: Install frontend deps (required for FrontendStack CDK asset)
+        run: npm ci --prefix frontend
+        working-directory: ${{ github.workspace }}
+
+      - name: Build frontend (required for FrontendStack CDK asset)
+        run: npm run build --prefix frontend
+        working-directory: ${{ github.workspace }}
+
+      - name: Run split:gates (7 rails; dist must be rebuilt before synth)
+        run: npm run split:gates -- dev
+        env:
+          # CI=true is required: the gate helpers' guardCdkOutInCi fails
+          # loud under CI=true when an expected cdk.out template is
+          # missing, and silently SKIPs (vacuous pass) when unset — this
+          # job's own split-gates.sh synth always produces cdk.out itself,
+          # but CI=true is still set so any future refactor that removes
+          # that internal synth call fails loud here instead of passing
+          # vacuously. nag stays enabled (bin/app.ts default; no -c
+          # nag=false context passed).
+          CI: "true"
+          CDK_DEFAULT_ACCOUNT: "000000000000"
+          CDK_DEFAULT_REGION: us-east-1
+
   # ── Governance: backend resolver tests + governance stack synth ──
   # Frontend governance-engine tests run in the Frontend job; arbiter
   # governance tests run in the Arbiter job. This job covers the backend

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -187,9 +187,9 @@ jobs:
 
       - name: Build Lambda bundles
         run: npm run build:lambda
-
-      - name: Build CDK
-        run: npm run build
+        # (kept: esbuild output for Lambda `Code.fromAsset` — split-gates.sh's
+        # internal `npm run build` only recompiles dist/bin,dist/lib via tsc,
+        # it never runs build:lambda)
 
       - uses: actions/setup-node@v5
         with:
@@ -204,7 +204,16 @@ jobs:
       - name: Build frontend (required for FrontendStack CDK asset)
         run: npm run build --prefix frontend
         working-directory: ${{ github.workspace }}
+        # (kept: bin/app.ts instantiates FrontendStack unconditionally, and
+        # its BucketDeployment asset reads frontend/build directly off disk —
+        # this is independent of and not covered by split-gates.sh's own
+        # dist rebuild, which only touches backend TS compilation)
 
+      # "Build CDK" (`npm run build` / tsc) step REMOVED here: split-gates.sh
+      # now rebuilds dist/ itself before every synth (PR 155, finding
+      # ef02d366) and aborts loud on a failed rebuild, so a prior tsc pass in
+      # this job is genuinely redundant — the script's own guard is what
+      # actually gates staleness now, not this job step.
       - name: Run split:gates (7 rails; dist must be rebuilt before synth)
         run: npm run split:gates -- dev
         env:
@@ -218,7 +227,30 @@ jobs:
           # nag=false context passed).
           CI: "true"
           CDK_DEFAULT_ACCOUNT: "000000000000"
-          CDK_DEFAULT_REGION: us-east-1
+          # us-west-2: must match backend/split-baseline/*.json's captured
+          # region so rail 6's comparison is valid — run-rails.ts now aborts
+          # before any rail (configuration error, not IAM drift) if the
+          # synthesized region differs from the baseline's (PR 156).
+          #
+          # BOTH CDK_DEFAULT_REGION and AWS_REGION/AWS_DEFAULT_REGION must be
+          # set: the aws-cdk CLI resolves its own "default env" for the app
+          # subprocess via the AWS SDK's credential/region provider chain and
+          # OVERWRITES CDK_DEFAULT_REGION in that subprocess's environment
+          # with whatever it resolves — it does not simply pass through a
+          # pre-set value. With no credentials and no IMDS (true on a
+          # GitHub-hosted runner) the SDK's region resolution falls back to
+          # AWS_REGION/AWS_DEFAULT_REGION if present, else a hardcoded
+          # "us-east-1" — silently discarding a CDK_DEFAULT_REGION-only
+          # setting (verified empirically: CDK_DEFAULT_REGION alone measured
+          # us-east-1 in the actual app process regardless of what this job
+          # set it to, while CDK_DEFAULT_ACCOUNT was NOT overwritten the same
+          # way, so this is specifically a region quirk, not a general
+          # env-passthrough issue). Setting the SDK-native vars too makes the
+          # resolution deterministic and account-for-account with the
+          # baseline instead of silently synthesizing us-east-1.
+          CDK_DEFAULT_REGION: us-west-2
+          AWS_REGION: us-west-2
+          AWS_DEFAULT_REGION: us-west-2
 
   # ── Governance: backend resolver tests + governance stack synth ──
   # Frontend governance-engine tests run in the Frontend job; arbiter


### PR DESCRIPTION
## Summary

`split:gates` is a seven-rail IAM/policy gate that was never wired into CI, so a PR adding IAM permissions could merge without the action-specific rail-6 allowlist entry it requires. This makes it blocking on every PR: `pull_request` trigger, no path filter that would skip IAM-only changes, no `continue-on-error`.

Runs credential-less in ~44 seconds, with **no AWS account ID in the workflow**.

## The false start, and what it cost

The first version of this job reported **26 rail-6 violations** that looked exactly like real IAM drift. They were an artefact: CI synthesizes credential-less with a placeholder account, while the baseline was account-coupled, so every account-scoped ARN read as uncovered. Three follow-up PRs made the gate trustworthy before this one could land:

- **#155** - rails could pass on stale `dist` or an incomplete satellite side; they now rebuild and fail loud
- **#156** - the real account id is sanitized out and rail 6 normalizes the account on both sides
- **#156** - a region mismatch now aborts with a *configuration error* naming both regions, instead of masquerading as a violation list

## The non-obvious part

Setting `CDK_DEFAULT_REGION` alone does nothing: the CDK CLI overwrites it for the app subprocess via its own SDK resolution and falls back to `us-east-1` when credential-less. `AWS_REGION` and `AWS_DEFAULT_REGION` are respected first, so all three are set to `us-west-2` - the region read from the baselines, not assumed.

## Steps

Removed the now-redundant CDK build step, since `split-gates.sh` rebuilds `dist` itself and aborts loudly on failure. Kept the Lambda esbuild bundle and the frontend build: `bin/app.ts` instantiates `FrontendStack` unconditionally and its asset needs the build output.

## Proofs, all executed credential-less

1. Exact job command sequence → rail 6 passes, 0 violations
2. Wrong region → aborts with `region mismatch ... configuration error, not IAM drift`, naming both regions
3. **A throwaway `S3:GetBucketAcl` grant on `ProjectResolverFunction` → rail 6 fails naming the resource and action**, restored byte-identically. This was the one that mattered: account normalization could have blunted detection, and did not 
 
No baseline, threshold or allowlist changed; no rail skipped or made optional.

## Testing

YAML valid, tsc 0, lint 0, full backend jest 507/508 suites and 7803/7810 tests (7 pre-existing skips from missing-synth-template guards).