### PR TITLE
fix (security): remove AWS account id from baselines

### DIFF
--- a/backend/scripts/__tests__/split-gates-account-id-guard.test.ts
+++ b/backend/scripts/__tests__/split-gates-account-id-guard.test.ts
@@ -1,0 +1,75 @@
+/**
+ * Permanent guard (finding 9f09e845): no committed split-gates baseline or
+ * template may carry a real 12-digit AWS account id.
+ *
+ * This repo is cloned by customers (aws-samples), and split-baseline JSON
+ * files are captured with real credentials (see the "Environment-derived
+ * tokens" comment in `template-utils.ts`) — historically this leaked the
+ * owner's real account id (~103 occurrences across the dev/test baselines
+ * before sanitization). A future baseline refresh (`split-baseline.ts`) run
+ * against a real account could silently reintroduce the disclosure if
+ * nothing catches it. This test scans every committed file under
+ * `split-baseline/` and asserts the ONLY 12-digit run of digits present is
+ * the fixed placeholder `000000000000` (the same value CI's credential-less
+ * synth uses, so it is also a legitimate token that must not itself be
+ * flagged).
+ */
+import * as fs from "fs";
+import * as path from "path";
+
+const SPLIT_BASELINE_DIR = path.resolve(
+  __dirname,
+  "..",
+  "..",
+  "split-baseline",
+);
+const PLACEHOLDER = "000000000000";
+// A standalone 12-digit run: not immediately preceded/followed by another
+// digit OR a lowercase hex letter (a-f). Without the hex-letter exclusion,
+// this regex spuriously matches a coincidental 12-digit substring embedded
+// inside a much longer SHA-256 hex digest (e.g. a resolver
+// `templateHash` field) and misidentifies it as an account id — observed
+// in practice: `...e4991121923239...` (hash) contains `499112192323` as a
+// substring, which is not an account id. Real AWS account ids in this
+// baseline appear only inside ARN account fields
+// (`arn:aws:SERVICE:REGION:ACCOUNT:...`) or bucket-name-style tokens, both
+// of which are always digit-delimited by `:`/`-`/quotes, never by a hex
+// letter.
+const TWELVE_DIGIT_RUN = /(?<![a-f0-9])\d{12}(?![a-f0-9])/g;
+
+function listBaselineFiles(dir: string): string[] {
+  if (!fs.existsSync(dir)) return [];
+  return fs
+    .readdirSync(dir)
+    .filter((name) => name.endsWith(".json"))
+    .map((name) => path.join(dir, name));
+}
+
+describe("split-gates baseline account-id guard (finding 9f09e845)", () => {
+  const files = listBaselineFiles(SPLIT_BASELINE_DIR);
+
+  it("finds at least one committed baseline file to check (sanity — guard is not vacuous)", () => {
+    expect(files.length).toBeGreaterThan(0);
+  });
+
+  it.each(files.length > 0 ? files : ["__no_baselines_found__"])(
+    "%s contains no 12-digit run other than the %s placeholder",
+    (filePath) => {
+      if (filePath === "__no_baselines_found__") {
+        // Handled by the sanity test above; skip body to avoid a bogus fs read.
+        return;
+      }
+      const content = fs.readFileSync(filePath, "utf-8");
+      const matches = content.match(TWELVE_DIGIT_RUN) ?? [];
+      const nonPlaceholder = matches.filter((m) => m !== PLACEHOLDER);
+      expect(nonPlaceholder).toEqual([]);
+    },
+  );
+
+  it("the placeholder itself is present in at least one baseline (guard checks something real)", () => {
+    const anyHasPlaceholder = files.some((f) =>
+      fs.readFileSync(f, "utf-8").includes(PLACEHOLDER),
+    );
+    expect(anyHasPlaceholder).toBe(true);
+  });
+});

