### PR TITLE
fix(ci): stop split:gates rails passing on stale input

### DIFF
--- a/backend/scripts/__tests__/split-gates-rail6.test.ts
+++ b/backend/scripts/__tests__/split-gates-rail6.test.ts
@@ -220,4 +220,76 @@ describe("rail 6 — IAM privilege-equivalence (negative: doctored broadened sta
       result.violations.some((v) => v.logicalId === "MissingBaselineFn"),
     ).toBe(true);
   });
+
+  // Regression test for finding ef02d366: a manifest entry whose
+  // satelliteLogicalId is absent from the satellite-derived
+  // lambdaRolePolicies map (e.g. because the satellite template was
+  // synthesized stale, or the moved Lambda's construct ID drifted) must
+  // FAIL LOUD naming the missing entry — it must NEVER be treated as "zero
+  // statements, therefore trivially covered" and pass. This simulates
+  // removing one manifest entry's logical ID from a fixture template: the
+  // satelliteLambdaPolicies map here plays the role of "what was actually
+  // found by parsing the satellite templates", and
+  // AgentImportResolverFnSat is simply never populated in it — as if its
+  // template were stale/missing the moved Lambda.
+  it("FAILS LOUD when a manifest entry's satellite logical ID is entirely absent from the satellite templates (finding ef02d366 regression)", () => {
+    const baseline = makeBaseline({
+      AgentImportResolverFn: [
+        stmt(
+          ["secretsmanager:GetSecretValue"],
+          ["arn:aws:secretsmanager:*:*:secret:citadel/agent-import/*"],
+        ),
+      ],
+      RegistryAgentRecordResolverFn: [
+        stmt(
+          ["dynamodb:GetItem"],
+          ["arn:aws:dynamodb:*:*:table/citadel-apps-dev"],
+        ),
+      ],
+    });
+    // Only RegistryAgentRecordResolverFnSat was found in the (fixture)
+    // satellite templates — AgentImportResolverFnSat is completely absent,
+    // simulating a manifest entry that got "lost" (e.g. stale dist/synth or
+    // a construct-ID drift), NOT a Lambda with zero IAM statements.
+    const satelliteLambdaPolicies: Record<string, NormalizedPolicyStatement[]> =
+      {
+        RegistryAgentRecordResolverFnSat: [
+          stmt(
+            ["dynamodb:GetItem"],
+            ["arn:aws:dynamodb:*:*:table/citadel-apps-dev"],
+          ),
+        ],
+      };
+    const result = runIamEquivalence(baseline, satelliteLambdaPolicies, [
+      {
+        baselineLogicalId: "AgentImportResolverFn",
+        satelliteLogicalId: "AgentImportResolverFnSat",
+        satelliteStackName: "citadel-registry-dev",
+      },
+      {
+        baselineLogicalId: "RegistryAgentRecordResolverFn",
+        satelliteLogicalId: "RegistryAgentRecordResolverFnSat",
+        satelliteStackName: "citadel-registry-dev",
+      },
+    ]);
+    expect(result.passed).toBe(false);
+    // Names the missing entry explicitly rather than silently contributing
+    // zero violations for it.
+    expect(
+      result.violations.some(
+        (v) =>
+          v.logicalId === "AgentImportResolverFnSat" &&
+          /NOT FOUND/.test(v.message) &&
+          /AgentImportResolverFn/.test(v.message),
+      ),
+    ).toBe(true);
+    // The found entry must still pass on its own merits — this proves the
+    // fix doesn't just fail everything, it correctly isolates the missing
+    // entry.
+    expect(
+      result.violations.some(
+        (v) => v.logicalId === "RegistryAgentRecordResolverFnSat",
+      ),
+    ).toBe(false);
+  });
 });

--- a/backend/scripts/split-gates.sh
+++ b/backend/scripts/split-gates.sh
@@ -36,6 +36,27 @@ cd "${BACKEND_DIR}"
 
 OVERALL_STATUS=0
 
+# --- Stale-dist guard (finding ef02d366) -----------------------------------
+# cdk.json runs the COMPILED app (`node dist/bin/app.js`), never the
+# TypeScript sources directly. If `dist/` is stale relative to `lib/`/`bin/`,
+# `cdk synth` happily synthesizes from the OLD compiled JS — producing
+# templates that are missing whatever logical IDs the newer source would
+# have produced (observed: dist/lib/registry-stack.js older than
+# lib/registry-stack.ts caused cdk.out to hide real IAM statements from
+# rail 6). A gate that synthesizes without ever rebuilding cannot be
+# trusted. We choose REBUILD-then-abort-on-failure over abort-only: a plain
+# staleness abort would make every local run of this script fail the first
+# time (dist is essentially always at least a few seconds older than the
+# sources you just edited), forcing a manual `npm run build` before every
+# invocation — friendlier to rebuild automatically. The honesty property is
+# preserved because we still abort, loudly, if that rebuild itself fails;
+# we never fall through to synthesizing from an old or partially-written
+# dist.
+log "=== split-gates: rebuilding dist/ before synth ==="
+if ! npm run build; then
+  die "npm run build failed — refusing to synth from a stale or partially-rebuilt dist/. The gate cannot be trusted on stale compiled output (finding ef02d366)."
+fi
+
 log "=== split-gates: synthesizing ${STACK_NAME} ==="
 if ! npx cdk synth "${STACK_NAME}" --quiet >/dev/null; then
   die "cdk synth failed for ${STACK_NAME}"

--- a/backend/scripts/split-gates/rails/rail6-iam-equivalence.ts
+++ b/backend/scripts/split-gates/rails/rail6-iam-equivalence.ts
@@ -74,8 +74,28 @@ export function runIamEquivalence(
       });
       continue;
     }
