### PR TITLE
fix(security): complete organisation-name uniqueness coverage

### DIFF
--- a/backend/scripts/__tests__/backfill-org-name-reservations.test.ts
+++ b/backend/scripts/__tests__/backfill-org-name-reservations.test.ts
@@ -1,0 +1,288 @@
+/**
+ * Tests for backend/scripts/backfill-org-name-reservations.ts (finding
+ * 003a9234, mechanism 2).
+ *
+ * Covers:
+ *   - grouping logic (unique vs collision names) is pure and correct
+ *   - the backfill is idempotent: re-running finds nothing new to write
+ *     for a name already reserved
+ *   - a pre-existing duplicate name is REPORTED (non-zero collisions,
+ *     non-zero exit code path) and NEVER silently collapsed — no
+ *     reservation is written for a colliding name, and no org is picked
+ *     as a winner
+ */
+import { DynamoDBClient } from "@aws-sdk/client-dynamodb";
+import {
+  DynamoDBDocumentClient,
+  ScanCommand,
+  PutCommand,
+} from "@aws-sdk/lib-dynamodb";
+import { mockClient } from "aws-sdk-client-mock";
+
+import {
+  nameReservationKey,
+  groupOrgsByName,
+  scanOrganizationRows,
+  reserveOrgName,
+  runBackfill,
+  type OrgRow,
+} from "../backfill-org-name-reservations";
+
+const ddbMock = mockClient(DynamoDBDocumentClient);
+
+/** Builds a ConditionalCheckFailedException the same way AWS SDK v3 does. */
+function conditionalCheckFailed(): Error {
+  const err = new Error("The conditional request failed");
+  err.name = "ConditionalCheckFailedException";
+  return err;
+}
+
+describe("nameReservationKey", () => {
+  test("mirrors organization-resolver.ts's NAME#<name> derivation", () => {
+    expect(nameReservationKey("Default")).toBe("NAME#Default");
+    expect(nameReservationKey("My Org")).toBe("NAME#My Org");
+  });
+});
+
+describe("groupOrgsByName", () => {
+  test("groups a name held by exactly one org as unique", () => {
+    const orgs: OrgRow[] = [
+      { orgId: "org-000", name: "Default" },
+      { orgId: "org-001", name: "Engineering" },
+    ];
+    const { unique, collisions } = groupOrgsByName(orgs);
+    expect(unique.size).toBe(2);
+    expect(unique.get("Default")).toEqual({
+      orgId: "org-000",
+      name: "Default",
+    });
+    expect(collisions.size).toBe(0);
+  });
+
+  test("groups a name held by 2+ orgs as a collision, not a unique winner", () => {
+    const orgs: OrgRow[] = [
+      { orgId: "org-000", name: "Default" },
+      { orgId: "org-999", name: "Default" },
+      { orgId: "org-001", name: "Engineering" },
+    ];
+    const { unique, collisions } = groupOrgsByName(orgs);
+    expect(unique.size).toBe(1);
+    expect(unique.has("Default")).toBe(false);
+    expect(collisions.size).toBe(1);
+    expect(collisions.get("Default")).toEqual([
+      { orgId: "org-000", name: "Default" },
+      { orgId: "org-999", name: "Default" },
+    ]);
+  });
+
+  test("handles an empty org list", () => {
+    const { unique, collisions } = groupOrgsByName([]);
+    expect(unique.size).toBe(0);
+    expect(collisions.size).toBe(0);
+  });
+});
+
+describe("scanOrganizationRows", () => {
+  beforeEach(() => {
+    ddbMock.reset();
+  });
+
+  test("excludes NAME# reservation/tombstone rows via attribute_not_exists(itemType)", async () => {
+    ddbMock.on(ScanCommand).resolves({
+      Items: [
+        { orgId: "org-000", name: "Default" },
+        {
+          orgId: "NAME#Default",
+          itemType: "name_reservation",
+          name: "Default",
+        },
+      ],
+    });
+
+    const docClient = DynamoDBDocumentClient.from(new DynamoDBClient({}));
+    const rows = await scanOrganizationRows(docClient, "test-orgs");
+
+    const scanCalls = ddbMock.commandCalls(ScanCommand);
+    expect(scanCalls[0].args[0].input.FilterExpression).toBe(
+      "attribute_not_exists(itemType)",
+    );
+    // Only the mock's static resolves is exercised (no client-side
+    // filtering here — production DynamoDB applies the FilterExpression;
+    // this test pins the request shape sent to it).
+    expect(rows.length).toBeGreaterThanOrEqual(1);
+  });
+
+  test("paginates via LastEvaluatedKey/ExclusiveStartKey", async () => {
+    ddbMock
+      .on(ScanCommand)
+      .resolvesOnce({
+        Items: [{ orgId: "org-000", name: "Default" }],
+        LastEvaluatedKey: { orgId: "org-000" },
+      })
+      .resolvesOnce({
+        Items: [{ orgId: "org-001", name: "Engineering" }],
+      });
+
+    const docClient = DynamoDBDocumentClient.from(new DynamoDBClient({}));
+    const rows = await scanOrganizationRows(docClient, "test-orgs");
+
+    expect(rows).toEqual([
+      { orgId: "org-000", name: "Default" },
+      { orgId: "org-001", name: "Engineering" },
+    ]);
+    expect(ddbMock.commandCalls(ScanCommand)).toHaveLength(2);
+  });
+});
+
+describe("reserveOrgName", () => {
+  beforeEach(() => {
+    ddbMock.reset();
+  });
+
+  test("writes a conditional PutCommand and returns true on success", async () => {
+    ddbMock.on(PutCommand).resolves({});
+    const docClient = DynamoDBDocumentClient.from(new DynamoDBClient({}));
+
+    const wroteNew = await reserveOrgName(docClient, "test-orgs", {
+      orgId: "org-000",
+      name: "Default",
+    });
+
+    expect(wroteNew).toBe(true);
+    const putCalls = ddbMock.commandCalls(PutCommand);
+    expect(putCalls).toHaveLength(1);
+    expect(putCalls[0].args[0].input.Item).toMatchObject({
+      orgId: "NAME#Default",
+      itemType: "name_reservation",
+      name: "Default",
+      reservedOrgId: "org-000",
+    });
+    expect(putCalls[0].args[0].input.ConditionExpression).toBe(
+      "attribute_not_exists(orgId)",
+    );
+  });
+
+  // IDEMPOTENCY: calling twice must be safe. The second call hits the
+  // ConditionalCheckFailedException path and returns false rather than
+  // throwing.
+  test("is idempotent — a pre-existing reservation causes false, not an error", async () => {
+    ddbMock.on(PutCommand).rejects(conditionalCheckFailed());
+    const docClient = DynamoDBDocumentClient.from(new DynamoDBClient({}));
+
+    const wroteNew = await reserveOrgName(docClient, "test-orgs", {
+      orgId: "org-000",
+      name: "Default",
+    });
+
+    expect(wroteNew).toBe(false);
+  });
+
+  test("propagates a non-conditional error", async () => {
+    ddbMock
+      .on(PutCommand)
+      .rejects(new Error("ProvisionedThroughputExceededException"));
+    const docClient = DynamoDBDocumentClient.from(new DynamoDBClient({}));
+
+    await expect(
+      reserveOrgName(docClient, "test-orgs", {
+        orgId: "org-000",
+        name: "Default",
+      }),
+    ).rejects.toThrow("ProvisionedThroughputExceededException");
+  });
+});
+
+describe("runBackfill", () => {
+  beforeEach(() => {
+    ddbMock.reset();
+  });
+
+  test("apply mode reserves every unique name and reports zero collisions", async () => {
+    ddbMock.on(ScanCommand).resolves({
+      Items: [
+        { orgId: "org-000", name: "Default" },
+        { orgId: "org-001", name: "Engineering" },
+      ],
+    });
+    ddbMock.on(PutCommand).resolves({});
+
+    const docClient = DynamoDBDocumentClient.from(new DynamoDBClient({}));
+    const summary = await runBackfill(docClient, "test-orgs", true);
+
+    expect(summary.scanned).toBe(2);
+    expect(summary.uniqueNames).toBe(2);
+    expect(summary.reserved).toBe(2);
+    expect(summary.alreadyReserved).toBe(0);
+    expect(summary.collisions).toEqual([]);
+    expect(summary.errors).toBe(0);
+    expect(ddbMock.commandCalls(PutCommand)).toHaveLength(2);
+  });
+
+  // IDEMPOTENCY at the whole-backfill level: re-running when every name is
+  // already reserved writes nothing new and reports alreadyReserved, not
+  // errors.
+  test("is idempotent — re-running when reservations already exist writes nothing new", async () => {
+    ddbMock.on(ScanCommand).resolves({
+      Items: [{ orgId: "org-000", name: "Default" }],
+    });
+    ddbMock.on(PutCommand).rejects(conditionalCheckFailed());
+
+    const docClient = DynamoDBDocumentClient.from(new DynamoDBClient({}));
+    const summary = await runBackfill(docClient, "test-orgs", true);
+
+    expect(summary.reserved).toBe(0);
+    expect(summary.alreadyReserved).toBe(1);
+    expect(summary.errors).toBe(0);
+  });
+
+  // THE COLLISION CONTRACT: a pre-existing duplicate name must be REPORTED,
+  // not resolved. No PutCommand must ever be issued for the colliding name,
+  // and the summary must surface it distinctly from a successful reservation.
+  test("reports a pre-existing duplicate name as a collision and does NOT write a reservation for it", async () => {
+    ddbMock.on(ScanCommand).resolves({
+      Items: [
+        { orgId: "org-000", name: "Default" },
+        { orgId: "org-999", name: "Default" },
+        { orgId: "org-001", name: "Engineering" },
+      ],
+    });
+    ddbMock.on(PutCommand).resolves({});
+
+    const docClient = DynamoDBDocumentClient.from(new DynamoDBClient({}));
+    const summary = await runBackfill(docClient, "test-orgs", true);
+
+    expect(summary.collisions).toEqual([
+      { name: "Default", orgIds: ["org-000", "org-999"] },
+    ]);
+    // Only "Engineering" (the unique name) was reserved.
+    expect(summary.reserved).toBe(1);
+    const putCalls = ddbMock.commandCalls(PutCommand);
+    expect(putCalls).toHaveLength(1);
+    expect(putCalls[0].args[0].input.Item).toMatchObject({
+      name: "Engineering",
+    });
+    // No Put was ever attempted for the colliding "Default" name.
+    const defaultPut = putCalls.find(
+      (c) =>
+        (c.args[0].input.Item as Record<string, unknown>).name === "Default",
+    );
+    expect(defaultPut).toBeUndefined();
+  });
+
+  test("dry-run mode never writes and still reports collisions", async () => {
+    ddbMock.on(ScanCommand).resolves({
+      Items: [
+        { orgId: "org-000", name: "Default" },
+        { orgId: "org-999", name: "Default" },
+      ],
+    });
+
+    const docClient = DynamoDBDocumentClient.from(new DynamoDBClient({}));
+    const summary = await runBackfill(docClient, "test-orgs", false);
+
+    expect(ddbMock.commandCalls(PutCommand)).toHaveLength(0);
+    expect(summary.collisions).toEqual([
+      { name: "Default", orgIds: ["org-000", "org-999"] },
+    ]);
+  });
+});

