### PR TITLE
fix(auth): send the ID token on AppSync requests

### DIFF
--- a/backend/src/utils/__tests__/auth-event.test.ts
+++ b/backend/src/utils/__tests__/auth-event.test.ts
@@ -402,4 +402,78 @@ describe("auth-event", () => {
       );
     });
   });
+
+  // Regression coverage for finding c7beb960 (high): the frontend switched
+  // from sending the access token to the ID token on AppSync requests,
+  // because the pre-token-generation trigger's claimsOverrideDetails only
+  // decorates the ID token with custom:organization. These tests pin the
+  // claims shape AppSync produces from an ID token (as opposed to the
+  // access-token shape that was silently reaching this code before the
+  // fix) so a future regression back to access-token claims is caught here
+  // rather than only in production CloudWatch logs.
+  describe("finding c7beb960: ID-token-shaped claims", () => {
+    test("extractOrgFromEvent resolves custom:organization from an ID-token-shaped identity (token_use='id')", async () => {
+      const idTokenEvent = {
+        identity: {
+          sub: "user-123",
+          username: "user-123",
+          token_use: "id",
+          "custom:organization": "Acme Corp",
+          "cognito:groups": ["admin"],
+        },
+      };
+
+      const result = await extractOrgFromEvent(idTokenEvent);
+
+      expect(result).toBe("Acme Corp");
+      expect(cognitoMock.commandCalls(AdminGetUserCommand).length).toBe(0);
+    });
+
+    test("extractOrgFromEvent returns null for an access-token-shaped identity lacking custom:organization (documents the bug this fix prevents)", async () => {
+      // An access token never carries custom:organization — this is the
+      // exact shape that reached extractOrgFromEvent for every caller
+      // before the frontend was switched to send the ID token. Without a
+      // resolvable USER_POOL_ID fallback match, this must resolve to null
+      // (fail closed), not silently succeed.
+      const accessTokenEvent = {
+        identity: {
+          sub: "user-123",
+          username: "user-123",
+          token_use: "access",
+          scope: "aws.cognito.signin.user.admin",
+          client_id: "abc123clientid",
+          "cognito:groups": ["admin"],
+        },
+      };
+      cognitoMock.rejects(new Error("user not found"));
+
+      const result = await extractOrgFromEvent(accessTokenEvent);
+
+      expect(result).toBeNull();
+    });
+
+    test("isAdminFromEvent resolves identically for ID-token-shaped and access-token-shaped identities (cognito:groups is present on both)", () => {
+      const idTokenEvent = {
+        identity: { token_use: "id", "cognito:groups": ["admin"] },
+      };
+      const accessTokenEvent = {
+        identity: { token_use: "access", "cognito:groups": ["admin"] },
+      };
+
+      expect(isAdminFromEvent(idTokenEvent)).toBe(true);
+      expect(isAdminFromEvent(accessTokenEvent)).toBe(true);
+    });
+
+    test("deriveRoles resolves identically for ID-token-shaped and access-token-shaped admin identities", () => {
+      const idTokenEvent = {
+        identity: { token_use: "id", "cognito:groups": ["admin"] },
+      };
+      const accessTokenEvent = {
+        identity: { token_use: "access", "cognito:groups": ["admin"] },
+      };
+
+      expect(deriveRoles(idTokenEvent)).toEqual(["admin"]);
+      expect(deriveRoles(accessTokenEvent)).toEqual(["admin"]);
+    });
+  });
 });