--- a/backend/scripts/__tests__/split-gates-rail2.test.ts
+++ b/backend/scripts/__tests__/split-gates-rail2.test.ts
@@ -116,7 +116,7 @@ describe("rail 2 — stateful logical-ID pin (negative: doctored templates must 
 describe("rail 2 — BucketName environment-token normalization (finding 389a16a)", () => {
   it("PASSES when only the account id and region segments of BucketName differ (CI sandbox vs baseline capture host)", () => {
     const baselineProps = {
-      BucketName: "citadel-documents-test-257192363080-us-west-2",
+      BucketName: "citadel-documents-test-000000000000-us-west-2",
     };
     const ciProps = {
       BucketName: "citadel-documents-test-000000000000-us-east-1",
@@ -129,12 +129,12 @@ describe("rail 2 — BucketName environment-token normalization (finding 389a16a
 
   it("BITE-PROOF: FAILS when the base bucket name itself changes, even with identical account/region", () => {
     const baselineProps = {
-      BucketName: "citadel-documents-test-257192363080-us-west-2",
+      BucketName: "citadel-documents-test-000000000000-us-west-2",
     };
     // Genuine rename: different base name, same account/region — must not
     // be masked by env-token normalization.
     const renamedProps = {
-      BucketName: "citadel-docs-renamed-test-257192363080-us-west-2",
+      BucketName: "citadel-docs-renamed-test-000000000000-us-west-2",
     };
     const { equal, diffs } = keyPropsEqual(baselineProps, renamedProps, [
       "BucketName",
@@ -144,7 +144,7 @@ describe("rail 2 — BucketName environment-token normalization (finding 389a16a
 
   it("BITE-PROOF: FAILS when both base name AND account/region differ (rename hiding behind an env mismatch)", () => {
     const baselineProps = {
-      BucketName: "citadel-documents-test-257192363080-us-west-2",
+      BucketName: "citadel-documents-test-000000000000-us-west-2",
     };
     const renamedInCiProps = {
       BucketName: "citadel-docs-renamed-test-000000000000-us-east-1",
@@ -163,7 +163,7 @@ describe("rail 2 — BucketName environment-token normalization (finding 389a16a
     // A 12-digit-looking table name segment must still be byte-compared —
     // TableName is not in ENV_DERIVED_KEYS.
     const freshProps = {
-      TableName: "citadel-projects-test-257192363080",
+      TableName: "citadel-projects-test-000000000000",
       KeySchema: [{ AttributeName: "id", KeyType: "HASH" }],
     };
     const { equal, diffs } = keyPropsEqual(baselineProps, freshProps, [

--- a/backend/scripts/split-gates/run-rails.ts
+++ b/backend/scripts/split-gates/run-rails.ts
@@ -17,7 +17,7 @@
  */
 import * as fs from "fs";
 import * as path from "path";
-import { loadTemplate } from "./template-utils";
+import { loadTemplate, extractArnRegions } from "./template-utils";
 import { buildBaseline } from "./baseline-builder";
 import { runRemovalsOnlyDiff } from "./rails/rail1-removals-only";
 import {
@@ -115,6 +115,39 @@ function main(): void {
 
   const baseline = loadBaseline(baselinePath);
   const freshTemplate = loadTemplate(freshTemplatePath);
+
+  // Region-consistency guard (finding 9f09e845): compare the region
+  // embedded in the baseline's account-scoped ARNs against the region
+  // embedded in the fresh synth's ARNs BEFORE running any rail. Account ids
+  // are normalized for comparison purposes elsewhere (rail 6), but region
+  // is deliberately NOT normalized — a genuine region misconfiguration must
+  // stay detectable. Without this guard, a region mismatch previously
+  // surfaced as a wall of confusing, unrelated-looking rail-6 violations
+  // (one per account-scoped ARN) instead of the single, clear
+  // configuration error it actually is — that misdiagnosis cost hours.
+  // Ambiguous cases (zero or multiple distinct regions found in either
+  // template's ARNs) are treated as "cannot verify" and skipped rather than
+  // guessed at.
+  const freshBaselineForRegionCheck = buildBaseline(stackName, freshTemplate);
+  const baselineRegions = extractArnRegions(baseline.lambdaRolePolicies);
+  const freshRegions = extractArnRegions(
+    freshBaselineForRegionCheck.lambdaRolePolicies,
+  );
+  if (baselineRegions.size === 1 && freshRegions.size === 1) {
+    const [baselineRegion] = baselineRegions;
+    const [freshRegion] = freshRegions;
+    if (baselineRegion !== freshRegion) {
+      process.stderr.write(
+        `ERROR: region mismatch between baseline and fresh synth — this comparison is invalid.\n` +
+          `  baseline region:     ${baselineRegion} (from ${baselinePath})\n` +
+          `  fresh synth region:  ${freshRegion} (from ${freshTemplatePath})\n` +
+          `This is a configuration error, not IAM drift. Re-synthesize with ` +
+          `CDK_DEFAULT_REGION=${baselineRegion} (matching the baseline) and re-run, ` +
+          `or re-capture the baseline for the intended region via split-baseline.ts.\n`,
+      );
+      process.exit(1);
+    }
+  }
 
   // rail1 expects CfnTemplate-shaped inputs; build one from the committed
   // baseline's resources map (Type/DeletionPolicy/UpdateReplacePolicy/Properties)

--- a/backend/scripts/split-gates/template-utils.ts
+++ b/backend/scripts/split-gates/template-utils.ts
@@ -165,11 +165,94 @@ function toStringArray(
  * `GETATT:<LogicalId>:<Attr>` / `REF:<LogicalId>` canonical form
  * `Fn::GetAtt`/`Fn::Ref` produce directly.
  */
+/**
+ * Normalize the account-id segment of an ARN-shaped string to a fixed
+ * placeholder, leaving every other segment (partition, service, region,
+ * resource) untouched. Scoped to two specific shapes rather than a blanket
+ * 12-digit-run replace, so a resource name that happens to contain 12
+ * digits (unlikely but not impossible) is never silently rewritten:
+ *
+ *   1. The ARN's own account FIELD —
+ *      `arn:PARTITION:SERVICE:REGION:ACCOUNT:RESOURCE`. SERVICE/REGION may
+ *      themselves be `*` (a wildcard resource ARN, e.g.
+ *      `arn:aws:lambda:*:<account>:function:*`) or empty (S3/IAM ARNs have
+ *      no region field), so the field-boundary regex must tolerate `*` and
+ *      the empty string in those positions — NOT just alphanumerics.
+ *   2. The account id EMBEDDED IN THE RESOURCE NAME segment for the
+ *      project's `<base>-<env>-<account>-<region>` bucket-naming
+ *      convention (see `backend/lib/backend-stack.ts`'s `AccessLogsBucket`
+ *      / `DocumentBucket` / `CodeBucket`, and rail 2's identical
+ *      `BucketName` coupling, finding 389a16a) — this shows up in S3 ARNs
+ *      as `arn:aws:s3:::citadel-code-dev-<account>-<region>` where the
+ *      ARN's own account FIELD is empty and the account instead sits
+ *      inside the resource path, immediately followed by `-<region>`.
+ *      Matched by requiring the digit run to be bounded by `-` on both
+ *      sides and immediately followed by a known region literal, so this
+ *      narrow case can't accidentally consume an unrelated 12-digit
+ *      substring elsewhere in a resource name.
+ *
+ * Rail 6 (IAM privilege-equivalence, finding 9f09e845) compares Action /
+ * Resource strings verbatim between the committed baseline (captured with
+ * real credentials, so account-scoped ARNs carry the real account id) and
+ * a fresh satellite synth (which may run credential-less in CI with the
+ * fixed sandbox account `000000000000`). Without normalizing the account
+ * on both sides, every account-scoped ARN in every statement fails to
+ * match — a spurious rail-6 violation, not real IAM drift (same root cause
+ * class as finding 389a16a's rail-2 BucketName coupling). The REGION
+ * segment is deliberately left alone in both shapes — a genuine region
+ * misconfiguration must still be distinguishable; `run-rails.ts` asserts
+ * baseline/fresh region equality up front and aborts with a clear
+ * diagnostic before rails run, rather than masking it inside this
+ * per-string normalizer.
+ */
+export function normalizeArnAccount(value: string): string {
+  const withArnFieldNormalized = value.replace(
+    /^(arn:[a-zA-Z0-9-]+:[a-zA-Z0-9*-]*:[a-zA-Z0-9*-]*:)\d{12}(:.*)$/,
+    "$1000000000000$2",
+  );
+  // Same region-literal set as REGION_RE below, kept local since exporting
+  // a shared constant isn't worth the coupling for this one use site.
+  return withArnFieldNormalized.replace(
+    /-\d{12}-(?=(us|eu|ap|sa|ca|me|af|il)-(north|south|east|west|central|northeast|northwest|southeast|southwest)-\d\b)/,
+    "-000000000000-",
+  );
+}
+
+/**
+ * Extract every distinct region literal from the account-scoped ARN strings
+ * embedded in a stack's captured Lambda-role IAM policies. Used by
+ * `run-rails.ts`'s region-consistency guard (finding 9f09e845) to compare
+ * the baseline's region against a fresh synth's region BEFORE running the
+ * rails, so a genuine region misconfiguration surfaces as one clear
+ * "region mismatch" abort rather than a wall of unrelated-looking rail
+ * violations (that misdiagnosis previously cost hours — see finding
+ * history). Region-less ARNs (e.g. `arn:aws:s3:::bucket-name`, IAM ARNs)
+ * are ignored; only ARNs with a non-empty, non-wildcard region field
+ * contribute.
+ */
+export function extractArnRegions(
+  lambdaRolePolicies: Record<string, NormalizedPolicyStatement[]>,
+): Set<string> {
+  const regions = new Set<string>();
+  const arnRe = /^arn:[a-zA-Z0-9-]+:[a-zA-Z0-9-]*:([a-zA-Z0-9-]+):\d{12}:/;
+  for (const statements of Object.values(lambdaRolePolicies)) {
+    for (const stmt of statements) {
+      for (const resource of stmt.resources) {
+        const match = arnRe.exec(resource);
+        if (match && match[1]) {
+          regions.add(match[1]);
+        }
+      }
+    }
+  }
+  return regions;
+}
+
 function resourceToComparableString(
   value: unknown,
   knownLogicalIds?: ReadonlySet<string>,
 ): string {
-  if (typeof value === "string") return value;
+  if (typeof value === "string") return normalizeArnAccount(value);
   if (
     value !== null &&
     typeof value === "object" &&
@@ -320,9 +403,12 @@ function flattenConditionKeys(condition: Record<string, unknown>): string[] {
  * pattern, not a project bug. `ci.yml` synthesizes with a fixed sandbox
  * `CDK_DEFAULT_ACCOUNT=000000000000` / `CDK_DEFAULT_REGION=us-east-1` (no
  * real AWS credentials in CI), while `split-baseline/citadel-backend-test.json`
- * was captured on a host with real credentials — account 257192363080,
- * region us-west-2. No committed baseline can ever byte-match CI for this
- * prop; the mismatch is structural, not a regression.
+ * was captured on a host with real credentials — the real account id is
+ * replaced with the same `000000000000` placeholder before this baseline is
+ * committed (finding 9f09e845; see the guard test asserting no committed
+ * baseline carries a real 12-digit account id) — region us-west-2. No
+ * committed baseline can ever byte-match CI for this prop; the mismatch is
+ * structural, not a regression.
  *
  * A 12-digit run of digits is normalized to a placeholder (covers any AWS
  * account id, real or the `000000000000` sandbox value) and each known AWS

--- a/backend/split-baseline/citadel-backend-dev.json
+++ b/backend/split-baseline/citadel-backend-dev.json
@@ -223,7 +223,7 @@
             }
           ]
         },
-        "BucketName": "citadel-s3-logs-dev-257192363080-us-west-2",
+        "BucketName": "citadel-s3-logs-dev-000000000000-us-west-2",
         "LifecycleConfiguration": {
           "Rules": [
             {
@@ -294,7 +294,7 @@
             }
           ]
         },
-        "BucketName": "citadel-documents-dev-257192363080-us-west-2",
+        "BucketName": "citadel-documents-dev-000000000000-us-west-2",
         "CorsConfiguration": {
           "CorsRules": [
             {
@@ -372,7 +372,7 @@
       "deletionPolicy": "Delete",
       "updateReplacePolicy": "Delete",
       "properties": {
-        "BucketName": "citadel-code-dev-257192363080-us-west-2",
+        "BucketName": "citadel-code-dev-000000000000-us-west-2",
         "LoggingConfiguration": {
           "DestinationBucketName": {
             "Ref": "AccessLogsBucket83982689"
@@ -1926,7 +1926,7 @@
             "ApiId"
           ]
         },
-        "DefinitionS3Location": "s3://cdk-hnb659fds-assets-257192363080-us-west-2/8a2064ed3d1346f5863ee2fb8e547295f378a699a3e896866d25e557d31b9bd5.graphql"
+        "DefinitionS3Location": "s3://cdk-hnb659fds-assets-000000000000-us-west-2/8a2064ed3d1346f5863ee2fb8e547295f378a699a3e896866d25e557d31b9bd5.graphql"
       }
     },
     "AgenticAIApiLogRetention0F17C899": {
@@ -4923,7 +4923,7 @@
           "dynamodb:PutItem"
         ],
         "resources": [
-          "arn:aws:dynamodb:us-west-2:257192363080:table/citadel-tools-dev"
+          "arn:aws:dynamodb:us-west-2:000000000000:table/citadel-tools-dev"
         ],
         "conditionKeys": []
       },
@@ -5256,8 +5256,8 @@
           "ssm:GetParameter"
         ],
         "resources": [
-          "arn:aws:ssm:us-west-2:257192363080:parameter/citadel/knowledge-base-datasource-id-dev",
-          "arn:aws:ssm:us-west-2:257192363080:parameter/citadel/knowledge-base-id-dev"
+          "arn:aws:ssm:us-west-2:000000000000:parameter/citadel/knowledge-base-datasource-id-dev",
+          "arn:aws:ssm:us-west-2:000000000000:parameter/citadel/knowledge-base-id-dev"
         ],
         "conditionKeys": []
       },
@@ -5278,8 +5278,8 @@
           "dynamodb:Query"
         ],
         "resources": [
-          "arn:aws:dynamodb:us-west-2:257192363080:table/citadel-document-ingestion-dev",
-          "arn:aws:dynamodb:us-west-2:257192363080:table/citadel-document-ingestion-dev/index/status-index"
+          "arn:aws:dynamodb:us-west-2:000000000000:table/citadel-document-ingestion-dev",
+          "arn:aws:dynamodb:us-west-2:000000000000:table/citadel-document-ingestion-dev/index/status-index"
         ],
         "conditionKeys": []
       }
@@ -5294,8 +5294,8 @@
           "s3:ListBucketVersions"
         ],
         "resources": [
-          "arn:aws:s3:::citadel-sessions-dev-257192363080-us-west-2",
-          "arn:aws:s3:::citadel-sessions-dev-257192363080-us-west-2/*"
+          "arn:aws:s3:::citadel-sessions-dev-000000000000-us-west-2",
+          "arn:aws:s3:::citadel-sessions-dev-000000000000-us-west-2/*"
         ],
         "conditionKeys": []
       },
@@ -5305,7 +5305,7 @@
           "s3:PutObject"
         ],
         "resources": [
-          "arn:aws:s3:::citadel-sessions-dev-257192363080-us-west-2/*"
+          "arn:aws:s3:::citadel-sessions-dev-000000000000-us-west-2/*"
         ],
         "conditionKeys": []
       },
@@ -5315,7 +5315,7 @@
           "lambda:InvokeFunction"
         ],
         "resources": [
-          "arn:aws:lambda:us-west-2:257192363080:function:citadel-pdf-generator-dev"
+          "arn:aws:lambda:us-west-2:000000000000:function:citadel-pdf-generator-dev"
         ],
         "conditionKeys": []
       }
@@ -5375,8 +5375,8 @@
           "ssm:GetParameter"
         ],
         "resources": [
-          "arn:aws:ssm:us-west-2:257192363080:parameter/citadel/governance/effective_at/dev",
-          "arn:aws:ssm:us-west-2:257192363080:parameter/citadel/governance/enforce/dev"
+          "arn:aws:ssm:us-west-2:000000000000:parameter/citadel/governance/effective_at/dev",
+          "arn:aws:ssm:us-west-2:000000000000:parameter/citadel/governance/enforce/dev"
         ],
         "conditionKeys": []
       },
@@ -5389,7 +5389,7 @@
           "iam:ListRolePolicies"
         ],
         "resources": [
-          "arn:aws:iam::257192363080:role/*"
+          "arn:aws:iam::000000000000:role/*"
         ],
         "conditionKeys": []
       },
@@ -5400,7 +5400,7 @@
           "iam:GetPolicyVersion"
         ],
         "resources": [
-          "arn:aws:iam::257192363080:policy/*"
+          "arn:aws:iam::000000000000:policy/*"
         ],
         "conditionKeys": []
       },
@@ -5467,7 +5467,7 @@
           "dynamodb:UpdateItem"
         ],
         "resources": [
-          "arn:aws:dynamodb:us-west-2:257192363080:table/citadel-authority-units-dev"
+          "arn:aws:dynamodb:us-west-2:000000000000:table/citadel-authority-units-dev"
         ],
         "conditionKeys": []
       },
@@ -5480,7 +5480,7 @@
           "secretsmanager:TagResource"
         ],
         "resources": [
-          "arn:aws:secretsmanager:us-west-2:257192363080:secret:/citadel/agents/*"
+          "arn:aws:secretsmanager:us-west-2:000000000000:secret:/citadel/agents/*"
         ],
         "conditionKeys": []
       },
@@ -5493,10 +5493,10 @@
           "lambda:InvokeFunction"
         ],
         "resources": [
-          "arn:aws:bedrock-agentcore:*:257192363080:runtime/*",
-          "arn:aws:bedrock:*:257192363080:agent-alias/*",
-          "arn:aws:execute-api:*:257192363080:*",
-          "arn:aws:lambda:*:257192363080:function:*"
+          "arn:aws:bedrock-agentcore:*:000000000000:runtime/*",
+          "arn:aws:bedrock:*:000000000000:agent-alias/*",
+          "arn:aws:execute-api:*:000000000000:*",
+          "arn:aws:lambda:*:000000000000:function:*"
         ],
         "conditionKeys": []
       },
