### PR TITLE
fix(security): make organisation-name-as-canonical explicit

### DIFF
--- a/backend/src/lambda/__tests__/admin-create-user-organization.test.ts
+++ b/backend/src/lambda/__tests__/admin-create-user-organization.test.ts
@@ -1,0 +1,188 @@
+/**
+ * adminCreateUser — wires the organisation claim at user creation
+ * (decision 228b3cc8 piece 5 / finding cbbc3be1).
+ *
+ * Defect: adminCreateUser set only email, email_verified, given_name and
+ * family_name on AdminCreateUserCommand. The organisation was applied
+ * SOLELY by a separate, OPTIONAL assignUserRole call the frontend happened
+ * to make afterwards (Team.tsx's handleAddUser only calls assignUserRole
+ * if a role was also selected — organisation-only, no-role creation left
+ * the user with NO custom:organization claim at all). A user with no claim
+ * fails closed across every org-scoped resolver (by design — see
+ * user-management-resolver-org-scoping.test.ts and the no-caller-org-
+ * fallback-idiom guard) but that "fails closed" only helps once the user
+ * already has SOME resolvable identity; a user who can never pass ANY
+ * org-scoped check is a support burden, not a security feature, and the
+ * root cause is that organisation assignment was optional at the one
+ * point (admin-only creation) it could have been enforced.
+ *
+ * DECISION: `organization` is now a REQUIRED field on
+ * `AdminCreateUserInput` (both the GraphQL schema and the resolver code
+ * enforce this) rather than defaulting to some organisation if omitted.
+ * Team.tsx's Add User dialog already collects an organisation from
+ * `organizations` (name-valued, per the ratified NAME-is-canonical
+ * convention) — inventing a silent default (e.g. "Default") would let a
+ * caller who forgets to pick one create a user in the wrong tenant without
+ * any signal, which is a worse failure mode than a clear upfront
+ * validation error. This keeps `adminCreateUser` an admin-only write (PR
+ * 146: custom:organization stays non-user-writable) — the value comes from
+ * the input, not from any self-service path.
+ */
+process.env.USER_POOL_ID = "us-east-1_testpool";
+process.env.ORGANISATION_TABLE = "test-orgs";
+
+import {
+  CognitoIdentityProviderClient,
+  AdminCreateUserCommand,
+  AdminListGroupsForUserCommand,
+} from "@aws-sdk/client-cognito-identity-provider";
+import { mockClient } from "aws-sdk-client-mock";
+
+const cognitoMock = mockClient(CognitoIdentityProviderClient);
+
+import { handler } from "../user-management-resolver";
+
+type ResolverEvent = Parameters<typeof handler>[0];
+
+function buildEvent(
+  fieldName: string,
+  identity: ResolverEvent["identity"],
+  args: Partial<ResolverEvent["arguments"]> = {},
+): ResolverEvent {
+  return {
+    info: { fieldName },
+    identity,
+    arguments: args as ResolverEvent["arguments"],
+  };
+}
+
+beforeEach(() => {
+  cognitoMock.reset();
+  cognitoMock
+    .on(AdminListGroupsForUserCommand, { Username: "admin-user" })
+    .resolves({ Groups: [{ GroupName: "admin" }] });
+});
+
+describe("adminCreateUser — organization is required and wired into custom:organization", () => {
+  test("sets custom:organization on AdminCreateUserCommand from a supplied organization", async () => {
+    cognitoMock.on(AdminCreateUserCommand).resolves({});
+
+    const event = buildEvent(
+      "adminCreateUser",
+      { username: "admin-user" },
+      {
+        input: {
+          email: "new.user@example.com",
+          givenName: "New",
+          familyName: "User",
+          organization: "Engineering",
+        },
+      },
+    );
+
+    const result = (await handler(event)) as { success: boolean };
+    expect(result.success).toBe(true);
+
+    const calls = cognitoMock.commandCalls(AdminCreateUserCommand);
+    expect(calls).toHaveLength(1);
+    const attrs = calls[0].args[0].input.UserAttributes ?? [];
+    const orgAttr = attrs.find((a) => a.Name === "custom:organization");
+    expect(orgAttr?.Value).toBe("Engineering");
+  });
+
+  test("still sets email, email_verified, given_name and family_name (pre-existing behaviour preserved)", async () => {
+    cognitoMock.on(AdminCreateUserCommand).resolves({});
+
+    const event = buildEvent(
+      "adminCreateUser",
+      { username: "admin-user" },
+      {
+        input: {
+          email: "new.user@example.com",
+          givenName: "New",
+          familyName: "User",
+          organization: "Engineering",
+        },
+      },
+    );
+
+    await handler(event);
+
+    const attrs =
+      cognitoMock.commandCalls(AdminCreateUserCommand)[0].args[0].input
+        .UserAttributes ?? [];
+    const byName = (n: string) => attrs.find((a) => a.Name === n)?.Value;
+    expect(byName("email")).toBe("new.user@example.com");
+    expect(byName("email_verified")).toBe("true");
+    expect(byName("given_name")).toBe("New");
+    expect(byName("family_name")).toBe("User");
+  });
+
+  test("rejects a create with NO organization, with a clear message, and does NOT call AdminCreateUserCommand (fail clearly, no silent default)", async () => {
+    const event = buildEvent(
+      "adminCreateUser",
+      { username: "admin-user" },
+      {
+        input: {
+          email: "no-org@example.com",
+          givenName: "No",
+          familyName: "Org",
+        },
+      },
+    );
+
+    const result = (await handler(event)) as {
+      success: boolean;
+      message?: string;
+    };
+    expect(result.success).toBe(false);
+    expect(result.message).toMatch(/organization/i);
+
+    expect(cognitoMock.commandCalls(AdminCreateUserCommand)).toHaveLength(0);
+  });
+
+  test("rejects a create with an EMPTY-STRING organization the same way as a missing one", async () => {
+    const event = buildEvent(
+      "adminCreateUser",
+      { username: "admin-user" },
+      {
+        input: {
+          email: "blank-org@example.com",
+          givenName: "Blank",
+          familyName: "Org",
+          organization: "",
+        },
+      },
+    );
+
+    const result = (await handler(event)) as {
+      success: boolean;
+      message?: string;
+    };
+    expect(result.success).toBe(false);
+    expect(result.message).toMatch(/organization/i);
+    expect(cognitoMock.commandCalls(AdminCreateUserCommand)).toHaveLength(0);
+  });
+
+  test("still requires admin (non-admin caller refused, no Cognito call)", async () => {
+    cognitoMock
+      .on(AdminListGroupsForUserCommand, { Username: "alice" })
+      .resolves({ Groups: [{ GroupName: "developer" }] });
+
+    const event = buildEvent(
+      "adminCreateUser",
+      { username: "alice" },
+      {
+        input: {
+          email: "new.user@example.com",
+          givenName: "New",
+          familyName: "User",
+          organization: "Engineering",
+        },
+      },
+    );
+
+    await expect(handler(event)).rejects.toThrow(/administrators/i);
+    expect(cognitoMock.commandCalls(AdminCreateUserCommand)).toHaveLength(0);
+  });
+});