+    // Manifest-completeness guard (finding ef02d366): a manifest entry
+    // whose satelliteLogicalId is simply ABSENT from
+    // satelliteLambdaPolicies must FAIL LOUD, never be treated as "zero
+    // statements, therefore trivially covered". An absent entry means the
+    // satellite template didn't contain the moved Lambda's role at all —
+    // most likely because it was synthesized from a stale dist/cdk.out, or
+    // because the move never actually happened — and either way the rail
+    // must say so instead of silently passing.
+    if (!(mapping.satelliteLogicalId in satelliteLambdaPolicies)) {
+      violations.push({
+        rail: "rail6",
+        logicalId: mapping.satelliteLogicalId,
+        message:
+          `Satellite Lambda "${mapping.satelliteLogicalId}" (moved from baseline "${mapping.baselineLogicalId}") ` +
+          `was NOT FOUND in the synthesized ${mapping.satelliteStackName} template. This manifest entry could not ` +
+          `be located — the rail cannot verify IAM equivalence and treats this as a failure, not a pass. ` +
+          `Check for a stale synth/dist or a manifest logical-ID mismatch.`,
+      });
+      continue;
+    }
     const satelliteStatements =
-      satelliteLambdaPolicies[mapping.satelliteLogicalId] ?? [];
+      satelliteLambdaPolicies[mapping.satelliteLogicalId];
     // CIT-125 slice A: a moved consumer's new sqs:SendMessage grant on its
     // stack's shared async DLQ is a deliberate, justified broadening —
     // covered here per satellite logical ID (move-manifest.ts's

--- a/backend/scripts/split-gates/run-rails.ts
+++ b/backend/scripts/split-gates/run-rails.ts
@@ -19,6 +19,7 @@ import * as fs from "fs";
 import * as path from "path";
 import { loadTemplate } from "./template-utils";
 import { buildBaseline } from "./baseline-builder";
+import { guardCdkOutInCi } from "../../test/helpers/cdk-out-guard";
 import { runRemovalsOnlyDiff } from "./rails/rail1-removals-only";
 import {
   runResolverParity,
@@ -147,12 +148,25 @@ function main(): void {
   );
 
   const satelliteTemplates: NamedTemplate[] = SATELLITE_STACK_NAMES.map(
-    (name) => ({
-      stackName: name,
-      template: loadTemplate(
-        path.join(backendDir, cdkOutDir, `${name}.template.json`),
-      ),
-    }),
+    (name) => {
+      const templatePath = path.join(
+        backendDir,
+        cdkOutDir,
+        `${name}.template.json`,
+      );
+      // guardCdkOutInCi throws under CI=true instead of letting a missing
+      // satellite template surface only as an opaque loadTemplate ENOENT
+      // (or, worse, silently letting rails 3/6/7 treat the whole satellite
+      // as if it moved nothing — finding ef02d366's rail 6 vacuous-pass
+      // shape). run-rails.ts previously never called this guard at all.
+      if (!fs.existsSync(templatePath)) {
+        guardCdkOutInCi(
+          `${name}.template.json (satellite stack for run-rails.ts rails 3/6/7)`,
+          `npx cdk synth ${stackName} ${SATELLITE_STACK_NAMES.join(" ")}`,
+        );
+      }
+      return { stackName: name, template: loadTemplate(templatePath) };
+    },
   );
   const rail3 = runResolverParity(
     baseline,


### PR DESCRIPTION
## Summary

Rails 3, 6 and 7 could report green while checking **nothing**. Two compounding causes:

1. `split-gates.sh` synthesizes but never rebuilds `dist`, while `cdk.json` runs the *compiled* app (`node dist/bin/app.js`). A stale `dist` produces templates missing the moved logical IDs. Observed directly: "dist/lib/registry-stack.js* was compiled four minutes *before* its source, and the `cdk.out` templates were synthesized from that stale output - so the branch's IAM statements were invisible locally.
2. Rail 6 iterates "MOVED_LAMBDA_ROLES" and reads "satelliteLambdaPolicies[logicalld] ?? [I*, so an absent satellite entry contributes **zero statements and passes**. A wholly missing template file throws via LoadTemplate', but a present-but-stale one passes silently. Nothing asserted that all 21 manifest entries were found, and "run-rails.ts' never called the `guardCdkOutInCi` fail-loud helper at all.

## Changes

- `split-gates.sh` rebuilds `dist` before synth and aborts if that build fails
- Rail 6 asserts satellite manifest completeness: any `MOVED_LAMBDA_ROLES` entry absent from the satellite templates **fails loud naming it** instead of contributing nothing
- 'run-rails.ts' routes satellite template loads through `guardCdkOutInCi`
- Rails 3 and 7 were checked and do not share the `MOVED_LAMBDA_ROLES` shape, so only rail 6 needed the guard

## Regression test

Removing one entry's satellite logical ID makes rail 6 fail *naming that entry*, while a second, present entry still passes on its own merits - proving the guard isolates rather than blanket-fails. Without this test the asymmetry could silently return.

## Why this mattered more than it looks

Every local gate run that skipped a rebuild had been giving false assurance, including the run behind a recent "all seven rails pass on main" claim. Fixing this is what made it possible to diagnose the 26 rail-6 violations that appeared when the gate first ran in real CI - and that diagnosis showed they were an artefact of a credential-less placeholder-account synth against an account-coupled baseline, **not** IAM drift. No baseline, threshold or allowlist was touched here, and none of those 26 statements was altered.

## Testing

tsc 0, lint 0, rail suites 41+39, full backend jest 7798, results deterministic across two consecutive runs.