@@ -5516,7 +5516,7 @@
           "sqs:SendMessage"
         ],
         "resources": [
-          "arn:aws:sqs:us-west-2:257192363080:citadel-fabricator-queue-dev"
+          "arn:aws:sqs:us-west-2:000000000000:citadel-fabricator-queue-dev"
         ],
         "conditionKeys": []
       },
@@ -5603,8 +5603,8 @@
           "bedrock-agentcore:DeleteGatewayTarget"
         ],
         "resources": [
-          "arn:aws:bedrock-agentcore:us-west-2:257192363080:gateway/*",
-          "arn:aws:bedrock-agentcore:us-west-2:257192363080:gateway/*/target/*"
+          "arn:aws:bedrock-agentcore:us-west-2:000000000000:gateway/*",
+          "arn:aws:bedrock-agentcore:us-west-2:000000000000:gateway/*/target/*"
         ],
         "conditionKeys": []
       },
@@ -5616,7 +5616,7 @@
           "bedrock-agentcore:UpdateApiKeyCredentialProvider"
         ],
         "resources": [
-          "arn:aws:bedrock-agentcore:us-west-2:257192363080:credential-provider/integration-*"
+          "arn:aws:bedrock-agentcore:us-west-2:000000000000:credential-provider/integration-*"
         ],
         "conditionKeys": []
       },