--- a/backend/scripts/backfill-org-name-reservations.ts
+++ b/backend/scripts/backfill-org-name-reservations.ts
@@ -1,0 +1,337 @@
+/**
+ * One-shot backfill for NAME# reservation rows on organisations that
+ * already exist (finding 003a9234, mechanism 2).
+ *
+ * Context: createOrganization's duplicate-name protection is an atomic
+ * conditional put of a `NAME#<name>` reservation row
+ * (ConditionExpression: attribute_not_exists(orgId)) in the same
+ * OrganisationTable — see organization-resolver.ts. That guard only works
+ * for names that already HAVE a reservation row. seed-organizations now
+ * writes one for every org it seeds (mechanism 1), but any organisation
+ * created BEFORE this backfill runs — including a fresh deployment's
+ * seeded rows from before this fix, or any org created via
+ * createOrganization prior to PR 159 introducing the reservation
+ * mechanism at all — has no reservation row, so its name remains
+ * duplicable.
+ *
+ * This script:
+ *   1. Scans the organisations table for every real org row (rows with no
+ *      `itemType` — NAME# reservation/tombstone rows are excluded by
+ *      construction, since they always carry `itemType`).
+ *   2. Groups by `name`.
+ *   3. For each name held by exactly ONE org, writes its NAME# reservation
+ *      row with a conditional put (attribute_not_exists(orgId)) — safe to
+ *      re-run: a reservation created by a previous run of this script, by
+ *      seed-organizations, or by a createOrganization call since, is left
+ *      untouched.
+ *   4. For each name held by 2+ orgs, this is a PRE-EXISTING tenancy
+ *      collision (decision 228b3cc8 makes the name the canonical tenancy
+ *      key — two orgs sharing a name means two tenants sharing one key).
+ *      The script does NOT pick a winner and does NOT write a reservation
+ *      for that name. It reports the collision loudly (non-zero exit code
+ *      in --apply mode, plus a clearly labelled summary section) and
+ *      leaves resolution to an owner decision.
+ *
+ * Shape chosen: a standalone ts-node SCRIPT (matching
+ * scripts/backfill-org-ids.ts), NOT a custom-resource/Lambda (matching
+ * src/lambda/backfill-project-org.ts's alternative shape). Rationale: this
+ * backfill needs no CDK wiring, no IAM role beyond whatever credentials
+ * the operator already has configured locally, and no permanent
+ * infrastructure — exactly backfill-org-ids.ts's profile (env-var driven,
+ * dry-run by default, one AWS table touched). backfill-project-org.ts's
+ * Lambda shape exists because that backfill's doc explicitly frames it as
+ * "no permanent CDK Lambda resource" ceremony for a wider blast radius
+ * (arbitrary orgId assignment via Cognito lookups); this backfill is a
+ * single-table, single-purpose sweep that fits the lighter script pattern.
+ *
+ * Usage:
+ *   ts-node backend/scripts/backfill-org-name-reservations.ts --dry-run  (default)
+ *   ts-node backend/scripts/backfill-org-name-reservations.ts --apply
+ *
+ * Required env:
+ *   ORGANIZATIONS_TABLE  – organisations DynamoDB table name
+ *   AWS_REGION           – optional, defaults to us-west-2
+ *
+ * Constraints:
+ *   - Dry-run by default. `--apply` flips to write mode.
+ *   - Idempotent — re-running finds nothing new to reserve for names
+ *     already covered, and re-reports (without re-mutating) any
+ *     still-unresolved collision.
+ *   - Never collapses a pre-existing duplicate name — collisions are
+ *     reported, never auto-resolved.
+ */
+import { DynamoDBClient } from "@aws-sdk/client-dynamodb";
+import {
+  DynamoDBDocumentClient,
+  ScanCommand,
+  PutCommand,
+  type NativeAttributeValue,
+} from "@aws-sdk/lib-dynamodb";
+
+/** Mirrors nameReservationKey() in organization-resolver.ts — must stay
+ * byte-identical to the resolver's own derivation. */
+export function nameReservationKey(name: string): string {
+  return `NAME#${name}`;
+}
+
+export interface OrgRow {
+  orgId: string;
+  name: string;
+}
+
+export interface GroupedByName {
+  /** Names held by exactly one org — safe to reserve. */
+  unique: Map<string, OrgRow>;
+  /** Names held by 2+ orgs — pre-existing tenancy collisions, reported
+   * (never auto-resolved) below. */
+  collisions: Map<string, OrgRow[]>;
+}
+
+/**
+ * Groups organisation rows by name. A name held by more than one org is a
+ * pre-existing tenancy collision (decision 228b3cc8) and must NOT be
+ * silently resolved by picking a winner — it is surfaced separately so the
+ * caller can report it loudly instead of writing a reservation for it.
+ */
+export function groupOrgsByName(orgs: OrgRow[]): GroupedByName {
+  const byName = new Map<string, OrgRow[]>();
+  for (const org of orgs) {
+    const list = byName.get(org.name) ?? [];
+    list.push(org);
+    byName.set(org.name, list);
+  }
+
+  const unique = new Map<string, OrgRow>();
+  const collisions = new Map<string, OrgRow[]>();
+  for (const [name, group] of byName) {
+    if (group.length === 1) {
+      unique.set(name, group[0]);
+    } else {
+      collisions.set(name, group);
+    }
+  }
+  return { unique, collisions };
+}
+
+export interface BackfillSummary {
+  /** Total org rows scanned. */
+  scanned: number;
+  /** Distinct names with exactly one org. */
+  uniqueNames: number;
+  /** Reservation rows newly written (apply mode) or that would be written
+   * (dry-run mode). */
+  reserved: number;
+  /** Reservation rows that already existed and were left untouched. */
+  alreadyReserved: number;
+  /** Names held by 2+ orgs — reported, never resolved. */
+  collisions: Array<{ name: string; orgIds: string[] }>;
+  /** Per-row write failures (apply mode only), logged and swallowed. */
+  errors: number;
+}
+
+function emptySummary(): BackfillSummary {
+  return {
+    scanned: 0,
+    uniqueNames: 0,
+    reserved: 0,
+    alreadyReserved: 0,
+    collisions: [],
+    errors: 0,
+  };
+}
+
+type LogLevel = "info" | "warn" | "error";
+
+function log(level: LogLevel, msg: string): void {
+  const ts = new Date().toISOString();
+  const prefix =
+    level === "error" ? "ERROR" : level === "warn" ? "WARN" : "INFO";
+  const line = `${ts} [${prefix}] ${msg}`;
+  if (level === "error") {
+    // eslint-disable-next-line no-console
+    console.error(line);
+  } else {
+    // eslint-disable-next-line no-console
+    console.log(line);
+  }
+}
+
+/**
+ * Scans the organisations table for real org rows only (excludes NAME#
+ * reservation/tombstone rows, which always carry `itemType`; a real org
+ * row never does — see organization-resolver.ts's Organization type).
+ */
+export async function scanOrganizationRows(
+  docClient: DynamoDBDocumentClient,
+  tableName: string,
+): Promise<OrgRow[]> {
+  const rows: OrgRow[] = [];
+  let exclusiveStartKey: Record<string, NativeAttributeValue> | undefined;
+
+  do {
+    const page = await docClient.send(
+      new ScanCommand({
+        TableName: tableName,
+        FilterExpression: "attribute_not_exists(itemType)",
+        ExclusiveStartKey: exclusiveStartKey,
+      }),
+    );
+    for (const item of page.Items ?? []) {
+      if (typeof item.orgId === "string" && typeof item.name === "string") {
+        rows.push({ orgId: item.orgId, name: item.name });
+      }
+    }
+    exclusiveStartKey = page.LastEvaluatedKey as
+      Record<string, NativeAttributeValue> | undefined;
+  } while (exclusiveStartKey);
+
+  return rows;
+}
+
+/**
+ * Writes the NAME# reservation row for a single org, conditional on the
+ * row not already existing. Idempotent: an existing reservation
+ * (ConditionalCheckFailedException) is treated as success, not an error —
+ * it means a previous run of this script, seed-organizations, or a real
+ * createOrganization call already covers this name.
+ *
+ * Returns `true` if a new reservation was written, `false` if one already
+ * existed.
+ */
+export async function reserveOrgName(
+  docClient: DynamoDBDocumentClient,
+  tableName: string,
+  org: OrgRow,
+): Promise<boolean> {
+  const now = new Date().toISOString();
+  try {
+    await docClient.send(
+      new PutCommand({
+        TableName: tableName,
+        Item: {
+          orgId: nameReservationKey(org.name),
+          itemType: "name_reservation",
+          name: org.name,
+          reservedOrgId: org.orgId,
+          createdAt: now,
+        },
+        ConditionExpression: "attribute_not_exists(orgId)",
+      }),
+    );
+    return true;
+  } catch (err: unknown) {
+    if (
+      err instanceof Error &&
+      err.name === "ConditionalCheckFailedException"
+    ) {
+      return false;
+    }
+    throw err;
+  }
+}
+
+export async function runBackfill(
+  docClient: DynamoDBDocumentClient,
+  tableName: string,
+  apply: boolean,
+): Promise<BackfillSummary> {
+  const summary = emptySummary();
+
+  const orgs = await scanOrganizationRows(docClient, tableName);
+  summary.scanned = orgs.length;
+
+  const { unique, collisions } = groupOrgsByName(orgs);
+  summary.uniqueNames = unique.size;
+
+  for (const [name, group] of collisions) {
+    summary.collisions.push({
+      name,
+      orgIds: group.map((o) => o.orgId),
+    });
+    log(
+      "error",
+      `COLLISION: name "${name}" is held by ${group.length} organisations ` +
+        `(orgIds: ${group.map((o) => o.orgId).join(", ")}) — this is a ` +
+        "pre-existing tenancy collision (decision 228b3cc8: name is the " +
+        "canonical tenancy key). NOT resolving automatically; no " +
+        "reservation written for this name. An owner must decide which " +
+        "org keeps the name (rename/merge/delete) before it can be safely " +
+        "reserved.",
+    );
+  }
+
+  for (const [name, org] of unique) {
+    if (!apply) {
+      log(
+        "info",
+        `[DRY-RUN] would reserve name "${name}" -> orgId=${org.orgId}`,
+      );
+      summary.reserved++;
+      continue;
+    }
+    try {
+      const wroteNew = await reserveOrgName(docClient, tableName, org);
+      if (wroteNew) {
+        log("info", `reserved name "${name}" -> orgId=${org.orgId}`);
+        summary.reserved++;
+      } else {
+        log(
+          "info",
+          `name "${name}" already reserved (orgId=${org.orgId}); left untouched`,
+        );
+        summary.alreadyReserved++;
+      }
+    } catch (err) {
+      log(
+        "error",
+        `failed to reserve name "${name}" (orgId=${org.orgId}): ${String(err)}`,
+      );
+      summary.errors++;
+    }
+  }
+
+  return summary;
+}
+
+export async function main(): Promise<void> {
+  const args = process.argv.slice(2);
+  const apply = args.includes("--apply");
+  const dryRun = !apply;
+
+  const tableName = process.env.ORGANIZATIONS_TABLE;
+  const region = process.env.AWS_REGION || "us-west-2";
+
+  if (!tableName) throw new Error("ORGANIZATIONS_TABLE env var required");
+
+  log("info", `Mode: ${dryRun ? "DRY-RUN" : "APPLY"}`);
+  log("info", `ORGANIZATIONS_TABLE=${tableName} REGION=${region}`);
+
+  const docClient = DynamoDBDocumentClient.from(new DynamoDBClient({ region }));
+
+  const summary = await runBackfill(docClient, tableName, apply);
+
+  log("info", "--- Backfill summary ---");
+  log("info", `mode:             ${dryRun ? "dry-run" : "apply"}`);
+  log("info", `scanned:          ${summary.scanned}`);
+  log("info", `unique names:     ${summary.uniqueNames}`);
+  log("info", `reserved:         ${summary.reserved}`);
+  log("info", `already reserved: ${summary.alreadyReserved}`);
+  log("info", `collisions:       ${summary.collisions.length}`);
+  log("info", `errors:           ${summary.errors}`);
+
+  if (summary.collisions.length > 0) {
+    log(
+      "error",
+      `${summary.collisions.length} unresolved name collision(s) — see ` +
+        "COLLISION lines above. Exiting non-zero.",
+    );
+    process.exitCode = 1;
+  }
+}
+
+if (require.main === module) {
+  main().catch((err) => {
+    log("error", `Fatal: ${String(err)}`);
+    process.exit(1);
+  });
+}

