### PR TITLE
fix(security): fail closed when the caller org is unresolved

### DIFF
--- a/backend/src/lambda/__tests__/datastore-resolver-org-scoping.test.ts
+++ b/backend/src/lambda/__tests__/datastore-resolver-org-scoping.test.ts
@@ -1,25 +1,30 @@
 /**
- * Org-scoping regression tests for datastore-resolver.ts (sweep finding
- * under 615aa5bb, filed against getDataStoreStats and re-swept across the
- * whole file).
+ * Org-scoping regression tests for datastore-resolver.ts (finding f0ce2b00,
+ * high — supersedes the sweep finding 615aa5bb coerce-based fix that
+ * shipped here previously).
  *
- * Before the fix: getDataStoreStats/listDataStores/listAvailableDataSources
- * all dispatched `event.arguments.orgId` straight into an OrgIndex query
- * with no identity validation — any authenticated caller could pass another
- * org's orgId and read that org's data store inventory / connection stats.
+ * The coerce-based fix (`callerOrgId || event.arguments.orgId`) inverted
+ * the trust direction it looked like it was enforcing: when a non-admin
+ * caller had NO resolvable `custom:organization` claim (reachable —
+ * `adminCreateUser` never sets that attribute, finding cbbc3be1),
+ * `callerOrgId` was `null`/`""`, so `||` fell through to the
+ * CLIENT-SUPPLIED `event.arguments.orgId` — handing that caller any
+ * tenant's full row set on request, since `orgId` is a required argument
+ * on all four affected queries per schema.graphql.
  *
- * Fix mirrors the read-path tenant gate used by listIntegrations
- * (integration-resolver.ts, same sweep) / listApps
- * (registry-agent-record-resolver.ts) / listProjects (project-resolver.ts):
- * a non-admin caller's server-derived org always wins over a mismatched
- * requested orgId (coerce, not reject). Admins may still pass an explicit
- * orgId.
+ * Fixed shape (mirrors `requireCallerOrg` in user-management-resolver.ts):
+ *   - Admin: use the supplied argument explicitly (reachable only via an
+ *     explicit `isAdminFromEvent` check, never via absence of a claim).
+ *   - Non-admin: use ONLY the caller's own resolved org.
+ *   - Unresolved effective org (non-admin, no claim): DENY via
+ *     PermissionError — never fall through to the client argument.
  */
 // ---- Mock setup ----
 const mockDynamoSend = jest.fn();
 jest.mock("../../utils/auth-event", () => ({
   extractOrgFromEvent: jest.fn(),
   isAdminFromEvent: jest.fn(),
+  assertRowOrg: jest.fn(),
 }));
 jest.mock("@aws-sdk/client-dynamodb", () => ({
   DynamoDBClient: jest.fn().mockImplementation(() => ({})),
@@ -39,6 +44,7 @@ jest.mock("@aws-sdk/lib-dynamodb", () => {
 
 import { handler } from "../datastore-resolver";
 import { extractOrgFromEvent, isAdminFromEvent } from "../../utils/auth-event";
+import { PermissionError } from "../adapters/errors";
 
 const mockExtractOrgFromEvent = extractOrgFromEvent as jest.Mock;
 const mockIsAdminFromEvent = isAdminFromEvent as jest.Mock;
@@ -70,91 +76,86 @@ beforeEach(() => {
   );
 });
 
-describe("getDataStoreStats — org scoping (sweep finding 615aa5bb)", () => {
-  it("ignores a cross-org orgId argument and scopes stats to the caller server-derived org", async () => {
-    mockExtractOrgFromEvent.mockResolvedValue("org-real");
+describe.each([
+  ["getDataStoreStats"],
+  ["listDataStores"],
+  ["listAvailableDataSources"],
+])("%s — fail-closed org scoping (finding f0ce2b00)", (fieldName) => {
+  it("DENIES a non-admin caller with no resolvable org claim, regardless of the orgId argument supplied — no rows leak", async () => {
+    mockExtractOrgFromEvent.mockResolvedValue(null);
     mockIsAdminFromEvent.mockReturnValue(false);
 
     const event = {
-      info: { fieldName: "getDataStoreStats" },
+      info: { fieldName },
       identity: { sub: "user-1" },
-      arguments: { orgId: "org-spoofed" },
+      arguments: { orgId: "org-real" },
     };
 
-    const result = await handler(event as never);
-
-    expect(result.total).toBe(1);
-    expect(result.connected).toBe(1);
-
-    // Verify the query was actually built with the caller's real org, not
-    // the spoofed argument — no unscoped/cross-org scan remains.
-    const call = mockDynamoSend.mock.calls[0][0];
-    expect(call.input.ExpressionAttributeValues[":orgId"]).toBe("org-real");
+    await expect(handler(event as never)).rejects.toBeInstanceOf(
+      PermissionError,
+    );
+    expect(mockDynamoSend).not.toHaveBeenCalled();
   });
 
-  it("returns empty stats for a cross-org caller instead of leaking the spoofed org data", async () => {
-    mockExtractOrgFromEvent.mockResolvedValue("org-empty");
+  it("DENIES a non-admin caller passing another tenant's orgId rather than returning that tenant's records", async () => {
+    mockExtractOrgFromEvent.mockResolvedValue("org-mine");
     mockIsAdminFromEvent.mockReturnValue(false);
 
     const event = {
-      info: { fieldName: "getDataStoreStats" },
+      info: { fieldName },
       identity: { sub: "user-2" },
-      arguments: { orgId: "org-real" }, // attacker-supplied, does not match identity
+      arguments: { orgId: "org-real" }, // attacker-supplied, does not match caller
     };
 
     const result = await handler(event as never);
-
-    expect(result.total).toBe(0);
+    // Must be scoped to the caller's OWN org (which the mock returns empty
+    // for), never the spoofed org-real — the caller receives nothing.
     const call = mockDynamoSend.mock.calls[0][0];
-    expect(call.input.ExpressionAttributeValues[":orgId"]).toBe("org-empty");
+    expect(call.input.ExpressionAttributeValues[":orgId"]).toBe("org-mine");
+    if (Array.isArray(result)) {
+      expect(result).toEqual([]);
+    } else {
+      expect(result.total).toBe(0);
+    }
   });
 
-  it("admin callers may pass an explicit orgId to read any org stats", async () => {
+  it("admin callers may still query a specified org explicitly", async () => {
     mockExtractOrgFromEvent.mockResolvedValue(null);
     mockIsAdminFromEvent.mockReturnValue(true);
 
     const event = {
-      info: { fieldName: "getDataStoreStats" },
+      info: { fieldName },
       identity: { sub: "admin-1", "custom:role": "admin" },
       arguments: { orgId: "org-real" },
     };
 
     const result = await handler(event as never);
-    expect(result.total).toBe(1);
+    const call = mockDynamoSend.mock.calls[0][0];
+    expect(call.input.ExpressionAttributeValues[":orgId"]).toBe("org-real");
+    if (Array.isArray(result)) {
+      expect(result.length).toBeGreaterThan(0);
+    } else {
+      expect(result.total).toBe(1);
+    }
   });
-});
 
-describe("listDataStores — org scoping (re-sweep, same mechanical shape)", () => {
-  it("ignores a cross-org orgId argument and scopes to the caller server-derived org", async () => {
+  it("a normal non-admin caller still sees their own org's rows", async () => {
     mockExtractOrgFromEvent.mockResolvedValue("org-real");
     mockIsAdminFromEvent.mockReturnValue(false);
 
     const event = {
-      info: { fieldName: "listDataStores" },
-      identity: { sub: "user-1" },
-      arguments: { orgId: "org-spoofed" },
+      info: { fieldName },
+      identity: { sub: "user-3" },
+      arguments: { orgId: "org-real" },
     };
 
     const result = await handler(event as never);
-    expect(result).toEqual([expect.objectContaining({ dataStoreId: "ds-1" })]);
     const call = mockDynamoSend.mock.calls[0][0];
     expect(call.input.ExpressionAttributeValues[":orgId"]).toBe("org-real");
-  });
-});
-
-describe("listAvailableDataSources — org scoping (re-sweep, same mechanical shape)", () => {
-  it("ignores a cross-org orgId argument and scopes to the caller server-derived org", async () => {
-    mockExtractOrgFromEvent.mockResolvedValue("org-real");
-    mockIsAdminFromEvent.mockReturnValue(false);
-
-    const event = {
-      info: { fieldName: "listAvailableDataSources" },
-      identity: { sub: "user-1" },
-      arguments: { orgId: "org-spoofed" },
-    };
-
-    await handler(event as never);
-    const call = mockDynamoSend.mock.calls[0][0];
-    expect(call.input.ExpressionAttributeValues[":orgId"]).toBe("org-real");
+    if (Array.isArray(result)) {
+      expect(result.length).toBeGreaterThan(0);
+    } else {
+      expect(result.total).toBe(1);
+    }
   });
 });

--- a/backend/src/lambda/__tests__/integration-resolver-org-scoping.test.ts
+++ b/backend/src/lambda/__tests__/integration-resolver-org-scoping.test.ts
@@ -1,97 +1,136 @@
 /**
- * Org-scoping regression test for listIntegrations (sweep finding under
- * 615aa5bb): the handler dispatched `event.arguments.orgId` straight into
- * listIntegrations() with no identity validation — any authenticated
- * caller could pass another org's orgId and receive that org's
- * integrations list (names, types, connection status).
+ * Org-scoping regression test for listIntegrations (finding f0ce2b00,
+ * high — supersedes the sweep finding under 615aa5bb coerce-based fix
+ * that shipped here previously).
  *
- * Fix mirrors the read-path precedent (listApps in
- * registry-agent-record-resolver.ts / listProjects in project-resolver.ts):
- * a non-admin caller's own server-derived org silently WINS over a
- * mismatched requested orgId (coerce, not reject) — reads use the
- * "you only ever see your own org" tenant gate. This differs from the
- * mutation-path decision in testTool/decideToolApproval (explicit reject
- * on mismatch) because a read has no side effect to block; silently
- * scoping to the caller's real org is sufficient and matches every other
- * list* query in this codebase.
+ * The coerce-based fix (`callerOrgId || event.arguments.orgId`) inverted
+ * the trust direction it looked like it was enforcing: when a non-admin
+ * caller had NO resolvable `custom:organization` claim (reachable —
+ * `adminCreateUser` never sets that attribute, finding cbbc3be1),
+ * `callerOrgId` was `null`/`""`, so `||` fell through to the
+ * CLIENT-SUPPLIED `event.arguments.orgId` — handing that caller another
+ * tenant's full integrations list (names, types, connection status) on
+ * request, since `orgId` is a required argument on this query per
+ * schema.graphql.
+ *
+ * Fixed shape (mirrors `requireCallerOrg` in user-management-resolver.ts):
+ *   - Admin: use the supplied argument explicitly.
+ *   - Non-admin: use ONLY the caller's own resolved org.
+ *   - Unresolved effective org (non-admin, no claim): DENY via
+ *     PermissionError — never fall through to the client argument.
  */
-import { handler } from "../integration-resolver";
-
+const mockSend = jest.fn();
 jest.mock("../../utils/auth-event", () => ({
   extractOrgFromEvent: jest.fn(),
   isAdminFromEvent: jest.fn(),
+  assertRowOrg: jest.fn(),
 }));
-
-import { extractOrgFromEvent, isAdminFromEvent } from "../../utils/auth-event";
-
-const mockExtractOrgFromEvent = extractOrgFromEvent as jest.Mock;
-const mockIsAdminFromEvent = isAdminFromEvent as jest.Mock;
-
+jest.mock("@aws-sdk/client-dynamodb", () => ({
+  DynamoDBClient: jest.fn().mockImplementation(() => ({})),
+}));
 jest.mock("@aws-sdk/lib-dynamodb", () => {
   const actual = jest.requireActual("@aws-sdk/lib-dynamodb");
   return {
     ...actual,
     DynamoDBDocumentClient: {
-      from: () => ({
-        send: jest.fn(async (command: unknown) => {
-          const input = (
-            command as {
-              input: { ExpressionAttributeValues?: Record<string, string> };
-            }
-          ).input;
-          const pk = input.ExpressionAttributeValues?.[":pk"];
-          // Simulate DynamoDB partition isolation: only ever returns rows
-          // matching the exact PK requested.
-          if (pk === "ORG#org-real") {
-            return {
-              Items: [
-                {
-                  integrationId: "int-1",
-                  integrationType: "SLACK",
-                  status: "CONNECTED",
-                  orgId: "org-real",
-                },
-              ],
-            };
-          }
-          return { Items: [] };
-        }),
-      }),
+      from: jest.fn().mockReturnValue({ send: mockSend }),
     },
+    QueryCommand: jest
+      .fn()
+      .mockImplementation((input) => ({ _type: "Query", input })),
   };
 });
 
+import { handler } from "../integration-resolver";
+import { extractOrgFromEvent, isAdminFromEvent } from "../../utils/auth-event";
+import { PermissionError } from "../adapters/errors";
+
+const mockExtractOrgFromEvent = extractOrgFromEvent as jest.Mock;
+const mockIsAdminFromEvent = isAdminFromEvent as jest.Mock;
+
 beforeEach(() => {
   jest.clearAllMocks();
+  mockSend.mockImplementation(async (command: unknown) => {
+    const input = (
+      command as {
+        input: { ExpressionAttributeValues?: Record<string, string> };
+      }
+    ).input;
+    const pk = input.ExpressionAttributeValues?.[":pk"];
+    // Simulate DynamoDB partition isolation: only ever returns rows
+    // matching the exact PK requested.
+    if (pk === "ORG#org-real") {
+      return {
+        Items: [
+          {
+            integrationId: "int-1",
+            integrationType: "SLACK",
+            status: "CONNECTED",
+            orgId: "org-real",
+          },
+        ],
+      };
+    }
+    return { Items: [] };
+  });
 });
 
-describe("listIntegrations — org scoping (sweep finding under 615aa5bb)", () => {
-  it("ignores a cross-org orgId argument and scopes to the caller's own server-derived org", async () => {
-    mockExtractOrgFromEvent.mockResolvedValue("org-real");
+describe("listIntegrations — fail-closed org scoping (finding f0ce2b00)", () => {
+  it("DENIES a non-admin caller with no resolvable org claim, regardless of the orgId argument supplied — no rows leak", async () => {
+    mockExtractOrgFromEvent.mockResolvedValue(null);
     mockIsAdminFromEvent.mockReturnValue(false);
 
     const event = {
       info: { fieldName: "listIntegrations" },
       identity: { sub: "user-1" },
-      arguments: { orgId: "org-spoofed" }, // attacker-supplied, does not match identity
+      arguments: { orgId: "org-real" },
+    };
+
+    await expect(handler(event as never)).rejects.toBeInstanceOf(
+      PermissionError,
+    );
+    expect(mockSend).not.toHaveBeenCalled();
+  });
+
+  it("DENIES a non-admin caller passing another tenant's orgId rather than returning that tenant's records", async () => {
+    mockExtractOrgFromEvent.mockResolvedValue("org-mine");
+    mockIsAdminFromEvent.mockReturnValue(false);
+
+    const event = {
+      info: { fieldName: "listIntegrations" },
+      identity: { sub: "user-2" },
+      arguments: { orgId: "org-real" }, // attacker-supplied
     };
 
     const result = await handler(event as never);
-
-    // Caller's real org's integration is returned, never the spoofed org's
-    // (which the mock would return empty for since it queries a different PK).
-    expect(result).toEqual([
-      expect.objectContaining({ integrationId: "int-1" }),
-    ]);
+    expect(result).toEqual([]);
+    const call = mockSend.mock.calls[0][0];
+    expect(call.input.ExpressionAttributeValues[":pk"]).toBe("ORG#org-mine");
   });
 
-  it("admin callers may pass an explicit orgId to list any org's integrations", async () => {
+  it("admin callers may still list a specified org's integrations explicitly", async () => {
     mockExtractOrgFromEvent.mockResolvedValue(null);
     mockIsAdminFromEvent.mockReturnValue(true);
 
     const event = {
       info: { fieldName: "listIntegrations" },
       identity: { sub: "admin-1", "custom:role": "admin" },
+      arguments: { orgId: "org-real" },
+    };
+
+    const result = await handler(event as never);
+    expect(result).toEqual([
+      expect.objectContaining({ integrationId: "int-1" }),
+    ]);
+  });
+
+  it("a normal non-admin caller still sees their own org's integrations", async () => {
+    mockExtractOrgFromEvent.mockResolvedValue("org-real");
+    mockIsAdminFromEvent.mockReturnValue(false);
+
+    const event = {
+      info: { fieldName: "listIntegrations" },
+      identity: { sub: "user-3" },
       arguments: { orgId: "org-real" },
     };
 

--- a/backend/src/lambda/__tests__/no-caller-org-fallback-idiom.guard.test.ts
+++ b/backend/src/lambda/__tests__/no-caller-org-fallback-idiom.guard.test.ts
@@ -1,0 +1,304 @@
+/**
+ * no-caller-org-fallback-idiom.guard.test.ts — pins closed finding f0ce2b00
+ * (high): four resolvers coerced an unresolvable caller org into a
+ * CLIENT-SUPPLIED argument via `const effectiveOrgId = callerOrgId ||
+ * event.arguments.orgId;` (datastore-resolver.ts listDataStores /
+ * getDataStoreStats / listAvailableDataSources; integration-resolver.ts
+ * listIntegrations). Because `orgId` is a required argument on all four
+ * GraphQL fields, and `adminCreateUser` never sets `custom:organization`
+ * (finding cbbc3be1) so a non-admin caller can legitimately have no
+ * resolvable org claim, this idiom let such a caller read ANY tenant's
+ * rows just by supplying that tenant's orgId — the `||` reads as
+ * defensive (falls back to *something*) while actually inverting the
+ * trust direction (falls back to attacker-controlled input).
+ *
+ * This guard is AST-based, per the repo lesson (documented in
+ * app-access-control-dead-code-guard.test.ts and this project's
+ * steering docs) that a regex over source text is defeated by
+ * reformatting, renaming through an intermediate variable, or the
+ * pattern being restated inside a comment/string. Parsing with the
+ * TypeScript compiler lets the check inspect the actual BinaryExpression
+ * shape (`<identifier-or-property-read> || <property-read ending in
+ * "orgId" read off an object other than the left operand's own base>`)
+ * rather than matching literal text.
+ *
+ * Detected shape: a `||` binary expression whose:
+ *   - LEFT operand is any expression (typically a caller-org identifier,
+ *     e.g. `callerOrgId`, or `event.something.orgId` naming the caller),
+ *   - RIGHT operand is a property-access expression whose final property
+ *     name is exactly `orgId`, AND whose access path contains an
+ *     `arguments` segment (`event.arguments.orgId`, `args.orgId`,
+ *     `evt.arguments.orgId`, etc. — the "client argument" shape) or is a
+ *     bare identifier literally named `orgId` that is not the same
+ *     identifier as the left operand (covers a destructured
+ *     `{ orgId } = event.arguments` shape feeding
+ *     `callerOrgId || orgId`).
+ *
+ * This intentionally does NOT flag:
+ *   - `rowOrgId || !callerOrgId || ...` used as a REJECT condition (e.g.
+ *     assertRowOrg in auth-event.ts: `!rowOrgId || !callerOrgId ||
+ *     rowOrgId !== callerOrgId`) — the right operand there is a
+ *     comparison/negation, not a bare `...orgId` value read off an
+ *     arguments-shaped path.
+ *   - `a.orgId === callerOrgId || a.orgId === ""` (per-row membership
+ *     filters in agent-config-resolver.ts) — the right operand is an
+ *     equality comparison, not an `orgId` property read.
+ *   - `callerOrgId || suppliedOrgId` in tool-sandbox.ts — structurally
+ *     different: the non-admin path already denies above (`!callerOrgId`
+ *     and a mismatched `suppliedOrgId` both return an UnauthorizedError
+ *     before this line runs), so by the time this line executes for a
+ *     non-admin, callerOrgId is already truthy; the fallback only
+ *     resolves for admins. Still caught by the RIGHT-operand-shape rule
+ *     below only if `suppliedOrgId` were a raw `event.arguments.orgId`
+ *     property read — it is a local variable, not a property-access
+ *     expression, so it is not flagged. This is a deliberate scope
+ *     boundary: this guard targets the specific
+ *     property-access-off-arguments shape that caused f0ce2b00, not every
+ *     local variable named similarly. If tool-sandbox.ts's admin fallback
+ *     is ever rewritten to read `event.arguments.orgId` directly inline,
+ *     that WOULD trip this guard (see the bites test below).
+ */
+import * as fs from "fs";
+import * as path from "path";
+import * as ts from "typescript";
+
+const REPO_ROOT = path.resolve(__dirname, "../../..");
+const SCAN_DIR = path.join("src");
+
+function listSourceFiles(dir: string): string[] {
+  const abs = path.join(REPO_ROOT, dir);
+  if (!fs.existsSync(abs)) return [];
+  const out: string[] = [];
+  const stack = [abs];
+  while (stack.length > 0) {
+    const current = stack.pop()!;
+    for (const entry of fs.readdirSync(current, { withFileTypes: true })) {
+      if (entry.name === "node_modules" || entry.name === "__tests__") {
+        continue;
+      }
+      const full = path.join(current, entry.name);
+      if (entry.isDirectory()) {
+        stack.push(full);
+      } else if (entry.isFile() && /\.tsx?$/.test(entry.name)) {
+        out.push(full);
+      }
+    }
+  }
+  return out;
+}
+
+function parseSourceFile(filePath: string, text?: string): ts.SourceFile {
+  const content = text ?? fs.readFileSync(filePath, "utf-8");
+  return ts.createSourceFile(
+    filePath,
+    content,
+    ts.ScriptTarget.ESNext,
+    /* setParentNodes */ true,
+    filePath.endsWith(".tsx") ? ts.ScriptKind.TSX : ts.ScriptKind.TS,
+  );
+}
+
+/**
+ * True when `node` is a property-access chain (e.g. `event.arguments.orgId`,
+ * `args.orgId`) whose FINAL property name is `orgId` and whose access path
+ * includes a segment literally named `arguments` OR `args` — the
+ * "client-supplied argument" shape. A bare identifier `orgId` is also
+ * treated as this shape (covers a destructured `{ orgId } =
+ * event.arguments` feeding a same-named local).
+ */
+function isClientArgumentOrgIdRead(node: ts.Expression): boolean {
+  if (ts.isIdentifier(node)) {
+    return node.text === "orgId";
+  }
+  if (!ts.isPropertyAccessExpression(node)) return false;
+  if (node.name.text !== "orgId") return false;
+
+  // Walk the access chain collecting every identifier/property name in it.
+  const segments: string[] = [];
+  let current: ts.Expression = node;
+  while (ts.isPropertyAccessExpression(current)) {
+    segments.unshift(current.name.text);
+    current = current.expression;
+  }
+  if (ts.isIdentifier(current)) {
+    segments.unshift(current.text);
+  }
+  return segments.some((s) => s === "arguments" || s === "args");
+}
+
+/**
+ * Returns every `||` BinaryExpression in `sf` whose right operand is a
+ * client-argument `orgId` read (per {@link isClientArgumentOrgIdRead})
+ * and whose left operand is NOT itself the exact same identifier as the
+ * right operand's bare-identifier form (avoids flagging a trivial
+ * `orgId || orgId` no-op, which is not the vulnerable shape).
+ */
+function findCallerOrgFallbackIdioms(sf: ts.SourceFile): ts.Node[] {
+  const hits: ts.Node[] = [];
+
+  function visit(node: ts.Node): void {
+    if (
+      ts.isBinaryExpression(node) &&
+      node.operatorToken.kind === ts.SyntaxKind.BarBarToken &&
+      isClientArgumentOrgIdRead(node.right)
+    ) {
+      const leftIsSameBareIdentifier =
+        ts.isIdentifier(node.left) &&
+        ts.isIdentifier(node.right) &&
+        node.left.text === node.right.text;
+      if (!leftIsSameBareIdentifier) {
+        hits.push(node);
+      }
+    }
+    ts.forEachChild(node, visit);
+  }
+
+  visit(sf);
+  return hits;
+}
+
+function scan(): string[] {
+  const violations: string[] = [];
+  for (const file of listSourceFiles(SCAN_DIR)) {
+    const relPath = path.relative(REPO_ROOT, file);
+    const sf = parseSourceFile(file);
+    if (findCallerOrgFallbackIdioms(sf).length > 0) {
+      violations.push(relPath);
+    }
+  }
+  return violations;
+}
+
+describe("no-caller-org-fallback-idiom guard (finding f0ce2b00)", () => {
+  it("no file under src/ contains a `<callerOrg> || <client-argument orgId>` fallback expression", () => {
+    const violations = scan();
+    expect(violations).toEqual([]);
+  });
+
+  it("bites: `callerOrgId || event.arguments.orgId` in a scratch file IS flagged", () => {
+    const sf = parseSourceFile(
+      "scratch.ts",
+      [
+        "function f(event: any, admin: boolean) {",
+        "  const callerOrgId = admin ? null : 'x';",
+        "  const effectiveOrgId = callerOrgId || event.arguments.orgId;",
+        "  return effectiveOrgId;",
+        "}",
+      ].join("\n"),
+    );
+    expect(findCallerOrgFallbackIdioms(sf).length).toBeGreaterThan(0);
+  });
+
+  it("bites: `callerOrgId || args.orgId` (shorthand arguments variable name) IS flagged", () => {
+    const sf = parseSourceFile(
+      "scratch.ts",
+      [
+        "function f(callerOrgId: string | null, args: { orgId: string }) {",
+        "  return callerOrgId || args.orgId;",
+        "}",
+      ].join("\n"),
+    );
+    expect(findCallerOrgFallbackIdioms(sf).length).toBeGreaterThan(0);
+  });
+
+  it("bites: `someOrg || evt.arguments.orgId` through a differently-named left operand IS flagged (catches the pattern by shape, not by the left-hand variable's name)", () => {
+    const sf = parseSourceFile(
+      "scratch.ts",
+      [
+        "function f(someOrg: string | null, evt: any) {",
+        "  return someOrg || evt.arguments.orgId;",
+        "}",
+      ].join("\n"),
+    );
+    expect(findCallerOrgFallbackIdioms(sf).length).toBeGreaterThan(0);
+  });
+
+  it("bites: destructured `{ orgId } = event.arguments` feeding `callerOrgId || orgId` IS flagged", () => {
+    const sf = parseSourceFile(
+      "scratch.ts",
+      [
+        "function f(event: any, callerOrgId: string | null) {",
+        "  const { orgId } = event.arguments;",
+        "  return callerOrgId || orgId;",
+        "}",
+      ].join("\n"),
+    );
+    expect(findCallerOrgFallbackIdioms(sf).length).toBeGreaterThan(0);
+  });
+
+  it("does NOT flag the reject-not-coerce comparison shape (`!rowOrgId || !callerOrgId || rowOrgId !== callerOrgId`, assertRowOrg's actual gate)", () => {
+    const sf = parseSourceFile(
+      "scratch.ts",
+      [
+        "function f(rowOrgId: string | undefined, callerOrgId: string | null) {",
+        "  if (!rowOrgId || !callerOrgId || rowOrgId !== callerOrgId) {",
+        "    throw new Error('denied');",
+        "  }",
+        "}",
+      ].join("\n"),
+    );
+    expect(findCallerOrgFallbackIdioms(sf).length).toBe(0);
+  });
+
+  it('does NOT flag a per-row membership filter (`a.orgId === callerOrgId || a.orgId === ""`)', () => {
+    const sf = parseSourceFile(
+      "scratch.ts",
+      [
+        "function f(rows: { orgId: string }[], callerOrgId: string | null) {",
+        "  return rows.filter((a) => a.orgId === callerOrgId || a.orgId === '');",
+        "}",
+      ].join("\n"),
+    );
+    expect(findCallerOrgFallbackIdioms(sf).length).toBe(0);
+  });
+
+  it("does NOT flag a local-variable fallback that is not itself a client-argument property read (tool-sandbox.ts's admin-only `callerOrgId || suppliedOrgId`, where suppliedOrgId is a destructured local, not an inline `event.arguments.orgId` read)", () => {
+    const sf = parseSourceFile(
+      "scratch.ts",
+      [
+        "function f(event: { arguments: { orgId: string } }, callerOrgId: string | null) {",
+        "  const suppliedOrgId = event.arguments.orgId;",
+        "  return callerOrgId || suppliedOrgId;",
+        "}",
+      ].join("\n"),
+    );
+    expect(findCallerOrgFallbackIdioms(sf).length).toBe(0);
+  });
+
+  it("does NOT flag a comment that merely mentions the idiom in prose (comment-defeat resistance)", () => {
+    const sf = parseSourceFile(
+      "scratch.ts",
+      [
+        "/**",
+        " * Do not write `callerOrgId || event.arguments.orgId` here — see",
+        " * finding f0ce2b00.",
+        " */",
+        "export function noop(): void {}",
+      ].join("\n"),
+    );
+    expect(findCallerOrgFallbackIdioms(sf).length).toBe(0);
+  });
+
+  it("does NOT flag a trivial `orgId || orgId` no-op (same bare identifier on both sides)", () => {
+    const sf = parseSourceFile(
+      "scratch.ts",
+      [
+        "function f(orgId: string | undefined) {",
+        "  return orgId || orgId;",
+        "}",
+      ].join("\n"),
+    );
+    expect(findCallerOrgFallbackIdioms(sf).length).toBe(0);
+  });
+
+  it("the four fixed sites (datastore-resolver.ts listDataStores/getDataStoreStats/listAvailableDataSources, integration-resolver.ts listIntegrations) no longer contain the idiom", () => {
+    const fixedFiles = [
+      path.join(REPO_ROOT, "src", "lambda", "datastore-resolver.ts"),
+      path.join(REPO_ROOT, "src", "lambda", "integration-resolver.ts"),
+    ];
+    for (const file of fixedFiles) {
+      const sf = parseSourceFile(file);
+      expect(findCallerOrgFallbackIdioms(sf)).toEqual([]);
+    }
+  });
+});

--- a/backend/src/lambda/__tests__/workflow-resolver.test.ts
+++ b/backend/src/lambda/__tests__/workflow-resolver.test.ts
@@ -180,6 +180,78 @@ describe("workflow-resolver", () => {
       const queryCall = ddbMock.commandCalls(QueryCommand)[0];
       expect(queryCall.args[0].input.IndexName).toBe("OrgStatusIndex");
     });
+
+    // Fail-closed org scoping (finding f0ce2b00, high — same one-line
+    // inversion shape found in datastore-resolver.ts/integration-resolver.ts:
+    // `const queryOrgId = userOrg || orgId;` coerced an unresolvable caller
+    // org into the CLIENT-SUPPLIED orgId argument instead of denying).
+    test("DENIES a non-admin caller with no resolvable org claim, regardless of the orgId argument supplied — no rows leak", async () => {
+      cognitoMock.reset();
+      cognitoMock.on(AdminGetUserCommand).resolves({ UserAttributes: [] });
+      ddbMock.on(QueryCommand).resolves({
+        Items: [
+          { workflowId: "wf-1", orgId: "org-real", isBlueprint: "false" },
+        ],
+      });
+
+      await expect(
+        invoke(makeEvent("listWorkflows", { orgId: "org-real" })),
+      ).rejects.toThrow();
+      expect(ddbMock.commandCalls(QueryCommand)).toHaveLength(0);
+    });
+
+    test("DENIES a non-admin caller passing another tenant's orgId rather than returning that tenant's records", async () => {
+      // beforeEach already resolves the caller's own org to "org-1".
+      ddbMock.on(QueryCommand).resolves({
+        Items: [
+          { workflowId: "wf-real", orgId: "org-real", isBlueprint: "false" },
+        ],
+      });
+
+      await invoke(makeEvent("listWorkflows", { orgId: "org-real" }));
+
+      const queryCall = ddbMock.commandCalls(QueryCommand)[0];
+      expect(queryCall.args[0].input.ExpressionAttributeValues[":orgId"]).toBe(
+        "org-1",
+      );
+    });
+
+    test("a normal non-admin caller still sees their own org's workflows", async () => {
+      const items = [
+        { workflowId: "wf-1", orgId: "org-1", isBlueprint: "false" },
+      ];
+      ddbMock.on(QueryCommand).resolves({ Items: items });
+
+      const result = await invoke(
+        makeEvent("listWorkflows", { orgId: "org-1" }),
+      );
+      expect(result).toEqual({ items, nextToken: undefined });
+    });
+
+    test("an admin caller may still query a specified org explicitly", async () => {
+      cognitoMock.reset();
+      cognitoMock.on(AdminGetUserCommand).resolves({ UserAttributes: [] });
+      const items = [
+        { workflowId: "wf-real", orgId: "org-real", isBlueprint: "false" },
+      ];
+      ddbMock.on(QueryCommand).resolves({ Items: items });
+
+      const adminEvent = {
+        info: { fieldName: "listWorkflows" },
+        arguments: { orgId: "org-real" },
+        identity: {
+          sub: "admin-1",
+          claims: { sub: "admin-1", "cognito:groups": ["admin"] },
+        },
+      } as unknown as HandlerEvent;
+
+      const result = await invoke(adminEvent);
+      expect(result).toEqual({ items, nextToken: undefined });
+      const queryCall = ddbMock.commandCalls(QueryCommand)[0];
+      expect(queryCall.args[0].input.ExpressionAttributeValues[":orgId"]).toBe(
+        "org-real",
+      );
+    });
   });
 
   // ─── listBlueprints ────────────────────────────────────────────

--- a/backend/src/lambda/datastore-resolver.ts
+++ b/backend/src/lambda/datastore-resolver.ts
@@ -122,6 +122,41 @@ interface AppSyncEvent extends Omit<
 
 // --- Handler ---
 
+/**
+ * Fail-closed resolution of the org a read-path query should be scoped to
+ * (finding f0ce2b00, high). Mirrors the `requireCallerOrg` pattern in
+ * user-management-resolver.ts, adapted for an explicit client-supplied
+ * `orgId` argument rather than a row lookup:
+ *
+ *   - Admin (explicit `isAdminFromEvent` check): use the supplied argument
+ *     as-is — admins may still query any org on request.
+ *   - Non-admin: use ONLY the caller's own server-derived org
+ *     (extractOrgFromEvent); the argument is never consulted.
+ *   - Unresolved effective org (non-admin with no resolvable
+ *     `custom:organization` claim — reachable, since adminCreateUser never
+ *     sets that attribute, finding cbbc3be1): DENY via PermissionError.
+ *
+ * The prior shape (`callerOrgId || event.arguments.orgId`) coerced an
+ * unresolvable caller org into the client-supplied argument instead of
+ * denying — inverting the trust direction. Never reintroduce that `||`
+ * fallback; see the `no-caller-org-fallback-idiom` guard test.
+ *
+ * The denial message intentionally does not confirm or deny whether the
+ * requested org exists.
+ */
+async function requireEffectiveOrgId(event: AppSyncEvent): Promise<string> {
+  if (isAdminFromEvent(event)) {
+    return event.arguments.orgId;
+  }
+  const callerOrgId = await extractOrgFromEvent(event);
+  if (!callerOrgId) {
+    throw new PermissionError(
+      "Access denied: no organization is provisioned for your account. Contact an administrator.",
+    );
+  }
+  return callerOrgId;
+}
+
 export async function handler(event: AppSyncEvent) {
   const sanitizedEvent = {
     ...event,
@@ -149,27 +184,23 @@ export async function handler(event: AppSyncEvent) {
   try {
     switch (fieldName) {
       case "listDataStores": {
-        // Org scoping (sweep finding 615aa5bb): a non-admin caller's
-        // server-derived org always wins over the requested orgId argument
-        // — same read-path tenant gate as listIntegrations
-        // (integration-resolver.ts) / listApps
-        // (registry-agent-record-resolver.ts) / listProjects
-        // (project-resolver.ts). Admins may pass an explicit orgId.
-        const admin = isAdminFromEvent(event);
-        const callerOrgId = admin ? null : await extractOrgFromEvent(event);
-        const effectiveOrgId = callerOrgId || event.arguments.orgId;
+        // Org scoping (finding f0ce2b00, high): fail closed, mirroring
+        // requireCallerOrg in user-management-resolver.ts. An admin uses the
+        // supplied argument explicitly; a non-admin uses ONLY their own
+        // resolved org; an unresolved effective org is a hard denial — it
+        // must never fall through to the client-supplied orgId argument
+        // (the prior `callerOrgId || event.arguments.orgId` coercion did
+        // exactly that, handing a caller with no org claim any tenant's
+        // rows on request).
+        const effectiveOrgId = await requireEffectiveOrgId(event);
         return await listDataStores(effectiveOrgId, event.arguments.category);
       }
       case "getDataStore":
         return await getDataStoreGuarded(event.arguments.dataStoreId, event);
       case "getDataStoreStats": {
-        // Org scoping (sweep finding 615aa5bb, filed as the getDataStoreStats
-        // defect): same coerce-not-reject read-path gate as listDataStores
-        // above — a read has no side effect to block, so silently scoping to
-        // the caller's real org is sufficient.
-        const admin = isAdminFromEvent(event);
-        const callerOrgId = admin ? null : await extractOrgFromEvent(event);
-        const effectiveOrgId = callerOrgId || event.arguments.orgId;
+        // Org scoping (finding f0ce2b00, high): same fail-closed gate as
+        // listDataStores above.
+        const effectiveOrgId = await requireEffectiveOrgId(event);
         return await getDataStoreStats(effectiveOrgId);
       }
       case "createDataStore":
@@ -192,11 +223,9 @@ export async function handler(event: AppSyncEvent) {
           event,
         );
       case "listAvailableDataSources": {
-        // Org scoping (sweep finding 615aa5bb): same coerce-not-reject
-        // read-path gate as listDataStores/getDataStoreStats above.
-        const admin = isAdminFromEvent(event);
-        const callerOrgId = admin ? null : await extractOrgFromEvent(event);
-        const effectiveOrgId = callerOrgId || event.arguments.orgId;
+        // Org scoping (finding f0ce2b00, high): same fail-closed gate as
+        // listDataStores/getDataStoreStats above.
+        const effectiveOrgId = await requireEffectiveOrgId(event);
         return await listAvailableDataSources(
           effectiveOrgId,
           event.arguments.usage,

--- a/backend/src/lambda/integration-resolver.ts
+++ b/backend/src/lambda/integration-resolver.ts
@@ -47,6 +47,7 @@ import {
   provisionCredentialProvider,
   deprovisionCredentialProvider,
 } from "../utils/gateway-target-manager";
+import { PermissionError } from "./adapters/errors";
 
 const dynamodb = DynamoDBDocumentClient.from(new DynamoDBClient({}));
 const secretsManager = new SecretsManagerClient({});
@@ -361,6 +362,36 @@ function sanitizeIntegrationForResponse(
   return sanitized;
 }
 
+/**
+ * Fail-closed resolution of the org a read-path query should be scoped to
+ * (finding f0ce2b00, high). Mirrors `requireCallerOrg` in
+ * user-management-resolver.ts / `requireEffectiveOrgId` in
+ * datastore-resolver.ts:
+ *
+ *   - Admin (explicit `isAdminFromEvent` check): use the supplied argument
+ *     as-is.
+ *   - Non-admin: use ONLY the caller's own server-derived org
+ *     (extractOrgFromEvent); the argument is never consulted.
+ *   - Unresolved effective org (non-admin with no resolvable
+ *     `custom:organization` claim — reachable, since adminCreateUser never
+ *     sets that attribute, finding cbbc3be1): DENY via PermissionError.
+ *
+ * Never reintroduce a `callerOrgId || event.arguments.orgId` fallback; see
+ * the `no-caller-org-fallback-idiom` guard test.
+ */
+async function requireEffectiveOrgId(event: AppSyncEvent): Promise<string> {
+  if (isAdminFromEvent(event)) {
+    return event.arguments.orgId;
+  }
+  const callerOrgId = await extractOrgFromEvent(event);
+  if (!callerOrgId) {
+    throw new PermissionError(
+      "Access denied: no organization is provisioned for your account. Contact an administrator.",
+    );
+  }
+  return callerOrgId;
+}
+
 export async function handler(event: AppSyncEvent) {
   const sanitizedEvent = sanitizeEventForLogging(event);
   console.log(
@@ -392,14 +423,15 @@ export async function handler(event: AppSyncEvent) {
           event,
         );
       case "listIntegrations": {
-        // Org scoping (sweep finding under 615aa5bb): a non-admin caller's
-        // server-derived org always wins over the requested orgId argument
-        // — same read-path tenant gate as listApps
-        // (registry-agent-record-resolver.ts) / listProjects
-        // (project-resolver.ts). Admins may pass an explicit orgId.
-        const admin = isAdminFromEvent(event);
-        const callerOrgId = admin ? null : await extractOrgFromEvent(event);
-        const effectiveOrgId = callerOrgId || event.arguments.orgId;
+        // Org scoping (finding f0ce2b00, high): fail closed, mirroring
+        // requireCallerOrg in user-management-resolver.ts /
+        // requireEffectiveOrgId in datastore-resolver.ts. An admin uses the
+        // supplied argument explicitly; a non-admin uses ONLY their own
+        // resolved org; an unresolved effective org is a hard denial — it
+        // must never fall through to the client-supplied orgId argument
+        // (the prior `callerOrgId || event.arguments.orgId` coercion did
+        // exactly that).
+        const effectiveOrgId = await requireEffectiveOrgId(event);
         return await listIntegrations(
           effectiveOrgId,
           event.arguments.integrationType,

--- a/backend/src/lambda/workflow-resolver.ts
+++ b/backend/src/lambda/workflow-resolver.ts
@@ -17,7 +17,8 @@ import {
 } from "@aws-sdk/client-eventbridge";
 import { v4 as uuidv4 } from "uuid";
 import { getUserId } from "../utils/appsync";
-import { extractOrgFromEvent } from "../utils/auth-event";
+import { extractOrgFromEvent, isAdminFromEvent } from "../utils/auth-event";
+import { PermissionError } from "./adapters/errors";
 
 const dynamoClient = new DynamoDBClient({});
 const docClient = DynamoDBDocumentClient.from(dynamoClient);
@@ -209,8 +210,25 @@ async function listWorkflows(
   userId: string,
   event: WorkflowResolverEvent,
 ): Promise<{ items: unknown[]; nextToken?: string }> {
-  const userOrg = await extractOrgFromEvent(event);
-  const queryOrgId = userOrg || orgId;
+  // Org scoping (finding f0ce2b00, high): fail closed, mirroring
+  // requireEffectiveOrgId in datastore-resolver.ts/integration-resolver.ts.
+  // An admin uses the supplied argument explicitly; a non-admin uses ONLY
+  // their own resolved org; an unresolved effective org is a hard denial —
+  // it must never fall through to the client-supplied orgId argument (the
+  // prior `userOrg || orgId` coercion did exactly that, handing a caller
+  // with no org claim any tenant's workflows on request).
+  let queryOrgId: string;
+  if (isAdminFromEvent(event)) {
+    queryOrgId = orgId;
+  } else {
+    const userOrg = await extractOrgFromEvent(event);
+    if (!userOrg) {
+      throw new PermissionError(
+        "Access denied: no organization is provisioned for your account. Contact an administrator.",
+      );
+    }
+    queryOrgId = userOrg;
+  }
 
   const params: QueryCommandInput = {
     TableName: WORKFLOWS_TABLE,


### PR DESCRIPTION
## Summary

Five resolvers coerced an unresolvable caller organisation into a **client-supplied** value - `callerOrgId || event.arguments.orgId` - and fed the result to a DynamoDB index key condition. An authenticated non-admin with no resolvable `custom:organization` could therefore read **another tenant's records in full** by passing that tenant's `orgId`, which the GraphQL schema makes a required argument on every one of these queries. 

The idiom reads as defensive while inverting the trust direction, contradicted the codebase's own convention: `assertRowOrg`, the agent-import checks, and `user-management-resolver`'s `requireCallerOrg` all deny when the caller organisation is absent.

The precondition is reachable through ordinary use, not hypothetical: `adminCreateUser` never sets `custom:organization`, so an admin creating a user and skipping the separate role assignment produces exactly such an account.

## Changes

A shared `requireEffectivergId` helper, following the existing `requireCallerorg` convention:

- **Admin** supplies the organisation explicitly, via an `isAdminFromEvent` check
- **Non-admin** uses only their server-derived organisation
- **Unresolved** throws *PermissionError with a message that neither reveals whether the requested organisation exists nor echoes it

Applied to `listDataStores`, `getDataStoreStats`, `listAvailableDataSources`, `listIntegrations`, `workflow-resolver`'s `listWorkflows`; same inversion, with no admin path at all. 

Reviewed and deliberately left unchanged as already fail-closed: `tool-sandbox`'s admin-only fallback (non-admin path denies above it), `agent-config`'s per-row membership filter, and `cost-http-shared`'s `resolveScopedorg` (explicit early deny).

## The guard is the durable part

An AST-based guard forbids the idiom returning - flagging any logical-or whose right operand is an `arguments`/`args`-derived `orgId` including renamed and destructured forms. **It found the `listWorkflows` instance on its first run.** Proven to fail when the idiom is reintroduced, and to produce no false positive when the idiom appears in a comment or a string literal.

## Testing

Attack executed, not described: a null-claim non-admin passing a foreign `orgId` is denied at every site with **no DynamoDB query issued** and no victim data in the response. Admin path and normal non-admin path verified intact; scope cannot be widened via the argument.

tsc 0, lint 0, all 14 gate-enumeration guards, full backend jest 7830. Seven files; no IAM or schema changes.