@@ -5626,7 +5626,7 @@
           "ssm:GetParameter"
         ],
         "resources": [
-          "arn:aws:ssm:us-west-2:257192363080:parameter/citadel/gateway-id-dev"
+          "arn:aws:ssm:us-west-2:000000000000:parameter/citadel/gateway-id-dev"
         ],
         "conditionKeys": []
       },
@@ -5691,8 +5691,8 @@
           "s3:PutObject"
         ],
         "resources": [
-          "arn:aws:s3:::citadel-code-dev-257192363080-us-west-2",
-          "arn:aws:s3:::citadel-code-dev-257192363080-us-west-2/agents/*"
+          "arn:aws:s3:::citadel-code-dev-000000000000-us-west-2",
+          "arn:aws:s3:::citadel-code-dev-000000000000-us-west-2/agents/*"
         ],
         "conditionKeys": []
       },
@@ -5724,7 +5724,7 @@
           "dynamodb:Scan"
         ],
         "resources": [
-          "arn:aws:dynamodb:us-west-2:257192363080:table/citadel-tools-dev"
+          "arn:aws:dynamodb:us-west-2:000000000000:table/citadel-tools-dev"
         ],
         "conditionKeys": []
       },
@@ -5753,7 +5753,7 @@
           "dynamodb:PutItem"
         ],
         "resources": [
-          "arn:aws:dynamodb:us-west-2:257192363080:table/citadel-fabrication-jobs-dev"
+          "arn:aws:dynamodb:us-west-2:000000000000:table/citadel-fabrication-jobs-dev"
         ],
         "conditionKeys": []
       },