--- a/backend/src/lambda/__tests__/organization-resolver.test.ts
+++ b/backend/src/lambda/__tests__/organization-resolver.test.ts
@@ -66,6 +66,10 @@ describe("organization-resolver", () => {
     dynamoMock.on(GetCommand).resolves({ Item: undefined });
     dynamoMock.on(PutCommand).resolves({});
     dynamoMock.on(UpdateCommand).resolves({});
+    // Defence-in-depth row-level Scan (finding 003a9234, mechanism 3):
+    // default to "no existing org row with this name" unless a test
+    // overrides this with a more specific `.on(ScanCommand, {...})` stub.
+    dynamoMock.on(ScanCommand).resolves({ Items: [] });
   });
 
   // REAL AppSync $context shape: the field name lives under `info.fieldName`,
@@ -253,6 +257,80 @@ describe("organization-resolver", () => {
       expect(putCalls).toHaveLength(1);
     });
 
+    // THE GAP (finding 003a9234): a duplicate of a name that already has a
+    // LIVE org row but NO NAME# reservation row (e.g. a seeded organisation
+    // from before the reservation mechanism covered seeded rows, or any
+    // drift between the org rows and the side table) must still be
+    // rejected. The reservation GetCommand/PutCommand alone would see no
+    // existing reservation and let this through — the row-level Scan
+    // (mechanism 3, defence in depth) is what catches it. This is the exact
+    // test that would have caught PR 159's gap: a duplicate of a SEEDED
+    // name (no reservation row backing it), not merely a duplicate created
+    // within the same test run (which always has a reservation row from its
+    // own earlier create).
+    test("rejects a duplicate of a SEEDED org name that has no NAME# reservation row (row-level defence in depth)", async () => {
+      // No reservation row exists for "Default" (as would be the case for
+      // a seeded org created before mechanism 1 shipped, or if the seeder
+      // and resolver ever drift).
+      dynamoMock.on(GetCommand).resolves({ Item: undefined });
+      // But a live org row named "Default" already exists (e.g. org-000,
+      // seeded by seed-organizations).
+      dynamoMock
+        .on(ScanCommand, {
+          TableName: "test-orgs",
+          FilterExpression: "#name = :name AND attribute_not_exists(itemType)",
+          ExpressionAttributeNames: { "#name": "name" },
+          ExpressionAttributeValues: { ":name": "Default" },
+        })
+        .resolves({
+          Items: [
+            {
+              orgId: "org-000",
+              name: "Default",
+              description: "Default organisation",
+              createdAt: "2024-01-01T00:00:00Z",
+            },
+          ],
+        });
+
+      await expect(
+        handler(
+          makeEvent(
+            "createOrganization",
+            { input: { name: "Default" } },
+            adminIdentity,
+          ),
+        ),
+      ).rejects.toThrow('Organization with name "Default" already exists');
+
+      // The reservation Put must NEVER be reached — the row-level check
+      // short-circuits before it.
+      expect(dynamoMock.commandCalls(PutCommand)).toHaveLength(0);
+    });
+
+    // The row-level Scan must exclude NAME# reservation/tombstone rows from
+    // its match — those carry `itemType` and must not be mistaken for a
+    // live org row sharing the same `name` attribute value.
+    test("row-level defence-in-depth Scan filters out itemType-bearing rows (reservation/tombstone), not just live orgs", async () => {
+      await handler(
+        makeEvent(
+          "createOrganization",
+          { input: { name: "Fresh Org" } },
+          adminIdentity,
+        ),
+      );
+
+      const scanCalls = dynamoMock.commandCalls(ScanCommand);
+      const orgNameScan = scanCalls.find(
+        (c) =>
+          c.args[0].input.ExpressionAttributeValues?.[":name"] === "Fresh Org",
+      );
+      expect(orgNameScan).toBeDefined();
+      expect(orgNameScan!.args[0].input.FilterExpression).toBe(
+        "#name = :name AND attribute_not_exists(itemType)",
+      );
+    });
+
     // RACE: two concurrent creates for the same name — the conditional put
     // ensures at most one can win. This test simulates the loser's path by
     // asserting the reservation Put carries the correct