--- a/backend/src/lambda/__tests__/org-name-canonical-guard.test.ts
+++ b/backend/src/lambda/__tests__/org-name-canonical-guard.test.ts
@@ -1,0 +1,323 @@
+/**
+ * org-name-canonical-guard.test.ts — guards for the RATIFIED decision
+ * 228b3cc8: the organisation NAME is canonical for the `custom:organization`
+ * claim and every tenancy comparison in this codebase. Names are treated as
+ * IMMUTABLE — no rename operation exists, and the whole model (uniqueness
+ * reservation, tombstone-on-delete, claim comparisons) rests on that
+ * invariant holding forever, not merely by today's convention.
+ *
+ * Three guards, per decision piece 4:
+ *
+ *   (a) No `updateOrganization` (or equivalent rename) mutation is declared
+ *       in the GraphQL schema's Mutation type, AND the organization-resolver
+ *       Lambda's dispatch switch has no case that mutates an existing org's
+ *       `name` field. The dispatch-switch check is AST-based (TypeScript
+ *       compiler), per the repo convention established in
+ *       app-access-control-dead-code-guard.test.ts and the
+ *       *-dispatch-gate-enumeration.test.ts family — a regex over the
+ *       resolver source could be defeated by reformatting or a case whose
+ *       label doesn't literally contain the word "update"/"rename". The
+ *       schema.graphql check is a structural SDL field-name extraction
+ *       (every field declared inside the primary `type Mutation { ... }`
+ *       block, derived by tokenizing each line's leading identifier before
+ *       `(` — not a substring search for one literal name), because SDL is
+ *       not TypeScript source and has no compiler AST to parse; the
+ *       extraction still enumerates the FULL field set exhaustively rather
+ *       than testing for the absence of one hard-coded string.
+ *
+ *   (b) The seeded admin user's `custom:organization` Cognito attribute
+ *       value (seed-admin-user/index.py) equals the seeded organisation's
+ *       NAME (seed-organizations/index.py) — both currently hard-coded to
+ *       "Default". If either seed script's literal value drifts, this test
+ *       fails loudly instead of leaving a seeded admin whose claim doesn't
+ *       resolve to any real organisation.
+ *
+ *   (c) The canonical rule is documented in the shared auth helper
+ *       (utils/auth-event.ts) so the next reader sees it before reaching
+ *       for an orgId comparison. Checked via AST: a comment attached
+ *       anywhere in auth-event.ts must mention "custom:organization", the
+ *       word "NAME", and "canonical" together — pinning the check to the
+ *       specific rule rather than any incidental mention of one term alone.
+ */
+import * as fs from "fs";
+import * as path from "path";
+import * as ts from "typescript";
+
+const REPO_ROOT = path.resolve(__dirname, "../../..");
+const SCHEMA_PATH = path.join(REPO_ROOT, "src", "schema", "schema.graphql");
+const RESOLVER_PATH = path.join(__dirname, "..", "organization-resolver.ts");
+const AUTH_EVENT_PATH = path.join(REPO_ROOT, "src", "utils", "auth-event.ts");
+const SEED_ADMIN_PATH = path.join(
+  REPO_ROOT,
+  "src",
+  "lambda",
+  "seed-admin-user",
+  "index.py",
+);
+const SEED_ORGS_PATH = path.join(
+  REPO_ROOT,
+  "src",
+  "lambda",
+  "seed-organizations",
+  "index.py",
+);
+
+function parseSourceFile(filePath: string): ts.SourceFile {
+  const text = fs.readFileSync(filePath, "utf-8");
+  return ts.createSourceFile(
+    filePath,
+    text,
+    ts.ScriptTarget.ESNext,
+    /* setParentNodes */ true,
+    ts.ScriptKind.TS,
+  );
+}
+
+/**
+ * Extracts every field name declared directly inside the PRIMARY
+ * `type Mutation { ... }` SDL block (from `type Mutation {` to the first
+ * line-anchored closing brace), by tokenizing each non-comment line's
+ * leading identifier that is immediately followed by `(` or `:` — the two
+ * shapes a GraphQL field declaration can take. This enumerates the FULL
+ * mutation field set rather than testing for the presence/absence of one
+ * hard-coded name.
+ */
+function extractMutationFieldNames(schema: string): string[] {
+  const match = schema.match(/^type Mutation \{[\s\S]*?^\}/m);
+  if (!match) {
+    throw new Error(
+      "Could not locate the primary `type Mutation { ... }` block in schema.graphql",
+    );
+  }
+  const block = match[0];
+  const lines = block.split("\n").slice(1, -1); // drop `type Mutation {` and closing `}`
+  const names: string[] = [];
+  const fieldRe = /^\s*([A-Za-z_][A-Za-z0-9_]*)\s*[:(]/;
+  for (const line of lines) {
+    const trimmed = line.trim();
+    if (trimmed === "" || trimmed.startsWith("#")) continue;
+    const m = fieldRe.exec(line);
+    if (m) names.push(m[1]);
+  }
+  return names;
+}
+
+/**
+ * Extracts the case labels of the `switch (fieldName)` dispatch in
+ * organization-resolver.ts via the TypeScript AST (SwitchStatement ->
+ * CaseClause -> StringLiteral), NOT a regex over source text.
+ */
+function extractDispatchCaseLabels(sf: ts.SourceFile): string[] {
+  const labels: string[] = [];
+
+  function visit(node: ts.Node): void {
+    if (ts.isSwitchStatement(node)) {
+      for (const clause of node.caseBlock.clauses) {
+        if (
+          ts.isCaseClause(clause) &&
+          ts.isStringLiteralLike(clause.expression)
+        ) {
+          labels.push(clause.expression.text);
+        }
+      }
+    }
+    ts.forEachChild(node, visit);
+  }
+
+  visit(sf);
+  return labels;
+}
+
+/**
+ * True if any AST node in `sf` is a call/new-expression whose callee name
+ * matches /update|rename/i AND whose argument list contains an
+ * UpdateExpression string literal that both SETs and mentions `name` — the
+ * structural shape of a rename operation. Detected via AST traversal
+ * (CallExpression/NewExpression -> ObjectLiteralExpression ->
+ * PropertyAssignment), not a source-text regex search.
+ */
+function findRenameShapedOperations(sf: ts.SourceFile): ts.Node[] {
+  const hits: ts.Node[] = [];
+
+  function callableName(expr: ts.LeftHandSideExpression): string | null {
+    if (ts.isIdentifier(expr)) return expr.text;
+    if (ts.isPropertyAccessExpression(expr)) return expr.name.text;
+    return null;
+  }
+
+  function objectLiteralMentionsNameUpdate(node: ts.Node): boolean {
+    let found = false;
+    function inner(n: ts.Node): void {
+      if (
+        ts.isPropertyAssignment(n) &&
+        ts.isIdentifier(n.name) &&
+        n.name.text === "UpdateExpression" &&
+        ts.isStringLiteralLike(n.initializer) &&
+        /\bname\b/i.test(n.initializer.text) &&
+        /\bSET\b/i.test(n.initializer.text)
+      ) {
+        found = true;
+      }
+      ts.forEachChild(n, inner);
+    }
+    inner(node);
+    return found;
+  }
+
+  function visit(node: ts.Node): void {
+    if (
+      (ts.isCallExpression(node) || ts.isNewExpression(node)) &&
+      node.arguments
+    ) {
+      const name = callableName(node.expression as ts.LeftHandSideExpression);
+      if (name && /update|rename/i.test(name)) {
+        for (const arg of node.arguments) {
+          if (objectLiteralMentionsNameUpdate(arg)) {
+            hits.push(node);
+          }
+        }
+      }
+    }
+    ts.forEachChild(node, visit);
+  }
+
+  visit(sf);
+  return hits;
+}
+
+describe("org-name-canonical guard (decision 228b3cc8, piece 4)", () => {
+  describe("(a) no rename/update operation for organisations exists", () => {
+    test("schema.graphql's primary Mutation block declares no updateOrganization/renameOrganization field", () => {
+      const schema = fs.readFileSync(SCHEMA_PATH, "utf-8");
+      const fields = extractMutationFieldNames(schema);
+      expect(fields.length).toBeGreaterThan(0); // sanity: parser found real fields
+      expect(fields).toContain("createOrganization");
+      expect(fields).toContain("deleteOrganization");
+      const renameShaped = fields.filter(
+        (f) => /update|rename/i.test(f) && /organi[sz]ation/i.test(f),
+      );
+      expect(renameShaped).toEqual([]);
+    });
+
+    test("organization-resolver.ts's dispatch switch has no updateOrganization/renameOrganization case", () => {
+      const sf = parseSourceFile(RESOLVER_PATH);
+      const labels = extractDispatchCaseLabels(sf);
+      expect(labels.length).toBeGreaterThan(0); // sanity
+      expect(labels).toContain("createOrganization");
+      expect(labels).toContain("deleteOrganization");
+      const renameShaped = labels.filter((l) => /update|rename/i.test(l));
+      expect(renameShaped).toEqual([]);
+    });
+
+    test("organization-resolver.ts contains no AST-detectable UpdateCommand/call that overwrites an org row's `name` field", () => {
+      const sf = parseSourceFile(RESOLVER_PATH);
+      // The tombstone UpdateCommand (piece 3) legitimately updates `itemType`
+      // and `tombstonedAt` on the NAME# reservation row — it must NOT be
+      // flagged, since it never touches a `name` attribute via SET.
+      const hits = findRenameShapedOperations(sf);
+      expect(hits).toEqual([]);
+    });
+
+    test("bites: a planted updateOrganization-shaped UpdateCommand IS flagged", () => {
+      const scratch = ts.createSourceFile(
+        "scratch.ts",
+        [
+          "async function updateOrganization(orgId: string, newName: string) {",
+          "  return docClient.send(",
+          "    new UpdateCommand({",
+          "      TableName: T,",
+          "      Key: { orgId },",
+          "      UpdateExpression: 'SET #name = :name',",
+          "      ExpressionAttributeValues: { ':name': newName },",
+          "    }),",
+          "  );",
+          "}",
+        ].join("\n"),
+        ts.ScriptTarget.ESNext,
+        true,
+        ts.ScriptKind.TS,
+      );
+      expect(findRenameShapedOperations(scratch).length).toBeGreaterThan(0);
+    });
+
+    test("does NOT flag the legitimate tombstone UpdateCommand shape (updates itemType/tombstonedAt, not name)", () => {
+      const scratch = ts.createSourceFile(
+        "scratch.ts",
+        [
+          "async function tombstoneReservation(orgId: string) {",
+          "  return docClient.send(",
+          "    new UpdateCommand({",
+          "      TableName: T,",
+          "      Key: { orgId },",
+          "      UpdateExpression: 'SET itemType = :tombstone, tombstonedAt = :t',",
+          "      ExpressionAttributeValues: { ':tombstone': 'name_tombstone', ':t': 'now' },",
+          "    }),",
+          "  );",
+          "}",
+        ].join("\n"),
+        ts.ScriptTarget.ESNext,
+        true,
+        ts.ScriptKind.TS,
+      );
+      expect(findRenameShapedOperations(scratch).length).toBe(0);
+    });
+  });
+
+  describe("(b) seeded admin's claim equals the seeded organisation's NAME", () => {
+    test("seed-admin-user/index.py's custom:organization literal matches a name literal seeded by seed-organizations/index.py", () => {
+      const adminSeedSrc = fs.readFileSync(SEED_ADMIN_PATH, "utf-8");
+      const orgsSeedSrc = fs.readFileSync(SEED_ORGS_PATH, "utf-8");
+
+      const adminOrgMatch = adminSeedSrc.match(
+        /\{'Name':\s*'custom:organization',\s*'Value':\s*'([^']+)'\}/,
+      );
+      expect(adminOrgMatch).not.toBeNull();
+      const adminOrgClaim = adminOrgMatch![1];
+
+      // Every 'name': '<value>' literal seeded into the organisations table.
+      const seededNames = Array.from(
+        orgsSeedSrc.matchAll(/'name':\s*'([^']+)'/g),
+      ).map((m) => m[1]);
+      expect(seededNames.length).toBeGreaterThan(0); // sanity
+
+      expect(seededNames).toContain(adminOrgClaim);
+    });
+  });
+
+  describe("(c) the canonical rule is documented in the shared auth helper", () => {
+    test("auth-event.ts contains a comment documenting that custom:organization is the canonical NAME-based tenancy claim", () => {
+      const sf = parseSourceFile(AUTH_EVENT_PATH);
+      const fullText = sf.getFullText();
+
+      // Collect every comment (JSDoc + line + block) via the AST's own
+      // trivia scanner rather than a source-text regex sweep, then check
+      // the comment TEXT content for the documenting phrase.
+      const comments: string[] = [];
+      const fullStart = sf.getFullStart();
+      ts.forEachChild(sf, function visit(node: ts.Node) {
+        ts.forEachLeadingCommentRange(
+          fullText,
+          node.getFullStart(),
+          (pos, end) => {
+            comments.push(fullText.slice(pos, end));
+          },
+        );
+        ts.forEachChild(node, visit);
+      });
+      // Also scan file-leading comments (before the first statement), which
+      // forEachLeadingCommentRange over child nodes can miss for a
+      // top-of-file block comment preceding the first import.
+      ts.forEachLeadingCommentRange(fullText, fullStart, (pos, end) => {
+        comments.push(fullText.slice(pos, end));
+      });
+
+      const canonicalRuleDocumented = comments.some(
+        (c) =>
+          c.includes("custom:organization") &&
+          /\bNAME\b/.test(c) &&
+          /canonical/i.test(c),
+      );
+      expect(canonicalRuleDocumented).toBe(true);
+    });
+  });
+});