@@ -5764,7 +5764,7 @@
           "sqs:SendMessage"
         ],
         "resources": [
-          "arn:aws:sqs:us-west-2:257192363080:citadel-fabricator-queue-dev"
+          "arn:aws:sqs:us-west-2:000000000000:citadel-fabricator-queue-dev"
         ],
         "conditionKeys": []
       }
@@ -5776,7 +5776,7 @@
           "dynamodb:Query"
         ],
         "resources": [
-          "arn:aws:dynamodb:us-west-2:257192363080:table/citadel-fabrication-jobs-dev/index/OrgIndex"
+          "arn:aws:dynamodb:us-west-2:000000000000:table/citadel-fabrication-jobs-dev/index/OrgIndex"
         ],
         "conditionKeys": []
       },
@@ -5787,7 +5787,7 @@
           "sqs:ReceiveMessage"
         ],
         "resources": [
-          "arn:aws:sqs:us-west-2:257192363080:citadel-fabricator-queue-dev"
+          "arn:aws:sqs:us-west-2:000000000000:citadel-fabricator-queue-dev"
         ],
         "conditionKeys": []
       }
@@ -5874,7 +5874,7 @@
           "secretsmanager:UpdateSecret"
         ],
         "resources": [
-          "arn:aws:secretsmanager:us-west-2:257192363080:secret:/citadel/integrations/*"
+          "arn:aws:secretsmanager:us-west-2:000000000000:secret:/citadel/integrations/*"
         ],
         "conditionKeys": []
       },
@@ -5887,8 +5887,8 @@
           "ssm:PutParameter"
         ],
         "resources": [
-          "arn:aws:ssm:us-west-2:257192363080:parameter/citadel/gateway/*",
-          "arn:aws:ssm:us-west-2:257192363080:parameter/citadel/integrations/*"
+          "arn:aws:ssm:us-west-2:000000000000:parameter/citadel/gateway/*",
+          "arn:aws:ssm:us-west-2:000000000000:parameter/citadel/integrations/*"
         ],
         "conditionKeys": []
       },
@@ -5913,8 +5913,8 @@
           "bedrock-agentcore:UpdateGatewayTarget"
         ],
         "resources": [
-          "arn:aws:bedrock-agentcore:us-west-2:257192363080:gateway/*",
-          "arn:aws:bedrock-agentcore:us-west-2:257192363080:token-vault/default/apikeycredentialprovider/*"
+          "arn:aws:bedrock-agentcore:us-west-2:000000000000:gateway/*",
+          "arn:aws:bedrock-agentcore:us-west-2:000000000000:token-vault/default/apikeycredentialprovider/*"
         ],
         "conditionKeys": []
       },
@@ -5933,7 +5933,7 @@
           "bedrock-agentcore:UpdateOauth2CredentialProvider"
         ],
         "resources": [
-          "arn:aws:bedrock-agentcore:us-west-2:257192363080:credential-provider/integration-*"
+          "arn:aws:bedrock-agentcore:us-west-2:000000000000:credential-provider/integration-*"
         ],
         "conditionKeys": []
       },
@@ -5946,7 +5946,7 @@
           "ssm:GetParameters"
         ],
         "resources": [
-          "JOIN::arn:aws:ssm:us-west-2:257192363080:parameterGETATT:OAuthReturnUrlParam5C6CC3B4:Ref"
+          "JOIN::arn:aws:ssm:us-west-2:000000000000:parameterGETATT:OAuthReturnUrlParam5C6CC3B4:Ref"
         ],
         "conditionKeys": []
       },
@@ -5962,7 +5962,7 @@
           "sts:AssumeRole"
         ],
         "resources": [
-          "arn:aws:iam::257192363080:role/citadel-int-*"
+          "arn:aws:iam::000000000000:role/citadel-int-*"
         ],
         "conditionKeys": []
       },
@@ -6010,8 +6010,8 @@
           "ssm:PutParameter"
         ],
         "resources": [
-          "arn:aws:ssm:us-west-2:257192363080:parameter/citadel/gateway-id-*",
-          "arn:aws:ssm:us-west-2:257192363080:parameter/citadel/gateway/*"
+          "arn:aws:ssm:us-west-2:000000000000:parameter/citadel/gateway-id-*",
+          "arn:aws:ssm:us-west-2:000000000000:parameter/citadel/gateway/*"
         ],
         "conditionKeys": []
       },
@@ -6021,7 +6021,7 @@
           "secretsmanager:GetSecretValue"
         ],
         "resources": [
-          "arn:aws:secretsmanager:us-west-2:257192363080:secret:/citadel/integrations/*"
+          "arn:aws:secretsmanager:us-west-2:000000000000:secret:/citadel/integrations/*"
         ],
         "conditionKeys": []
       },
@@ -6033,8 +6033,8 @@
           "bedrock-agentcore:GetGatewayTarget"
         ],
         "resources": [
-          "arn:aws:bedrock-agentcore:us-west-2:257192363080:gateway/*",
-          "arn:aws:bedrock-agentcore:us-west-2:257192363080:gateway/*/target/*"
+          "arn:aws:bedrock-agentcore:us-west-2:000000000000:gateway/*",
+          "arn:aws:bedrock-agentcore:us-west-2:000000000000:gateway/*/target/*"
         ],
         "conditionKeys": []
       },
@@ -6047,7 +6047,7 @@
           "bedrock-agentcore:GetOauth2CredentialProvider"
         ],
         "resources": [
-          "arn:aws:bedrock-agentcore:us-west-2:257192363080:credential-provider/integration-*"
+          "arn:aws:bedrock-agentcore:us-west-2:000000000000:credential-provider/integration-*"
         ],
         "conditionKeys": []
       },
@@ -6060,7 +6060,7 @@
           "ssm:GetParameters"
         ],
         "resources": [
-          "JOIN::arn:aws:ssm:us-west-2:257192363080:parameterGETATT:OAuthReturnUrlParam5C6CC3B4:Ref"
+          "JOIN::arn:aws:ssm:us-west-2:000000000000:parameterGETATT:OAuthReturnUrlParam5C6CC3B4:Ref"
         ],
         "conditionKeys": []
       },