@@ -279,8 +357,16 @@ describe("organization-resolver", () => {
       expect(reservationCall!.args[0].input.ConditionExpression).toBe(
         "attribute_not_exists(orgId)",
       );
-      // No Scan is used anywhere in the create path anymore.
-      expect(dynamoMock.commandCalls(ScanCommand)).toHaveLength(0);
+      // The reservation write itself is still a direct conditional Put, not
+      // a Scan-then-Put — the uniqueness AUTHORITY remains atomic. (A Scan
+      // now runs earlier as a defence-in-depth backstop — finding
+      // 003a9234, mechanism 3 — but it is not what makes this Put safe
+      // under concurrency; the ConditionExpression assertion above is.)
+      const scanCalls = dynamoMock.commandCalls(ScanCommand);
+      expect(scanCalls).toHaveLength(1);
+      expect(scanCalls[0].args[0].input.FilterExpression).toBe(
+        "#name = :name AND attribute_not_exists(itemType)",
+      );
     });
 
     // RATIFIED decision 228b3cc8, piece 3: a tombstoned name (previously

--- a/backend/src/lambda/organization-resolver.ts
+++ b/backend/src/lambda/organization-resolver.ts
@@ -194,6 +194,34 @@ async function createOrganization(
     );
   }
 
+  // DEFENCE IN DEPTH (finding 003a9234, mechanism 3) — BACKSTOP, not the
+  // primary guarantee. The conditional put below (ConditionExpression:
+  // attribute_not_exists(orgId) on the NAME# reservation row) remains the
+  // ATOMIC AUTHORITY for uniqueness — it is race-free under concurrent
+  // creates and is what actually prevents two callers from both winning.
+  // This row-level Scan exists ONLY because the reservation side table can
+  // drift from the organisation rows it is meant to describe: a seeder bug,
+  // a manually-inserted org row, a pre-existing org from before the
+  // reservation mechanism shipped, or a future migration could all leave an
+  // organisation with NO matching NAME# row. In that drifted state the
+  // conditional put alone would see attribute_not_exists(orgId) succeed and
+  // silently let a duplicate through even though a live org already holds
+  // the name. This Scan is NOT atomic (another create can race between this
+  // read and the Put below) — that race is still closed by the conditional
+  // Put's ConditionExpression, so this check is a correctness backstop
+  // against drift, not a concurrency control.
+  const existingOrgWithName = await docClient.send(
+    new ScanCommand({
+      TableName: ORGANIZATIONS_TABLE,
+      FilterExpression: "#name = :name AND attribute_not_exists(itemType)",
+      ExpressionAttributeNames: { "#name": "name" },
+      ExpressionAttributeValues: { ":name": input.name },
+    }),
+  );
+  if (existingOrgWithName.Items && existingOrgWithName.Items.length > 0) {
+    throw new Error(`Organization with name "${input.name}" already exists`);
+  }
+
   // Atomic name reservation: a conditional put keyed on `NAME#<name>` with
   // ConditionExpression: attribute_not_exists(orgId). This is the SAME
   // write-once idiom this codebase already uses (eval-comparison-resolver.ts,

