### PR TITLE
fix(ui): stop the datastore create path sending a placeholder org

### DIFF
--- a/backend/src/lambda/__tests__/datastore-resolver-create-org-messages.test.ts
+++ b/backend/src/lambda/__tests__/datastore-resolver-create-org-messages.test.ts
@@ -1,0 +1,210 @@
+/**
+ * TDD (red-first) for the createDataStore org fail-closed message split.
+ *
+ * Background: decision b5d463f2 removed the admin bypass so createDataStore
+ * rejects an org mismatch for EVERYONE, including admins (see the block
+ * comment above createDataStore in datastore-resolver.ts). That correctly
+ * exposed a pre-existing diagnosability defect: the single check
+ *   `if (!callerOrgId || callerOrgId !== input.orgId)`
+ * threw the SAME message ("Access denied: orgId does not match caller's
+ * organization") whether the caller had NO resolvable org claim at all (a
+ * provisioning gap — nothing to compare against) or had a real org that
+ * simply didn't match the submitted orgId (a genuine cross-org attempt).
+ * That made "your account isn't provisioned yet" look identical to "you
+ * tried to write into someone else's org".
+ *
+ * This test asserts the two cases now produce distinct, actionable
+ * messages, that BOTH still reject (fail closed — no coercion, no admin
+ * bypass), and that neither message leaks another tenant's org id.
+ */
+
+// ---- Mock setup (mirrors datastore-resolver-create.test.ts) ----
+const mockDynamoSend = jest.fn();
+jest.mock("@aws-sdk/client-dynamodb", () => ({
+  DynamoDBClient: jest.fn().mockImplementation(() => ({})),
+}));
+jest.mock("@aws-sdk/lib-dynamodb", () => {
+  const actual = jest.requireActual("@aws-sdk/lib-dynamodb");
+  return {
+    ...actual,
+    DynamoDBDocumentClient: {
+      from: jest.fn().mockReturnValue({ send: mockDynamoSend }),
+    },
+    PutCommand: jest
+      .fn()
+      .mockImplementation((input) => ({ _type: "Put", input })),
+    GetCommand: jest
+      .fn()
+      .mockImplementation((input) => ({ _type: "Get", input })),
+    UpdateCommand: jest
+      .fn()
+      .mockImplementation((input) => ({ _type: "Update", input })),
+    DeleteCommand: jest
+      .fn()
+      .mockImplementation((input) => ({ _type: "Delete", input })),
+    QueryCommand: jest
+      .fn()
+      .mockImplementation((input) => ({ _type: "Query", input })),
+  };
+});
+
+const mockSecretsSend = jest.fn();
+jest.mock("@aws-sdk/client-secrets-manager", () => ({
+  SecretsManagerClient: jest
+    .fn()
+    .mockImplementation(() => ({ send: mockSecretsSend })),
+  CreateSecretCommand: jest
+    .fn()
+    .mockImplementation((input) => ({ _type: "CreateSecret", input })),
+  GetSecretValueCommand: jest
+    .fn()
+    .mockImplementation((input) => ({ _type: "GetSecretValue", input })),
+  DeleteSecretCommand: jest
+    .fn()
+    .mockImplementation((input) => ({ _type: "DeleteSecret", input })),
+}));
+
+jest.mock("../adapters/registry", () => ({
+  getAdapter: jest.fn().mockReturnValue({
+    category: "datastore",
+    spec: {
+      type: "KNOWLEDGE_BASE",
+      provider: "AWS",
+      category: "datastore",
+      authentication: { method: "IAM_ROLE", fields: [], secretStructure: {} },
+      configuration: { required: [], optional: [], ssmParameters: [] },
+    },
+    requiredPolicies: jest.fn().mockReturnValue({ provision: [], connect: [] }),
+    provision: jest
+      .fn()
+      .mockResolvedValue({
+        resourceArn: "arn:aws:bedrock:us-east-1:123:knowledge-base/KB1",
+      }),
+    connect: jest.fn().mockResolvedValue(undefined),
+    disconnect: jest.fn().mockResolvedValue(undefined),
+    deprovision: jest.fn().mockResolvedValue(undefined),
+    testConnection: jest
+      .fn()
+      .mockResolvedValue({ success: true, message: "OK" }),
+    getMetrics: jest.fn().mockResolvedValue({ size: "0 MB", records: 0 }),
+  }),
+}));
+
+jest.mock("../../utils/policy-manager", () => ({
+  PolicyManager: jest.fn().mockImplementation(() => ({
+    getAccountContext: jest
+      .fn()
+      .mockResolvedValue({ accountId: "123456789012", region: "us-east-1" }),
+    ensureRole: jest.fn().mockResolvedValue(undefined),
+    assumeScopedRole: jest.fn().mockResolvedValue({
+      accessKeyId: "AKID",
+      secretAccessKey: "SECRET",
+      sessionToken: "TOKEN",
+    }),
+    deleteRole: jest.fn().mockResolvedValue(undefined),
+  })),
+}));
+
+jest.mock("uuid", () => ({ v4: jest.fn().mockReturnValue("test-uuid") }));
+
+jest.mock("../../utils/auth-event", () => ({
+  extractOrgFromEvent: jest.fn(),
+  isAdminFromEvent: jest.fn(),
+  assertRowOrg: jest.fn(),
+}));
+
+process.env.DATASTORES_TABLE = "TestDataStoresTable";
+
+import { handler } from "../datastore-resolver";
+import { extractOrgFromEvent } from "../../utils/auth-event";
+
+const mockExtractOrgFromEvent = extractOrgFromEvent as jest.Mock;
+
+type HandlerEvent = Parameters<typeof handler>[0];
+
+const makeCreateEvent = (
+  input: Record<string, unknown>,
+  identity: Record<string, unknown> = { username: "test-user" },
+): HandlerEvent =>
+  ({
+    info: { fieldName: "createDataStore" },
+    arguments: { input },
+    identity,
+  }) as unknown as HandlerEvent;
+
+describe("createDataStore — distinct fail-closed org messages", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockDynamoSend.mockImplementation((cmd: { _type?: string }) => {
+      if (cmd._type === "Query") return Promise.resolve({ Items: [] });
+      if (cmd._type === "Put") return Promise.resolve({});
+      return Promise.resolve({});
+    });
+  });
+
+  const baseInput = {
+    name: "test-kb",
+    type: "KNOWLEDGE_BASE",
+    category: "KNOWLEDGE_BASE",
+    provisionMode: "CREATE_NEW",
+    config: JSON.stringify({ resourceName: "test-kb" }),
+    clientRequestToken: "tok-1",
+  };
+
+  test("no resolvable org claim → provisioning-gap message telling caller to contact an administrator", async () => {
+    mockExtractOrgFromEvent.mockResolvedValue(null);
+
+    const event = makeCreateEvent({ ...baseInput, orgId: "org-target" });
+
+    await expect(handler(event)).rejects.toMatchObject({
+      message: expect.stringMatching(/contact.*administrator/i),
+    });
+    // Must NOT be the generic mismatch wording, and must not echo the
+    // submitted orgId back (nothing to leak, but guard the shape anyway).
+    await expect(handler(event)).rejects.not.toMatchObject({
+      message: expect.stringContaining("does not match"),
+    });
+  });
+
+  test("resolved org differs from submitted orgId → mismatch message, without leaking either org id", async () => {
+    mockExtractOrgFromEvent.mockResolvedValue("org-real");
+
+    const event = makeCreateEvent({ ...baseInput, orgId: "org-other-tenant" });
+
+    await expect(handler(event)).rejects.toMatchObject({
+      message: expect.stringMatching(/does not match/i),
+    });
+    await expect(handler(event)).rejects.not.toMatchObject({
+      message: expect.stringContaining("org-real"),
+    });
+    await expect(handler(event)).rejects.not.toMatchObject({
+      message: expect.stringContaining("org-other-tenant"),
+    });
+    // Must be distinguishable from the no-claim message.
+    await expect(handler(event)).rejects.not.toMatchObject({
+      message: expect.stringMatching(/contact.*administrator/i),
+    });
+  });
+
+  test("both cases still reject — no admin bypass, no coercion to make the call succeed", async () => {
+    mockExtractOrgFromEvent.mockResolvedValue(null);
+    const noClaimEvent = makeCreateEvent(
+      { ...baseInput, orgId: "org-target" },
+      { username: "admin-user", "custom:role": "admin" },
+    );
+    await expect(handler(noClaimEvent)).rejects.toBeTruthy();
+
+    mockExtractOrgFromEvent.mockResolvedValue("org-real");
+    const mismatchEvent = makeCreateEvent(
+      { ...baseInput, orgId: "org-other-tenant" },
+      { username: "admin-user", "custom:role": "admin" },
+    );
+    await expect(handler(mismatchEvent)).rejects.toBeTruthy();
+  });
+});
+
+// Note: the "matching org succeeds" control case is already covered by
+// datastore-resolver-create.test.ts (config enrichment suite), which uses
+// makeCreateEvent with identity['custom:organization'] === input.orgId.
+// Not duplicated here to avoid re-running the ~10s IAM-propagation wait
+// inside createDataStore's CREATE_NEW path per test.