--- a/frontend/src/services/__tests__/server.idToken.test.ts
+++ b/frontend/src/services/__tests__/server.idToken.test.ts
@@ -1,0 +1,129 @@
+/**
+ * Regression test for finding c7beb960 (high): AppSync requests must carry
+ * Cognito's ID TOKEN, not the access token.
+ *
+ * Root cause: Amplify v6's default `userPool` auth mode sends the ACCESS
+ * token on every AppSync request, but the pre-token-generation trigger only
+ * decorates the ID token with `custom:organization`
+ * (`claimsOverrideDetails` targets ID-token claims only). An
+ * access-token-authenticated request therefore reaches the backend with no
+ * `custom:organization` claim, so `extractOrgFromEvent` returns null for
+ * every caller and every non-admin org gate fails closed.
+ *
+ * This test asserts the header-override function used at client
+ * construction resolves to the ID token (not the access token), and that
+ * `generateClient` is invoked with that override — covering queries,
+ * mutations, and subscriptions uniformly, since Amplify applies a client's
+ * `headers` option to all three.
+ */
+
+jest.mock('aws-amplify/auth', () => ({
+  signIn: jest.fn(),
+  signOut: jest.fn(),
+  signUp: jest.fn(),
+  confirmSignUp: jest.fn(),
+  confirmSignIn: jest.fn(),
+  resendSignUpCode: jest.fn(),
+  getCurrentUser: jest.fn(),
+  fetchAuthSession: jest.fn(),
+  resetPassword: jest.fn(),
+  confirmResetPassword: jest.fn(),
+}));
+
+jest.mock('aws-amplify/api', () => ({
+  generateClient: jest.fn(() => ({ graphql: jest.fn() })),
+}));
+
+jest.mock('aws-amplify', () => ({
+  Amplify: { configure: jest.fn() },
+}));
+
+import { generateClient } from 'aws-amplify/api';
+import { fetchAuthSession } from 'aws-amplify/auth';
+import { withIdTokenHeader } from '../server';
+
+describe('finding c7beb960: AppSync client sends the ID token, not the access token', () => {
+  // Captured once, before any beforeEach clears mock call history — the
+  // constructor call happened exactly once at module-import time, above.
+  const clientConstructionCallArgs = (generateClient as jest.Mock).mock.calls[0];
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('constructs the client with a headers override (applies to queries, mutations, AND subscriptions)', () => {
+    expect(clientConstructionCallArgs).toBeDefined();
+    const options = clientConstructionCallArgs[0];
+    expect(options).toBeDefined();
+    expect(typeof options.headers).toBe('function');
+    // The same function reference is what's under test below — confirms
+    // this isn't a second, divergent header-builder.
+    expect(options.headers).toBe(withIdTokenHeader);
+  });
+
+  it('withIdTokenHeader resolves Authorization to the ID token string, never the access token', async () => {
+    const idTokenString = 'eyIDTOKEN.header.payload.signature';
+    const accessTokenString = 'eyACCESSTOKEN.header.payload.signature';
+
+    (fetchAuthSession as jest.Mock).mockResolvedValue({
+      tokens: {
+        idToken: { toString: () => idTokenString },
+        accessToken: { toString: () => accessTokenString },
+      },
+    });
+
+    const headers = await withIdTokenHeader();
+
+    expect(headers.Authorization).toBe(idTokenString);
+    expect(headers.Authorization).not.toBe(accessTokenString);
+  });
+
+  it('withIdTokenHeader produces a claims-bearing token shape the backend expects (custom:organization present)', async () => {
+    // Simulate the ID token's decoded claim payload (what the
+    // pre-token-generation trigger decorates) to document the contract:
+    // whatever fetchAuthSession returns as idToken must be the token that
+    // carries custom:organization end-to-end through AppSync's identity.
+    const decodedIdTokenPayload = {
+      sub: 'user-123',
+      token_use: 'id',
+      'custom:organization': 'Acme Corp',
+      'cognito:groups': ['admin'],
+    };
+    const idTokenString = 'signed.id.token';
+
+    (fetchAuthSession as jest.Mock).mockResolvedValue({
+      tokens: {
+        idToken: {
+          toString: () => idTokenString,
+          payload: decodedIdTokenPayload,
+        },
+      },
+    });
+
+    const headers = await withIdTokenHeader();
+
+    expect(headers.Authorization).toBe(idTokenString);
+    // Document (not assert against Amplify internals) that the underlying
+    // session token this header is derived from is claim-bearing for org.
+    const session = await fetchAuthSession();
+    expect(session.tokens?.idToken?.payload['custom:organization']).toBe('Acme Corp');
+  });
+
+  it('falls back to no Authorization override when no session exists (e.g. unauthenticated api-key mode)', async () => {
+    (fetchAuthSession as jest.Mock).mockResolvedValue({ tokens: undefined });
+
+    const headers = await withIdTokenHeader();
+
+    expect(headers.Authorization).toBeUndefined();
+  });
+
+  it('does not throw and returns empty headers when fetchAuthSession rejects', async () => {
+    (fetchAuthSession as jest.Mock).mockRejectedValue(new Error('network error'));
+    const consoleSpy = jest.spyOn(console, 'warn').mockImplementation();
+
+    const headers = await withIdTokenHeader();
+
+    expect(headers).toEqual({});
+    consoleSpy.mockRestore();
+  });
+});

--- a/frontend/src/services/integrationServiceBackend.ts
+++ b/frontend/src/services/integrationServiceBackend.ts
@@ -1,6 +1,13 @@
 import { generateClient } from 'aws-amplify/api';
+import { withIdTokenHeader } from './server';
 