@@ -6070,7 +6070,7 @@
           "s3:GetObject"
         ],
         "resources": [
-          "arn:aws:s3:::citadel-schemas-dev-257192363080-us-west-2/*"
+          "arn:aws:s3:::citadel-schemas-dev-000000000000-us-west-2/*"
         ],
         "conditionKeys": []
       }
@@ -6307,7 +6307,7 @@
           "dynamodb:UpdateItem"
         ],
         "resources": [
-          "arn:aws:dynamodb:us-west-2:257192363080:table/citadel-authority-units-dev"
+          "arn:aws:dynamodb:us-west-2:000000000000:table/citadel-authority-units-dev"
         ],
         "conditionKeys": []
       },
@@ -6334,7 +6334,7 @@
           "iam:UntagRole"
         ],
         "resources": [
-          "arn:aws:iam::257192363080:role/citadel-agent-*"
+          "arn:aws:iam::000000000000:role/citadel-agent-*"
         ],
         "conditionKeys": []
       },
@@ -6354,7 +6354,7 @@
           "ssm:GetParameter"
         ],
         "resources": [
-          "arn:aws:ssm:us-west-2:257192363080:parameter/citadel/dev/app-api-key-pepper"
+          "arn:aws:ssm:us-west-2:000000000000:parameter/citadel/dev/app-api-key-pepper"
         ],
         "conditionKeys": []
       },
@@ -6364,7 +6364,7 @@
           "kms:Decrypt"
         ],
         "resources": [
-          "arn:aws:kms:us-west-2:257192363080:alias/aws/ssm"
+          "arn:aws:kms:us-west-2:000000000000:alias/aws/ssm"
         ],
         "conditionKeys": []
       },
@@ -6538,7 +6538,7 @@
           "ssm:GetParameters"
         ],
         "resources": [
-          "arn:aws:ssm:us-west-2:257192363080:parameter/citadel/agents/*"
+          "arn:aws:ssm:us-west-2:000000000000:parameter/citadel/agents/*"
         ],
         "conditionKeys": []
       },
@@ -6548,7 +6548,7 @@
           "secretsmanager:GetSecretValue"
         ],
         "resources": [
-          "arn:aws:secretsmanager:us-west-2:257192363080:secret:/citadel/agents/*"
+          "arn:aws:secretsmanager:us-west-2:000000000000:secret:/citadel/agents/*"
         ],
         "conditionKeys": []
       },
@@ -6685,7 +6685,7 @@
           "appsync:GraphQL"
         ],
         "resources": [
-          "JOIN::arn:aws:appsync:us-west-2:257192363080:apis/GETATT:AgenticAIApiABAE82BE:ApiId/types/Mutation/fields/publishAssessmentCompletion"
+          "JOIN::arn:aws:appsync:us-west-2:000000000000:apis/GETATT:AgenticAIApiABAE82BE:ApiId/types/Mutation/fields/publishAssessmentCompletion"
         ],
         "conditionKeys": []
       }
@@ -6709,7 +6709,7 @@
           "appsync:GraphQL"
         ],
         "resources": [
-          "JOIN::arn:aws:appsync:us-west-2:257192363080:apis/GETATT:AgenticAIApiABAE82BE:ApiId/types/Mutation/fields/publishDesignProgress"
+          "JOIN::arn:aws:appsync:us-west-2:000000000000:apis/GETATT:AgenticAIApiABAE82BE:ApiId/types/Mutation/fields/publishDesignProgress"
         ],
         "conditionKeys": []
       }
@@ -6736,7 +6736,7 @@
           "dynamodb:Query"
         ],
         "resources": [
-          "arn:aws:dynamodb:us-west-2:257192363080:table/citadel-session-memory-dev"
+          "arn:aws:dynamodb:us-west-2:000000000000:table/citadel-session-memory-dev"
         ],
         "conditionKeys": []
       }
@@ -6750,8 +6750,8 @@
           "s3:ListBucket"
         ],
         "resources": [
-          "arn:aws:s3:::citadel-sessions-dev-257192363080-us-west-2",
-          "arn:aws:s3:::citadel-sessions-dev-257192363080-us-west-2/*"
+          "arn:aws:s3:::citadel-sessions-dev-000000000000-us-west-2",
+          "arn:aws:s3:::citadel-sessions-dev-000000000000-us-west-2/*"
         ],
         "conditionKeys": []
       },
@@ -6806,7 +6806,7 @@
           "secretsmanager:UpdateSecret"
         ],
         "resources": [
-          "arn:aws:secretsmanager:us-west-2:257192363080:secret:/citadel/datastores/*"
+          "arn:aws:secretsmanager:us-west-2:000000000000:secret:/citadel/datastores/*"
         ],
         "conditionKeys": []
       },
@@ -6823,7 +6823,7 @@
           "sts:AssumeRole"
         ],
         "resources": [
-          "arn:aws:iam::257192363080:role/citadel-ds-*"
+          "arn:aws:iam::000000000000:role/citadel-ds-*"
         ],
         "conditionKeys": []
       },
@@ -6856,7 +6856,7 @@
           "ssm:GetParameter"
         ],
         "resources": [
-          "arn:aws:ssm:us-west-2:257192363080:parameter/citadel/health-monitor-role-dev"
+          "arn:aws:ssm:us-west-2:000000000000:parameter/citadel/health-monitor-role-dev"
         ],
         "conditionKeys": []
       }

--- a/backend/split-baseline/citadel-backend-test.json
+++ b/backend/split-baseline/citadel-backend-test.json
@@ -223,7 +223,7 @@
             }
           ]
         },
-        "BucketName": "citadel-s3-logs-test-257192363080-us-west-2",
+        "BucketName": "citadel-s3-logs-test-000000000000-us-west-2",
         "LifecycleConfiguration": {
           "Rules": [
             {
@@ -294,7 +294,7 @@
             }
           ]
         },