--- a/backend/src/lambda/__tests__/organization-resolver.test.ts
+++ b/backend/src/lambda/__tests__/organization-resolver.test.ts
@@ -12,6 +12,17 @@
  *     into the DynamoDB item — it must default to '' (matching
  *     project-resolver.ts `input.description || ''`) so PutCommand marshalling
  *     in the real (unmocked) client cannot throw.
+ *
+ * Decision 228b3cc8, pieces 2 and 3 — name uniqueness and reuse prevention:
+ *   - `createOrganization` no longer does a Scan-then-Put for uniqueness
+ *     (non-atomic, race-prone). It now does an atomic conditional Put of a
+ *     `NAME#<name>` reservation row (`ConditionExpression:
+ *     attribute_not_exists(orgId)`) in the SAME OrganisationTable, mirroring
+ *     the write-once idiom used across this codebase.
+ *   - `deleteOrganization` no longer leaves the name free for reuse: the
+ *     reservation row is flipped to a permanent tombstone instead of being
+ *     removed, and `createOrganization` rejects a tombstoned name with a
+ *     clear message.
  */
 // Env vars must be set BEFORE the resolver module loads — the resolver
 // captures process.env values into top-level constants at import time.
@@ -21,7 +32,9 @@ process.env.USER_POOL_ID = "us-east-1_testpool";
 import {
   DynamoDBDocumentClient,
   PutCommand,
+  UpdateCommand,
   DeleteCommand,
+  GetCommand,
   ScanCommand,
 } from "@aws-sdk/lib-dynamodb";
 import {
@@ -37,10 +50,22 @@ jest.mock("uuid", () => ({ v4: jest.fn().mockReturnValue("org-uuid-123") }));
 
 import { handler } from "../organization-resolver";
 
+/** Builds a ConditionalCheckFailedException the same way AWS SDK v3 does. */
+function conditionalCheckFailed(): Error {
+  const err = new Error("The conditional request failed");
+  err.name = "ConditionalCheckFailedException";
+  return err;
+}
+
 describe("organization-resolver", () => {
   beforeEach(() => {
     dynamoMock.reset();
     cognitoMock.reset();
+    // Default: no existing reservation/tombstone row for any name, unless a
+    // test overrides this with a more specific `.on(GetCommand, {...})` stub.
+    dynamoMock.on(GetCommand).resolves({ Item: undefined });
+    dynamoMock.on(PutCommand).resolves({});
+    dynamoMock.on(UpdateCommand).resolves({});
   });
 
   // REAL AppSync $context shape: the field name lives under `info.fieldName`,
@@ -77,7 +102,7 @@ describe("organization-resolver", () => {
         ),
       ).rejects.toThrow(/UnauthorizedError/);
 
-      expect(dynamoMock.commandCalls(ScanCommand)).toHaveLength(0);
+      expect(dynamoMock.commandCalls(GetCommand)).toHaveLength(0);
       expect(dynamoMock.commandCalls(PutCommand)).toHaveLength(0);
       expect(cognitoMock.commandCalls(ListUsersCommand)).toHaveLength(0);
     });
@@ -95,7 +120,7 @@ describe("organization-resolver", () => {
         ),
       ).rejects.toThrow(/UnauthorizedError/);
 
-      expect(dynamoMock.commandCalls(ScanCommand)).toHaveLength(0);
+      expect(dynamoMock.commandCalls(GetCommand)).toHaveLength(0);
       expect(dynamoMock.commandCalls(PutCommand)).toHaveLength(0);
     });
 