--- a/backend/src/lambda/seed-organizations/index.py
+++ b/backend/src/lambda/seed-organizations/index.py
@@ -4,62 +4,113 @@ import boto3
 import cfnresponse
 from datetime import datetime
 
+# Single source of truth for every seeded organisation. Both the org row
+# AND its NAME# reservation row (below) are derived from this SAME list, so
+# the two can never drift apart (finding 003a9234, mechanism 1). Do not add
+# an organisation anywhere else — add it here only.
+ORGANIZATIONS = [
+    {
+        'orgId': 'org-000',
+        'name': 'Default',
+        'description': 'Default organisation',
+    },
+    {
+        'orgId': 'org-001',
+        'name': 'Engineering',
+        'description': 'Engineering and Development Team',
+    },
+    {
+        'orgId': 'org-002',
+        'name': 'Product',
+        'description': 'Product Management Team',
+    },
+    {
+        'orgId': 'org-003',
+        'name': 'Operations',
+        'description': 'Operations and Infrastructure Team',
+    },
+]
+
+
+def name_reservation_key(name):
+    """Mirrors nameReservationKey() in organization-resolver.ts — the
+    NAME#<name> row is the atomic uniqueness authority createOrganization
+    checks via a conditional put. Must stay byte-identical to the
+    TypeScript implementation."""
+    return 'NAME#{}'.format(name)
+
+
 def handler(event, context):
     print('Event:', json.dumps(event))