-        "BucketName": "citadel-documents-test-257192363080-us-west-2",
+        "BucketName": "citadel-documents-test-000000000000-us-west-2",
         "CorsConfiguration": {
           "CorsRules": [
             {
@@ -372,7 +372,7 @@
       "deletionPolicy": "Delete",
       "updateReplacePolicy": "Delete",
       "properties": {
-        "BucketName": "citadel-code-test-257192363080-us-west-2",
+        "BucketName": "citadel-code-test-000000000000-us-west-2",
         "LoggingConfiguration": {
           "DestinationBucketName": {
             "Ref": "AccessLogsBucket83982689"
@@ -1747,7 +1747,7 @@
             "ApiId"
           ]
         },
-        "DefinitionS3Location": "s3://cdk-hnb659fds-assets-257192363080-us-west-2/bd1e851146f86e7581263229fdbb3c0dfe191ea0cb6fd211c742acdc71a511d4.graphql"
+        "DefinitionS3Location": "s3://cdk-hnb659fds-assets-000000000000-us-west-2/bd1e851146f86e7581263229fdbb3c0dfe191ea0cb6fd211c742acdc71a511d4.graphql"
       }
     },
     "AgenticAIApiLogRetention0F17C899": {
@@ -4565,8 +4565,8 @@
           "ssm:GetParameter"
         ],
         "resources": [
-          "arn:aws:ssm:us-west-2:257192363080:parameter/citadel/governance/effective_at/test",
-          "arn:aws:ssm:us-west-2:257192363080:parameter/citadel/governance/enforce/test"
+          "arn:aws:ssm:us-west-2:000000000000:parameter/citadel/governance/effective_at/test",
+          "arn:aws:ssm:us-west-2:000000000000:parameter/citadel/governance/enforce/test"
         ],
         "conditionKeys": []
       },
@@ -4579,7 +4579,7 @@
           "iam:ListRolePolicies"
         ],
         "resources": [
-          "arn:aws:iam::257192363080:role/*"
+          "arn:aws:iam::000000000000:role/*"
         ],
         "conditionKeys": []
       },
@@ -4590,7 +4590,7 @@
           "iam:GetPolicyVersion"
         ],
         "resources": [
-          "arn:aws:iam::257192363080:policy/*"
+          "arn:aws:iam::000000000000:policy/*"
         ],
         "conditionKeys": []
       },
@@ -4649,7 +4649,7 @@
           "dynamodb:Scan"
         ],
         "resources": [
-          "arn:aws:dynamodb:us-west-2:257192363080:table/citadel-tools-test"
+          "arn:aws:dynamodb:us-west-2:000000000000:table/citadel-tools-test"
         ],
         "conditionKeys": []
       },
@@ -4753,7 +4753,7 @@
           "secretsmanager:UpdateSecret"
         ],
         "resources": [
-          "arn:aws:secretsmanager:us-west-2:257192363080:secret:/citadel/integrations/*"
+          "arn:aws:secretsmanager:us-west-2:000000000000:secret:/citadel/integrations/*"
         ],
         "conditionKeys": []
       },
@@ -4766,8 +4766,8 @@
           "ssm:PutParameter"
         ],
         "resources": [
-          "arn:aws:ssm:us-west-2:257192363080:parameter/citadel/gateway/*",
-          "arn:aws:ssm:us-west-2:257192363080:parameter/citadel/integrations/*"
+          "arn:aws:ssm:us-west-2:000000000000:parameter/citadel/gateway/*",
+          "arn:aws:ssm:us-west-2:000000000000:parameter/citadel/integrations/*"
         ],
         "conditionKeys": []
       },
@@ -4792,8 +4792,8 @@
           "bedrock-agentcore:UpdateGatewayTarget"
         ],
         "resources": [
-          "arn:aws:bedrock-agentcore:us-west-2:257192363080:gateway/*",
-          "arn:aws:bedrock-agentcore:us-west-2:257192363080:token-vault/default/apikeycredentialprovider/*"
+          "arn:aws:bedrock-agentcore:us-west-2:000000000000:gateway/*",
+          "arn:aws:bedrock-agentcore:us-west-2:000000000000:token-vault/default/apikeycredentialprovider/*"
         ],
         "conditionKeys": []
       },
@@ -4812,7 +4812,7 @@
           "bedrock-agentcore:UpdateOauth2CredentialProvider"
         ],
         "resources": [
-          "arn:aws:bedrock-agentcore:us-west-2:257192363080:credential-provider/integration-*"
+          "arn:aws:bedrock-agentcore:us-west-2:000000000000:credential-provider/integration-*"
         ],
         "conditionKeys": []
       },
@@ -4825,7 +4825,7 @@
           "ssm:GetParameters"
         ],
         "resources": [
-          "JOIN::arn:aws:ssm:us-west-2:257192363080:parameterGETATT:OAuthReturnUrlParam5C6CC3B4:Ref"
+          "JOIN::arn:aws:ssm:us-west-2:000000000000:parameterGETATT:OAuthReturnUrlParam5C6CC3B4:Ref"
         ],
         "conditionKeys": []
       },
@@ -4841,7 +4841,7 @@
           "sts:AssumeRole"
         ],
         "resources": [
-          "arn:aws:iam::257192363080:role/citadel-int-*"
+          "arn:aws:iam::000000000000:role/citadel-int-*"
         ],
         "conditionKeys": []
       },
@@ -4899,8 +4899,8 @@
           "ssm:PutParameter"
         ],
         "resources": [
-          "arn:aws:ssm:us-west-2:257192363080:parameter/citadel/gateway-id-*",
-          "arn:aws:ssm:us-west-2:257192363080:parameter/citadel/gateway/*"
+          "arn:aws:ssm:us-west-2:000000000000:parameter/citadel/gateway-id-*",
+          "arn:aws:ssm:us-west-2:000000000000:parameter/citadel/gateway/*"
         ],
         "conditionKeys": []
       },
@@ -4910,7 +4910,7 @@
           "secretsmanager:GetSecretValue"
         ],
         "resources": [
-          "arn:aws:secretsmanager:us-west-2:257192363080:secret:/citadel/integrations/*"
+          "arn:aws:secretsmanager:us-west-2:000000000000:secret:/citadel/integrations/*"
         ],
         "conditionKeys": []
       },
@@ -4922,8 +4922,8 @@
           "bedrock-agentcore:GetGatewayTarget"
         ],
         "resources": [
-          "arn:aws:bedrock-agentcore:us-west-2:257192363080:gateway/*",
-          "arn:aws:bedrock-agentcore:us-west-2:257192363080:gateway/*/target/*"
+          "arn:aws:bedrock-agentcore:us-west-2:000000000000:gateway/*",
+          "arn:aws:bedrock-agentcore:us-west-2:000000000000:gateway/*/target/*"
         ],
         "conditionKeys": []
       },