--- a/backend/src/lambda/datastore-resolver.ts
+++ b/backend/src/lambda/datastore-resolver.ts
@@ -436,10 +436,36 @@ async function createDataStore(
   // genuinely need to provision on a tenant's behalf, that requires an
   // EXPLICIT separate operator path — intentionally not built speculatively
   // here; this fix only removes the implicit bypass.
+  //
+  // Diagnosability fix (UX defect exposed by the above): a single check
+  // `!callerOrgId || callerOrgId !== input.orgId` threw the SAME message for
+  // two different fail-closed causes — no org claim resolved for the caller
+  // AT ALL (a provisioning gap: the account has nothing to compare against)
+  // versus a genuinely mismatched orgId (a cross-org write attempt). The
+  // former made a provisioning gap look like a security bug. Split into two
+  // branches with distinct, actionable messages. Neither branch echoes an
+  // org id back to the caller (no cross-tenant leak); logs carry only the
+  // caller's own resolved org (or its absence) and the caller's username —
+  // no PII, no other tenant's identifiers.
   const callerOrgId = await extractOrgFromEvent(event);
-  if (!callerOrgId || callerOrgId !== input.orgId) {
+  if (!callerOrgId) {
+    console.warn("createDataStore: no organization claim resolved for caller", {
+      createdBy,
+    });
     throw new PermissionError(
-      "Access denied: orgId does not match caller's organization",
+      "Access denied: no organization is provisioned for your account. Contact an administrator.",
+    );
+  }
+  if (callerOrgId !== input.orgId) {
+    console.warn(
+      "createDataStore: submitted orgId does not match caller's organization",
+      {
+        createdBy,
+        callerOrgId,
+      },
+    );
+    throw new PermissionError(
+      "Access denied: the requested organization does not match your organization.",
     );
   }
 

--- a/frontend/src/pages/DataStores.tsx
+++ b/frontend/src/pages/DataStores.tsx
@@ -9,6 +9,7 @@ import { AlertDialog, AlertDialogAction, AlertDialogCancel, AlertDialogContent, 
 import { Input } from "@/components/ui/input";
 import { Textarea } from "@/components/ui/textarea";
 import { Label } from "@/components/ui/label";
+import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from "@/components/ui/tooltip";
 import {
   Database,
   Search,
@@ -96,8 +97,21 @@ const statusIcons: Record<string, LucideIcon> = {
 };
 
 export function DataStores() {
-  const { selectedOrganization } = useOrganization();
+  const { selectedOrganization, currentUser } = useOrganization();
   const orgId = selectedOrganization || "default";
+
+  // Create-target org resolution (UX/diagnosability fix — b5d463f2 background):
+  // 'All Organizations' and a null selection are FILTER SCOPES for the list
+  // above, not valid creation targets. The create path must submit the
+  // CALLER'S OWN organisation (never the selector value), and must never
+  // fall back to a placeholder like "default" — createDataStore now rejects
+  // an org mismatch for everyone, including admins, so a placeholder can
+  // never succeed and only produces a confusing "access denied".
+  const callerOrgId = currentUser?.organization || null;
+  const canCreateDataStore = Boolean(callerOrgId);
+  const createDisabledReason = !callerOrgId
+    ? "No organization is provisioned for your account. Contact an administrator."
+    : null;
 
   const [dataStores, setDataStores] = useState<DataStore[]>([]);
   const [loading, setLoading] = useState(true);
@@ -178,16 +192,33 @@ export function DataStores() {
           </p>
         </div>
         <div className="flex items-center gap-2">
-          <Button
-            variant="outline"
-            className="gap-1 text-xs py-1 px-2 h-7"
-            onClick={() => setWizardOpen(true)}
-          >
-            <Plus className="size-3" />
-            Add Data Store
-          </Button>
+          <TooltipProvider>
+            <Tooltip>
+              <TooltipTrigger asChild>
+                <span className="inline-flex">
+                  <Button
+                    variant="outline"
+                    className="gap-1 text-xs py-1 px-2 h-7"
+                    onClick={() => setWizardOpen(true)}
+                    disabled={!canCreateDataStore}
+                    aria-disabled={!canCreateDataStore}
+                  >
+                    <Plus className="size-3" />
+                    Add Data Store
+                  </Button>
+                </span>
+              </TooltipTrigger>
+              {createDisabledReason && (
+                <TooltipContent>{createDisabledReason}</TooltipContent>
+              )}
+            </Tooltip>
+          </TooltipProvider>
         </div>
       </div>
+
+      {!canCreateDataStore && createDisabledReason && (
+        <p className="text-muted-foreground text-xs mb-3 -mt-1">{createDisabledReason}</p>
+      )}
 
       {/* Stats Cards */}
       <div className="grid grid-cols-3 gap-4 mb-6">
@@ -470,9 +501,9 @@ export function DataStores() {
 
       {/* Create Data Store Wizard */}
       <CreateDataStoreWizard
-        open={wizardOpen}
+        open={wizardOpen && canCreateDataStore}
         onOpenChange={setWizardOpen}
-        orgId={orgId}
+        orgId={callerOrgId ?? ""}
         onCreated={loadDataStores}
       />
     </PageContainer>

--- a/frontend/src/pages/__tests__/DataStores.orgSelection.test.tsx
+++ b/frontend/src/pages/__tests__/DataStores.orgSelection.test.tsx
@@ -1,0 +1,203 @@
+/**
+ * TDD (red-first) for the DataStores "Add Data Store" org-selection UX
+ * defect exposed by decision b5d463f2 (createDataStore now rejects a
+ * cross-org / placeholder orgId for everyone, including admins).
+ *
+ * Before the fix: DataStores.tsx:100 did
+ *   `const orgId = selectedOrganization || "default";`
+ * and passed that straight into CreateDataStoreWizard as the creation
+ * target — so an admin viewing "All Organizations" (selectedOrganization
+ * === 'All Organizations') or a user with no organization at all
+ * (selectedOrganization === null) would submit the literal string
+ * "default" as input.orgId, which can never match a real org claim and
+ * always gets rejected server-side with no clear explanation.
+ *
+ * This test asserts:
+ *  1. The "Add Data Store" action is disabled, with an actionable message,
+ *     when the caller has no organisation OR the selector is on
+ *     "All Organizations"/null.
+ *  2. When enabled, the wizard is opened with the CALLER'S OWN organisation
+ *     (currentUser.organization), never the selector value, and never the
+ *     literal placeholder "default".
+ */
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import '@testing-library/jest-dom';
+
+jest.mock('@/components/ui/card', () => ({
+  Card: ({ children, className }: any) => <div className={className}>{children}</div>,
+}));
+jest.mock('@/components/ui/button', () => ({
+  Button: ({ children, onClick, disabled, ...rest }: any) => (
+    <button onClick={onClick} disabled={disabled} {...rest}>{children}</button>
+  ),
+}));
+jest.mock('@/components/ui/tabs', () => ({
+  Tabs: ({ children, value }: any) => <div data-value={value}>{children}</div>,
+  TabsContent: ({ children, value }: any) => <div data-tabcontent={value}>{children}</div>,
+  TabsList: ({ children }: any) => <div role="tablist">{children}</div>,
+  TabsTrigger: ({ children, value, onClick }: any) => (
+    <button role="tab" data-value={value} onClick={onClick}>{children}</button>
+  ),
+}));
+jest.mock('@/components/ui/dialog', () => ({
+  Dialog: ({ children, open }: any) => open ? <div data-testid="dialog">{children}</div> : null,
+  DialogContent: ({ children }: any) => <div>{children}</div>,
+  DialogDescription: ({ children }: any) => <p>{children}</p>,
+  DialogHeader: ({ children }: any) => <div>{children}</div>,
+  DialogTitle: ({ children }: any) => <h2>{children}</h2>,
+}));
+jest.mock('@/components/ui/alert-dialog', () => ({
+  AlertDialog: ({ children, open }: any) => open ? <div data-testid="alert-dialog">{children}</div> : null,
+  AlertDialogAction: ({ children, onClick }: any) => <button onClick={onClick}>{children}</button>,
+  AlertDialogCancel: ({ children, onClick }: any) => <button onClick={onClick}>{children}</button>,
+  AlertDialogContent: ({ children }: any) => <div>{children}</div>,
+  AlertDialogDescription: ({ children }: any) => <p>{children}</p>,
+  AlertDialogFooter: ({ children }: any) => <div>{children}</div>,
+  AlertDialogHeader: ({ children }: any) => <div>{children}</div>,
+}));
+jest.mock('@/components/ui/input', () => ({
+  Input: (props: any) => <input {...props} />,
+}));
+jest.mock('@/components/ui/textarea', () => ({
+  Textarea: (props: any) => <textarea {...props} />,
+}));
+jest.mock('@/components/ui/label', () => ({
+  Label: ({ children, ...props }: any) => <label {...props}>{children}</label>,
+}));
+jest.mock('@/components/ui/utils', () => ({
+  cn: (...args: any[]) => args.filter(Boolean).join(' '),
+}));
+jest.mock('@/components/ui/tooltip', () => ({
+  Tooltip: ({ children }: any) => <>{children}</>,
+  TooltipContent: ({ children }: any) => <div role="tooltip">{children}</div>,
+  TooltipProvider: ({ children }: any) => <>{children}</>,
+  TooltipTrigger: ({ children }: any) => <>{children}</>,
+}));
+jest.mock('@/components/PageContainer', () => ({
+  PageContainer: ({ children }: any) => <div>{children}</div>,
+}));
+jest.mock('@/components/SearchInput', () => ({
+  SearchInput: ({ value, onChange, placeholder }: any) => (
+    <input data-testid="search-input" value={value} onChange={onChange} placeholder={placeholder} />
+  ),
+}));
+jest.mock('@/components/DataStoreCard', () => ({
+  DataStoreCard: ({ dataStore }: any) => (
+    <div data-testid={`datastore-card-${dataStore.id}`}>{dataStore.name}</div>
+  ),
+}));
+
+let capturedWizardProps: any = null;
+jest.mock('@/components/CreateDataStoreWizard', () => ({
+  CreateDataStoreWizard: (props: any) => {
+    capturedWizardProps = props;
+    return props.open ? <div data-testid="create-wizard" /> : null;
+  },
+}));
+
+let mockOrgContext: any = {};
+jest.mock('@/contexts/OrganizationContext', () => ({
+  useOrganization: () => mockOrgContext,
+}));
+
+jest.mock('sonner', () => ({
+  toast: { success: jest.fn(), error: jest.fn(), info: jest.fn() },
+}));
+
+jest.mock('@/services/datastoreService', () => ({
+  datastoreService: {
+    listDataStores: jest.fn().mockResolvedValue([]),
+    getDataStoreStats: jest.fn().mockResolvedValue({ total: 0, connected: 0, error: 0 }),
+    deleteDataStore: jest.fn().mockResolvedValue(undefined),
+  },
+  DataStoreStatus: {
+    CREATED: 'CREATED', CONNECTING: 'CONNECTING', CONNECTED: 'CONNECTED',
+    PROVISIONING: 'PROVISIONING', PROVISIONED: 'PROVISIONED',
+    DISCONNECTED: 'DISCONNECTED', ERROR: 'ERROR', DELETING: 'DELETING',
+  },
+  DataStoreCategory: {
+    KNOWLEDGE_BASE: 'KNOWLEDGE_BASE', RELATIONAL_DATABASE: 'RELATIONAL_DATABASE',
+    NOSQL_DATABASE: 'NOSQL_DATABASE', S3_STORAGE: 'S3_STORAGE',
+    DATA_WAREHOUSE: 'DATA_WAREHOUSE', DATA_LAKE: 'DATA_LAKE',
+    SEARCH_ENGINE: 'SEARCH_ENGINE', GRAPH_DATABASE: 'GRAPH_DATABASE',
+    TIME_SERIES: 'TIME_SERIES', DOCUMENT_DATABASE: 'DOCUMENT_DATABASE',
+    CACHE: 'CACHE', EXTERNAL: 'EXTERNAL',
+  },
+}));
+jest.mock('@/pages/datastoreFilterUtils', () => ({
+  filterDataStoresByUsage: (stores: any[]) => stores,
+  UsageFilterTab: {},
+}));
+
+import { DataStores } from '../DataStores';
+
+describe('DataStores — Add Data Store org-selection guard', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    capturedWizardProps = null;
+  });
+
+  test('disables Add Data Store with an actionable message when caller has no organisation', async () => {
+    mockOrgContext = {
+      selectedOrganization: null,
+      currentUser: { organization: undefined, role: 'user' },
+      isAdmin: false,
+      loading: false,
+    };
+
+    render(<DataStores />);
+
+    await waitFor(() => {
+      const addBtn = screen.getByRole('button', { name: /add data store/i });
+      expect(addBtn).toBeDisabled();
+    });
+    expect(
+      screen.getAllByText(/no organization.*contact an administrator/i).length,
+    ).toBeGreaterThan(0);
+  });
+
+  test('disables Add Data Store with an actionable message when an admin has no organisation of their own, even while viewing All Organizations', async () => {
+    mockOrgContext = {
+      selectedOrganization: 'All Organizations',
+      currentUser: { organization: undefined, role: 'admin' },
+      isAdmin: true,
+      loading: false,
+    };
+
+    render(<DataStores />);
+
+    await waitFor(() => {
+      const addBtn = screen.getByRole('button', { name: /add data store/i });
+      expect(addBtn).toBeDisabled();
+    });
+    expect(
+      screen.getAllByText(/no organization.*contact an administrator/i).length,
+    ).toBeGreaterThan(0);
+  });
+
+  test('enables Add Data Store and opens wizard with the caller\'s own organisation, never the selector value or a placeholder', async () => {
+    mockOrgContext = {
+      selectedOrganization: 'All Organizations',
+      currentUser: { organization: 'org-real', role: 'user' },
+      isAdmin: false,
+      loading: false,
+    };
+
+    render(<DataStores />);
+
+    const user = userEvent.setup();
+    const addBtn = await screen.findByRole('button', { name: /add data store/i });
+    expect(addBtn).not.toBeDisabled();
+
+    await user.click(addBtn);
+
+    await waitFor(() => {
+      expect(screen.getByTestId('create-wizard')).toBeInTheDocument();
+    });
+
+    expect(capturedWizardProps.orgId).toBe('org-real');
+    expect(capturedWizardProps.orgId).not.toBe('default');
+    expect(capturedWizardProps.orgId).not.toBe('All Organizations');
+  });
+});

--- a/frontend/src/pages/__tests__/DataStores.regression.test.tsx
+++ b/frontend/src/pages/__tests__/DataStores.regression.test.tsx
@@ -52,6 +52,12 @@ jest.mock('@/components/ui/label', () => ({
 jest.mock('@/components/ui/utils', () => ({
   cn: (...args: any[]) => args.filter(Boolean).join(' '),
 }));
+jest.mock('@/components/ui/tooltip', () => ({
+  Tooltip: ({ children }: any) => <>{children}</>,
+  TooltipContent: ({ children }: any) => <div role="tooltip">{children}</div>,
+  TooltipProvider: ({ children }: any) => <>{children}</>,
+  TooltipTrigger: ({ children }: any) => <>{children}</>,
+}));
 jest.mock('@/components/PageContainer', () => ({
   PageContainer: ({ children }: any) => <div>{children}</div>,
 }));
@@ -76,7 +82,12 @@ jest.mock('@/components/CreateDataStoreWizard', () => ({
   ),
 }));
 jest.mock('@/contexts/OrganizationContext', () => ({
-  useOrganization: () => ({ selectedOrganization: 'test-org' }),
+  useOrganization: () => ({
+    selectedOrganization: 'test-org',
+    currentUser: { organization: 'test-org', role: 'user' },
+    isAdmin: false,
+    loading: false,
+  }),
 }));
 jest.mock('sonner', () => ({
   toast: { success: jest.fn(), error: jest.fn() },


### PR DESCRIPTION
## Summary

Add Datastore failed with `Access denied: orgId does not match caller's organization`. This is **not a regression in the security fix** - PR 144 removed the admin bypass on `createDataStore`, and that removal exposed two pre-existing defects the bypass had been masking.

- The organisation selector defaults to "ALl Organizations", which `DataStores.tsx` turned into the literal string `"default"` and submitted as `input.orgId`
- a placeholder that can never match a real claim
- The resolver emitted the same message whether the caller's organisation claim was **missing**
genuinely **mismatched**, which made a provisioning gap look like a security bug

## Changes

- The create path now submits the **caller's own organisation**, never the selector value. The `|| "default"` fallback is gone from the create path and retained only for the filter scope, where it is correct
- Add Data Store is disabled with a tooltip and visible text - "No organization is provisioned for your account. Contact an administrator." - when no organisation resolves, matching `ToolCard`'s existing disabled-with-reason convention
- The resolver splits one rejection into two distinct `PermissionError`s: no claim resolved, versus supplied organisation does not match. Both still reject

## What was deliberately not weakened

No admin bypass reintroduced. No coercion or defaulting of a missing organisation. The server still validates against the caller's verified claim and Logs carry `createdBy` never treats the client's value authoritative and at most the caller's *own* resolved organisation - never another tenant's.

Review verified the gate by test (claim-less caller rejected; admin with a differing organisation rejected) and by bite: removing the mismatch check permits cross-org creation, restored byte-identically.

## Testing

Red-first on both halves. Backend tsc 0, lint o, targeted jest 40, full jest 7806. Frontend tsc 0, jest 2067, vite build 0.