-const client = generateClient();
+// finding c7beb960: without this header override, Amplify's default
+// userPool auth mode sends the ACCESS token, which never carries
+// custom:organization (see server.ts's withIdTokenHeader for the full
+// explanation). This client is used for both queries/mutations and any
+// subscriptions issued through it, so the override must live here at
+// construction time rather than per-call.
+const client = generateClient({ headers: withIdTokenHeader });
 
 export interface Integration {
   integrationId: string;

--- a/frontend/src/services/server.ts
+++ b/frontend/src/services/server.ts
@@ -49,12 +49,46 @@ interface SignInParams {
   password: string;
 }
 
+/**
+ * Amplify authorization-header override for AppSync (finding c7beb960).
+ *
+ * Amplify v6's default `userPool` auth mode sends Cognito's ACCESS token
+ * on every AppSync request (query, mutation, AND subscription — this
+ * header function is invoked uniformly by the client for all three). The
+ * backend's pre-token-generation trigger only decorates the ID token with
+ * `custom:organization` (`claimsOverrideDetails` targets ID-token claims
+ * only), so an access-token-authenticated request always arrives at
+ * `extractOrgFromEvent` with no `custom:organization` claim — every
+ * non-admin org gate fails closed, and admins pass only because
+ * `isAdminFromEvent`/`cognito:groups` happens to be present on both token
+ * types.
+ *
+ * Fix: explicitly fetch the current session's ID token and set it as the
+ * `Authorization` header, overriding Amplify's default access-token
+ * selection. `fetchAuthSession()` transparently refreshes an expired
+ * session, so this stays correct across the token lifetime.
+ *
+ * Falls back to no override (Amplify's default access-token behavior) if
+ * no session exists (e.g. unauthenticated API-key-mode requests) — Amplify
+ * ignores an empty Authorization header value for those callers.
+ */
+async function withIdTokenHeader(): Promise<Record<string, string>> {
+  try {
+    const session = await fetchAuthSession();
+    const idToken = session.tokens?.idToken?.toString();
+    return idToken ? { Authorization: idToken } : {};
+  } catch (error) {
+    console.warn("withIdTokenHeader: failed to fetch auth session:", error);
+    return {};
+  }
+}
+
 class ServerService {
   private client: any;
   private config: AmplifyConfig | null = null;
 
   constructor() {
-    this.client = generateClient();
+    this.client = generateClient({ headers: withIdTokenHeader });
   }
 
   /**
@@ -345,5 +379,5 @@ class ServerService {
 const serverService = new ServerService();
 
 export default serverService;
-export { ServerService };
+export { ServerService, withIdTokenHeader };
 export type { AmplifyConfig, SignUpParams, SignInParams, ResetPasswordOutput };


### PR DESCRIPTION
## Summary

The organisation claim never reached any resolver. The frontend sent Cognito's AppSync, but `custom:organization` **access token** to exists only in the **ID token** - the pre-token-generation trigger runs at `V1_0`, which decorates the ID token alone. Live Cloudwatch evidence: the AppSync event carried `token_use: "access"` and no custom claim.

So `extractOrgFromEvent` returned null for **every user at all 59 call sites across 22 files**. Every organisation gate failed closed for non-admins, while admins passed via bypass. The `AdminGetUser` fallback that appears to cover this is dead twice over on the deployed resolver: no `USER_POOL_ID` environment variable, so it returns null at the guard, and no `cognito-idp` permission on the role.

This is fail-closed, so it is a functional defect rather than cross-tenant exposure - but it means the organisation isolation shipped recently has never actually executed. It is likely why governance findings still showed no stamped organisation after the stamping change deployed, and why datastore rows carry the UI selector label instead of a tenant.

## Changes

Both `generateClient()` sites now send the ID token via shared `withIdTokenHeader` override:
- `services/server.ts` - backs every query, mutation **and subscription**, since the subscription call sites all route through `serverService`
- `services/integrationServiceBackend.ts` - constructs its own independent client

A fix covering queries but not subscriptions would have looked correct while leaving live updates unauthorised, so both agents enumerated the sites independently.

## Claim compatibility, verified not assumed

| Claim | ID token | Access token | Read by |
|---|---|---|---|
| `custom:organization` | ✅ | ❌ | `extractorgFromEvent` - the bug |
| `cognito:groups` | ✅ | ✅ | `isAdminFromEvent`, `deriveRoles` |
| `sub` / `username` | ✅ | ✅ | userId derivation |

**Admin detection is unaffected** - `cognito:groups` is in both, and that is asserted by test across both token shapes rather than reasoned about, since breaking admin detection would be worse than the original bug. No code on the AppSync path reads `token_use`, `scope` or `client_id`; `auth.ts`'s `GetUserCommand` flow is a separate REST path, untouched.

## Deliberately not done

No `USER_POOL_ID` environment variable and no `cognito-idp` grant - wiring the fallback was rejected because it would add a per-request Cognito call to every gated operation and widen IAM across 22 files to carry data the token should hold natively. No backend authorization logic changed.

## Testing

Regression tests on both sides, proven to bite: reverting the client to the access token produces five failures, restored byte-identically.

Frontend tsc 0, jest 2073, build 0; backend tsc 0, lint 0, jest 7872.

**Honest limit:** local tests cannot confirm the deployed AppSync authorizer accepts the ID token, or that the claim arrives end to end. That requires a deployed test.

## Follow-ups

- The `AdminGetUser` fallback is dead code that reads like safety net - remove or annotate it
- After deploying, the organisation isolation paths become exercisable for the first time and should be tested deliberately, including whether governance findings now stamp an organisation