### PR TITLE
fix(security): remove unused IAM role-management grant

### DIFF
--- a/backend/lib/registry-stack.ts
+++ b/backend/lib/registry-stack.ts
@@ -955,22 +955,6 @@ export class RegistryStack extends cdk.Stack {
     registryAgentRecordResolverFunction.addToRolePolicy(
       new iam.PolicyStatement({
         effect: iam.Effect.ALLOW,
-        actions: [
-          "iam:CreateRole",
-          "iam:DeleteRole",
-          "iam:PutRolePolicy",
-          "iam:DeleteRolePolicy",
-          "iam:GetRole",
-          "iam:PassRole",
-          "iam:TagRole",
-          "iam:UntagRole",
-        ],
-        resources: [`arn:aws:iam::${this.account}:role/citadel-agent-*`],
-      }),
-    );
-    registryAgentRecordResolverFunction.addToRolePolicy(
-      new iam.PolicyStatement({
-        effect: iam.Effect.ALLOW,
         actions: ["sts:GetCallerIdentity"],
         resources: ["*"],
       }),

--- a/backend/test/registry-stack.test.ts
+++ b/backend/test/registry-stack.test.ts
@@ -354,10 +354,45 @@ describe("RegistryStack — backend-stack-split phase 2", () => {
 
   test("no other moved Lambda has functionName pinning (auto-named, invoked via in-stack grantInvoke)", () => {
     const fns = template.findResources("AWS::Lambda::Function");
-    for (const [logicalId, fn] of Object.entries(fns)) {
+    for (const [_logicalId, fn] of Object.entries(fns)) {
       const handler = (fn as any).Properties?.Handler;
       if (handler === "registry-agent-record-resolver.handler") continue;
       expect((fn as any).Properties?.FunctionName).toBeUndefined();
+    }
+  });
+
+  test("registry-agent-record-resolver's role has NO iam:CreateRole, iam:PutRolePolicy, or iam:PassRole statement (finding 7d7da47a: unused agent-role-provisioning grant removed)", () => {
+    const fns = template.findResources("AWS::Lambda::Function", {
+      Properties: Match.objectLike({
+        Handler: "registry-agent-record-resolver.handler",
+      }),
+    });
+    const fnIds = Object.keys(fns);
+    expect(fnIds.length).toBe(1);
+    const roleRef = JSON.stringify(
+      (fns[fnIds[0]] as any).Properties.Role,
+    );
+    const roleLogicalIdMatch = roleRef.match(
+      /([A-Za-z0-9]+ServiceRole[A-Za-z0-9]+)/,
+    );
+    expect(roleLogicalIdMatch).not.toBeNull();
+    const roleLogicalId = roleLogicalIdMatch![1];
+
+    const policies = template.findResources("AWS::IAM::Policy");
+    const forbidden = ["iam:CreateRole", "iam:PutRolePolicy", "iam:PassRole"];
+    for (const policy of Object.values(policies)) {
+      const rolesRef = JSON.stringify((policy as any).Properties?.Roles);
+      if (!rolesRef.includes(roleLogicalId)) continue;
+      const statements = (policy as any).Properties?.PolicyDocument?.Statement;
+      if (!Array.isArray(statements)) continue;
+      for (const stmt of statements) {
+        const actions = Array.isArray(stmt.Action)
+          ? stmt.Action
+          : [stmt.Action];
+        for (const forbiddenAction of forbidden) {
+          expect(actions).not.toContain(forbiddenAction);
+        }
+      }
     }
   });
 


### PR DESCRIPTION
## Summary

`RegistryAgentRecordResolverFunction`'s execution role granted `iam:CreateRole`, `DeleteRole`, `PutRolePolicy`, `DeleteRolePolicy`, `PassRole`, `TagRole`, `role/citadel-agent-*`, and `UntagRole` on with **no condition on `PpassRole`**. Nothing on the resolver's call path uses IAM, so this was an unused privilege-escalation primitive: `CreateRole` + `PutRolePolicy` + unconditioned `PassRole` lets whoever influences the function mint a role with a policy of its choosing and pass it onward. The `citadel-agent-*` prefix bounds the blast radius but does not remove the primitive.

Pre-existing over-privilege, live in deployed dev - **not** drift.

## The unused claim was verified twice before deleting anything

Both the implementer and the reviewer independently walked the resolver's transitive import closure (24 files, down to leaf modules) searching for `@aws-sdk/client-iam`, `IAMCLient`, `CreateRoleCommand`, `PutRolePolicyCommand`, `PassRole`, dynamic imports, and any `AccessDenied`-tolerant `catch` that would imply a runtime dependency. Zero hits.

Real agent-role provisioning lives in `policy-manager.ts` (which holds the actual `CreateRole` / `PutRolePolicy` calls) behind `agent-credential-vender.ts` - a separate Lambda with a separate role in the arbiter stack. The capability was never being exercised from this role.

## Blast radius of the change

Synthesized template diff: exactly one policy resource changed, this function's default policy going from 10 statements to 9, the flagged grant removed, nothing added, and **no other function's policy altered**. A pinning test asserts the synthesized role contains no `*iam:CreateRole`, `PutRolePolicy` or `PassRole` proven to fail on reintroduction and restored byte-identically.

No allowlist entry, no baseline change.

If the analysis were wrong the symptom would be `AccessDenied` in the resolver's Cloudwatch logs - ruled out by the transitive scan, but worth stating rather than asserting safety.

## Testing

tsc 0, lint 0, full backend jest 7798, nag-enabled synth 0, `cdk synth --all` 0.