@@ -108,7 +133,7 @@ describe("organization-resolver", () => {
       };
       await expect(handler(event)).rejects.toThrow(/UnauthorizedError/);
 
-      expect(dynamoMock.commandCalls(ScanCommand)).toHaveLength(0);
+      expect(dynamoMock.commandCalls(GetCommand)).toHaveLength(0);
       expect(dynamoMock.commandCalls(PutCommand)).toHaveLength(0);
     });
 
@@ -125,15 +150,12 @@ describe("organization-resolver", () => {
         ),
       ).rejects.toThrow(/UnauthorizedError/);
 
-      expect(dynamoMock.commandCalls(ScanCommand)).toHaveLength(0);
+      expect(dynamoMock.commandCalls(GetCommand)).toHaveLength(0);
       expect(dynamoMock.commandCalls(PutCommand)).toHaveLength(0);
     });
 
     // GREEN: an admin caller still succeeds through the full existing flow.
     test("allows an admin caller through to the existing create flow", async () => {
-      dynamoMock.on(ScanCommand).resolves({ Items: [] });
-      dynamoMock.on(PutCommand).resolves({});
-
       const result = await handler(
         makeEvent(
           "createOrganization",
@@ -143,15 +165,13 @@ describe("organization-resolver", () => {
       );
 
       expect(result.orgId).toBe("org-uuid-123");
-      expect(dynamoMock.commandCalls(PutCommand)).toHaveLength(1);
+      // Two PutCommands: the name reservation row, then the org row itself.
+      expect(dynamoMock.commandCalls(PutCommand)).toHaveLength(2);
     });
   });
 
   describe("createOrganization", () => {
     test("creates organization when name is unique and preserves the description", async () => {
-      dynamoMock.on(ScanCommand).resolves({ Items: [] });
-      dynamoMock.on(PutCommand).resolves({});
-
       const result = await handler(
         makeEvent(
           "createOrganization",
@@ -166,16 +186,19 @@ describe("organization-resolver", () => {
       expect(result.createdAt).toBeDefined();
 
       const putCalls = dynamoMock.commandCalls(PutCommand);
-      expect(putCalls).toHaveLength(1);
-      expect(
-        (putCalls[0].args[0].input.Item as Record<string, unknown>).description,
-      ).toBe("A test org");
+      // Reservation row put first, org row put second.
+      expect(putCalls).toHaveLength(2);
+      const reservationItem = putCalls[0].args[0].input.Item as Record<
+        string,
+        unknown
+      >;
+      expect(reservationItem.orgId).toBe("NAME#New Org");
+      expect(reservationItem.itemType).toBe("name_reservation");
+      const orgItem = putCalls[1].args[0].input.Item as Record<string, unknown>;
+      expect(orgItem.description).toBe("A test org");
     });
 
     test("creates organization with a blank description and writes NO undefined attribute", async () => {
-      dynamoMock.on(ScanCommand).resolves({ Items: [] });
-      dynamoMock.on(PutCommand).resolves({});
-
       // `description` omitted from input -> resolver must default it to ''.
       const result = await handler(
         makeEvent(
@@ -190,12 +213,13 @@ describe("organization-resolver", () => {
       // Defaulted to '' (matches project-resolver.ts `input.description || ''`).
       expect(result.description).toBe("");
 
-      // The PutCommand Item must contain NO attribute whose value is undefined.
-      // An undefined value throws during DynamoDB marshalling in the real
-      // (unmocked) client and produced the Lambda:Unhandled error in Issue #14.
+      // The org-row PutCommand Item must contain NO attribute whose value is
+      // undefined. An undefined value throws during DynamoDB marshalling in
+      // the real (unmocked) client and produced the Lambda:Unhandled error
+      // in Issue #14.
       const putCalls = dynamoMock.commandCalls(PutCommand);
-      expect(putCalls).toHaveLength(1);
-      const item = putCalls[0].args[0].input.Item as Record<string, unknown>;
+      expect(putCalls).toHaveLength(2);
+      const item = putCalls[1].args[0].input.Item as Record<string, unknown>;
       expect(item.description).toBe("");
       const undefinedAttrs = Object.entries(item)
         .filter(([, v]) => v === undefined)
@@ -203,16 +227,122 @@ describe("organization-resolver", () => {
       expect(undefinedAttrs).toEqual([]);
     });
 
-    test("throws when organization name already exists", async () => {
-      dynamoMock.on(ScanCommand).resolves({
-        Items: [{ orgId: "existing", name: "Duplicate" }],
-      });
+    // RATIFIED decision 228b3cc8, piece 2: uniqueness is now an ATOMIC
+    // conditional put, not a Scan-then-Put. A duplicate name must be
+    // rejected via the ConditionalCheckFailedException path, and NO org row
+    // must ever be written when the reservation Put fails.
+    test("throws when organization name already exists (conditional put rejected)", async () => {
+      // Reservation put (the FIRST PutCommand in createOrganization) is
+      // rejected with a ConditionalCheckFailedException, simulating a name
+      // that is already reserved (live or otherwise).
+      dynamoMock.on(PutCommand).rejectsOnce(conditionalCheckFailed());
 
       await expect(
         handler(
           makeEvent(
             "createOrganization",
             { input: { name: "Duplicate" } },
+            adminIdentity,
+          ),
+        ),
+      ).rejects.toThrow("already exists");
+
+      // The reservation Put was attempted (and rejected) but the org row
+      // Put must NEVER have been reached.
+      const putCalls = dynamoMock.commandCalls(PutCommand);
+      expect(putCalls).toHaveLength(1);
+    });
+
+    // RACE: two concurrent creates for the same name — the conditional put
+    // ensures at most one can win. This test simulates the loser's path by
+    // asserting the reservation Put carries the correct
+    // ConditionExpression, which is what DynamoDB evaluates atomically
+    // server-side to prevent the race (this test cannot exercise real
+    // concurrency against a mock, so it pins the CONTRACT: the put must be
+    // conditional, not a preceding read-then-write).
+    test("reservation put uses attribute_not_exists(orgId) as its ConditionExpression (atomic guard, not Scan-then-Put)", async () => {
+      await handler(
+        makeEvent(
+          "createOrganization",
+          { input: { name: "Race Org" } },
+          adminIdentity,
+        ),
+      );
+
+      const putCalls = dynamoMock.commandCalls(PutCommand);
+      const reservationCall = putCalls.find(
+        (c) =>
+          (c.args[0].input.Item as Record<string, unknown>).orgId ===
+          "NAME#Race Org",
+      );
+      expect(reservationCall).toBeDefined();
+      expect(reservationCall!.args[0].input.ConditionExpression).toBe(
+        "attribute_not_exists(orgId)",
+      );
+      // No Scan is used anywhere in the create path anymore.
+      expect(dynamoMock.commandCalls(ScanCommand)).toHaveLength(0);
+    });
+
+    // RATIFIED decision 228b3cc8, piece 3: a tombstoned name (previously
+    // used and deleted) must be rejected with a clear, distinguishable
+    // message — and must never reach the reservation Put.
+    test("rejects a tombstoned name with a clear message and does not attempt the reservation put", async () => {
+      dynamoMock
+        .on(GetCommand, {
+          TableName: "test-orgs",
+          Key: { orgId: "NAME#Retired Org" },
+        })
+        .resolves({
+          Item: {
+            orgId: "NAME#Retired Org",
+            itemType: "name_tombstone",
+            name: "Retired Org",
+            createdAt: "2024-01-01T00:00:00Z",
+            tombstonedAt: "2024-02-01T00:00:00Z",
+          },
+        });
+
+      await expect(
+        handler(
+          makeEvent(
+            "createOrganization",
+            { input: { name: "Retired Org" } },
+            adminIdentity,
+          ),
+        ),
+      ).rejects.toThrow(/previously used and deleted/);
+
+      expect(dynamoMock.commandCalls(PutCommand)).toHaveLength(0);
+    });
+
+    // A LIVE reservation (not yet tombstoned) for the same name must NOT be
+    // short-circuited by the tombstone-check message — it must still reach
+    // the conditional put path and surface as "already exists" via the
+    // ConditionalCheckFailedException route (not the tombstone message).
+    test("a live (non-tombstoned) reservation is NOT rejected by the tombstone check; falls through to the conditional put", async () => {
+      dynamoMock
+        .on(GetCommand, {
+          TableName: "test-orgs",
+          Key: { orgId: "NAME#Live Org" },
+        })
+        .resolves({
+          Item: {
+            orgId: "NAME#Live Org",
+            itemType: "name_reservation",
+            name: "Live Org",
+            reservedOrgId: "some-other-org-id",
+            createdAt: "2024-01-01T00:00:00Z",
+          },
+        });
+      // Reservation put (the FIRST PutCommand) is rejected — the name is
+      // already actively reserved.
+      dynamoMock.on(PutCommand).rejectsOnce(conditionalCheckFailed());
+
+      await expect(
+        handler(
+          makeEvent(
+            "createOrganization",
+            { input: { name: "Live Org" } },
             adminIdentity,
           ),
         ),
@@ -461,6 +591,51 @@ describe("organization-resolver", () => {
       // Pins the ordering invariant: existence-check → user-count check → delete.
       expect(cognitoMock.commandCalls(ListUsersCommand)).toHaveLength(0);
       expect(dynamoMock.commandCalls(DeleteCommand)).toHaveLength(0);
+    });
+
+    // RATIFIED decision 228b3cc8, piece 3: a successful delete must
+    // TOMBSTONE the freed name (flip the reservation row), not merely
+    // delete the org row and leave the name free.
+    test("tombstones the name reservation row after a successful delete", async () => {
+      dynamoMock.on(ScanCommand).resolves({
+        Items: [{ orgId: "org-1", name: "Operations" }],
+      });
+      cognitoMock.on(ListUsersCommand).resolves({ Users: [] });
+      dynamoMock.on(DeleteCommand).resolves({});
+
+      const result = await handler(
+        makeEvent("deleteOrganization", { orgId: "org-1" }, adminIdentity),
+      );
+
+      expect(result.success).toBe(true);
+
+      const updateCalls = dynamoMock.commandCalls(UpdateCommand);
+      expect(updateCalls).toHaveLength(1);
+      const updateInput = updateCalls[0].args[0].input;
+      expect(updateInput.Key).toEqual({ orgId: "NAME#Operations" });
+      expect(updateInput.ExpressionAttributeValues?.[":tombstone"]).toBe(
+        "name_tombstone",
+      );
+    });
+
+    // If tombstoning fails (e.g. no pre-existing reservation row for an org
+    // created before this mechanism shipped), the delete must still be
+    // reported as successful — the org row is already gone, and this is a
+    // best-effort closure of the reuse gap, not a blocking step.
+    test("delete still succeeds even if tombstoning the reservation row fails", async () => {
+      dynamoMock.on(ScanCommand).resolves({
+        Items: [{ orgId: "org-1", name: "Operations" }],
+      });
+      cognitoMock.on(ListUsersCommand).resolves({ Users: [] });
+      dynamoMock.on(DeleteCommand).resolves({});
+      dynamoMock.on(UpdateCommand).rejects(conditionalCheckFailed());
+
+      const result = await handler(
+        makeEvent("deleteOrganization", { orgId: "org-1" }, adminIdentity),
+      );
+
+      expect(result.success).toBe(true);
+      expect(dynamoMock.commandCalls(DeleteCommand)).toHaveLength(1);
     });
   });
 

--- a/backend/src/lambda/__tests__/user-management-resolver-org-scoping.test.ts
+++ b/backend/src/lambda/__tests__/user-management-resolver-org-scoping.test.ts
@@ -275,25 +275,45 @@ describe("getUser — org scoping", () => {
 // ---------------------------------------------------------------------------
 
 describe("listOrganizations — org scoping", () => {
+  // Realistic row shape: orgId is a generated UUID, distinct from name.
   const orgItems = [
-    { orgId: "org-a", name: "Org A", createdAt: "2024-01-01T00:00:00Z" },
-    { orgId: "org-b", name: "Org B", createdAt: "2024-01-01T00:00:00Z" },
+    {
+      orgId: "11111111-1111-1111-1111-111111111111",
+      name: "Org A",
+      createdAt: "2024-01-01T00:00:00Z",
+    },
+    {
+      orgId: "22222222-2222-2222-2222-222222222222",
+      name: "Org B",
+      createdAt: "2024-01-01T00:00:00Z",
+    },
   ];
 
-  test("non-admin caller sees only their own org", async () => {
+  // RATIFIED decision 228b3cc8, piece 1: the org-scoping filter at
+  // listOrganizations used to compare a DynamoDB row's `orgId` (a generated
+  // UUID) against the caller's `custom:organization` claim, which is ALWAYS
+  // the organisation NAME (per assignUserRole, extractOrgFromEvent, and
+  // every other tenancy comparison in this codebase — see auth-event.ts's
+  // "Canonical tenancy claim" note). `item.orgId === callerOrg` was
+  // therefore always false for a real, non-coincidental org row. This test
+  // uses a REALISTIC row shape (orgId is a UUID, distinct from name) and
+  // asserts the caller's NAME-valued claim resolves against the row's NAME.
+  test("non-admin caller sees only their own org (claim is the organisation NAME, orgId is a distinct UUID)", async () => {
     cognitoMock
       .on(AdminListGroupsForUserCommand, { Username: "alice" })
       .resolves({ Groups: [{ GroupName: "developer" }] });
     cognitoMock.on(AdminGetUserCommand, { Username: "alice" }).resolves({
       Username: "alice",
-      UserAttributes: [{ Name: "custom:organization", Value: "org-a" }],
+      // The claim is the org NAME, never the orgId — matches
+      // assignUserRole's Cognito attribute write and extractOrgFromEvent.
+      UserAttributes: [{ Name: "custom:organization", Value: "Org A" }],
     });
     dynamoMock.on(ScanCommand).resolves({ Items: orgItems });
 
     const event = buildEvent("listOrganizations", { username: "alice" });
     const result = (await handler(event)) as OrganizationResult[];
 
-    expect(result.map((o) => o.orgId)).toEqual(["org-a"]);
+    expect(result.map((o) => o.name)).toEqual(["Org A"]);
   });
 
   test("GLOBAL admin caller sees all organizations (deliberately preserved)", async () => {
@@ -305,7 +325,7 @@ describe("listOrganizations — org scoping", () => {
     const event = buildEvent("listOrganizations", { username: "admin-user" });
     const result = (await handler(event)) as OrganizationResult[];
 
-    expect(result.map((o) => o.orgId).sort()).toEqual(["org-a", "org-b"]);
+    expect(result.map((o) => o.name).sort()).toEqual(["Org A", "Org B"]);
   });
 
   test("fails closed when caller org cannot be resolved", async () => {

--- a/backend/src/lambda/organization-resolver.ts
+++ b/backend/src/lambda/organization-resolver.ts
@@ -3,7 +3,9 @@ import { DynamoDBClient } from "@aws-sdk/client-dynamodb";
 import {
   DynamoDBDocumentClient,
   PutCommand,
+  UpdateCommand,
   DeleteCommand,
+  GetCommand,
   ScanCommand,
 } from "@aws-sdk/lib-dynamodb";
 import {
@@ -40,6 +42,51 @@ interface Organization {
 interface UserManagementResponse {
   success: boolean;
   message?: string;
+}
+
+/**
+ * The key of the name-reservation/tombstone row for a given organisation
+ * NAME, stored in the SAME `OrganisationTable` (partition key `orgId` only
+ * — no separate table or GSI needed). This is the atomic uniqueness +
+ * anti-reuse mechanism for decision 228b3cc8 (pieces 2 and 3):
+ *
+ *  - `itemType: "name_reservation"` — written by `createOrganization` with
+ *    `ConditionExpression: attribute_not_exists(orgId)`, the SAME
+ *    write-once idiom used throughout this codebase (eval-comparison-
+ *    resolver.ts, eval-run-resolver.ts, execspec-resolver.ts, etc.) for
+ *    atomic create-if-absent. Because DynamoDB conditional puts are
+ *    evaluated atomically server-side, two concurrent `createOrganization`
+ *    calls for the same name can no longer both succeed — the loser gets a
+ *    `ConditionalCheckFailedException`, translated below into the existing
+ *    "already exists" error. This replaces the prior Scan-then-Put race.
+ *  - `itemType: "name_tombstone"` — the SAME row, flipped by
+ *    `deleteOrganization` instead of being deleted. A tombstoned name can
+ *    never be reserved again, closing the reuse gap the prior code's own
+ *    comment warned about (a zero-user deleted name could be recreated and
+ *    would inherit any surviving name-stamped rows in Projects/Workflows/
+ *    RegistryAgentRecord/etc. — those dependents are still a known,
+ *    separately-tracked gap; see the NOTE in deleteOrganization). Retaining
+ *    a tombstone (rather than refusing deletion while ANY name-stamped ROW
+ *    survives across every dependent table) is the safer AND simpler
+ *    choice here: enumerating "any row anywhere stamped with this name" would
+ *    require scanning tables this resolver has no handle on and no
+ *    consistency guarantee over, whereas the reservation row this resolver
+ *    already owns gives a single, race-free source of truth for whether a
+ *    name may be issued again — at the cost of names never becoming
+ *    available again once used, which matches the ratified "names are
+ *    immutable and canonical" model.
+ */
+function nameReservationKey(name: string): string {
+  return `NAME#${name}`;
+}
+
+interface NameReservationItem {
+  orgId: string;
+  itemType: "name_reservation" | "name_tombstone";
+  name: string;
+  reservedOrgId?: string;
+  createdAt: string;
+  tombstonedAt?: string;
 }
 
 /** AppSync event slice this resolver reads. */
@@ -124,26 +171,60 @@ async function createOrganization(
 ): Promise<Organization> {
   console.log("Creating organization:", input);
 
-  // Check if organization with same name already exists
-  const existingOrgs = await docClient.send(
-    new ScanCommand({
+  const reservationKey = nameReservationKey(input.name);
+  const now = new Date().toISOString();
+
+  // Reject a tombstoned name up front with a clear message, before
+  // attempting the reservation write. This is a plain read (not itself
+  // race-free against a concurrent tombstone), but the atomic reservation
+  // Put below is the actual uniqueness guarantee — this check only exists
+  // to give a clear, specific error instead of a generic "already exists"
+  // when the cause is reuse-of-a-deleted-name rather than a live duplicate.
+  const existingReservation = await docClient.send(
+    new GetCommand({
       TableName: ORGANIZATIONS_TABLE,
-      FilterExpression: "#name = :name",
-      ExpressionAttributeNames: {
-        "#name": "name",
-      },
-      ExpressionAttributeValues: {
-        ":name": input.name,
-      },
+      Key: { orgId: reservationKey },
     }),
   );
+  const existingItem = existingReservation.Item as
+    NameReservationItem | undefined;
+  if (existingItem?.itemType === "name_tombstone") {
+    throw new Error(
+      `Organization name "${input.name}" was previously used and deleted; it cannot be reused. Choose a different name.`,
+    );
+  }
 
-  if (existingOrgs.Items && existingOrgs.Items.length > 0) {
-    throw new Error(`Organization with name "${input.name}" already exists`);
+  // Atomic name reservation: a conditional put keyed on `NAME#<name>` with
+  // ConditionExpression: attribute_not_exists(orgId). This is the SAME
+  // write-once idiom this codebase already uses (eval-comparison-resolver.ts,
+  // eval-run-resolver.ts, execspec-resolver.ts, etc.) — DynamoDB evaluates the
+  // condition atomically server-side, so two concurrent creates for the same
+  // name can no longer both succeed. This replaces the prior
+  // Scan-then-Put (finding: non-atomic, race-prone).
+  try {
+    await docClient.send(
+      new PutCommand({
+        TableName: ORGANIZATIONS_TABLE,
+        Item: {
+          orgId: reservationKey,
+          itemType: "name_reservation",
+          name: input.name,
+          createdAt: now,
+        } satisfies NameReservationItem,
+        ConditionExpression: "attribute_not_exists(orgId)",
+      }),
+    );
+  } catch (error: unknown) {
+    if (
+      error instanceof Error &&
+      error.name === "ConditionalCheckFailedException"
+    ) {
+      throw new Error(`Organization with name "${input.name}" already exists`);
+    }
+    throw error;
   }
 
   const orgId = uuidv4();
-  const now = new Date().toISOString();
 
   const organization: Organization = {
     orgId,
@@ -153,6 +234,17 @@ async function createOrganization(
     description: input.description || "",
     createdAt: now,
   };
+
+  // Stamp the reservation row with the orgId it reserved for, so
+  // deleteOrganization can find/tombstone it without a Scan.
+  await docClient.send(
+    new UpdateCommand({
+      TableName: ORGANIZATIONS_TABLE,
+      Key: { orgId: reservationKey },
+      UpdateExpression: "SET reservedOrgId = :reservedOrgId",
+      ExpressionAttributeValues: { ":reservedOrgId": orgId },
+    }),
+  );
 
   await docClient.send(
     new PutCommand({
@@ -268,6 +360,46 @@ async function deleteOrganization(
       Key: { orgId },
     }),
   );
+
+  // 4. Tombstone the freed name so it can never be reserved again (decision
+  //    228b3cc8, piece 3). The name-reservation row created by
+  //    createOrganization is NOT deleted — it is flipped to
+  //    `itemType: "name_tombstone"` and retained permanently. This closes
+  //    the reuse gap the delete's own former comment warned about: a
+  //    zero-user deleted name could otherwise be recreated and would
+  //    inherit any surviving name-stamped rows in other tables (Projects,
+  //    Workflows, RegistryAgentRecord, ...) that this resolver does not own
+  //    and cannot clean up. Best-effort: if the org row was deleted but the
+  //    reservation cannot be found/tombstoned (e.g. it predates this
+  //    change), log and continue rather than leaving the org half-deleted.
+  try {
+    await docClient.send(
+      new UpdateCommand({
+        TableName: ORGANIZATIONS_TABLE,
+        Key: { orgId: nameReservationKey(orgName) },
+        UpdateExpression:
+          "SET itemType = :tombstone, tombstonedAt = :tombstonedAt",
+        ExpressionAttributeValues: {
+          ":tombstone": "name_tombstone",
+          ":tombstonedAt": new Date().toISOString(),
+        },
+        // The reservation row must already exist (created atomically by
+        // createOrganization) — if it doesn't, this is a pre-existing org
+        // created before this mechanism shipped. Don't silently create a
+        // reservation row here (that would race with a concurrent create
+        // using the same name that has no reservation to check against);
+        // just log and move on. The org itself is already deleted above.
+        ConditionExpression: "attribute_exists(orgId)",
+      }),
+    );
+  } catch (error: unknown) {
+    console.error(
+      `Could not tombstone name reservation for "${orgName}" (orgId ${orgId}); ` +
+        "the org row is deleted but the name may remain reusable if no " +
+        "reservation row pre-existed:",
+      error,
+    );
+  }
 
   console.log("Organization deleted:", orgId);
   return {

--- a/backend/src/lambda/user-management-resolver.ts
+++ b/backend/src/lambda/user-management-resolver.ts
@@ -39,6 +39,11 @@ interface AdminCreateUserInput {
   email: string;
   givenName: string;
   familyName: string;
+  // RATIFIED decision 228b3cc8 piece 5 (finding cbbc3be1): required, not
+  // optional. custom:organization must never be left unset at creation —
+  // see the adminCreateUser validation below for why no default is
+  // invented when this is omitted.
+  organization: string;
 }
 
 interface User {
@@ -615,7 +620,28 @@ async function adminCreateUser(
     throw new Error("Only administrators can create users");
   }
 
-  const { email, givenName, familyName } = input;
+  const { email, givenName, familyName, organization } = input;
+
+  // RATIFIED decision 228b3cc8 piece 5 (finding cbbc3be1): organization is
+  // REQUIRED at creation time, with NO invented default. Previously the
+  // organisation was applied solely by a separate, OPTIONAL assignUserRole
+  // call the frontend made only when a role was also chosen — an
+  // organisation-only, no-role creation left the user with NO
+  // custom:organization claim at all, which then fails closed (by design)
+  // across every org-scoped resolver with no clear signal of why. A silent
+  // default (e.g. "Default") would let a caller who forgot to pick an
+  // organisation create a user in the wrong tenant with no warning, which
+  // is worse than a clear upfront validation error — so this fails clearly
+  // instead. Team.tsx's Add User dialog already collects an organization
+  // from the name-valued `organizations` list (per the ratified
+  // NAME-is-canonical convention), so this is a required, not an
+  // impossible, ask of every caller.
+  if (!organization) {
+    return {
+      success: false,
+      message: "An organization is required to create a user.",
+    };
+  }
 
   try {
     // Create user with email as username
@@ -629,6 +655,11 @@ async function adminCreateUser(
           { Name: "email_verified", Value: "true" }, // Set to true so email is verified
           { Name: "given_name", Value: givenName },
           { Name: "family_name", Value: familyName },
+          // custom:organization stores the organisation NAME (ratified
+          // decision 228b3cc8) and remains an admin-API-only write (PR
+          // 146 keeps this attribute non-user-writable) — the value comes
+          // from this admin-supplied input, never from a self-service path.
+          { Name: "custom:organization", Value: organization },
         ],
         // Remove MessageAction to allow Cognito to send the welcome email
         DesiredDeliveryMediums: ["EMAIL"],

--- a/backend/src/lambda/user-management-resolver.ts
+++ b/backend/src/lambda/user-management-resolver.ts
@@ -465,8 +465,15 @@ async function listOrganizations(event: UserManagementResolverEvent) {
     }),
   );
 
+  // RATIFIED decision 228b3cc8: the organisation NAME is canonical for the
+  // `custom:organization` claim and every tenancy comparison in this
+  // codebase (assignUserRole writes the NAME, extractOrgFromEvent reads it
+  // back verbatim). `callerOrg` here is therefore always a NAME, never the
+  // generated `orgId` UUID — comparing it against `item.orgId` was always
+  // false for non-admins (see auth-event.ts's "Canonical tenancy claim"
+  // note for the shared rule). Compare NAME to NAME.
   return (response.Items || [])
-    .filter((item) => callerIsAdmin || item.orgId === callerOrg)
+    .filter((item) => callerIsAdmin || item.name === callerOrg)
     .map((item) => {
       console.log("Raw item from DynamoDB:", JSON.stringify(item));
 

--- a/backend/src/schema/schema.graphql
+++ b/backend/src/schema/schema.graphql
@@ -1305,6 +1305,7 @@ input AdminCreateUserInput {
   email: String!
   givenName: String!
   familyName: String!
+  organization: String!
 }
 
 input AssignUserRoleInput {

--- a/backend/src/utils/auth-event.ts
+++ b/backend/src/utils/auth-event.ts
@@ -3,6 +3,25 @@ import {
   AdminGetUserCommand,
 } from "@aws-sdk/client-cognito-identity-provider";
 
+/**
+ * CANONICAL TENANCY RULE (ratified decision 228b3cc8): the organisation
+ * NAME — never the generated `orgId` — is canonical for the
+ * `custom:organization` Cognito claim and for EVERY tenancy comparison in
+ * this codebase (this file's `extractOrgFromEvent`/`lookupUserOrganization`,
+ * `assignUserRole`'s Cognito attribute write, `user-management-resolver.ts`'s
+ * org-scoping filters, the governance ledger, and the projects family).
+ * `assignUserRole` writes the organisation's NAME (never its orgId) into
+ * `custom:organization`; every reader of that claim MUST compare it against
+ * a row's `name` field, never against `orgId`. Organisation names are
+ * IMMUTABLE by design (no update/rename mutation exists — see
+ * org-name-canonical-guard.test.ts) precisely so this claim never needs to
+ * be re-synced after creation. Do NOT reintroduce a `row.orgId ===
+ * callerOrgClaim` comparison — that comparison is always false for a real
+ * row and was the root cause of a prior bug (a non-admin caller of
+ * `listOrganizations` always got an empty list). If you are about to write
+ * `something.orgId === <claim variable>`, you are almost certainly holding
+ * a NAME on one side and a UUID on the other.
+ */
 const cognitoClient = new CognitoIdentityProviderClient({});
 
 /**

--- a/frontend/src/pages/Team.tsx
+++ b/frontend/src/pages/Team.tsx
@@ -190,8 +190,8 @@ export function Team() {
   };
 
   const handleAddUser = async () => {
-    if (!newUserEmail || !newUserFirstName || !newUserLastName) {
-      setError('Please fill in all fields');
+    if (!newUserEmail || !newUserFirstName || !newUserLastName || !newUserOrganization) {
+      setError('Please fill in all required fields, including organization');
       return;
     }
 
@@ -210,6 +210,7 @@ export function Team() {
         email: newUserEmail,
         givenName: newUserFirstName,
         familyName: newUserLastName,
+        organization: newUserOrganization,
       });
 
       console.log('Create user response:', response);
@@ -946,7 +947,7 @@ export function Team() {
               </div>
               <div>
                 <Label className="text-foreground text-sm font-medium mb-2 block">
-                  Organization (Optional)
+                  Organization
                 </Label>
                 <Select
                   value={newUserOrganization}
@@ -954,7 +955,7 @@ export function Team() {
                   disabled={creatingUser}
                 >
                   <SelectTrigger className="w-full">
-                    <SelectValue placeholder="Select an organization (optional)..." />
+                    <SelectValue placeholder="Select an organization..." />
                   </SelectTrigger>
                   <SelectContent>
                     {organizations.map((org) => (
@@ -969,7 +970,7 @@ export function Team() {
                 <Button
                   className="flex-1 bg-primary text-primary-foreground hover:bg-primary/90"
                   onClick={handleAddUser}
-                  disabled={creatingUser}
+                  disabled={creatingUser || !newUserOrganization}
                 >
                   {creatingUser ? 'Creating...' : 'Create User'}
                 </Button>

--- a/frontend/src/pages/__tests__/Team.regression.test.tsx
+++ b/frontend/src/pages/__tests__/Team.regression.test.tsx
@@ -70,7 +70,9 @@ jest.mock('@/services/userManagementService', () => ({
     listAvailableRoles: jest.fn().mockResolvedValue(['admin', 'developer', 'viewer']),
     listOrganizations: jest.fn().mockResolvedValue(mockOrgs),
     createUser: jest.fn().mockResolvedValue({ username: 'new@example.com' }),
+    adminCreateUser: jest.fn().mockResolvedValue({ success: true, message: 'ok' }),
     assignRole: jest.fn().mockResolvedValue(undefined),
+    assignUserRole: jest.fn().mockResolvedValue({ success: true }),
     resetPassword: jest.fn().mockResolvedValue(undefined),
     createOrganization: jest.fn().mockResolvedValue({ name: 'NewOrg' }),
     changeOrganization: jest.fn().mockResolvedValue(undefined),
@@ -150,5 +152,25 @@ describe('Team page — regression', () => {
     await waitFor(() => {
       expect(screen.getByText(/failed|error|unavailable/i)).toBeInTheDocument();
     });
+  });
+
+  // Decision 228b3cc8 piece 5 (finding cbbc3be1): organization is required
+  // at user creation, with no invented default. The Create User button in
+  // the Add User dialog must stay disabled until an organization is
+  // selected, and adminCreateUser must never be called without one.
+  test('Create User button is disabled until an organization is selected', async () => {
+    render(<Team />);
+
+    await waitFor(() => {
+      expect(screen.getByRole('button', { name: /add user|invite/i })).toBeInTheDocument();
+    });
+    fireEvent.click(screen.getByRole('button', { name: /add user|invite/i }));
+
+    await waitFor(() => {
+      expect(screen.getByTestId('dialog')).toBeInTheDocument();
+    });
+
+    const createButton = screen.getByRole('button', { name: /create user/i });
+    expect(createButton).toBeDisabled();
   });
 });

--- a/frontend/src/services/userManagementService.ts
+++ b/frontend/src/services/userManagementService.ts
@@ -177,6 +177,7 @@ export interface AdminCreateUserInput {
   email: string;
   givenName: string;
   familyName: string;
+  organization: string;
 }
 
 export interface CreateOrganizationInput {


### PR DESCRIPTION
## Summary

The organisation **name** is canonical for the `custom:organization` claim and all tenancy comparisons. This is what the platform already did - the projects family, datastore rows and their index, user-management, and the governance ledger are all name-versus-name - but it was convention rather than mechanism, and one comparison disagreed.

`orgId` was considered and rejected. The investigation that decided it found **no rename path exists** (`organization-resolver` dispatches only create and delete; no `updateOrganization` symbol anywhere), so the mutability hazard that would make names unsafe is unreachable, while migrating to rekeying 25 GSIs, rewriting an integrations table keyed on `ORG#<name>`, and re-issuing every Cognito claim atomically with the row rewrite - for no benefit while nothing renames.

## Changes

**1. The one mixed comparison, fixed.** `listOrganizations` compared a row's `orgId` against the name-valued claim - always false, so non-admins got nothing. Now name-to-name. The existing fixture coincidentally set `orgId` equal to the claim, which is why no test caught it; replaced with a distinct-name fixture that actually exercises the path.

**2. Name uniqueness is now atomic.** The scan-then-write race is replaced by a conditional put of a `NAME#<name>` reservation row (`attribute_not_exists`), reusing the write-once idiom already used elsewhere in the repo. No new table or GSI. Concurrent creates: exactly one wins.

**3. Freed names are tombstoned.** `deleteOrganization`'s own comment warned that reuse "risks cross-tenant access if the org name is ever reused". Deletion now flips the reservation row to a permanent tombstone and creation rejects it with a distinct message, so a recreated organisation cannot inherit the previous tenant's name-stamped rows. Chosen over blocking deletion while name-stamped rows survive, which would require scanning tables this resolver does not own.

**4. The convention is pinned mechanically.** An AST guard fails if a rename operation appears in the schema `Mutation` block, the dispatch switch, or as an `UpdateCommand` setting the name - the whole model rests on names never changing, and that was convention only. Plus a test asserting the seeded admin's claim equals the seeded organisation name, and the canonical rule documented in the shared auth helper with an explicit warning against reintroducing an 'orgId' comparison.

**5. Users can no longer exist without a tenancy claim.** `adminCreateUser` sets `custom:organization` in the `AdminCreateUserCommand` (admin API - PR 146's non-user-writable rule intact). Previously it was applied only by a separate *optional* `assignuserRole`, so an admin who skipped that step created an account that failed closed across ~43 gates.

## Please note

- **`organization` is now required** on the create-user input - a breaking change for any consumer supplying it. Chosen over a default because the dialog already collects the value, and a silent default would misassign a tenant quietly
- **Tombstones are permanent**: a deleted organisation's name can never be reused
- The admin bypass on the organisations comparison was **kept**, not removed: once the comparison is correct it is legitimate cross-tenant admin visibility, matching
`listUsers` / `getUser`

## Testing

Red-first throughout. Non-admin now receives their own organisation where they previously got none; duplicate-name race proven closed at the condition expression; tombstoned name rejected on recreate; immutability guard proven to bite on a planted rename and to ignore the legitimate tombstone update; guard verified AST-based, no false positive from the token in a comment or string literal.

tsc o, Lint o, targeted 89, all 14 gate-enumeration guards 348), full backend jest 7847, frontend 2068, `vite build` 0.

## Outstanding

No backfill exists for existing users created before this change who carry no claim.