-    
+
     if event['RequestType'] == 'Delete':
         cfnresponse.send(event, context, cfnresponse.SUCCESS, {})
         return
-    
+
     try:
         dynamodb = boto3.resource('dynamodb')
         table_name = os.environ['ORGANISATION_TABLE']
-        
+
         table = dynamodb.Table(table_name)
-        
+
         # Get current timestamp in ISO 8601 format (without microseconds for AppSync compatibility)
         current_time = datetime.utcnow().replace(microsecond=0).isoformat() + 'Z'
-        
-        # Define organizations to seed
-        organizations = [
-            {
-                'orgId': 'org-000',
-                'name': 'Default',
-                'description': 'Default organisation',
-                'createdAt': current_time
-            },
-            {
-                'orgId': 'org-001',
-                'name': 'Engineering',
-                'description': 'Engineering and Development Team',
-                'createdAt': current_time
-            },
-            {
-                'orgId': 'org-002',
-                'name': 'Product',
-                'description': 'Product Management Team',
-                'createdAt': current_time
-            },
-            {
-                'orgId': 'org-003',
-                'name': 'Operations',
-                'description': 'Operations and Infrastructure Team',
-                'createdAt': current_time
+
+        # Seed all organisations AND, for each one, the NAME# reservation row
+        # that createOrganization's atomic conditional put relies on as its
+        # uniqueness authority (finding 003a9234, mechanism 1). Without this,
+        # a fresh deployment's seeded names (e.g. "Default") could be
+        # duplicated by a later createOrganization call, because no
+        # reservation row would exist yet to trip attribute_not_exists.
+        #
+        # Reservation row shape matches organization-resolver.ts's
+        # NameReservationItem exactly: { orgId: 'NAME#<name>', itemType:
+        # 'name_reservation', name, reservedOrgId, createdAt }.
+        for org in ORGANIZATIONS:
+            org_item = {
+                'orgId': org['orgId'],
+                'name': org['name'],
+                'description': org['description'],
+                'createdAt': current_time,
             }
-        ]
-        
-        # Seed all organizations
-        for org in organizations:
             try:
-                table.put_item(Item=org)
-                print(f"✓ Created organization: {org['name']}")
+                table.put_item(Item=org_item)
+                print("Created organization: {}".format(org['name']))
             except Exception as e:
-                print(f"Warning creating organization {org['name']}: {str(e)}")
+                print("Warning creating organization {}: {}".format(org['name'], str(e)))
                 # Continue even if one fails (might already exist)
-        
+
+            reservation_item = {
+                'orgId': name_reservation_key(org['name']),
+                'itemType': 'name_reservation',
+                'name': org['name'],
+                'reservedOrgId': org['orgId'],
+                'createdAt': current_time,
+            }
+            try:
+                # Conditional put mirrors createOrganization's own
+                # attribute_not_exists guard, so re-running this seeder
+                # (idempotent Custom Resource semantics) never clobbers a
+                # reservation that already exists — e.g. one created since by
+                # a real createOrganization call, or a tombstone written by
+                # deleteOrganization.
+                table.put_item(
+                    Item=reservation_item,
+                    ConditionExpression='attribute_not_exists(orgId)',
+                )
+                print("Reserved organization name: {}".format(org['name']))
+            except Exception as e:
+                print(
+                    "Warning reserving organization name {}: {}".format(
+                        org['name'], str(e)
+                    )
+                )
+                # Continue — a pre-existing reservation (or tombstone) row is
+                # expected on re-run and is not an error.
+
         cfnresponse.send(event, context, cfnresponse.SUCCESS, {
             'Message': 'Organizations seeded successfully',
-            'Count': len(organizations)
+            'Count': len(ORGANIZATIONS)
         })
     except Exception as e:
         print(f"Error seeding organizations: {str(e)}")


### PR DESCRIPTION
## Summary

PR 159 replaced `createOrganization`'s scan-then-write duplicate check with an atomic conditional put on a `NAME# <name>` reservation row. That closed the race but opened a hole: **nothing creates reservation rows for organisations that already exist**, so a duplicate of any such name passes both the tombstone lookup and the 'attribute_not_exists' condition.

We had traded a check that was **complete but non-atomic** for one that was **atomic but incomplete**.

This is not an upgrade-path problem: `seed-organizations` writes only the four organisation rows and no reservation rows, so even a **fresh deployment's** seeded names were duplicable. Only names created through 'createOrganization after deploy were protected.

The organisation name is the canonical tenancy key, two organisations sharing a name means two tenants sharing one key - the non-admin users and name-stamped rows of each become visible to the other.

`createOrganization` is admin-only, so the realistic risk is an **accidental** duplicate silently merging two tenants' visibility rather than escalation.

## Three mechanisms, because any one alone leaves a hole

1. **Seeder** - writes a `NAME#` reservation row for every organisation it seeds, derived from the *same constant* as the organisation row. Proven undriftable: changing the seeded name in one place fails a test rather than silently diverging
2. **Backfill** - a standalone idempotent script for organisations that already exist. Chosen in the script shape matching `backfill-org-ids.ts` over a custom resource, since it needs no CDK wiring or IAM role. A re-run writes nothing new. **A name held by two or more organisations is reported as a collision with a non-zero exit, never auto-resolved** - that's a pre-existing tenancy collision and an owner decision
3. **Row-Level backstop** - `createOrganization` regains an existence check against real organisation rows. The conditional put remains the sole atomic authority; comments state explicitly which is primary and which is defence in depth, so the guarantee no longer rests solely on a side table that can drift

## The test that would have caught the original gap

A duplicate of a **seeded** name is rejected - both with its reservation row present, and with it absent, where the backstop must catch it. The existing test only proved a duplicate of a name created *within the same test* was rejected, which is why the gap passed review. 

Plus backfill idempotency, and a test asserting the backfill reports a pre-existing duplicate rather than collapsing it.

## Testing

tsc 0, lint 0, targeted 46, all 16 guard suites (363), full backend jest 7862, nag-enabled synth of all 9 stacks clean.

No IAM changes, so 'splitigates" is out of scope. Tombstones verified intact, and the
backfill will not resurrect a tombstoned name.

## After merging

Existing deployments need `scripts/backfill-org-name-reservations.ts` run to gain reservation rows. Until then the row-level backstop is what protects them.