@@ -4936,7 +4936,7 @@
           "bedrock-agentcore:GetOauth2CredentialProvider"
         ],
         "resources": [
-          "arn:aws:bedrock-agentcore:us-west-2:257192363080:credential-provider/integration-*"
+          "arn:aws:bedrock-agentcore:us-west-2:000000000000:credential-provider/integration-*"
         ],
         "conditionKeys": []
       },
@@ -4949,7 +4949,7 @@
           "ssm:GetParameters"
         ],
         "resources": [
-          "JOIN::arn:aws:ssm:us-west-2:257192363080:parameterGETATT:OAuthReturnUrlParam5C6CC3B4:Ref"
+          "JOIN::arn:aws:ssm:us-west-2:000000000000:parameterGETATT:OAuthReturnUrlParam5C6CC3B4:Ref"
         ],
         "conditionKeys": []
       },
@@ -4959,7 +4959,7 @@
           "s3:GetObject"
         ],
         "resources": [
-          "arn:aws:s3:::citadel-schemas-test-257192363080-us-west-2/*"
+          "arn:aws:s3:::citadel-schemas-test-000000000000-us-west-2/*"
         ],
         "conditionKeys": []
       }
@@ -5328,7 +5328,7 @@
           "ssm:GetParameters"
         ],
         "resources": [
-          "arn:aws:ssm:us-west-2:257192363080:parameter/citadel/agents/*"
+          "arn:aws:ssm:us-west-2:000000000000:parameter/citadel/agents/*"
         ],
         "conditionKeys": []
       },
@@ -5338,7 +5338,7 @@
           "secretsmanager:GetSecretValue"
         ],
         "resources": [
-          "arn:aws:secretsmanager:us-west-2:257192363080:secret:/citadel/agents/*"
+          "arn:aws:secretsmanager:us-west-2:000000000000:secret:/citadel/agents/*"
         ],
         "conditionKeys": []
       },
@@ -5485,7 +5485,7 @@
           "secretsmanager:UpdateSecret"
         ],
         "resources": [
-          "arn:aws:secretsmanager:us-west-2:257192363080:secret:/citadel/datastores/*"
+          "arn:aws:secretsmanager:us-west-2:000000000000:secret:/citadel/datastores/*"
         ],
         "conditionKeys": []
       },
@@ -5502,7 +5502,7 @@
           "sts:AssumeRole"
         ],
         "resources": [
-          "arn:aws:iam::257192363080:role/citadel-ds-*"
+          "arn:aws:iam::000000000000:role/citadel-ds-*"
         ],
         "conditionKeys": []
       },
@@ -5535,7 +5535,7 @@
           "ssm:GetParameter"
         ],
         "resources": [
-          "arn:aws:ssm:us-west-2:257192363080:parameter/citadel/health-monitor-role-test"
+          "arn:aws:ssm:us-west-2:000000000000:parameter/citadel/health-monitor-role-test"
         ],
         "conditionKeys": []
       }

--- a/scripts/test-deploy-sh.sh
+++ b/scripts/test-deploy-sh.sh
@@ -618,8 +618,8 @@ LAYER_AND_JSON_DIFF='            [-]   "Resource": {
             [-]   }
  └─ [~] Layers
      └─ [~] .0:
-         ├─ [-] arn:aws:lambda:us-west-2:257192363080:layer:ArbiterCatalogLayer:58
-         └─ [+] arn:aws:lambda:us-west-2:257192363080:layer:ArbiterCatalogLayer:59'
+         ├─ [-] arn:aws:lambda:us-west-2:000000000000:layer:ArbiterCatalogLayer:58
+         └─ [+] arn:aws:lambda:us-west-2:000000000000:layer:ArbiterCatalogLayer:59'
 set +e
 layerjson_out=$(extract_cdk_deletions "$LAYER_AND_JSON_DIFF")
 set -e 2>/dev/null || true


### PR DESCRIPTION
## Summary
The committed split-gates baselines contained a real 12-digit AWS account id. An account id is not a credential, but can be avoided.

**The exposure was wider than first reported: 103 occurrences across 5 files**, not 197 in one.

| File | Occurrences |
|---|--- |
`backend/split-baseline/citadel-backend-dev.json` | 65 |
`backend/split-baseline/citadel-backend-test.json` | 30 |
`backend/scripts/__tests__/split-gates-rail2.test.ts` | 5 |
`scripts/test-deploy-sh.sh` | 2 |
`backend/scripts/split-gates/template-utils.ts` | 1 (comment) |

All replaced with `000000000000`, matching what a credential-less synth produces. Other 12-digit hits were verified as AWS documentation placeholders or a coincidental substring inside a SHA-256 hash.

## Substitution, not regeneration

Decided not to regenerate the baseline, because re-capturing from a current synth would absorb real drift. This is a mechanical substitution: the baseline changed **only** in the account-id substring, with no statement added, removed or reordered - verified line by line, and independently confirmed by review.

## The gate is now account-agnostic

Rail 6 normalizes the account on both sides before comparison - covering both the ARN account field (including wildcard service/region forms, a gap caught by a real rail run that produced 5 false violations) and the account embedded in the project's `<base>-<env>-<account>-<region›` bucket-name convention. Rail 6 now passes **both** with real credentials and credential-less, and detection is proven intact: an uncovered IAM statement still fails the rail. 

This is what lets `split:gates` run in CI without hardcoding an account id.

## Region stays honest

Region is deliberately **not** normalized, so a genuine region misconfiguration remains detectable. Instead, a mismatch now aborts before any rail with a message naming both regions and stating plainly that this is a configuration error, not IAM drift. That exact misdiagnosis produced 26 apparent "security violations" earlier and cost hours - the guard exists so it reports itself next time.

## Permanent protection

A new guard test scans every baseline for any 12-digit account id other than the placeholder (excluding hex-hash embeddings), so a future refresh cannot silently reintroduce the disclosure.

## Testing

Merged with current `main` and re-verified after integration: tsc 0, lint 0, full backend jest 7810, all seven rails pass, account-id guard green, and "dist" rebuild-before-synth from #155 still in effect.

**Caveat:** the region guard's end-to-end abort was demonstrated with a hand-edited synth template rather than a live cross-region synth, because the CDK CLI's own region resolution overrode the forced environment in this sandbox. The guard logic itself is unit-verified.